### PR TITLE
feat(adapters): DynamoDB output connector

### DIFF
--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -55,6 +55,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      dynamodb:
+        image: amazon/dynamodb-local:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -94,6 +96,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUST_TEST_THREADS: 16
           REDIS_URL: redis://localhost:6379/0
+          DYNAMODB_ENDPOINT: http://localhost:8000
           POSTGRES_URL: postgres://postgres:password@localhost:5432
           REDPANDA_BROKERS: 127.0.0.1
           # This thing can't resolve `localhost` (?), needs to be an IP address

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4063,6 +4063,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-msk-iam-sasl-signer",
+ "aws-sdk-dynamodb",
  "aws-sdk-s3",
  "aws-types",
  "backoff",
@@ -4155,6 +4156,7 @@ dependencies = [
  "serde",
  "serde_arrow",
  "serde_bytes",
+ "serde_dynamo",
  "serde_json",
  "serde_json_path_to_error",
  "serde_urlencoded",
@@ -5213,6 +5215,7 @@ dependencies = [
  "anyhow",
  "apache-avro 0.18.0",
  "arrow",
+ "aws-sdk-dynamodb",
  "bytemuck",
  "chrono",
  "datafusion",
@@ -5220,6 +5223,7 @@ dependencies = [
  "dyn-clone",
  "erased-serde 0.3.31",
  "feldera-sqllib",
+ "feldera-storage",
  "feldera-types",
  "num-derive",
  "num-traits",
@@ -5227,6 +5231,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_arrow",
+ "serde_dynamo",
  "serde_json",
  "serde_json_path_to_error",
  "serde_yaml",
@@ -11299,6 +11304,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_dynamo"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873a97c3f7a67dd042bceb47d056d288424b82d4c66b0a25e1a3b34675620951"
+dependencies = [
+ "aws-sdk-dynamodb",
+ "base64 0.21.7",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ async-trait = "0.1"
 atomic = "0.6.0"
 awc = "3.5.1"
 aws-config = "1.8.13"
+aws-sdk-dynamodb = { version = "1.110.0", default-features = false, features = [
+  "default-https-client",
+  "rt-tokio",
+  "behavior-version-latest"
+] }
 aws-sdk-s3 = { version = "1.122.0", default-features = false, features = [
   "default-https-client",
   "rt-tokio",
@@ -243,6 +248,7 @@ ryu = "1.0.20"
 schema_registry_converter = "4.2.0"
 semver = "1.0.27"
 serde = "1.0.213"
+serde_dynamo = { version = "4.3.0", features = ["aws-sdk-dynamodb+1"] }
 serde_arrow = { version = "0.14.1", features = ["arrow-58"] }
 serde_bytes = "0.11.15"
 serde_json = { version = "1.0.132", features = ["arbitrary_precision"] }

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -15,12 +15,15 @@ publish = true
 
 [features]
 with-avro = ["apache-avro"]
+with-dynamodb = ["aws-sdk-dynamodb", "serde_dynamo"]
 
 [dependencies]
 feldera-types = { workspace = true }
 feldera-sqllib = { workspace = true }
+feldera-storage = { workspace = true }
 dbsp = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
+aws-sdk-dynamodb = { workspace = true, optional = true }
 serde_yaml = { workspace = true }
 actix-web = { workspace = true, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
 erased-serde = { workspace = true }
@@ -29,6 +32,7 @@ arrow = { workspace = true, features = ["chrono-tz"] }
 apache-avro = { workspace = true, optional = true }
 serde_arrow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_dynamo = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true, features = ["with-serde"] }

--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -1,4 +1,6 @@
 use std::any::Any;
+#[cfg(any(feature = "with-avro", feature = "with-dynamodb"))]
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::atomic::AtomicUsize;
@@ -12,6 +14,8 @@ use apache_avro::{
     types::Value as AvroValue,
 };
 use arrow::record_batch::RecordBatch;
+#[cfg(feature = "with-dynamodb")]
+use aws_sdk_dynamodb::types::AttributeValue;
 use dbsp::circuit::NodeId;
 use dbsp::dynamic::{ClonableTrait, DynData, DynVec, Erase, Factory};
 use dbsp::operator::StagedBuffers;
@@ -22,8 +26,6 @@ use feldera_types::format::json::JsonFlavor;
 use feldera_types::program_schema::{Relation, SqlIdentifier};
 use feldera_types::serde_with_context::SqlSerdeConfig;
 use serde_arrow::ArrayBuilder;
-#[cfg(feature = "with-avro")]
-use std::collections::HashMap;
 
 use crate::errors::controller::ControllerError;
 use crate::format::InputBuffer;
@@ -46,6 +48,9 @@ pub enum RecordFormat {
     #[cfg(feature = "with-avro")]
     Avro,
     Raw(String),
+    /// Output-only format for the DynamoDB connector.
+    #[cfg(feature = "with-dynamodb")]
+    DynamoDB,
 }
 
 /// An input handle that deserializes and buffers records.
@@ -507,6 +512,11 @@ impl SerCursor for SplitCursor<'_> {
         self.cursor.key_to_json()
     }
 
+    #[cfg(feature = "with-dynamodb")]
+    fn key_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        self.cursor.key_to_dynamodb_item()
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -568,6 +578,11 @@ impl SerCursor for SplitCursor<'_> {
 
     fn val_to_json(&mut self) -> AnyResult<serde_json::Value> {
         self.cursor.val_to_json()
+    }
+
+    #[cfg(feature = "with-dynamodb")]
+    fn val_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        self.cursor.val_to_dynamodb_item()
     }
 
     #[cfg(feature = "with-avro")]
@@ -668,6 +683,11 @@ impl<'a> SerCursor for SerCursorFlattened<'a> {
         self.cursor.val_to_json()
     }
 
+    #[cfg(feature = "with-dynamodb")]
+    fn key_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        self.cursor.val_to_dynamodb_item()
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -728,6 +748,11 @@ impl<'a> SerCursor for SerCursorFlattened<'a> {
 
     fn val_to_json(&mut self) -> AnyResult<serde_json::Value> {
         panic!("val_to_json is not supported for flattened cursors");
+    }
+
+    #[cfg(feature = "with-dynamodb")]
+    fn val_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        panic!("val_to_dynamodb_item is not supported for flattened cursors");
     }
 
     #[cfg(feature = "with-avro")]
@@ -801,6 +826,10 @@ pub trait SerCursor: Send {
     /// representation of the key.
     fn key_to_json(&mut self) -> AnyResult<serde_json::Value>;
 
+    /// Serialize current key to a DynamoDB item.
+    #[cfg(feature = "with-dynamodb")]
+    fn key_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>>;
+
     /// Like `serialize_key`, but only serializes the specified fields of the key.
     fn serialize_key_fields(
         &mut self,
@@ -854,6 +883,10 @@ pub trait SerCursor: Send {
     /// Convert value to JSON. Used for error reporting to generate a human-readable
     /// representation of the value.
     fn val_to_json(&mut self) -> AnyResult<serde_json::Value>;
+
+    /// Serialize current value to a DynamoDB item.
+    #[cfg(feature = "with-dynamodb")]
+    fn val_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>>;
 
     #[cfg(feature = "with-avro")]
     /// Convert current value to Avro.
@@ -985,6 +1018,11 @@ impl SerCursor for CursorWithPolarity<'_> {
         self.cursor.key_to_json()
     }
 
+    #[cfg(feature = "with-dynamodb")]
+    fn key_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        self.cursor.key_to_dynamodb_item()
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -1046,6 +1084,11 @@ impl SerCursor for CursorWithPolarity<'_> {
 
     fn val_to_json(&mut self) -> AnyResult<serde_json::Value> {
         self.cursor.val_to_json()
+    }
+
+    #[cfg(feature = "with-dynamodb")]
+    fn val_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        self.cursor.val_to_dynamodb_item()
     }
 
     #[cfg(feature = "with-avro")]

--- a/crates/adapterlib/src/metrics.rs
+++ b/crates/adapterlib/src/metrics.rs
@@ -1,3 +1,5 @@
+use feldera_storage::histogram::ExponentialHistogramSnapshot;
+
 /// The type of a connector metric.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ValueType {
@@ -16,6 +18,23 @@ impl ValueType {
     }
 }
 
+/// A connector histogram metric.
+///
+/// The histogram is exported in the unit it was recorded in, so `name` should
+/// name that unit (for example, a histogram of microseconds should be named
+/// `..._microseconds`).
+pub struct ConnectorHistogram {
+    /// Metric name; must be a valid Prometheus metric name component (no spaces,
+    /// no special characters other than `_`).
+    pub name: &'static str,
+
+    /// Human-readable help text.
+    pub help: &'static str,
+
+    /// The recorded histogram.
+    pub snapshot: ExponentialHistogramSnapshot,
+}
+
 /// Connector-specific metrics exported via the Prometheus `/metrics` endpoint.
 ///
 /// Connectors that have metrics beyond the standard `InputEndpointMetrics`
@@ -27,4 +46,12 @@ pub trait ConnectorMetrics: Send + Sync {
     /// The returned `name`s must be valid Prometheus metric name components
     /// (no spaces, no special characters other than `_`).
     fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)>;
+
+    /// Return the connector's histogram metrics.
+    ///
+    /// Defaults to an empty list, so connectors that export only scalar metrics
+    /// need not implement it.
+    fn histograms(&self) -> Vec<ConnectorHistogram> {
+        Vec::new()
+    }
 }

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -25,6 +25,7 @@ default = [
     "with-redis",
     "with-nats",
     "with-postgres-cdc",
+    "with-dynamodb",
 ]
 with-kafka = ["rdkafka"]
 with-deltalake = ["deltalake", "deltalake-catalog-unity"]
@@ -34,6 +35,11 @@ with-avro = [
     "apache-avro",
     "schema_registry_converter",
     "feldera-adapterlib/with-avro",
+]
+with-dynamodb = [
+    "aws-sdk-dynamodb",
+    "serde_dynamo",
+    "feldera-adapterlib/with-dynamodb",
 ]
 with-nexmark = ["dbsp_nexmark"]
 with-redis = ["redis", "r2d2"]
@@ -78,6 +84,7 @@ crossbeam = { workspace = true }
 dbsp = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
+serde_dynamo = { workspace = true, optional = true }
 erased-serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
@@ -91,6 +98,7 @@ rdkafka = { workspace = true, features = [
     "libz",
 ], optional = true }
 aws-config = { workspace = true }
+aws-sdk-dynamodb = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true }
 aws-types = { workspace = true }
 actix = { workspace = true }

--- a/crates/adapters/benches/bench_common.rs
+++ b/crates/adapters/benches/bench_common.rs
@@ -13,6 +13,36 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 // ---------------------------------------------------------------------------
+// Shared benchmark configuration
+// ---------------------------------------------------------------------------
+
+/// Worker-thread counts used by all output-connector encode benchmarks.
+pub const BENCH_WORKER_COUNTS: [usize; 4] = [1, 2, 4, 8];
+
+/// Record counts used by the scaling benchmarks.
+pub const BENCH_RECORD_COUNTS: [usize; 3] = [100_000, 1_000_000, 2_000_000];
+
+/// Runs `iters` Criterion timing iterations.
+///
+/// `timed` is called inside the stopwatch; `after` is called outside it and
+/// can be used for correctness checks or inter-iteration cleanup (e.g. table
+/// truncation). Returns the total elapsed time of the `timed` calls only.
+pub fn bench_iter(
+    iters: u64,
+    mut timed: impl FnMut(),
+    mut after: impl FnMut(),
+) -> std::time::Duration {
+    let mut total = std::time::Duration::ZERO;
+    for _ in 0..iters {
+        let start = std::time::Instant::now();
+        timed();
+        total += start.elapsed();
+        after();
+    }
+    total
+}
+
+// ---------------------------------------------------------------------------
 // Common type definitions for benchmarks
 // ---------------------------------------------------------------------------
 

--- a/crates/adapters/benches/postgres_output.rs
+++ b/crates/adapters/benches/postgres_output.rs
@@ -1,6 +1,9 @@
 mod bench_common;
 
-use bench_common::{BenchKeyStruct, BenchTestStruct, build_indexed_batch, generate_test_data};
+use bench_common::{
+    BENCH_RECORD_COUNTS, BENCH_WORKER_COUNTS, BenchKeyStruct, BenchTestStruct, bench_iter,
+    build_indexed_batch, generate_test_data,
+};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use dbsp_adapters::Encoder;
 use dbsp_adapters::SerBatch;
@@ -79,6 +82,7 @@ fn create_endpoint(config: &PostgresWriterConfig) -> PostgresOutputEndpoint {
         &Some(BenchKeyStruct::relation_schema()),
         &BenchTestStruct::relation_schema(),
         Weak::new(),
+        true,
     )
     .expect("failed to create PostgresOutputEndpoint")
 }
@@ -94,20 +98,20 @@ fn bench_encode_iter(
     num_records: usize,
     iters: u64,
 ) -> std::time::Duration {
-    let mut total = std::time::Duration::ZERO;
-    for _ in 0..iters {
-        let start = std::time::Instant::now();
-        endpoint.consumer().batch_start(0, OutputBatchType::Delta);
-        endpoint
-            .encode(batch.clone().arc_as_batch_reader())
-            .unwrap();
-        endpoint.consumer().batch_end();
-        total += start.elapsed();
-
-        let truncated = truncate_bench_table(pg_client);
-        assert_eq!(truncated, num_records as u64);
-    }
-    total
+    bench_iter(
+        iters,
+        || {
+            endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+            endpoint
+                .encode(batch.clone().arc_as_batch_reader())
+                .unwrap();
+            endpoint.consumer().batch_end();
+        },
+        || {
+            let truncated = truncate_bench_table(pg_client);
+            assert_eq!(truncated, num_records as u64);
+        },
+    )
 }
 
 /// Benchmark Postgres output with 100k records across 1/2/4/8 worker threads.
@@ -123,7 +127,7 @@ fn bench_postgres_encode(c: &mut Criterion) {
     group.throughput(criterion::Throughput::Elements(num_records as u64));
     group.sample_size(10);
 
-    for workers in [1, 2, 4, 8] {
+    for workers in BENCH_WORKER_COUNTS {
         let config = make_config(workers);
         group.bench_with_input(BenchmarkId::new("workers", workers), &workers, |b, _| {
             let mut endpoint = create_endpoint(&config);
@@ -145,11 +149,11 @@ fn bench_postgres_encode_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("postgres_output_encode_scaling");
     group.sample_size(10);
 
-    for num_records in [100_000, 1_000_000, 2_000_000] {
+    for num_records in BENCH_RECORD_COUNTS {
         let data = generate_test_data(num_records);
         let batch = build_indexed_batch(&data);
 
-        for workers in [1, 2, 4, 8] {
+        for workers in BENCH_WORKER_COUNTS {
             let config = make_config(workers);
             group.throughput(criterion::Throughput::Elements(num_records as u64));
             group.bench_with_input(

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -1890,8 +1890,7 @@ impl Controller {
             },
         );
 
-        // Export connector-specific (custom) metrics registered via
-        // `InputConsumer::set_custom_metrics`.
+        // Export connector-specific (custom) metrics.
         write_custom_metrics(status, metrics, labels);
 
         fn write_output_metric<F, M>(
@@ -2260,8 +2259,7 @@ fn write_fbuf_slab_metrics<F>(
     );
 }
 
-/// Write connector-specific (custom) metrics registered via
-/// [`InputConsumer::set_custom_metrics`] into `metrics`.
+/// Write connector-specific metrics into `metrics`.
 ///
 /// Groups values by `(name, help, ValueType)` so that all endpoints' values
 /// for the same metric are emitted in a single Prometheus block (the
@@ -2288,10 +2286,53 @@ pub(crate) fn write_custom_metrics<F>(
             }
         }
     }
+    for output in status.output_status().values() {
+        if let Some(cm) = &output.custom_metrics {
+            for (name, help, vtype, value) in cm.metrics() {
+                grouped
+                    .entry((name, help, vtype))
+                    .or_default()
+                    .push((output.endpoint_name.clone(), value));
+            }
+        }
+    }
     for ((name, help, vtype), entries) in &grouped {
         metrics.values(name, help, *vtype, |w| {
             for (endpoint_name, value) in entries {
                 w.write_value(&labels.with("endpoint", endpoint_name), *value);
+            }
+        });
+    }
+
+    // Histograms are grouped and emitted the same way: all endpoints' values for
+    // a given histogram appear together under one `# TYPE` header.
+    type HistogramKey = (&'static str, &'static str);
+    type HistogramValues = Vec<(String, ExponentialHistogramSnapshot)>;
+    let mut grouped_histograms: BTreeMap<HistogramKey, HistogramValues> = BTreeMap::new();
+    for input in status.input_status().values() {
+        if let Some(cm) = &input.custom_metrics {
+            for histogram in cm.histograms() {
+                grouped_histograms
+                    .entry((histogram.name, histogram.help))
+                    .or_default()
+                    .push((input.endpoint_name.clone(), histogram.snapshot));
+            }
+        }
+    }
+    for output in status.output_status().values() {
+        if let Some(cm) = &output.custom_metrics {
+            for histogram in cm.histograms() {
+                grouped_histograms
+                    .entry((histogram.name, histogram.help))
+                    .or_default()
+                    .push((output.endpoint_name.clone(), histogram.snapshot));
+            }
+        }
+    }
+    for ((name, help), entries) in grouped_histograms {
+        metrics.histograms(name, help, |w| {
+            for (endpoint_name, snapshot) in entries {
+                w.write_histogram(&labels.with("endpoint", &endpoint_name), &snapshot);
             }
         });
     }
@@ -7877,7 +7918,7 @@ impl InputConsumer for InputProbe {
     fn set_custom_metrics(&self, metrics: Arc<dyn ConnectorMetrics>) {
         self.controller
             .status
-            .set_custom_metrics(self.endpoint_id, metrics);
+            .set_input_custom_metrics(self.endpoint_id, metrics);
     }
 
     fn update_connector_health(&self, health: ConnectorHealth) {

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -752,7 +752,11 @@ impl ControllerStatus {
     }
 
     /// Register connector-specific metrics for an input endpoint.
-    pub fn set_custom_metrics(&self, endpoint_id: EndpointId, metrics: Arc<dyn ConnectorMetrics>) {
+    pub fn set_input_custom_metrics(
+        &self,
+        endpoint_id: EndpointId,
+        metrics: Arc<dyn ConnectorMetrics>,
+    ) {
         if let Some(status) = self.inputs.write().get_mut(&endpoint_id) {
             status.custom_metrics = Some(metrics);
         }
@@ -761,6 +765,17 @@ impl ControllerStatus {
     /// Output endpoint stats.
     pub fn output_status(&self) -> RwLockReadGuard<'_, BTreeMap<EndpointId, OutputEndpointStatus>> {
         self.outputs.read_recursive()
+    }
+
+    /// Register connector-specific metrics for an output endpoint.
+    pub fn set_output_custom_metrics(
+        &self,
+        endpoint_id: EndpointId,
+        metrics: Arc<dyn ConnectorMetrics>,
+    ) {
+        if let Some(status) = self.outputs.write().get_mut(&endpoint_id) {
+            status.custom_metrics = Some(metrics);
+        }
     }
 
     /// Register a batch-progress counter for an output endpoint.
@@ -2589,6 +2604,9 @@ pub struct OutputEndpointStatus {
     pub transport_errors: Mutex<ConnectorErrorList>,
 
     pub health: Mutex<Option<ConnectorHealth>>,
+
+    /// Connector-specific metrics for Prometheus export.
+    pub custom_metrics: Option<Arc<dyn ConnectorMetrics>>,
 }
 
 impl OutputEndpointStatus {
@@ -2668,6 +2686,7 @@ impl OutputEndpointStatus {
             encode_errors: Mutex::new(encode_errors),
             transport_errors: Mutex::new(transport_errors),
             health: Mutex::new(None),
+            custom_metrics: None,
         }
     }
 

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2864,7 +2864,7 @@ fn test_external_controller_status_serialization() {
     );
 }
 
-/// Test that custom connector metrics registered via `set_custom_metrics` are
+/// Test that custom connector metrics registered via `set_input_custom_metrics` are
 /// included in the Prometheus output produced by the custom-metrics loop in
 /// `write_metrics`.
 #[test]
@@ -2921,7 +2921,7 @@ fn test_custom_connector_metrics_prometheus_output() {
     status.inputs.write().insert(0, endpoint);
 
     // Register custom metrics on the endpoint.
-    status.set_custom_metrics(0, Arc::new(MockMetrics));
+    status.set_input_custom_metrics(0, Arc::new(MockMetrics));
 
     let mut writer = MetricsWriter::<PrometheusFormatter>::new();
     let labels = LabelStack::new();
@@ -2948,6 +2948,97 @@ fn test_custom_connector_metrics_prometheus_output() {
     assert!(
         output.contains("1000"),
         "output missing counter value 1000:\n{output}"
+    );
+}
+
+/// Test that custom connector metrics registered on output endpoints are
+/// included in Prometheus output.
+#[test]
+fn test_custom_output_connector_metrics_prometheus_output() {
+    use crate::{
+        ControllerStatus,
+        controller::write_custom_metrics,
+        server::metrics::{LabelStack, MetricsWriter, PrometheusFormatter},
+    };
+    use feldera_adapterlib::metrics::{ConnectorHistogram, ConnectorMetrics, ValueType};
+    use feldera_storage::histogram::ExponentialHistogram;
+    use feldera_types::config::OutputEndpointConfig;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    struct MockMetrics;
+
+    impl ConnectorMetrics for MockMetrics {
+        fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)> {
+            vec![(
+                "mock_metric_total",
+                "Mock connector-specific metric for the output connector.",
+                ValueType::Counter,
+                3.0,
+            )]
+        }
+
+        fn histograms(&self) -> Vec<ConnectorHistogram> {
+            let histogram = ExponentialHistogram::new();
+            histogram.record(5u64);
+            histogram.record(15u64);
+            vec![ConnectorHistogram {
+                name: "mock_latency_microseconds",
+                help: "Mock connector-specific histogram for the output connector.",
+                snapshot: histogram.snapshot(),
+            }]
+        }
+    }
+
+    let config = serde_json::from_value(json!({
+        "name": "test_output_custom_metrics",
+        "workers": 1,
+    }))
+    .unwrap();
+    let status = ControllerStatus::new(config, 0, None, Uuid::nil());
+
+    let output_config: OutputEndpointConfig = serde_json::from_value(json!({
+        "stream": "s",
+        "transport": { "name": "http_output", "config": {} },
+        "format": { "name": "json", "config": {} }
+    }))
+    .unwrap();
+    status.add_output(&0, "mock_output", &output_config, None);
+    status.set_output_custom_metrics(0, Arc::new(MockMetrics));
+
+    let mut writer = MetricsWriter::<PrometheusFormatter>::new();
+    let labels = LabelStack::new();
+    write_custom_metrics(&status, &mut writer, &labels);
+    let output = writer.into_output();
+
+    assert!(
+        output.contains("mock_metric_total"),
+        "output missing mock_metric_total:\n{output}"
+    );
+    assert!(
+        output.contains(r#"endpoint="mock_output""#),
+        "output missing endpoint label:\n{output}"
+    );
+    assert!(output.contains("3"), "output missing value 3:\n{output}");
+
+    // The histogram is exported with its standard `_bucket`, `_sum`, and
+    // `_count` series under a single `# TYPE ... histogram` header.  The mock
+    // records observations of 5 and 15, so sum is 20 and count is 2.
+    assert!(
+        output.contains("# TYPE mock_latency_microseconds histogram"),
+        "output missing histogram type header:\n{output}"
+    );
+    assert!(
+        output.contains(r#"mock_latency_microseconds_bucket{endpoint="mock_output","#),
+        "output missing histogram bucket:\n{output}"
+    );
+    assert!(
+        output.contains(r#"mock_latency_microseconds_sum{endpoint="mock_output"} 20"#),
+        "output missing histogram sum:\n{output}"
+    );
+    assert!(
+        output.contains(r#"mock_latency_microseconds_count{endpoint="mock_output"} 2"#),
+        "output missing histogram count:\n{output}"
     );
 }
 
@@ -2999,7 +3090,7 @@ fn test_custom_connector_metrics_prometheus_grouping() {
             None,
         );
         status.inputs.write().insert(id, endpoint);
-        status.set_custom_metrics(id, Arc::new(MockMetrics));
+        status.set_input_custom_metrics(id, Arc::new(MockMetrics));
     }
 
     let mut writer = MetricsWriter::<PrometheusFormatter>::new();

--- a/crates/adapters/src/integrated.rs
+++ b/crates/adapters/src/integrated.rs
@@ -8,8 +8,12 @@ use std::sync::{Arc, Weak};
 
 #[cfg(feature = "with-deltalake")]
 pub mod delta_table;
+#[cfg(feature = "with-dynamodb")]
+mod dynamodb;
 mod postgres;
 
+#[cfg(feature = "with-dynamodb")]
+pub use crate::integrated::dynamodb::DynamoDBOutputEndpoint;
 #[cfg(feature = "with-postgres-cdc")]
 use crate::integrated::postgres::PostgresCdcInputEndpoint;
 use crate::integrated::postgres::PostgresInputEndpoint;
@@ -62,6 +66,16 @@ pub fn create_integrated_output_endpoint(
             is_index,
         )?),
         TransportConfig::PostgresOutput(config) => Box::new(PostgresOutputEndpoint::new(
+            endpoint_id,
+            endpoint_name,
+            config,
+            key_schema,
+            schema,
+            controller,
+            is_index,
+        )?),
+        #[cfg(feature = "with-dynamodb")]
+        TransportConfig::DynamoDBOutput(config) => Box::new(DynamoDBOutputEndpoint::new(
             endpoint_id,
             endpoint_name,
             config,

--- a/crates/adapters/src/integrated/dynamodb.rs
+++ b/crates/adapters/src/integrated/dynamodb.rs
@@ -1,0 +1,7 @@
+mod helpers;
+pub(crate) mod metrics;
+pub(crate) mod output;
+#[cfg(test)]
+mod test;
+
+pub use output::DynamoDBOutputEndpoint;

--- a/crates/adapters/src/integrated/dynamodb/helpers.rs
+++ b/crates/adapters/src/integrated/dynamodb/helpers.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result as AnyResult, anyhow, bail};
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::error::DisplayErrorContext;
+use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem, WriteRequest};
+use aws_types::region::Region;
+use dbsp::circuit::tokio::TOKIO;
+use feldera_types::transport::dynamodb::DynamoDBWriterConfig;
+use rand::Rng;
+use tracing::warn;
+
+use super::metrics::DynamoDBOutputMetrics;
+
+/// Sends one pre-chunked `BatchWriteItem` request, retrying unprocessed items with backoff.
+pub(crate) async fn write_batch_chunk(
+    client: Client,
+    endpoint_name: String,
+    table: String,
+    requests: Vec<WriteRequest>,
+    max_retries: Option<usize>,
+    metrics: &DynamoDBOutputMetrics,
+) -> AnyResult<u64> {
+    let mut request_items = HashMap::from([(table, requests)]);
+    let mut retry = 0usize;
+
+    loop {
+        let call_start = Instant::now();
+        let output_result = client
+            .batch_write_item()
+            .set_request_items(Some(request_items.clone()))
+            .send()
+            .await;
+        metrics.record_write_call_latency(call_start.elapsed());
+
+        let output = output_result
+            .map_err(|error| {
+                // `SdkError` display can hide the underlying DynamoDB service error.
+                anyhow!(
+                    "dynamodb output connector '{endpoint_name}' failed to write batch \
+                     chunk: {}",
+                    DisplayErrorContext(&error)
+                )
+            })
+            .inspect_err(|error| warn!("{error:#}"))?;
+
+        let Some(unprocessed) = output.unprocessed_items() else {
+            return Ok(retry as u64);
+        };
+        if unprocessed.is_empty() {
+            return Ok(retry as u64);
+        }
+
+        let count = unprocessed.values().map(Vec::len).sum::<usize>();
+        // Unprocessed items are writes DynamoDB rejected for lack of capacity.
+        metrics.record_throttled_items(count as u64);
+        if max_retries.is_some_and(|max| retry >= max) {
+            metrics.record_failed_items(count as u64);
+            bail!(
+                "dynamodb output connector '{endpoint_name}' failed to write \
+                 {count} unprocessed item(s) after {retry} retries"
+            );
+        }
+
+        request_items = unprocessed.clone();
+        warn!(
+            "dynamodb output connector '{endpoint_name}' retrying \
+             {count} unprocessed batch item(s) (attempt {})",
+            retry + 1,
+        );
+
+        retry += 1;
+        tokio::time::sleep(backoff_delay(retry)).await;
+    }
+}
+
+/// Converts a `WriteRequest` (put or delete) into a `TransactWriteItem` for use in `TransactWriteItems`.
+pub(crate) fn to_transact_item(
+    table: &str,
+    request: &WriteRequest,
+) -> AnyResult<TransactWriteItem> {
+    match (request.put_request(), request.delete_request()) {
+        (Some(put_request), None) => Ok(TransactWriteItem::builder()
+            .put(
+                Put::builder()
+                    .table_name(table)
+                    .set_item(Some(put_request.item().clone()))
+                    .build()?,
+            )
+            .build()),
+        (None, Some(delete_request)) => Ok(TransactWriteItem::builder()
+            .delete(
+                Delete::builder()
+                    .table_name(table)
+                    .set_key(Some(delete_request.key().clone()))
+                    .build()?,
+            )
+            .build()),
+        _ => bail!("expected exactly one put or delete request"),
+    }
+}
+
+/// Sends one pre-chunked `TransactWriteItems` request, retrying on failure with backoff.
+pub(crate) async fn write_transact_chunk(
+    client: Client,
+    endpoint_name: String,
+    transact_items: Vec<TransactWriteItem>,
+    max_retries: Option<usize>,
+    metrics: &DynamoDBOutputMetrics,
+) -> AnyResult<u64> {
+    let mut retry = 0usize;
+
+    loop {
+        let call_start = Instant::now();
+        let result = client
+            .transact_write_items()
+            .set_transact_items(Some(transact_items.clone()))
+            .send()
+            .await;
+        metrics.record_write_call_latency(call_start.elapsed());
+
+        match result {
+            Ok(_) => return Ok(retry as u64),
+            Err(error) => {
+                // Count every failed TransactWriteItems attempt; these are
+                // retried below (or dropped once retries are exhausted).
+                metrics.record_transact_write_failure();
+                let exhausted = max_retries.is_some_and(|max| retry >= max);
+                // Render the underlying DynamoDB error into the message via
+                // `DisplayErrorContext`; the bare `SdkError` `Display`  would
+                // otherwise hide the real cause when shown with `{}`.
+                let error = anyhow!(
+                    "dynamodb output connector '{endpoint_name}' TransactWriteItems request \
+                     with {} item(s) failed (attempt {}), {}: {}",
+                    transact_items.len(),
+                    retry + 1,
+                    if exhausted { "giving up" } else { "retrying" },
+                    DisplayErrorContext(&error),
+                );
+                warn!("{error:#}");
+                if exhausted {
+                    // A transaction is all-or-nothing, so every item is dropped.
+                    metrics.record_failed_items(transact_items.len() as u64);
+                    return Err(error);
+                }
+            }
+        }
+
+        retry += 1;
+        tokio::time::sleep(backoff_delay(retry)).await;
+    }
+}
+
+/// Returns the exponential backoff delay for retry attempt `retry`, with full jitter.
+///
+/// The max delay would be ~12.8s, which happens after 8 retries.
+fn backoff_delay(retry: usize) -> Duration {
+    let ceiling_ms = 50 * (1u64 << retry.min(8));
+    Duration::from_millis(rand::thread_rng().gen_range(0..=ceiling_ms))
+}
+
+pub(crate) fn item_size(item: &HashMap<String, AttributeValue>) -> usize {
+    item.iter()
+        .map(|(key, value)| key.len() + attribute_value_size(value))
+        .sum()
+}
+
+fn attribute_value_size(value: &AttributeValue) -> usize {
+    match value {
+        AttributeValue::S(value) | AttributeValue::N(value) => value.len(),
+        AttributeValue::B(value) => value.as_ref().len(),
+        AttributeValue::Bool(_) | AttributeValue::Null(_) => 1,
+        AttributeValue::M(values) => item_size(values),
+        AttributeValue::L(values) => values.iter().map(attribute_value_size).sum(),
+        AttributeValue::Ss(values) | AttributeValue::Ns(values) => {
+            values.iter().map(String::len).sum()
+        }
+        AttributeValue::Bs(values) => values.iter().map(|value| value.as_ref().len()).sum(),
+        // `AttributeValue` is `#[non_exhaustive]`, so a future SDK version may
+        // add a variant we do not size here, silently undercounting
+        // `bytes_written`. Fail loudly in debug/test builds so we notice and
+        // extend this match; in release, fall back to 0.
+        other => {
+            debug_assert!(
+                false,
+                "unhandled DynamoDB AttributeValue variant in size estimation: {other:?}"
+            );
+            0
+        }
+    }
+}
+
+pub(crate) fn make_client(config: &DynamoDBWriterConfig) -> Client {
+    let mut config_builder =
+        aws_sdk_dynamodb::Config::builder().region(Region::new(config.region.clone()));
+
+    if let Some(endpoint_url) = &config.endpoint_url {
+        config_builder = config_builder.endpoint_url(endpoint_url);
+    }
+
+    if let (Some(access_key), Some(secret_key)) =
+        (&config.aws_access_key_id, &config.aws_secret_access_key)
+    {
+        let credentials = aws_sdk_dynamodb::config::Credentials::new(
+            access_key,
+            secret_key,
+            None,
+            None,
+            "credential-provider",
+        );
+        Client::from_conf(config_builder.credentials_provider(credentials).build())
+    } else {
+        let provider = TOKIO.block_on(async {
+            aws_config::default_provider::credentials::default_provider().await
+        });
+        Client::from_conf(config_builder.credentials_provider(provider).build())
+    }
+}

--- a/crates/adapters/src/integrated/dynamodb/metrics.rs
+++ b/crates/adapters/src/integrated/dynamodb/metrics.rs
@@ -1,0 +1,178 @@
+//! Connector-specific metrics for the DynamoDB output connector.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use feldera_adapterlib::metrics::{ConnectorHistogram, ConnectorMetrics, ValueType};
+use feldera_storage::histogram::ExponentialHistogram;
+
+/// DynamoDB-specific metrics exported to Prometheus alongside the standard
+/// output-endpoint statistics.
+#[derive(Default)]
+pub(crate) struct DynamoDBOutputMetrics {
+    /// Write retries performed against DynamoDB.  A rising value signals
+    /// throttling or contention on the target table.
+    retries: AtomicU64,
+
+    /// Item-writes rejected by DynamoDB for lack of capacity, counted each time
+    /// `BatchWriteItem` returns them as unprocessed.  Unlike `retries`, which
+    /// counts retry rounds regardless of cause, this isolates throttling and
+    /// points at raising table capacity rather than connector concurrency.
+    throttled_items: AtomicU64,
+
+    /// `TransactWriteItems` requests that failed and were retried.  This is the
+    /// transactional-mode analogue of `throttled_items`: in transactional mode a
+    /// failure surfaces as a whole-request error rather than as unprocessed
+    /// items.
+    transact_write_failures: AtomicU64,
+
+    /// Output records dropped after exhausting the configured write retries.
+    /// This can only happen in bounded-retry mode; a non-zero value means data
+    /// failed to reach the target table and was discarded.
+    failed_items: AtomicU64,
+
+    /// Output records dropped because they exceed DynamoDB's 400 KB item-size
+    /// limit.  Such a record can never be written, so the connector drops it
+    /// while encoding rather than letting it fail the `BatchWriteItem` chunk or
+    /// `TransactWriteItems` transaction it would otherwise share with valid
+    /// records.  A non-zero value means data was discarded.
+    oversized_items_dropped: AtomicU64,
+
+    /// Distribution of the time that worker threads spent blocked waiting for a
+    /// write slot (the per-worker `max_concurrent_requests` semaphore).  A
+    /// shift toward longer waits is backpressure: the connector is producing
+    /// writes faster than DynamoDB accepts them, so consider raising
+    /// `max_concurrent_requests` or table capacity.  Recorded and exported in
+    /// microseconds.
+    semaphore_wait_ms: ExponentialHistogram,
+
+    /// `BatchWriteItem` / `TransactWriteItems` requests submitted.  This is the
+    /// DynamoDB request count that drives both cost and throttling.
+    write_chunks: AtomicU64,
+
+    /// Distribution of the time spent awaiting individual DynamoDB write API
+    /// calls. Each retry attempt records a separate observation.
+    write_call_latency: ExponentialHistogram,
+
+    /// Output records skipped because their key was not unique.  A non-zero
+    /// value points to a view that does not satisfy the connector's uniqueness
+    /// requirement.
+    duplicate_keys_skipped: AtomicU64,
+}
+
+impl DynamoDBOutputMetrics {
+    /// Add the retries performed while committing a batch.
+    pub(super) fn record_retries(&self, retries: u64) {
+        self.retries.fetch_add(retries, Ordering::Relaxed);
+    }
+
+    /// Add `count` item-writes returned by DynamoDB as unprocessed (throttled).
+    pub(super) fn record_throttled_items(&self, count: u64) {
+        self.throttled_items.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Record a failed `TransactWriteItems` request (which is then retried).
+    pub(super) fn record_transact_write_failure(&self) {
+        self.transact_write_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add `count` records dropped after exhausting the configured retries.
+    pub(super) fn record_failed_items(&self, count: u64) {
+        self.failed_items.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Record an output record dropped for exceeding the DynamoDB item-size limit.
+    pub(super) fn record_oversized_item_dropped(&self) {
+        self.oversized_items_dropped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record the time a worker spent blocked acquiring a write slot.
+    pub(super) fn record_semaphore_wait(&self, elapsed: Duration) {
+        self.semaphore_wait_ms.record_duration(elapsed);
+    }
+
+    /// Record submission of a single DynamoDB write chunk.
+    pub(super) fn record_write_chunk(&self) {
+        self.write_chunks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record the latency of a single DynamoDB write API call attempt.
+    pub(super) fn record_write_call_latency(&self, elapsed: Duration) {
+        self.write_call_latency.record_duration(elapsed);
+    }
+
+    /// Record an output record skipped due to a non-unique key.
+    pub(super) fn record_duplicate_key_skip(&self) {
+        self.duplicate_keys_skipped.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl ConnectorMetrics for DynamoDBOutputMetrics {
+    fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)> {
+        vec![
+            (
+                "dynamodb_output_retries_total",
+                "Total number of DynamoDB write retries performed by the output connector.",
+                ValueType::Counter,
+                self.retries.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_throttled_items_total",
+                "Total number of item-writes returned by DynamoDB as unprocessed due to \
+                 insufficient capacity (throttling).",
+                ValueType::Counter,
+                self.throttled_items.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_transact_write_failures_total",
+                "Total number of TransactWriteItems requests that failed and were retried.",
+                ValueType::Counter,
+                self.transact_write_failures.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_failed_items_total",
+                "Total number of output records dropped after exhausting the configured write \
+                 retries.",
+                ValueType::Counter,
+                self.failed_items.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_oversized_items_dropped_total",
+                "Total number of output records dropped because they exceed DynamoDB's 400 KB \
+                 item-size limit.",
+                ValueType::Counter,
+                self.oversized_items_dropped.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_write_chunks_total",
+                "Total number of DynamoDB write chunks (BatchWriteItem/TransactWriteItems requests) \
+                 submitted by the output connector.",
+                ValueType::Counter,
+                self.write_chunks.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_duplicate_keys_skipped_total",
+                "Total number of output records skipped because their key was not unique.",
+                ValueType::Counter,
+                self.duplicate_keys_skipped.load(Ordering::Relaxed) as f64,
+            ),
+        ]
+    }
+
+    fn histograms(&self) -> Vec<ConnectorHistogram> {
+        vec![
+            ConnectorHistogram {
+                name: "dynamodb_output_semaphore_wait_microseconds",
+                help: "Time worker threads spent blocked waiting for a write slot (the per-worker \
+                       max_concurrent_requests semaphore).",
+                snapshot: self.semaphore_wait_ms.snapshot(),
+            },
+            ConnectorHistogram {
+                name: "dynamodb_output_write_call_latency_microseconds",
+                help: "Latency of individual DynamoDB write API calls \
+                       (BatchWriteItem/TransactWriteItems), including retry attempts.",
+                snapshot: self.write_call_latency.snapshot(),
+            },
+        ]
+    }
+}

--- a/crates/adapters/src/integrated/dynamodb/output.rs
+++ b/crates/adapters/src/integrated/dynamodb/output.rs
@@ -328,10 +328,10 @@ impl DynamoDBWorker {
                         task_records_written.fetch_add(rows as u64, Ordering::Relaxed);
                         task_bytes_written.fetch_add(bytes as u64, Ordering::Relaxed);
                         task_metrics.record_retries(retries);
-                        if allow_cross_step_write_overlap {
-                            if let Some(controller) = task_controller.upgrade() {
-                                controller.status.output_buffer(endpoint_id, bytes, rows);
-                            }
+                        if allow_cross_step_write_overlap
+                            && let Some(controller) = task_controller.upgrade()
+                        {
+                            controller.status.output_buffer(endpoint_id, bytes, rows);
                         }
                         Ok(retries)
                     }

--- a/crates/adapters/src/integrated/dynamodb/output.rs
+++ b/crates/adapters/src/integrated/dynamodb/output.rs
@@ -1,0 +1,897 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Weak;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Result as AnyResult, anyhow, bail};
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, PutRequest, WriteRequest};
+use dbsp::circuit::tokio::TOKIO;
+use feldera_adapterlib::catalog::SplitCursorBuilder;
+use feldera_adapterlib::transport::{AsyncErrorCallback, OutputBatchType, Step};
+use feldera_types::program_schema::{Relation, SqlIdentifier};
+use feldera_types::transport::dynamodb::{DynamoDBWriteMode, DynamoDBWriterConfig};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+use tracing::{debug, info, info_span, warn};
+
+use crate::ControllerError;
+use crate::catalog::{RecordFormat, SerBatchReader, SerCursor};
+use crate::controller::{ControllerInner, EndpointId};
+use crate::format::{Encoder, OutputConsumer};
+use crate::transport::OutputEndpoint;
+use crate::util::{IndexedOperationType, indexed_operation_type};
+
+use super::helpers;
+use super::metrics::DynamoDBOutputMetrics;
+
+/// DynamoDB rejects any item larger than 400 KB (name plus value bytes). A
+/// record at or below this size may still be written; one above it never can,
+/// so the connector drops it during encoding. The value is compared against
+/// [`helpers::item_size`], which is an approximation of DynamoDB's own size
+/// accounting.
+const MAX_ITEM_SIZE_BYTES: usize = 400 * 1024;
+
+/// Minimum interval between throughput log lines emitted at batch end. The
+/// connector accumulates rows/bytes/retries across batches and logs an average
+/// at most once per interval to keep the log readable under high batch rates.
+const THROUGHPUT_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+// The connector runs a pool of worker threads, each owning a DynamoDB client
+// and write buffer for a disjoint key range. The endpoint drives them over
+// channels using the message types below: it hands each worker the key range to
+// encode and broadcasts batch lifecycle events, and each worker reports back the
+// outcome.
+
+/// Lifecycle event broadcast to every worker (as opposed to the per-worker
+/// [`WorkerCommand::Encode`]). `BatchStart`/`BatchEnd` bracket a step so workers
+/// can reset state and flush; `Shutdown` tells them to drain and exit.
+#[derive(Clone, Copy)]
+enum BroadcastCommand {
+    BatchStart,
+    BatchEnd,
+    Shutdown,
+}
+
+/// A unit of work sent to a single worker thread: either a broadcast lifecycle
+/// event, or an `Encode` request carrying the key-range split that worker should
+/// encode and write.
+enum WorkerCommand {
+    Broadcast(BroadcastCommand),
+    Encode(SplitCursorBuilder),
+}
+
+/// A worker's reply to a [`WorkerCommand`]. `num_retries` is propagated so the
+/// endpoint can aggregate it into connector metrics; `Err` surfaces a write
+/// failure back to the controller.
+enum WorkerResult {
+    Ok { num_retries: u64 },
+    Err(anyhow::Error),
+}
+
+pub(crate) struct DynamoDBWorker {
+    endpoint_id: EndpointId,
+    endpoint_name: String,
+    controller: Weak<ControllerInner>,
+    table: String,
+    write_mode: DynamoDBWriteMode,
+    allow_cross_step_write_overlap: bool,
+    batch_size: usize,
+    max_retries: Option<u8>,
+    client: Client,
+    key_schema: Relation,
+    value_schema: Relation,
+    /// Write requests accumulated since the last flush. Flushed when the count
+    /// reaches `batch_size` or the byte total reaches `max_buffer_size_bytes`.
+    pub(crate) pending: Vec<WriteRequest>,
+    pending_bytes: usize,
+    max_buffer_size_bytes: usize,
+    /// Records successfully written to DynamoDB in the current batch.
+    pub(crate) records_written: Arc<AtomicU64>,
+    /// Bytes successfully written to DynamoDB in the current batch.
+    pub(crate) bytes_written: Arc<AtomicU64>,
+    pub(crate) metrics: Arc<DynamoDBOutputMetrics>,
+    /// Limits the number of DynamoDB write requests in flight at once.
+    write_semaphore: Arc<Semaphore>,
+    /// Tokio tasks spawned by `flush()` writing batches to DynamoDB concurrently.
+    /// Completed tasks are drained eagerly in `flush()` and fully at `batch_end`.
+    pending_writes: JoinSet<AnyResult<u64>>,
+    completed_retries: u64,
+}
+
+impl DynamoDBWorker {
+    #[cfg(test)]
+    pub(crate) fn with_client(
+        client: Client,
+        endpoint_name: &str,
+        config: &DynamoDBWriterConfig,
+        key_schema: &Relation,
+        value_schema: &Relation,
+    ) -> Self {
+        let metrics = Arc::new(DynamoDBOutputMetrics::default());
+        Self::with_client_and_controller(
+            client,
+            EndpointId::default(),
+            endpoint_name,
+            Weak::new(),
+            config,
+            key_schema,
+            value_schema,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            metrics,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn with_client_and_controller(
+        client: Client,
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        controller: Weak<ControllerInner>,
+        config: &DynamoDBWriterConfig,
+        key_schema: &Relation,
+        value_schema: &Relation,
+        records_written: Arc<AtomicU64>,
+        bytes_written: Arc<AtomicU64>,
+        metrics: Arc<DynamoDBOutputMetrics>,
+    ) -> Self {
+        Self {
+            endpoint_id,
+            endpoint_name: endpoint_name.to_string(),
+            controller,
+            table: config.table.clone(),
+            write_mode: config.write_mode,
+            allow_cross_step_write_overlap: config.allow_cross_step_write_overlap,
+            batch_size: config.effective_batch_size(),
+            max_retries: config.max_retries,
+            client,
+            key_schema: key_schema.clone(),
+            value_schema: value_schema.clone(),
+            pending: Vec::new(),
+            pending_bytes: 0,
+            max_buffer_size_bytes: config.max_buffer_size_bytes,
+            records_written,
+            bytes_written,
+            metrics,
+            write_semaphore: Arc::new(Semaphore::new(config.max_concurrent_requests)),
+            pending_writes: JoinSet::new(),
+            completed_retries: 0,
+        }
+    }
+
+    fn view_name(&self) -> &SqlIdentifier {
+        &self.value_schema.name
+    }
+
+    fn index_name(&self) -> &SqlIdentifier {
+        &self.key_schema.name
+    }
+
+    /// Drains completed writes without waiting for in-flight writes, collecting retries and errors.
+    fn drain_completed_writes(&mut self) -> (u64, Vec<anyhow::Error>) {
+        let mut total_retries = std::mem::take(&mut self.completed_retries);
+        let mut errors = Vec::new();
+
+        while let Some(result) = self.pending_writes.try_join_next() {
+            match result {
+                Ok(Ok(retries)) => total_retries += retries,
+                Ok(Err(e)) => errors.push(e),
+                Err(e) => errors.push(anyhow!("write task panicked: {e}")),
+            }
+        }
+
+        (total_retries, errors)
+    }
+
+    /// Drains all `pending_writes`, collecting retries and errors.
+    fn drain_pending_writes(&mut self) -> (u64, Vec<anyhow::Error>) {
+        let (mut total_retries, mut errors) = self.drain_completed_writes();
+        TOKIO.block_on(async {
+            while let Some(result) = self.pending_writes.join_next().await {
+                match result {
+                    Ok(Ok(retries)) => total_retries += retries,
+                    Ok(Err(e)) => errors.push(e),
+                    Err(e) => errors.push(anyhow!("write task panicked: {e}")),
+                }
+            }
+        });
+        (total_retries, errors)
+    }
+
+    pub(crate) fn batch_start_inner(&mut self) {
+        self.pending.clear();
+        self.pending_bytes = 0;
+        self.completed_retries = 0;
+    }
+
+    pub(crate) fn batch_end_inner(&mut self) -> AnyResult<u64> {
+        let flush_result = self.flush();
+
+        let (total_retries, mut errors) = if self.allow_cross_step_write_overlap {
+            self.drain_completed_writes()
+        } else {
+            self.drain_pending_writes()
+        };
+
+        if let Err(e) = flush_result {
+            errors.push(e);
+        }
+
+        if !errors.is_empty() {
+            let msg = errors
+                .iter()
+                .map(|e| format!("{e:#}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("DynamoDB writes failed: {msg}");
+        }
+
+        Ok(total_retries)
+    }
+
+    fn push_request(&mut self, request: WriteRequest, bytes: usize) -> AnyResult<()> {
+        self.pending.push(request);
+        self.pending_bytes += bytes;
+
+        if self.pending.len() >= self.batch_size || self.pending_bytes >= self.max_buffer_size_bytes
+        {
+            self.flush()
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn flush(&mut self) -> AnyResult<()> {
+        if self.pending.is_empty() {
+            return Ok(());
+        }
+
+        // Block until a write slot is free, then drain any completed tasks before spawning.
+        let wait_start = Instant::now();
+        let permit = TOKIO
+            .block_on(Arc::clone(&self.write_semaphore).acquire_owned())
+            .map_err(|_| anyhow!("DynamoDB write semaphore closed"))?;
+        self.metrics.record_semaphore_wait(wait_start.elapsed());
+        let (retries, errors) = self.drain_completed_writes();
+        self.completed_retries += retries;
+        if !errors.is_empty() {
+            let msg = errors
+                .iter()
+                .map(|e| format!("{e:#}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("DynamoDB writes failed: {msg}");
+        }
+
+        let requests = std::mem::replace(&mut self.pending, Vec::with_capacity(self.batch_size));
+        let rows = requests.len();
+        let bytes = std::mem::take(&mut self.pending_bytes);
+
+        let client = self.client.clone();
+        let endpoint_name = self.endpoint_name.clone();
+        let table = self.table.clone();
+        let write_mode = self.write_mode;
+        let max_retries: Option<usize> = self.max_retries.map(|n| n as usize);
+        let allow_cross_step_write_overlap = self.allow_cross_step_write_overlap;
+        let endpoint_id = self.endpoint_id;
+        let task_controller = self.controller.clone();
+        self.metrics.record_write_chunk();
+        let task_metrics = self.metrics.clone();
+        let task_records_written = self.records_written.clone();
+        let task_bytes_written = self.bytes_written.clone();
+        self.pending_writes.spawn_on(
+            async move {
+                let _permit = permit;
+                let start = Instant::now();
+                let result: AnyResult<u64> = match write_mode {
+                    DynamoDBWriteMode::Batch => {
+                        helpers::write_batch_chunk(
+                            client,
+                            endpoint_name.clone(),
+                            table,
+                            requests,
+                            max_retries,
+                            &task_metrics,
+                        )
+                        .await
+                    }
+                    DynamoDBWriteMode::Transactional => {
+                        let transact_items = requests
+                            .iter()
+                            .map(|r| helpers::to_transact_item(&table, r))
+                            .collect::<AnyResult<Vec<_>>>()?;
+                        helpers::write_transact_chunk(
+                            client,
+                            endpoint_name.clone(),
+                            transact_items,
+                            max_retries,
+                            &task_metrics,
+                        )
+                        .await
+                    }
+                };
+                debug!(
+                    endpoint = %endpoint_name,
+                    rows,
+                    bytes,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    success = result.is_ok(),
+                    "dynamodb: flushed batch",
+                );
+                // Count rows and bytes as written only once the chunk lands in
+                // DynamoDB; a failed chunk drops its items rather than recording
+                // progress.
+                match result {
+                    Ok(retries) => {
+                        task_records_written.fetch_add(rows as u64, Ordering::Relaxed);
+                        task_bytes_written.fetch_add(bytes as u64, Ordering::Relaxed);
+                        task_metrics.record_retries(retries);
+                        if allow_cross_step_write_overlap {
+                            if let Some(controller) = task_controller.upgrade() {
+                                controller.status.output_buffer(endpoint_id, bytes, rows);
+                            }
+                        }
+                        Ok(retries)
+                    }
+                    Err(error) => {
+                        if allow_cross_step_write_overlap {
+                            if let Some(controller) = task_controller.upgrade() {
+                                controller.output_transport_error(
+                                    endpoint_id,
+                                    &endpoint_name,
+                                    false,
+                                    error,
+                                    Some("dynamodb_async_write"),
+                                );
+                            } else {
+                                warn!(
+                                    endpoint = %endpoint_name,
+                                    "dynamodb: write failed after endpoint shutdown"
+                                );
+                            }
+                            Ok(0)
+                        } else {
+                            Err(error)
+                        }
+                    }
+                }
+            },
+            TOKIO.handle(),
+        );
+
+        Ok(())
+    }
+
+    pub(crate) fn encode_cursor(&mut self, cursor: &mut dyn SerCursor) -> AnyResult<()> {
+        while cursor.key_valid() {
+            let op = match indexed_operation_type(self.view_name(), self.index_name(), cursor) {
+                Ok(op) => op,
+                Err(e) => {
+                    self.metrics.record_duplicate_key_skip();
+                    if let Some(controller) = self.controller.upgrade() {
+                        controller.output_transport_error(
+                            self.endpoint_id,
+                            &self.endpoint_name,
+                            false,
+                            e,
+                            Some("dynamodb_uniqueness_violation"),
+                        );
+                    } else {
+                        warn!(
+                            endpoint = %self.endpoint_name,
+                            "dynamodb: skipping non-unique output key: {e:#}"
+                        );
+                    }
+                    None
+                }
+            };
+
+            if let Some(op) = op {
+                cursor.rewind_vals();
+                let (request, bytes) = match op {
+                    IndexedOperationType::Insert => {
+                        let item = self.item(cursor)?;
+                        let bytes = helpers::item_size(&item);
+                        (
+                            WriteRequest::builder()
+                                .put_request(PutRequest::builder().set_item(Some(item)).build()?)
+                                .build(),
+                            bytes,
+                        )
+                    }
+                    IndexedOperationType::Delete => {
+                        let key = self.key(cursor)?;
+                        let bytes = helpers::item_size(&key);
+                        (
+                            WriteRequest::builder()
+                                .delete_request(
+                                    DeleteRequest::builder().set_key(Some(key)).build()?,
+                                )
+                                .build(),
+                            bytes,
+                        )
+                    }
+                    IndexedOperationType::Upsert => {
+                        if cursor.weight() < 0 {
+                            cursor.step_val();
+                        }
+                        let item = self.item(cursor)?;
+                        let bytes = helpers::item_size(&item);
+                        (
+                            WriteRequest::builder()
+                                .put_request(PutRequest::builder().set_item(Some(item)).build()?)
+                                .build(),
+                            bytes,
+                        )
+                    }
+                };
+
+                if bytes > MAX_ITEM_SIZE_BYTES {
+                    // The item exceeds DynamoDB's 400 KB limit and will be
+                    // rejected on every attempt. That rejection fails the whole
+                    // `BatchWriteItem` chunk / `TransactWriteItems` transaction
+                    // it would share with valid items, so drop it here: the rest
+                    // of the batch still lands, and we waste no retries on a
+                    // write that can never succeed.
+                    self.metrics.record_oversized_item_dropped();
+                    let error = anyhow!(
+                        "dropping record that exceeds DynamoDB's {MAX_ITEM_SIZE_BYTES}-byte \
+                         item-size limit (estimated {bytes} bytes)"
+                    );
+                    if let Some(controller) = self.controller.upgrade() {
+                        controller.output_transport_error(
+                            self.endpoint_id,
+                            &self.endpoint_name,
+                            false,
+                            error,
+                            Some("dynamodb_item_too_large"),
+                        );
+                    } else {
+                        warn!(endpoint = %self.endpoint_name, "dynamodb: {error:#}");
+                    }
+                } else {
+                    self.push_request(request, bytes)?;
+                }
+            }
+
+            cursor.step_key();
+        }
+
+        Ok(())
+    }
+
+    fn item(&mut self, cursor: &mut dyn SerCursor) -> AnyResult<HashMap<String, AttributeValue>> {
+        cursor.val_to_dynamodb_item()
+    }
+
+    fn key(&mut self, cursor: &mut dyn SerCursor) -> AnyResult<HashMap<String, AttributeValue>> {
+        let key = cursor.key_to_dynamodb_item()?;
+        if key.is_empty() {
+            bail!("unreachable: dynamodb output connector requires a non-empty index key");
+        }
+        Ok(key)
+    }
+
+    fn run(
+        mut self,
+        cmd_rx: crossbeam::channel::Receiver<WorkerCommand>,
+        result_tx: crossbeam::channel::Sender<WorkerResult>,
+    ) {
+        while let Ok(cmd) = cmd_rx.recv() {
+            match cmd {
+                WorkerCommand::Broadcast(BroadcastCommand::BatchStart) => {
+                    self.batch_start_inner();
+                    let _ = result_tx.send(WorkerResult::Ok { num_retries: 0 });
+                }
+                WorkerCommand::Encode(cursor_builder) => {
+                    let mut cursor = cursor_builder.build();
+                    match self.encode_cursor(&mut cursor) {
+                        Ok(()) => {
+                            let _ = result_tx.send(WorkerResult::Ok { num_retries: 0 });
+                        }
+                        Err(e) => {
+                            let _ = result_tx.send(WorkerResult::Err(e));
+                        }
+                    }
+                }
+                WorkerCommand::Broadcast(BroadcastCommand::BatchEnd) => {
+                    match self.batch_end_inner() {
+                        Ok(num_retries) => {
+                            let _ = result_tx.send(WorkerResult::Ok { num_retries });
+                        }
+                        Err(e) => {
+                            let _ = result_tx.send(WorkerResult::Err(e));
+                        }
+                    }
+                }
+                WorkerCommand::Broadcast(BroadcastCommand::Shutdown) => {
+                    let (_, errors) = self.drain_pending_writes();
+                    if !errors.is_empty() {
+                        let msg = errors
+                            .iter()
+                            .map(|e| format!("{e:#}"))
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        warn!(
+                            endpoint = %self.endpoint_name,
+                            "dynamodb: write error(s) on shutdown (data may be lost): {msg}"
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+pub(crate) struct WorkerHandle {
+    cmd_tx: crossbeam::channel::Sender<WorkerCommand>,
+    result_rx: crossbeam::channel::Receiver<WorkerResult>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+pub struct DynamoDBOutputEndpoint {
+    pub(crate) endpoint_id: EndpointId,
+    pub(crate) endpoint_name: String,
+    pub(crate) config: DynamoDBWriterConfig,
+    pub(crate) controller: Weak<ControllerInner>,
+    pub(crate) handles: Vec<WorkerHandle>,
+    pub(crate) records_written: Arc<AtomicU64>,
+    pub(crate) bytes_written: Arc<AtomicU64>,
+    // Rows, bytes, retries, and batches written since the last throughput log,
+    // used to print average throughput once per `THROUGHPUT_LOG_INTERVAL`.
+    pub(crate) rows_since_last_log: u64,
+    pub(crate) bytes_since_last_log: u64,
+    pub(crate) retries_since_last_log: u64,
+    pub(crate) batches_since_last_log: u64,
+    pub(crate) last_throughput_log: Instant,
+}
+
+impl Drop for DynamoDBOutputEndpoint {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            let _ = handle
+                .cmd_tx
+                .send(WorkerCommand::Broadcast(BroadcastCommand::Shutdown));
+        }
+        for handle in &mut self.handles {
+            if let Some(thread) = handle.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+}
+
+impl DynamoDBOutputEndpoint {
+    pub fn new(
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        config: &DynamoDBWriterConfig,
+        key_schema: &Option<Relation>,
+        value_schema: &Relation,
+        controller: Weak<ControllerInner>,
+        is_index: bool,
+    ) -> Result<Self, ControllerError> {
+        Self::new_with_metrics(
+            endpoint_id,
+            endpoint_name,
+            config,
+            key_schema,
+            value_schema,
+            controller,
+            is_index,
+            Arc::new(DynamoDBOutputMetrics::default()),
+        )
+    }
+
+    /// Constructs the endpoint using a caller-supplied metrics handle, shared with
+    /// every worker thread. [`new`](Self::new) creates a fresh handle; tests pass
+    /// one they retain so they can inspect connector metrics after driving the
+    /// endpoint.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_metrics(
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        config: &DynamoDBWriterConfig,
+        key_schema: &Option<Relation>,
+        value_schema: &Relation,
+        controller: Weak<ControllerInner>,
+        is_index: bool,
+        metrics: Arc<DynamoDBOutputMetrics>,
+    ) -> Result<Self, ControllerError> {
+        config.validate().map_err(|e| {
+            ControllerError::invalid_transport_configuration(endpoint_name, &e.to_string())
+        })?;
+
+        if !is_index || key_schema.is_none() {
+            return Err(ControllerError::not_supported(
+                "DynamoDB output connector requires the view to have a unique key. Please specify the `index` property in the connector configuration. For more details, see: https://docs.feldera.com/connectors/unique_keys",
+            ));
+        }
+
+        let key_schema = key_schema.as_ref().unwrap();
+        let records_written = Arc::new(AtomicU64::new(0));
+        let bytes_written = Arc::new(AtomicU64::new(0));
+        if let Some(controller) = controller.upgrade() {
+            controller
+                .status
+                .register_batch_progress_counter(&endpoint_id, records_written.clone());
+            controller
+                .status
+                .set_output_custom_metrics(endpoint_id, metrics.clone());
+        }
+
+        let client = helpers::make_client(config);
+        let mut handles = Vec::with_capacity(config.threads);
+        for i in 0..config.threads {
+            let worker = DynamoDBWorker::with_client_and_controller(
+                client.clone(),
+                endpoint_id,
+                endpoint_name,
+                controller.clone(),
+                config,
+                key_schema,
+                value_schema,
+                records_written.clone(),
+                bytes_written.clone(),
+                metrics.clone(),
+            );
+
+            let (cmd_tx, cmd_rx) = crossbeam::channel::bounded(1);
+            let (result_tx, result_rx) = crossbeam::channel::bounded(1);
+            let thread_name = format!("dynamodb-output-{endpoint_name}-{i}");
+            let thread = std::thread::Builder::new()
+                .name(thread_name)
+                .spawn(move || worker.run(cmd_rx, result_tx))
+                .map_err(|e| {
+                    ControllerError::output_transport_error(
+                        endpoint_name,
+                        true,
+                        anyhow!("failed to spawn worker thread: {e}"),
+                    )
+                })?;
+
+            handles.push(WorkerHandle {
+                cmd_tx,
+                result_rx,
+                thread: Some(thread),
+            });
+        }
+
+        Ok(Self {
+            endpoint_id,
+            endpoint_name: endpoint_name.to_string(),
+            config: config.clone(),
+            controller,
+            handles,
+            records_written,
+            bytes_written,
+            rows_since_last_log: 0,
+            bytes_since_last_log: 0,
+            retries_since_last_log: 0,
+            batches_since_last_log: 0,
+            last_throughput_log: Instant::now(),
+        })
+    }
+
+    fn broadcast_and_collect(&mut self, command: BroadcastCommand) -> AnyResult<u64> {
+        for handle in &self.handles {
+            let _ = handle.cmd_tx.send(WorkerCommand::Broadcast(command));
+        }
+
+        let mut num_retries = 0u64;
+        let mut errors = Vec::new();
+        for handle in &self.handles {
+            match handle.result_rx.recv() {
+                Ok(WorkerResult::Ok {
+                    num_retries: retries,
+                }) => {
+                    num_retries += retries;
+                }
+                Ok(WorkerResult::Err(e)) => errors.push(e),
+                Err(_) => errors.push(anyhow!("worker thread disconnected")),
+            }
+        }
+
+        if !errors.is_empty() {
+            let msg = errors
+                .iter()
+                .map(|e| format!("{e:#}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("{} DynamoDB worker(s) failed: {msg}", errors.len());
+        }
+
+        Ok(num_retries)
+    }
+}
+
+impl OutputConsumer for DynamoDBOutputEndpoint {
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.config.max_buffer_size_bytes
+    }
+
+    fn batch_start(&mut self, _step: Step, _batch_type: OutputBatchType) {
+        self.records_written.store(0, Ordering::Relaxed);
+        self.bytes_written.store(0, Ordering::Relaxed);
+        if let Err(error) = self
+            .broadcast_and_collect(BroadcastCommand::BatchStart)
+            .map(|_| ())
+            && let Some(controller) = self.controller.upgrade()
+        {
+            controller.output_transport_error(
+                self.endpoint_id,
+                &self.endpoint_name,
+                true,
+                error,
+                None,
+            );
+        }
+    }
+
+    fn push_buffer(&mut self, _buffer: &[u8], _num_records: usize) {
+        unreachable!("dynamodb integrated endpoint encodes batches via encode(), not push_buffer")
+    }
+
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+        _num_records: usize,
+    ) {
+        unreachable!("dynamodb integrated endpoint encodes batches via encode(), not push_key")
+    }
+
+    fn batch_end(&mut self) {
+        match self.broadcast_and_collect(BroadcastCommand::BatchEnd) {
+            Ok(batch_retries) => {
+                let num_rows = self.records_written.load(Ordering::Relaxed);
+                let num_bytes = self.bytes_written.load(Ordering::Relaxed);
+
+                if !self.config.allow_cross_step_write_overlap
+                    && let Some(controller) = self.controller.upgrade()
+                {
+                    controller.status.output_buffer(
+                        self.endpoint_id,
+                        num_bytes as usize,
+                        num_rows as usize,
+                    );
+                }
+                self.rows_since_last_log += num_rows;
+                self.bytes_since_last_log += num_bytes;
+                self.retries_since_last_log += batch_retries;
+                self.batches_since_last_log += 1;
+
+                let since_last = self.last_throughput_log.elapsed();
+                if since_last >= THROUGHPUT_LOG_INTERVAL {
+                    let secs = since_last.as_secs_f64();
+                    let avg_retries = if self.batches_since_last_log > 0 {
+                        self.retries_since_last_log as f64 / self.batches_since_last_log as f64
+                    } else {
+                        0.0
+                    };
+                    info!(
+                        "dynamodb throughput: {:.0} rows/sec, {:.0} bytes/sec, \
+                         avg {:.2} retries/batch ({} batches over {:.1}s)",
+                        self.rows_since_last_log as f64 / secs,
+                        self.bytes_since_last_log as f64 / secs,
+                        avg_retries,
+                        self.batches_since_last_log,
+                        secs,
+                    );
+                    self.rows_since_last_log = 0;
+                    self.bytes_since_last_log = 0;
+                    self.retries_since_last_log = 0;
+                    self.batches_since_last_log = 0;
+                    self.last_throughput_log = Instant::now();
+                }
+            }
+            Err(error) => {
+                if let Some(controller) = self.controller.upgrade() {
+                    // A write failure here means the chunk exhausted its retries
+                    // and the affected items were dropped (counted in
+                    // `failed_items`).
+                    controller.output_transport_error(
+                        self.endpoint_id,
+                        &self.endpoint_name,
+                        false,
+                        error,
+                        None,
+                    );
+                }
+            }
+        }
+
+        self.records_written.store(0, Ordering::Relaxed);
+        self.bytes_written.store(0, Ordering::Relaxed);
+    }
+}
+
+impl Encoder for DynamoDBOutputEndpoint {
+    fn consumer(&mut self) -> &mut dyn OutputConsumer {
+        self
+    }
+
+    fn encode(&mut self, batch: Arc<dyn SerBatchReader>) -> AnyResult<()> {
+        let _span = info_span!(
+            "dynamodb_output",
+            endpoint = &*self.endpoint_name,
+            table = &*self.config.table,
+        )
+        .entered();
+
+        let num_workers = self.handles.len();
+        let mut bounds = batch.keys_factory().default_box();
+        batch.partition_keys(num_workers, &mut *bounds);
+
+        let mut workers_dispatched = 0;
+        for i in 0..=bounds.len() {
+            let Some(cursor_builder) =
+                SplitCursorBuilder::from_bounds(batch.clone(), &*bounds, i, RecordFormat::DynamoDB)
+            else {
+                continue;
+            };
+
+            assert!(
+                workers_dispatched < num_workers,
+                "DynamoDB output connector split batch into more partitions than worker threads"
+            );
+
+            self.handles[workers_dispatched]
+                .cmd_tx
+                .send(WorkerCommand::Encode(cursor_builder))
+                .map_err(|_| anyhow!("worker thread disconnected"))?;
+            workers_dispatched += 1;
+        }
+
+        let mut errors = Vec::new();
+        for i in 0..workers_dispatched {
+            match self.handles[i].result_rx.recv() {
+                Ok(WorkerResult::Ok { .. }) => {}
+                Ok(WorkerResult::Err(e)) => errors.push(e),
+                Err(_) => errors.push(anyhow!("worker thread disconnected")),
+            }
+        }
+
+        if !errors.is_empty() {
+            let msg = errors
+                .iter()
+                .map(|e| format!("{e:#}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("{} DynamoDB worker(s) failed: {msg}", errors.len());
+        }
+
+        Ok(())
+    }
+}
+
+impl OutputEndpoint for DynamoDBOutputEndpoint {
+    fn connect(&mut self, _: AsyncErrorCallback) -> AnyResult<()> {
+        unreachable!("DynamoDB is an integrated endpoint; connect() is never called")
+    }
+
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.config.max_buffer_size_bytes
+    }
+
+    fn push_buffer(&mut self, _buffer: &[u8]) -> AnyResult<()> {
+        unreachable!("dynamodb integrated endpoint does not use OutputEndpoint::push_buffer")
+    }
+
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
+        unreachable!("dynamodb integrated endpoint does not use OutputEndpoint::push_key")
+    }
+
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}

--- a/crates/adapters/src/integrated/dynamodb/test.rs
+++ b/crates/adapters/src/integrated/dynamodb/test.rs
@@ -1,0 +1,1832 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ScalarAttributeType,
+};
+use dbsp::OrdIndexedZSet;
+use dbsp::circuit::tokio::TOKIO;
+use dbsp::utils::Tup2;
+use feldera_adapterlib::catalog::SerBatch;
+use feldera_adapterlib::metrics::ConnectorMetrics;
+use feldera_adapterlib::transport::OutputBatchType;
+use feldera_macros::IsNone;
+use feldera_sqllib::{
+    ByteArray, Date, F32, F64, SqlDecimal, SqlString, Time, Timestamp, Uuid, Variant,
+};
+use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
+use feldera_types::transport::dynamodb::{DynamoDBWriteMode, DynamoDBWriterConfig};
+use feldera_types::{
+    deserialize_table_record, deserialize_without_context, serialize_struct, serialize_table_record,
+};
+use rand::Rng;
+use rand::distributions::Alphanumeric;
+use size_of::SizeOf;
+
+use crate::catalog::RecordFormat;
+use crate::controller::EndpointId;
+use crate::format::Encoder;
+use crate::static_compile::seroutput::SerBatchImpl;
+use crate::test::TestStruct;
+
+use super::helpers::make_client;
+use super::metrics::DynamoDBOutputMetrics;
+use super::output::{DynamoDBOutputEndpoint, DynamoDBWorker};
+
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct TestRecord {
+    id: i32,
+    sort: String,
+    b: bool,
+    i: Option<i64>,
+    s: String,
+}
+
+deserialize_without_context!(TestRecord);
+
+serialize_struct!(TestRecord()[5]{
+    id["id"]: i32,
+    sort["sort"]: String,
+    b["b"]: bool,
+    i["i"]: Option<i64>,
+    s["s"]: String
+});
+
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct TestKey {
+    id: i32,
+    sort: String,
+}
+
+deserialize_without_context!(TestKey);
+
+serialize_struct!(TestKey()[2]{
+    id["id"]: i32,
+    sort["sort"]: String
+});
+
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct AllTypesRecord {
+    id: i32,
+    boolean_: bool,
+    tinyint_: i8,
+    smallint_: i16,
+    int_: i32,
+    bigint_: i64,
+    decimal_: SqlDecimal<38, 10>,
+    float_: F32,
+    double_: F64,
+    varchar_: SqlString,
+    time_: Time,
+    date_: Date,
+    timestamp_: Timestamp,
+    variant_: Variant,
+    uuid_: Uuid,
+    varbinary_: ByteArray,
+    struct_: TestStruct,
+    string_array_: Vec<SqlString>,
+    struct_array_: Vec<TestStruct>,
+    map_: BTreeMap<SqlString, TestStruct>,
+    nullable_: Option<i64>,
+}
+
+serialize_table_record!(AllTypesRecord[21]{
+    id["id"]: i32,
+    boolean_["boolean_"]: bool,
+    tinyint_["tinyint_"]: i8,
+    smallint_["smallint_"]: i16,
+    int_["int_"]: i32,
+    bigint_["bigint_"]: i64,
+    decimal_["decimal_"]: SqlDecimal,
+    float_["float_"]: F32,
+    double_["double_"]: F64,
+    varchar_["varchar_"]: SqlString,
+    time_["time_"]: Time,
+    date_["date_"]: Date,
+    timestamp_["timestamp_"]: Timestamp,
+    variant_["variant_"]: Variant,
+    uuid_["uuid_"]: Uuid,
+    varbinary_["varbinary_"]: ByteArray,
+    struct_["struct_"]: TestStruct,
+    string_array_["string_array_"]: Vec<SqlString>,
+    struct_array_["struct_array_"]: Vec<TestStruct>,
+    map_["map_"]: BTreeMap<SqlString, TestStruct>,
+    nullable_["nullable_"]: Option<i64>
+});
+
+deserialize_table_record!(AllTypesRecord["AllTypesRecord", Variant, 21] {
+    (id, "id", false, i32, |_| None),
+    (boolean_, "boolean_", false, bool, |_| None),
+    (tinyint_, "tinyint_", false, i8, |_| None),
+    (smallint_, "smallint_", false, i16, |_| None),
+    (int_, "int_", false, i32, |_| None),
+    (bigint_, "bigint_", false, i64, |_| None),
+    (decimal_, "decimal_", false, SqlDecimal<38, 10>, |_| None),
+    (float_, "float_", false, F32, |_| None),
+    (double_, "double_", false, F64, |_| None),
+    (varchar_, "varchar_", false, SqlString, |_| None),
+    (time_, "time_", false, Time, |_| None),
+    (date_, "date_", false, Date, |_| None),
+    (timestamp_, "timestamp_", false, Timestamp, |_| None),
+    (variant_, "variant_", false, Variant, |_| None),
+    (uuid_, "uuid_", false, Uuid, |_| None),
+    (varbinary_, "varbinary_", false, ByteArray, |_| None),
+    (struct_, "struct_", false, TestStruct, |_| None),
+    (string_array_, "string_array_", false, Vec<SqlString>, |_| None),
+    (struct_array_, "struct_array_", false, Vec<TestStruct>, |_| None),
+    (map_, "map_", false, BTreeMap<SqlString, TestStruct>, |_| None),
+    (nullable_, "nullable_", true, Option<i64>, |_| None)
+});
+
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct AllTypesKey {
+    id: i32,
+}
+
+deserialize_without_context!(AllTypesKey);
+
+serialize_struct!(AllTypesKey()[1]{
+    id["id"]: i32
+});
+
+fn key_relation() -> Relation {
+    Relation {
+        name: SqlIdentifier::new("test_idx", false),
+        fields: vec![
+            Field::new("id".into(), ColumnType::int(false)),
+            Field::new("sort".into(), ColumnType::varchar(false)),
+        ],
+        materialized: false,
+        properties: BTreeMap::new(),
+        primary_key: None,
+    }
+}
+
+fn value_relation() -> Relation {
+    Relation {
+        name: SqlIdentifier::new("test_view", false),
+        fields: vec![
+            Field::new("id".into(), ColumnType::int(false)),
+            Field::new("sort".into(), ColumnType::varchar(false)),
+            Field::new("b".into(), ColumnType::boolean(false)),
+            Field::new("i".into(), ColumnType::bigint(true)),
+            Field::new("s".into(), ColumnType::varchar(false)),
+        ],
+        materialized: true,
+        properties: BTreeMap::new(),
+        primary_key: Some(vec!["id".into(), "sort".into()]),
+    }
+}
+
+fn all_types_key_relation() -> Relation {
+    Relation {
+        name: SqlIdentifier::new("all_types_idx", false),
+        fields: vec![Field::new("id".into(), ColumnType::int(false))],
+        materialized: false,
+        properties: BTreeMap::new(),
+        primary_key: None,
+    }
+}
+
+fn all_types_value_relation() -> Relation {
+    Relation {
+        name: SqlIdentifier::new("all_types_view", false),
+        fields: vec![
+            Field::new("id".into(), ColumnType::int(false)),
+            Field::new("boolean_".into(), ColumnType::boolean(false)),
+            Field::new("tinyint_".into(), ColumnType::tinyint(false)),
+            Field::new("smallint_".into(), ColumnType::smallint(false)),
+            Field::new("int_".into(), ColumnType::int(false)),
+            Field::new("bigint_".into(), ColumnType::bigint(false)),
+            Field::new("decimal_".into(), ColumnType::decimal(38, 10, false)),
+            Field::new("float_".into(), ColumnType::real(false)),
+            Field::new("double_".into(), ColumnType::double(false)),
+            Field::new("varchar_".into(), ColumnType::varchar(false)),
+            Field::new("time_".into(), ColumnType::time(false)),
+            Field::new("date_".into(), ColumnType::date(false)),
+            Field::new("timestamp_".into(), ColumnType::timestamp(false)),
+            Field::new("variant_".into(), ColumnType::variant(false)),
+            Field::new("uuid_".into(), ColumnType::uuid(false)),
+            Field::new("varbinary_".into(), ColumnType::varbinary(false)),
+            Field::new(
+                "struct_".into(),
+                ColumnType::structure(false, &TestStruct::schema()),
+            ),
+            Field::new(
+                "string_array_".into(),
+                ColumnType::array(false, ColumnType::varchar(false)),
+            ),
+            Field::new(
+                "struct_array_".into(),
+                ColumnType::array(false, ColumnType::structure(false, &TestStruct::schema())),
+            ),
+            Field::new(
+                "map_".into(),
+                ColumnType::map(
+                    false,
+                    ColumnType::varchar(false),
+                    ColumnType::structure(false, &TestStruct::schema()),
+                ),
+            ),
+            Field::new("nullable_".into(), ColumnType::bigint(true)),
+        ],
+        materialized: true,
+        properties: BTreeMap::new(),
+        primary_key: Some(vec!["id".into()]),
+    }
+}
+
+fn config(batch_size: usize) -> DynamoDBWriterConfig {
+    DynamoDBWriterConfig {
+        table: "test_table".to_string(),
+        region: "us-east-1".to_string(),
+        endpoint_url: None,
+        aws_access_key_id: None,
+        aws_secret_access_key: None,
+        batch_size: Some(batch_size),
+        write_mode: DynamoDBWriteMode::Batch,
+        max_buffer_size_bytes: 1024 * 1024,
+        max_concurrent_requests: 16,
+        threads: 1,
+        allow_cross_step_write_overlap: false,
+        max_retries: Some(10),
+    }
+}
+
+fn dynamodb_region() -> String {
+    std::env::var("DYNAMODB_REGION")
+        .or_else(|_| std::env::var("AWS_REGION"))
+        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+        .unwrap_or_else(|_| "us-east-1".to_string())
+}
+
+fn endpoint_config(
+    table: String,
+    endpoint_url: Option<String>,
+    threads: usize,
+) -> DynamoDBWriterConfig {
+    let use_static_dummy_credentials = endpoint_url.is_some();
+    DynamoDBWriterConfig {
+        table,
+        region: dynamodb_region(),
+        endpoint_url,
+        aws_access_key_id: use_static_dummy_credentials.then(|| "dummy".to_string()),
+        aws_secret_access_key: use_static_dummy_credentials.then(|| "dummy".to_string()),
+        batch_size: None,
+        write_mode: DynamoDBWriteMode::Batch,
+        max_buffer_size_bytes: 1024 * 1024,
+        max_concurrent_requests: 16,
+        threads,
+        allow_cross_step_write_overlap: false,
+        max_retries: Some(10),
+    }
+}
+
+/// Creates a client pointed at a non-existent endpoint. Writes will fail,
+/// but encoding tests never await the spawned write tasks.
+fn dummy_client() -> Client {
+    make_client(&DynamoDBWriterConfig {
+        endpoint_url: Some("http://localhost:0".to_string()),
+        aws_access_key_id: Some("dummy".to_string()),
+        aws_secret_access_key: Some("dummy".to_string()),
+        ..config(25)
+    })
+}
+
+fn worker(batch_size: usize) -> DynamoDBWorker {
+    DynamoDBWorker::with_client(
+        dummy_client(),
+        "",
+        &config(batch_size),
+        &key_relation(),
+        &value_relation(),
+    )
+}
+
+fn worker_with_max_buffer_size(batch_size: usize, max_buffer_size_bytes: usize) -> DynamoDBWorker {
+    let mut config = config(batch_size);
+    config.max_buffer_size_bytes = max_buffer_size_bytes;
+    DynamoDBWorker::with_client(
+        dummy_client(),
+        "",
+        &config,
+        &key_relation(),
+        &value_relation(),
+    )
+}
+
+fn worker_with_config(config: DynamoDBWriterConfig) -> DynamoDBWorker {
+    DynamoDBWorker::with_client(
+        dummy_client(),
+        "",
+        &config,
+        &key_relation(),
+        &value_relation(),
+    )
+}
+
+fn empty_endpoint_with_counter(records_written: Arc<AtomicU64>) -> DynamoDBOutputEndpoint {
+    DynamoDBOutputEndpoint {
+        endpoint_id: EndpointId::default(),
+        endpoint_name: "test_dynamodb_endpoint".to_string(),
+        config: config(25),
+        controller: Weak::new(),
+        handles: Vec::new(),
+        records_written,
+        bytes_written: Arc::new(AtomicU64::new(0)),
+        rows_since_last_log: 0,
+        bytes_since_last_log: 0,
+        retries_since_last_log: 0,
+        batches_since_last_log: 0,
+        last_throughput_log: Instant::now(),
+    }
+}
+
+fn dynamodb_metric(metrics: &DynamoDBOutputMetrics, name: &str) -> f64 {
+    metrics
+        .metrics()
+        .into_iter()
+        .find_map(|(metric_name, _, _, value)| (metric_name == name).then_some(value))
+        .unwrap_or_else(|| panic!("missing DynamoDB metric {name}"))
+}
+
+fn build_batch(tuples: Vec<(TestRecord, i64)>) -> Arc<dyn SerBatch> {
+    let tuples: Vec<_> = tuples
+        .into_iter()
+        .map(|(record, weight)| {
+            Tup2(
+                Tup2(
+                    TestKey {
+                        id: record.id,
+                        sort: record.sort.clone(),
+                    },
+                    record,
+                ),
+                weight,
+            )
+        })
+        .collect();
+    let zset = OrdIndexedZSet::from_tuples((), tuples);
+    Arc::new(SerBatchImpl::<_, TestKey, TestRecord>::new(zset))
+}
+
+fn build_all_types_batch(tuples: Vec<(AllTypesRecord, i64)>) -> Arc<dyn SerBatch> {
+    let tuples: Vec<_> = tuples
+        .into_iter()
+        .map(|(record, weight)| Tup2(Tup2(AllTypesKey { id: record.id }, record), weight))
+        .collect();
+    let zset = OrdIndexedZSet::from_tuples((), tuples);
+    Arc::new(SerBatchImpl::<_, AllTypesKey, AllTypesRecord>::new(zset))
+}
+
+fn record(id: i32, sort: &str, i: Option<i64>, s: &str) -> TestRecord {
+    TestRecord {
+        id,
+        sort: sort.to_string(),
+        b: id % 2 == 0,
+        i,
+        s: s.to_string(),
+    }
+}
+
+fn all_types_record() -> AllTypesRecord {
+    let mut map = BTreeMap::new();
+    map.insert(
+        SqlString::from_ref("nested"),
+        TestStruct {
+            id: 7,
+            b: true,
+            i: Some(70),
+            s: "inside-map".to_string(),
+        },
+    );
+
+    AllTypesRecord {
+        id: 42,
+        boolean_: true,
+        tinyint_: -8,
+        smallint_: 16,
+        int_: 32,
+        bigint_: 64,
+        decimal_: SqlDecimal::<38, 10>::new(12345, 3).unwrap(),
+        float_: F32::new(1.5),
+        double_: F64::new(2.25),
+        varchar_: SqlString::from_ref("hello"),
+        time_: Time::from_time(chrono::NaiveTime::from_hms_micro_opt(1, 2, 3, 456).unwrap()),
+        date_: Date::from_date(chrono::NaiveDate::from_ymd_opt(2024, 5, 25).unwrap()),
+        timestamp_: Timestamp::from_naiveDateTime(
+            chrono::NaiveDate::from_ymd_opt(2024, 5, 25)
+                .unwrap()
+                .and_hms_micro_opt(1, 2, 3, 456)
+                .unwrap(),
+        ),
+        variant_: Variant::String(SqlString::from_ref("variant-value")),
+        uuid_: uuid::uuid!("550e8400-e29b-41d4-a716-446655440000").into(),
+        varbinary_: ByteArray::from_vec(vec![1, 2, 3, 4]),
+        struct_: TestStruct {
+            id: 5,
+            b: false,
+            i: Some(50),
+            s: "inside-struct".to_string(),
+        },
+        string_array_: vec![SqlString::from_ref("a"), SqlString::from_ref("b")],
+        struct_array_: vec![TestStruct {
+            id: 6,
+            b: true,
+            i: None,
+            s: "inside-array".to_string(),
+        }],
+        map_: map,
+        nullable_: None,
+    }
+}
+
+fn all_types_worker() -> DynamoDBWorker {
+    DynamoDBWorker::with_client(
+        dummy_client(),
+        "",
+        &config(25),
+        &all_types_key_relation(),
+        &all_types_value_relation(),
+    )
+}
+
+fn encode_batch(worker: &mut DynamoDBWorker, batch: &Arc<dyn SerBatch>) {
+    let reader = batch.clone().arc_as_batch_reader();
+    let mut cursor = reader.cursor(RecordFormat::DynamoDB).unwrap();
+    worker.batch_start_inner();
+    worker.encode_cursor(&mut *cursor).unwrap();
+    worker.batch_end_inner().unwrap();
+}
+
+fn stage_batch(worker: &mut DynamoDBWorker, batch: &Arc<dyn SerBatch>) {
+    let reader = batch.clone().arc_as_batch_reader();
+    let mut cursor = reader.cursor(RecordFormat::DynamoDB).unwrap();
+    worker.batch_start_inner();
+    worker.encode_cursor(&mut *cursor).unwrap();
+}
+
+fn encode_endpoint_batch(endpoint: &mut DynamoDBOutputEndpoint, batch: &Arc<dyn SerBatch>) {
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    endpoint
+        .encode(batch.clone().arc_as_batch_reader())
+        .unwrap();
+    endpoint.consumer().batch_end();
+}
+
+fn attr_s<'a>(item: &'a HashMap<String, AttributeValue>, field: &str) -> &'a str {
+    item.get(field).unwrap().as_s().unwrap()
+}
+
+fn attr_n<'a>(item: &'a HashMap<String, AttributeValue>, field: &str) -> &'a str {
+    item.get(field).unwrap().as_n().unwrap()
+}
+
+#[test]
+fn encoder_insert_as_put_item() {
+    let mut worker = worker(25);
+    let batch = build_batch(vec![(record(1, "a", Some(10), "inserted"), 1)]);
+    stage_batch(&mut worker, &batch);
+    assert_eq!(worker.pending.len(), 1);
+    let item = worker.pending[0].put_request().unwrap().item();
+    assert_eq!(attr_n(item, "id"), "1");
+    assert_eq!(attr_s(item, "sort"), "a");
+    assert_eq!(item.get("b").unwrap().as_bool().unwrap(), &false);
+    assert_eq!(attr_n(item, "i"), "10");
+    assert_eq!(attr_s(item, "s"), "inserted");
+}
+
+#[test]
+fn encoder_delete_as_delete_item_key_only() {
+    let mut worker = worker(25);
+    let batch = build_batch(vec![(record(2, "b", Some(20), "deleted"), -1)]);
+    stage_batch(&mut worker, &batch);
+    assert_eq!(worker.pending.len(), 1);
+    assert!(worker.pending[0].put_request().is_none());
+    let key = worker.pending[0].delete_request().unwrap().key();
+    assert_eq!(key.len(), 2);
+    assert_eq!(attr_n(key, "id"), "2");
+    assert_eq!(attr_s(key, "sort"), "b");
+}
+
+#[test]
+fn encoder_upsert_as_put_item_with_new_value() {
+    let mut worker = worker(25);
+    let batch = build_batch(vec![
+        (record(3, "c", Some(30), "old"), -1),
+        (record(3, "c", None, "new"), 1),
+    ]);
+    stage_batch(&mut worker, &batch);
+    assert_eq!(worker.pending.len(), 1);
+    let item = worker.pending[0].put_request().unwrap().item();
+    assert_eq!(attr_n(item, "id"), "3");
+    assert_eq!(attr_s(item, "sort"), "c");
+    assert_eq!(item.get("i").unwrap().as_null().unwrap(), &true);
+    assert_eq!(attr_s(item, "s"), "new");
+}
+
+#[test]
+fn encoder_stages_until_batch_end() {
+    let mut worker = worker(100);
+    let batch = build_batch(
+        (0..5)
+            .map(|id| (record(id, "chunk", Some(id as i64), "r"), 1))
+            .collect(),
+    );
+
+    stage_batch(&mut worker, &batch);
+    // pending holds all records until flush is called
+    assert_eq!(worker.pending.len(), 5);
+
+    let pending = worker.pending.clone();
+    worker.flush().unwrap();
+    // flush hands the staged records off to the write task, draining `pending`.
+    assert!(worker.pending.is_empty());
+
+    let mut ids = pending
+        .iter()
+        .map(|r| {
+            r.put_request()
+                .unwrap()
+                .item()
+                .get("id")
+                .unwrap()
+                .as_n()
+                .unwrap()
+                .parse::<i32>()
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    ids.sort();
+    assert_eq!(ids, vec![0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn encoder_flushes_when_buffer_limit_is_reached() {
+    // max_buffer_size_bytes=1 forces a flush after the first record.
+    let mut worker = worker_with_max_buffer_size(25, 1);
+    let batch = build_batch(vec![(record(9, "early", Some(90), "flushed"), 1)]);
+    stage_batch(&mut worker, &batch);
+    // pending is empty because the record was flushed mid-encode.
+    // (`records_written` can't be checked here: the dummy client's writes fail,
+    // and the counter only advances on a successful write. End-to-end counting
+    // is covered by the `dynamodb_progress_counter_*` integration tests.)
+    assert!(worker.pending.is_empty());
+}
+
+#[test]
+fn encoder_flushes_when_record_threshold_is_reached() {
+    // threshold = batch_size(2) × max_concurrent_requests(2) = 4
+    let mut config = config(2);
+    config.max_concurrent_requests = 2;
+    config.max_buffer_size_bytes = usize::MAX;
+    let mut worker = worker_with_config(config);
+    let batch = build_batch(
+        (0..4)
+            .map(|id| (record(id, "threshold", Some(id as i64), "r"), 1))
+            .collect(),
+    );
+    stage_batch(&mut worker, &batch);
+    // Reaching the record threshold drains `pending` via a mid-encode flush.
+    assert!(worker.pending.is_empty());
+}
+
+#[test]
+fn encoder_empty_batch_single_thread() {
+    let mut worker = worker(25);
+    encode_batch(&mut worker, &build_batch(Vec::new()));
+    assert!(worker.pending.is_empty());
+    assert_eq!(worker.records_written.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn encoder_empty_batch_multi_thread() {
+    let batch = build_batch(Vec::new());
+    for _ in 0..4 {
+        let mut worker = worker(25);
+        encode_batch(&mut worker, &batch);
+        assert!(worker.pending.is_empty());
+        assert_eq!(worker.records_written.load(Ordering::Relaxed), 0);
+    }
+}
+
+#[test]
+fn encoder_multiple_batches_insert_upsert_delete() {
+    let mut worker = worker(25);
+
+    stage_batch(
+        &mut worker,
+        &build_batch(vec![(record(11, "sequence", Some(110), "insert"), 1)]),
+    );
+    assert_eq!(worker.pending.len(), 1);
+    assert!(worker.pending[0].put_request().is_some());
+
+    stage_batch(
+        &mut worker,
+        &build_batch(vec![
+            (record(11, "sequence", Some(110), "insert"), -1),
+            (record(11, "sequence", Some(111), "upsert"), 1),
+        ]),
+    );
+    assert_eq!(worker.pending.len(), 1);
+    assert_eq!(
+        attr_s(worker.pending[0].put_request().unwrap().item(), "s"),
+        "upsert"
+    );
+
+    stage_batch(
+        &mut worker,
+        &build_batch(vec![(record(11, "sequence", Some(111), "upsert"), -1)]),
+    );
+    assert_eq!(worker.pending.len(), 1);
+    assert!(worker.pending[0].delete_request().is_some());
+}
+
+#[test]
+fn encoder_non_unique_key_is_skipped_without_failing_batch() {
+    let mut worker = worker(25);
+    let batch = build_batch(vec![
+        (record(1, "duplicate", Some(10), "first"), 1),
+        (record(1, "duplicate", Some(11), "second"), 1),
+        (record(2, "unique", Some(20), "kept"), 1),
+    ]);
+
+    stage_batch(&mut worker, &batch);
+
+    assert_eq!(worker.pending.len(), 1);
+    let item = worker.pending[0].put_request().unwrap().item();
+    assert_eq!(attr_n(item, "id"), "2");
+    assert_eq!(attr_s(item, "sort"), "unique");
+    assert_eq!(attr_s(item, "s"), "kept");
+}
+
+#[test]
+fn encoder_non_unique_key_updates_connector_metric() {
+    let mut worker = worker(25);
+    let batch = build_batch(vec![
+        (record(1, "duplicate", Some(10), "first"), 1),
+        (record(1, "duplicate", Some(11), "second"), 1),
+        (record(2, "unique", Some(20), "kept"), 1),
+    ]);
+
+    stage_batch(&mut worker, &batch);
+
+    assert_eq!(
+        dynamodb_metric(
+            &worker.metrics,
+            "dynamodb_output_duplicate_keys_skipped_total"
+        ),
+        1.0
+    );
+}
+
+#[test]
+fn encoder_drops_oversized_item_keeping_the_rest() {
+    let mut worker = worker(25);
+    // The middle record's `s` attribute alone exceeds the 400 KB item-size
+    // limit; the other two are ordinary.
+    let oversized_value = "x".repeat(410 * 1024);
+    let batch = build_batch(vec![
+        (record(1, "a", Some(10), "one"), 1),
+        (record(2, "b", Some(20), &oversized_value), 1),
+        (record(3, "c", Some(30), "three"), 1),
+    ]);
+
+    stage_batch(&mut worker, &batch);
+
+    // Only the two normal records are buffered for writing.
+    assert_eq!(worker.pending.len(), 2);
+    assert_eq!(
+        attr_n(worker.pending[0].put_request().unwrap().item(), "id"),
+        "1"
+    );
+    assert_eq!(
+        attr_n(worker.pending[1].put_request().unwrap().item(), "id"),
+        "3"
+    );
+}
+
+#[test]
+fn encoder_oversized_item_updates_connector_metric() {
+    let mut worker = worker(25);
+    let oversized_value = "x".repeat(410 * 1024);
+    let batch = build_batch(vec![(record(1, "a", Some(10), &oversized_value), 1)]);
+
+    stage_batch(&mut worker, &batch);
+
+    assert!(worker.pending.is_empty());
+    assert_eq!(
+        dynamodb_metric(
+            &worker.metrics,
+            "dynamodb_output_oversized_items_dropped_total"
+        ),
+        1.0
+    );
+}
+
+/// A write that never succeeds must surface as an error rather than being
+/// silently swallowed. This drives the full concurrency path against an
+/// unreachable endpoint: `batch_end_inner` flushes (spawning a write task on the
+/// `JoinSet`), then blocks draining it and aggregates the task's error. With
+/// `max_retries = 0` the worker does not retry, so the failure surfaces promptly.
+#[test]
+fn worker_surfaces_write_failure_at_batch_end() {
+    let mut config = config(25);
+    config.max_retries = Some(0);
+    let mut worker = DynamoDBWorker::with_client(
+        dummy_client(),
+        "test",
+        &config,
+        &key_relation(),
+        &value_relation(),
+    );
+
+    let batch = build_batch(vec![(record(1, "a", Some(10), "one"), 1)]);
+    let reader = batch.arc_as_batch_reader();
+    let mut cursor = reader.cursor(RecordFormat::DynamoDB).unwrap();
+    worker.batch_start_inner();
+    worker.encode_cursor(&mut *cursor).unwrap();
+
+    let error = worker
+        .batch_end_inner()
+        .expect_err("write to an unreachable endpoint must fail");
+    assert!(
+        format!("{error:#}").contains("DynamoDB writes failed"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[test]
+fn connector_metrics_accumulate_transact_write_failures() {
+    let metrics = DynamoDBOutputMetrics::default();
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_transact_write_failures_total"),
+        0.0
+    );
+
+    metrics.record_transact_write_failure();
+    metrics.record_transact_write_failure();
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_transact_write_failures_total"),
+        2.0
+    );
+}
+
+#[test]
+fn connector_metrics_accumulate_failed_items() {
+    let metrics = DynamoDBOutputMetrics::default();
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_failed_items_total"),
+        0.0
+    );
+
+    metrics.record_failed_items(3);
+    metrics.record_failed_items(2);
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_failed_items_total"),
+        5.0
+    );
+}
+
+#[test]
+fn connector_metrics_accumulate_throttled_items() {
+    let metrics = DynamoDBOutputMetrics::default();
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_throttled_items_total"),
+        0.0
+    );
+
+    metrics.record_throttled_items(10);
+    metrics.record_throttled_items(5);
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_throttled_items_total"),
+        15.0
+    );
+}
+
+#[test]
+fn connector_metrics_record_semaphore_wait_histogram() {
+    let metrics = DynamoDBOutputMetrics::default();
+
+    metrics.record_semaphore_wait(Duration::from_micros(400));
+    metrics.record_semaphore_wait(Duration::from_micros(600));
+
+    let histograms = metrics.histograms();
+    let wait = histograms
+        .iter()
+        .find(|h| h.name == "dynamodb_output_semaphore_wait_microseconds")
+        .expect("missing semaphore-wait histogram");
+
+    // 400us + 600us recorded; the snapshot sum is in microseconds.
+    assert_eq!(wait.snapshot.sum(), 1000);
+
+    let count: u64 = wait
+        .snapshot
+        .iter_buckets()
+        .map(|bucket| bucket.count)
+        .sum();
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn connector_metrics_record_write_call_latency_histogram() {
+    let metrics = DynamoDBOutputMetrics::default();
+
+    metrics.record_write_call_latency(Duration::from_micros(1_500));
+    metrics.record_write_call_latency(Duration::from_micros(2_500));
+
+    let histograms = metrics.histograms();
+    let latency = histograms
+        .iter()
+        .find(|h| h.name == "dynamodb_output_write_call_latency_microseconds")
+        .expect("missing write-call latency histogram");
+
+    // 1,500us + 2,500us recorded; the snapshot sum is in microseconds.
+    assert_eq!(latency.snapshot.sum(), 4_000);
+
+    let count: u64 = latency
+        .snapshot
+        .iter_buckets()
+        .map(|bucket| bucket.count)
+        .sum();
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn encoder_progress_counter_resets_at_batch_start_and_end() {
+    let records_written = Arc::new(AtomicU64::new(99));
+    let mut endpoint = empty_endpoint_with_counter(records_written.clone());
+
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    assert_eq!(records_written.load(Ordering::Relaxed), 0);
+
+    records_written.store(88, Ordering::Relaxed);
+    endpoint.consumer().batch_end();
+    assert_eq!(records_written.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn encoder_all_supported_sql_types() {
+    let mut worker = all_types_worker();
+    let batch = build_all_types_batch(vec![(all_types_record(), 1)]);
+    stage_batch(&mut worker, &batch);
+    assert_eq!(worker.pending.len(), 1);
+    let item = worker.pending[0].put_request().unwrap().item();
+
+    assert_eq!(attr_n(item, "id"), "42");
+    assert_eq!(item.get("boolean_").unwrap().as_bool().unwrap(), &true);
+    assert_eq!(attr_n(item, "tinyint_"), "-8");
+    assert_eq!(attr_n(item, "smallint_"), "16");
+    assert_eq!(attr_n(item, "int_"), "32");
+    assert_eq!(attr_n(item, "bigint_"), "64");
+    assert_eq!(attr_n(item, "decimal_"), "12.345");
+    assert_eq!(attr_n(item, "float_"), "1.5");
+    assert_eq!(attr_n(item, "double_"), "2.25");
+    assert_eq!(attr_s(item, "varchar_"), "hello");
+    assert!(item.get("time_").unwrap().is_s());
+    assert!(item.get("date_").unwrap().is_s());
+    assert!(item.get("timestamp_").unwrap().is_s());
+    assert_eq!(attr_s(item, "variant_"), "variant-value");
+    assert_eq!(
+        attr_s(item, "uuid_"),
+        "550e8400-e29b-41d4-a716-446655440000"
+    );
+    assert!(item.get("varbinary_").unwrap().is_b());
+    assert!(item.get("struct_").unwrap().is_m());
+    assert!(item.get("string_array_").unwrap().is_l());
+    assert!(item.get("struct_array_").unwrap().is_l());
+    assert!(item.get("map_").unwrap().is_m());
+    assert_eq!(item.get("nullable_").unwrap().as_null().unwrap(), &true);
+}
+
+fn encoded_variant_attribute(variant: Variant) -> AttributeValue {
+    let mut record = all_types_record();
+    record.variant_ = variant;
+
+    let mut worker = all_types_worker();
+    let batch = build_all_types_batch(vec![(record, 1)]);
+    stage_batch(&mut worker, &batch);
+    worker.pending[0]
+        .put_request()
+        .unwrap()
+        .item()
+        .get("variant_")
+        .unwrap()
+        .clone()
+}
+
+#[test]
+fn encoder_variant_decimal_serializes_as_number() {
+    let variant = encoded_variant_attribute(Variant::SqlDecimal((12345, 2)));
+
+    assert_eq!(variant.as_n().unwrap(), "123.45");
+}
+
+#[test]
+fn encoder_variant_map_preserves_private_number_key() {
+    let variant = encoded_variant_attribute(Variant::Map(Arc::new(BTreeMap::from([
+        (
+            Variant::String(SqlString::from_ref("$serde_json::private::Number")),
+            Variant::String(SqlString::from_ref("not-a-number-token")),
+        ),
+        (
+            Variant::String(SqlString::from_ref("other")),
+            Variant::Int(1),
+        ),
+    ]))));
+    let variant = variant.as_m().unwrap();
+
+    assert_eq!(
+        variant
+            .get("$serde_json::private::Number")
+            .unwrap()
+            .as_s()
+            .unwrap(),
+        "not-a-number-token"
+    );
+    assert_eq!(variant.get("other").unwrap().as_n().unwrap(), "1");
+}
+
+#[test]
+fn encoder_variant_list_recursively_serializes_numbers() {
+    let variant = encoded_variant_attribute(Variant::Array(Arc::new(vec![
+        Variant::SqlDecimal((12345, 2)),
+        Variant::Map(Arc::new(BTreeMap::from([(
+            Variant::String(SqlString::from_ref("nested")),
+            Variant::SqlDecimal((6789, 3)),
+        )]))),
+    ])));
+    let values = variant.as_l().unwrap();
+
+    assert_eq!(values[0].as_n().unwrap(), "123.45");
+    assert_eq!(
+        values[1]
+            .as_m()
+            .unwrap()
+            .get("nested")
+            .unwrap()
+            .as_n()
+            .unwrap(),
+        "6.789"
+    );
+}
+
+#[test]
+fn encoder_split_cursor_partitions_encode_disjoint_key_ranges() {
+    use feldera_adapterlib::catalog::SplitCursorBuilder;
+
+    let batch = build_batch(
+        (0..10)
+            .map(|id| (record(id, "split", Some(id as i64), "r"), 1))
+            .collect(),
+    );
+    let reader = batch.arc_as_batch_reader();
+    let mut bounds = reader.keys_factory().default_box();
+    reader.partition_keys(3, &mut *bounds);
+
+    let mut all_requests = Vec::new();
+    for i in 0..=bounds.len() {
+        let Some(cursor_builder) =
+            SplitCursorBuilder::from_bounds(reader.clone(), &*bounds, i, RecordFormat::DynamoDB)
+        else {
+            continue;
+        };
+        let mut worker = worker(100);
+        let mut cursor = cursor_builder.build();
+        worker.batch_start_inner();
+        worker.encode_cursor(&mut cursor).unwrap();
+        all_requests.extend(worker.pending.iter().cloned());
+    }
+
+    let mut ids = all_requests
+        .iter()
+        .map(|request| {
+            request
+                .put_request()
+                .unwrap()
+                .item()
+                .get("id")
+                .unwrap()
+                .as_n()
+                .unwrap()
+                .parse::<i32>()
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    ids.sort();
+    assert_eq!(ids, (0..10).collect::<Vec<_>>());
+}
+
+#[test]
+fn encoder_composite_key_delete_excludes_non_key_fields() {
+    // A delete request must carry exactly the two key columns. Value-only
+    // fields ("b", "i", "s") must not appear; including them would be rejected
+    // by DynamoDB as an invalid key.
+    let mut worker = worker(25);
+    let batch = build_batch(vec![(record(5, "alpha", Some(50), "composite"), -1)]);
+    stage_batch(&mut worker, &batch);
+    assert_eq!(worker.pending.len(), 1);
+    assert!(worker.pending[0].put_request().is_none());
+    let key = worker.pending[0].delete_request().unwrap().key();
+    assert_eq!(
+        key.len(),
+        2,
+        "delete key should contain exactly the two composite key fields"
+    );
+    assert_eq!(attr_n(key, "id"), "5");
+    assert_eq!(attr_s(key, "sort"), "alpha");
+    assert!(!key.contains_key("b"));
+    assert!(!key.contains_key("i"));
+    assert!(!key.contains_key("s"));
+}
+
+#[test]
+fn encoder_json_to_attribute_value_encodes_nested_values() {
+    let item = HashMap::from([
+        ("n".to_string(), AttributeValue::N("1.25".to_string())),
+        ("s".to_string(), AttributeValue::S("x".to_string())),
+        ("b".to_string(), AttributeValue::Bool(true)),
+        ("null".to_string(), AttributeValue::Null(true)),
+        (
+            "list".to_string(),
+            AttributeValue::L(vec![
+                AttributeValue::N("1".to_string()),
+                AttributeValue::S("two".to_string()),
+            ]),
+        ),
+        (
+            "map".to_string(),
+            AttributeValue::M(HashMap::from([(
+                "nested".to_string(),
+                AttributeValue::Bool(false),
+            )])),
+        ),
+    ]);
+
+    assert_eq!(attr_n(&item, "n"), "1.25");
+    assert_eq!(attr_s(&item, "s"), "x");
+    assert_eq!(item.get("b").unwrap().as_bool().unwrap(), &true);
+    assert_eq!(item.get("null").unwrap().as_null().unwrap(), &true);
+    assert!(item.get("list").unwrap().is_l());
+    assert!(item.get("map").unwrap().is_m());
+}
+
+fn dynamodb_endpoint_url() -> Option<String> {
+    const DEFAULT_DYNAMODB_ENDPOINT: &str = "http://127.0.0.1:8000";
+
+    Some(
+        std::env::var("DYNAMODB_ENDPOINT")
+            .ok()
+            .filter(|endpoint| !endpoint.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_DYNAMODB_ENDPOINT.to_string()),
+    )
+}
+
+fn dynamodb_client(endpoint_url: Option<&str>) -> Client {
+    make_client(&endpoint_config(
+        "unused".to_string(),
+        endpoint_url.map(str::to_string),
+        1,
+    ))
+}
+
+fn wait_for_dynamodb(client: &Client) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        if TOKIO
+            .block_on(client.list_tables().send())
+            .map(|_| ())
+            .is_ok()
+        {
+            return;
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for DynamoDB endpoint"
+        );
+        sleep(Duration::from_millis(250));
+    }
+}
+
+fn test_table_name(suffix: &str) -> String {
+    // A random suffix keeps concurrently running tests that share `suffix` (for
+    // example the single- and multi-threaded variants) on separate tables.
+    let random: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(12)
+        .map(char::from)
+        .collect();
+    format!("feldera_dynamodb_{suffix}_{random}")
+}
+
+fn create_table(client: &Client, table: &str, sort_key: bool) {
+    let mut create = client
+        .create_table()
+        .table_name(table)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::N)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest);
+
+    if sort_key {
+        create = create
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("sort")
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .unwrap(),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("sort")
+                    .key_type(KeyType::Range)
+                    .build()
+                    .unwrap(),
+            );
+    }
+
+    TOKIO.block_on(create.send()).unwrap();
+}
+
+fn delete_table(client: &Client, table: &str) {
+    let _ = TOKIO.block_on(client.delete_table().table_name(table).send());
+}
+
+/// Creates a DynamoDB table and deletes it when dropped, so a test that panics
+/// mid-way still cleans up after itself rather than leaking the table.
+struct TempDynamoTable {
+    client: Client,
+    name: String,
+}
+
+impl TempDynamoTable {
+    fn new(client: &Client, name: &str, sort_key: bool) -> Self {
+        create_table(client, name, sort_key);
+        TempDynamoTable {
+            client: client.clone(),
+            name: name.to_string(),
+        }
+    }
+}
+
+impl Drop for TempDynamoTable {
+    fn drop(&mut self) {
+        delete_table(&self.client, &self.name);
+    }
+}
+
+fn scan_table(client: &Client, table: &str) -> Vec<HashMap<String, AttributeValue>> {
+    let mut rows = TOKIO
+        .block_on(client.scan().table_name(table).send())
+        .unwrap()
+        .items()
+        .to_vec();
+    rows.sort_by_key(|row| {
+        row.get("id")
+            .unwrap()
+            .as_n()
+            .unwrap()
+            .parse::<i32>()
+            .unwrap()
+    });
+    rows
+}
+
+fn dynamodb_endpoint(
+    threads: usize,
+    table: &str,
+    endpoint_url: Option<&str>,
+) -> DynamoDBOutputEndpoint {
+    let config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), threads);
+    DynamoDBOutputEndpoint::new(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(key_relation()),
+        &value_relation(),
+        Weak::new(),
+        true,
+    )
+    .unwrap()
+}
+
+fn dynamodb_all_types_endpoint(table: &str, endpoint_url: Option<&str>) -> DynamoDBOutputEndpoint {
+    let config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), 2);
+    DynamoDBOutputEndpoint::new(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(all_types_key_relation()),
+        &all_types_value_relation(),
+        Weak::new(),
+        true,
+    )
+    .unwrap()
+}
+
+fn expected_all_types_item() -> HashMap<String, AttributeValue> {
+    let mut worker = all_types_worker();
+    let batch = build_all_types_batch(vec![(all_types_record(), 1)]);
+    stage_batch(&mut worker, &batch);
+    worker.pending[0].put_request().unwrap().item().clone()
+}
+
+#[test]
+fn dynamodb_insert() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("insert");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(3, &table, endpoint_url.as_deref());
+
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), 1),
+            (record(2, "b", Some(20), "two"), 1),
+        ]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(attr_n(&rows[0], "id"), "1");
+    assert_eq!(attr_s(&rows[0], "s"), "one");
+    assert_eq!(attr_n(&rows[1], "id"), "2");
+    assert_eq!(attr_s(&rows[1], "s"), "two");
+}
+
+#[test]
+fn dynamodb_upsert() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("upsert");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(3, &table, endpoint_url.as_deref());
+
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![(record(2, "b", Some(20), "two"), 1)]),
+    );
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(2, "b", Some(20), "two"), -1),
+            (record(2, "b", None, "two-updated"), 1),
+        ]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(attr_n(&rows[0], "id"), "2");
+    assert_eq!(attr_s(&rows[0], "sort"), "b");
+    assert_eq!(rows[0].get("i").unwrap().as_null().unwrap(), &true);
+    assert_eq!(attr_s(&rows[0], "s"), "two-updated");
+}
+
+#[test]
+fn dynamodb_delete() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("delete");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(3, &table, endpoint_url.as_deref());
+
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), 1),
+            (record(3, "c", Some(30), "three"), 1),
+        ]),
+    );
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![(record(1, "a", Some(10), "one"), -1)]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(attr_n(&rows[0], "id"), "3");
+    assert_eq!(attr_s(&rows[0], "sort"), "c");
+    assert_eq!(attr_s(&rows[0], "s"), "three");
+}
+
+#[test]
+fn dynamodb_all_supported_sql_types_round_trip() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("all_types");
+    let _table_guard = TempDynamoTable::new(&client, &table, false);
+    let mut endpoint = dynamodb_all_types_endpoint(&table, endpoint_url.as_deref());
+    let batch = build_all_types_batch(vec![(all_types_record(), 1)]);
+
+    encode_endpoint_batch(&mut endpoint, &batch);
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], expected_all_types_item());
+}
+
+/// Encodes a batch holding two normal-sized records and one record that exceeds
+/// DynamoDB's 400 KB item-size limit, then verifies that the oversized record is
+/// dropped while the normal records are written. The three records share a
+/// single write chunk, so this also confirms the oversized record does not
+/// poison the chunk it travels in: it is never sent and therefore never
+/// retried.
+fn check_oversized_item_dropped(write_mode: DynamoDBWriteMode) {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("oversized");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+
+    let mut config = endpoint_config(table.clone(), endpoint_url.clone(), 1);
+    config.write_mode = write_mode;
+
+    let metrics = Arc::new(DynamoDBOutputMetrics::default());
+    let mut endpoint = DynamoDBOutputEndpoint::new_with_metrics(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(key_relation()),
+        &value_relation(),
+        Weak::new(),
+        true,
+        metrics.clone(),
+    )
+    .unwrap();
+
+    // The middle record's `s` attribute alone is larger than the 400 KB limit;
+    // the other two are ordinary.
+    let oversized_value = "x".repeat(410 * 1024);
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), 1),
+            (record(2, "b", Some(20), &oversized_value), 1),
+            (record(3, "c", Some(30), "three"), 1),
+        ]),
+    );
+
+    // The two normal records land; the oversized record is dropped.
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(attr_n(&rows[0], "id"), "1");
+    assert_eq!(attr_s(&rows[0], "s"), "one");
+    assert_eq!(attr_n(&rows[1], "id"), "3");
+    assert_eq!(attr_s(&rows[1], "s"), "three");
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_oversized_items_dropped_total"),
+        1.0,
+    );
+
+    // The oversized record was dropped before it was sent, so it was never
+    // retried and nothing failed downstream.
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_failed_items_total"),
+        0.0,
+    );
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_transact_write_failures_total"),
+        0.0,
+    );
+}
+
+#[test]
+fn dynamodb_oversized_item_dropped_batch_mode() {
+    check_oversized_item_dropped(DynamoDBWriteMode::Batch);
+}
+
+#[test]
+fn dynamodb_oversized_item_dropped_transactional_mode() {
+    check_oversized_item_dropped(DynamoDBWriteMode::Transactional);
+}
+
+fn records_written(endpoint: &DynamoDBOutputEndpoint) -> u64 {
+    endpoint.records_written.load(Ordering::Relaxed)
+}
+
+fn dynamodb_endpoint_flush_every(
+    max_buffer_size_bytes: usize,
+    threads: usize,
+    table: &str,
+    endpoint_url: Option<&str>,
+) -> DynamoDBOutputEndpoint {
+    let mut config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), threads);
+    config.max_buffer_size_bytes = max_buffer_size_bytes;
+    DynamoDBOutputEndpoint::new(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(key_relation()),
+        &value_relation(),
+        Weak::new(),
+        true,
+    )
+    .unwrap()
+}
+
+// Integration test: an empty batch completes without error and writes nothing.
+#[test]
+fn dynamodb_empty_batch() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("empty");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(1, &table, endpoint_url.as_deref());
+
+    encode_endpoint_batch(&mut endpoint, &build_batch(vec![]));
+
+    assert_eq!(scan_table(&client, &table).len(), 0);
+}
+
+// Integration test: insert → upsert → delete across multiple successive batches.
+#[test]
+fn dynamodb_multiple_batches() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("multi");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(3, &table, endpoint_url.as_deref());
+
+    // Batch 1: insert two records.
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), 1),
+            (record(2, "b", Some(20), "two"), 1),
+        ]),
+    );
+    assert_eq!(scan_table(&client, &table).len(), 2);
+
+    // Batch 2: upsert record 1.
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), -1),
+            (record(1, "a", Some(99), "one-updated"), 1),
+        ]),
+    );
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(attr_n(&rows[0], "i"), "99");
+    assert_eq!(attr_s(&rows[0], "s"), "one-updated");
+
+    // Batch 3: delete record 2.
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![(record(2, "b", Some(20), "two"), -1)]),
+    );
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(attr_n(&rows[0], "id"), "1");
+}
+
+// Integration test: with write concurrency capped at a single in-flight request
+// and a flush forced after every record, all records still land. This stresses
+// the semaphore + JoinSet backpressure path: each flush must block on the lone
+// permit and drain the previous in-flight write before spawning the next.
+fn backpressure_writes_all_records(threads: usize) {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("backpressure");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+
+    let mut config = endpoint_config(table.clone(), endpoint_url.clone(), threads);
+    config.max_buffer_size_bytes = 1; // flush after every record
+    config.max_concurrent_requests = 1; // a single in-flight write per worker
+    let mut endpoint = DynamoDBOutputEndpoint::new(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(key_relation()),
+        &value_relation(),
+        Weak::new(),
+        true,
+    )
+    .unwrap();
+
+    let num_records = 200i32;
+    let batch = build_batch(
+        (0..num_records)
+            .map(|i| (record(i, "x", Some(i as i64), "r"), 1))
+            .collect(),
+    );
+    encode_endpoint_batch(&mut endpoint, &batch);
+
+    assert_eq!(scan_table(&client, &table).len(), num_records as usize);
+    // Counter resets to 0 at the end of every batch.
+    assert_eq!(records_written(&endpoint), 0);
+}
+
+#[test]
+fn dynamodb_backpressure_single_thread() {
+    backpressure_writes_all_records(1);
+}
+
+#[test]
+fn dynamodb_backpressure_multi_thread() {
+    backpressure_writes_all_records(4);
+}
+
+// Progress counter: starts at zero, and resets to zero after every batch.
+fn progress_basic(threads: usize) {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("progress_basic");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(threads, &table, endpoint_url.as_deref());
+    let batch = build_batch(
+        (0..100i32)
+            .map(|i| (record(i, "x", Some(i as i64), "r"), 1))
+            .collect(),
+    );
+
+    assert_eq!(records_written(&endpoint), 0);
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    assert_eq!(records_written(&endpoint), 0);
+    endpoint
+        .encode(batch.clone().arc_as_batch_reader())
+        .unwrap();
+    endpoint.consumer().batch_end();
+    // Counter resets to 0 at the end of every batch.
+    assert_eq!(records_written(&endpoint), 0);
+
+    assert_eq!(scan_table(&client, &table).len(), 100);
+}
+
+#[test]
+fn dynamodb_progress_counter_single_thread() {
+    progress_basic(1);
+}
+
+#[test]
+fn dynamodb_progress_counter_multi_thread() {
+    progress_basic(3);
+}
+
+// Progress counter: an empty batch leaves the counter at zero throughout.
+#[test]
+fn dynamodb_progress_counter_empty_batch() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("progress_empty");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(1, &table, endpoint_url.as_deref());
+
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    endpoint
+        .encode(build_batch(vec![]).arc_as_batch_reader())
+        .unwrap();
+    assert_eq!(records_written(&endpoint), 0);
+    endpoint.consumer().batch_end();
+    assert_eq!(records_written(&endpoint), 0);
+}
+
+// Progress counter: advances during encode when mid-batch flushes occur.
+fn progress_advances_mid_batch(threads: usize) {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("progress_mid");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    // max_buffer_size_bytes=1 forces a flush after every single encoded record.
+    let mut endpoint = dynamodb_endpoint_flush_every(1, threads, &table, endpoint_url.as_deref());
+    let num_records = 50usize;
+    let batch = build_batch(
+        (0..num_records as i32)
+            .map(|i| (record(i, "x", Some(i as i64), "r"), 1))
+            .collect(),
+    );
+
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    endpoint
+        .encode(batch.clone().arc_as_batch_reader())
+        .unwrap();
+
+    // With per-record flushes, the counter must be > 0 before batch_end.
+    let mid_count = records_written(&endpoint);
+    assert!(
+        mid_count > 0,
+        "expected records_written > 0 mid-batch, got {mid_count}"
+    );
+    assert!(
+        mid_count <= num_records as u64,
+        "records_written {mid_count} exceeds total {num_records}"
+    );
+
+    endpoint.consumer().batch_end();
+    assert_eq!(records_written(&endpoint), 0);
+
+    assert_eq!(scan_table(&client, &table).len(), num_records);
+}
+
+#[test]
+fn dynamodb_progress_counter_advances_mid_batch_single_thread() {
+    progress_advances_mid_batch(1);
+}
+
+#[test]
+fn dynamodb_progress_counter_advances_mid_batch_multi_thread() {
+    progress_advances_mid_batch(3);
+}
+
+// Progress counter: batch_start resets a stale counter from a prior batch.
+#[test]
+fn dynamodb_progress_counter_batch_start_resets() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("progress_reset");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(1, &table, endpoint_url.as_deref());
+
+    // Simulate a stale counter left over from a previous batch.
+    endpoint.records_written.store(99, Ordering::Relaxed);
+    endpoint.consumer().batch_start(0, OutputBatchType::Delta);
+    assert_eq!(records_written(&endpoint), 0);
+
+    // Close cleanly so the worker does not leak an open state.
+    endpoint.consumer().batch_end();
+}
+
+// Integration test: two rows sharing the same hash key are stored as separate rows
+// (disambiguated by the sort key), and deleting one leaves the other untouched.
+#[test]
+fn dynamodb_composite_key_same_hash_different_sort() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("composite");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(1, &table, endpoint_url.as_deref());
+
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "first", Some(10), "row-one"), 1),
+            (record(1, "second", Some(20), "row-two"), 1),
+        ]),
+    );
+
+    assert_eq!(
+        scan_table(&client, &table).len(),
+        2,
+        "both rows with id=1 should be stored separately by sort key"
+    );
+
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![(record(1, "first", Some(10), "row-one"), -1)]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(
+        rows.len(),
+        1,
+        "deleting sort=first should leave sort=second intact"
+    );
+    assert_eq!(attr_n(&rows[0], "id"), "1");
+    assert_eq!(attr_s(&rows[0], "sort"), "second");
+    assert_eq!(attr_s(&rows[0], "s"), "row-two");
+}
+
+// Progress counter: resets to zero between successive batches.
+#[test]
+fn dynamodb_progress_counter_multiple_batches() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("progress_multi");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let mut endpoint = dynamodb_endpoint(1, &table, endpoint_url.as_deref());
+
+    let batch1 = build_batch(
+        (0..50i32)
+            .map(|i| (record(i, "x", Some(i as i64), "r"), 1))
+            .collect(),
+    );
+    encode_endpoint_batch(&mut endpoint, &batch1);
+    assert_eq!(records_written(&endpoint), 0);
+
+    let batch2 = build_batch(
+        (50..80i32)
+            .map(|i| (record(i, "x", Some(i as i64), "r"), 1))
+            .collect(),
+    );
+    encode_endpoint_batch(&mut endpoint, &batch2);
+    assert_eq!(records_written(&endpoint), 0);
+
+    assert_eq!(scan_table(&client, &table).len(), 80);
+}

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -297,6 +297,10 @@ where
             RecordFormat::Avro => {
                 todo!()
             }
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                unreachable!("DynamoDB is an output-only format")
+            }
         }
     }
 }
@@ -427,6 +431,10 @@ where
                         (config, column_name.clone()),
                     ),
                 ))
+            }
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                unreachable!("DynamoDB is an output-only format")
             }
         }
     }
@@ -922,6 +930,10 @@ where
                         (raw_serde_config(), column_name.clone()),
                     ),
                 ))
+            }
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                unreachable!("DynamoDB is an output-only format")
             }
         }
     }
@@ -1437,6 +1449,10 @@ where
                 self.update_key_func.clone(),
                 (raw_serde_config(), column_name.clone()),
             ))),
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                unreachable!("DynamoDB is an output-only format")
+            }
         }
     }
 

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -12,6 +12,8 @@ use apache_avro::Schema as AvroSchema;
 use apache_avro::schema::NamesRef;
 #[cfg(feature = "with-avro")]
 use apache_avro::types::Value as AvroValue;
+#[cfg(feature = "with-dynamodb")]
+use aws_sdk_dynamodb::types::AttributeValue;
 use csv::{Writer as CsvWriter, WriterBuilder as CsvWriterBuilder};
 use dbsp::{
     Batch, BatchReader, OutputHandle, Trace,
@@ -33,6 +35,8 @@ use dbsp::{
 };
 use erased_serde::{Serialize as ErasedSerialize, Serializer as ErasedSerializer};
 use feldera_storage::tokio::TOKIO;
+#[cfg(feature = "with-dynamodb")]
+use feldera_types::serde_with_context::serde_config::{BinaryFormat, VariantFormat};
 use feldera_types::serde_with_context::serialize::{
     SerializeFieldsWithContextWrapper, SerializeWithContextWrapper,
 };
@@ -43,6 +47,8 @@ use feldera_types::{
 use rand::thread_rng;
 use serde::Serialize;
 use serde_arrow::ArrayBuilder;
+#[cfg(feature = "with-dynamodb")]
+use std::collections::HashMap;
 use std::{any::Any, collections::HashSet, fmt::Debug, iter::once};
 use std::{cell::RefCell, io, io::Write, marker::PhantomData, ops::DerefMut, sync::Arc};
 
@@ -359,6 +365,55 @@ where
     }
 }
 
+#[cfg(feature = "with-dynamodb")]
+fn to_dynamodb_item<T>(value: T, description: &str) -> AnyResult<HashMap<String, AttributeValue>>
+where
+    T: Serialize,
+{
+    let item = serde_dynamo::aws_sdk_dynamodb_1::to_item(value)
+        .map_err(|e| anyhow!("Failed to serialize {description} to DynamoDB item: {e}"))?;
+    item.into_iter()
+        .map(|(k, v)| Ok((k, fix_number_attribute(v)?)))
+        .collect()
+}
+
+/// The token used by `serde_json` (with `arbitrary_precision`) and by `fxp::Fixed` to serialize
+/// decimal numbers as a single-field struct, which non-JSON serializers see as a map.
+#[cfg(feature = "with-dynamodb")]
+const SERDE_JSON_NUMBER_TOKEN: &str = "$serde_json::private::Number";
+
+/// Recursively convert any `M({"$serde_json::private::Number": S(n)})` produced by
+/// `serde_dynamo` back into the intended `N(n)`.  This arises because `SqlDecimal` and
+/// `serde_json::Value::Number` (used by `VARIANT`) serialize using the same internal struct
+/// format that `serde_json` uses for arbitrary-precision numbers.
+///
+/// `serde_dynamo` does not handle this case (see https://github.com/zenlist/serde_dynamo/issues/90);
+/// remove this function if that is ever fixed.
+#[cfg(feature = "with-dynamodb")]
+fn fix_number_attribute(value: AttributeValue) -> AnyResult<AttributeValue> {
+    match value {
+        AttributeValue::M(mut map)
+            if map.len() == 1 && map.contains_key(SERDE_JSON_NUMBER_TOKEN) =>
+        {
+            match map.remove(SERDE_JSON_NUMBER_TOKEN) {
+                Some(AttributeValue::S(n)) => Ok(AttributeValue::N(n)),
+                _ => Err(anyhow!("unable to serialize arbitrary-precision number")),
+            }
+        }
+        AttributeValue::M(map) => Ok(AttributeValue::M(
+            map.into_iter()
+                .map(|(k, v)| Ok((k, fix_number_attribute(v)?)))
+                .collect::<AnyResult<_>>()?,
+        )),
+        AttributeValue::L(list) => Ok(AttributeValue::L(
+            list.into_iter()
+                .map(fix_number_attribute)
+                .collect::<AnyResult<_>>()?,
+        )),
+        other => Ok(other),
+    }
+}
+
 /// [`SerBatch`] implementation that wraps a `BatchReader`.
 #[repr(transparent)]
 pub struct SerBatchImpl<B, KD, VD>
@@ -446,6 +501,17 @@ where
                 AvroSerializer::create(),
             )),
             RecordFormat::Raw(_) => todo!(),
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                let serde_config = SqlSerdeConfig::default()
+                    .with_variant_format(VariantFormat::Json)
+                    .with_binary_format(BinaryFormat::Bytes);
+                Box::new(<SerCursorImpl<'a, JsonSerializer, B, KD, VD>>::new(
+                    &self.batch,
+                    serde_config,
+                    JsonSerializer::create(),
+                ))
+            }
         })
     }
 
@@ -715,6 +781,14 @@ where
         .map_err(|e| anyhow!("Failed to serialize key to JSON: {}", e))
     }
 
+    #[cfg(feature = "with-dynamodb")]
+    fn key_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        to_dynamodb_item(
+            SerializeWithContextWrapper::new(self.key.as_ref().unwrap(), &self.serde_config),
+            "key",
+        )
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -822,6 +896,14 @@ where
             &self.serde_config,
         ))
         .map_err(|e| anyhow!("Failed to serialize value to JSON: {}", e))
+    }
+
+    #[cfg(feature = "with-dynamodb")]
+    fn val_to_dynamodb_item(&mut self) -> AnyResult<HashMap<String, AttributeValue>> {
+        to_dynamodb_item(
+            SerializeWithContextWrapper::new(self.val.as_ref().unwrap(), &self.serde_config),
+            "value",
+        )
     }
 
     #[cfg(feature = "with-avro")]

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -182,6 +182,10 @@ where
                 self.clone(),
                 (raw_serde_config(), column_name.clone()),
             ))),
+            #[cfg(feature = "with-dynamodb")]
+            RecordFormat::DynamoDB => {
+                unreachable!("DynamoDB is an output-only format")
+            }
         }
     }
 

--- a/crates/adapters/src/transport.rs
+++ b/crates/adapters/src/transport.rs
@@ -121,6 +121,7 @@ pub fn input_transport_config_to_endpoint(
         | TransportConfig::KafkaOutput(_)
         | TransportConfig::DeltaTableInput(_)
         | TransportConfig::DeltaTableOutput(_)
+        | TransportConfig::DynamoDBOutput(_)
         | TransportConfig::PostgresInput(_)
         | TransportConfig::PostgresCdcInput(_)
         | TransportConfig::PostgresOutput(_)

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -12,6 +12,7 @@ use crate::transport::adhoc::AdHocInputConfig;
 use crate::transport::clock::ClockConfig;
 use crate::transport::datagen::DatagenInputConfig;
 use crate::transport::delta_table::{DeltaTableReaderConfig, DeltaTableWriterConfig};
+use crate::transport::dynamodb::DynamoDBWriterConfig;
 use crate::transport::file::{FileInputConfig, FileOutputConfig};
 use crate::transport::http::{HttpInputConfig, HttpOutputConfig};
 use crate::transport::iceberg::IcebergReaderConfig;
@@ -1826,6 +1827,10 @@ pub enum TransportConfig {
     S3Input(S3InputConfig),
     DeltaTableInput(DeltaTableReaderConfig),
     DeltaTableOutput(DeltaTableWriterConfig),
+    // Snake case would rename "DynamoDBOutput" to `dynamo_db_output`.
+    // However, DynamoDB is a single word, so override the tag to `dynamodb_output`.
+    #[serde(rename = "dynamodb_output")]
+    DynamoDBOutput(DynamoDBWriterConfig),
     RedisOutput(RedisOutputConfig),
     // Prevent rust from complaining about large size difference between enum variants.
     IcebergInput(Box<IcebergReaderConfig>),
@@ -1860,6 +1865,7 @@ impl TransportConfig {
             TransportConfig::S3Input(_) => "s3_input".to_string(),
             TransportConfig::DeltaTableInput(_) => "delta_table_input".to_string(),
             TransportConfig::DeltaTableOutput(_) => "delta_table_output".to_string(),
+            TransportConfig::DynamoDBOutput(_) => "dynamodb_output".to_string(),
             TransportConfig::IcebergInput(_) => "iceberg_input".to_string(),
             TransportConfig::PostgresInput(_) => "postgres_input".to_string(),
             TransportConfig::PostgresCdcInput(_) => "postgres_cdc_input".to_string(),

--- a/crates/feldera-types/src/transport.rs
+++ b/crates/feldera-types/src/transport.rs
@@ -2,6 +2,7 @@ pub mod adhoc;
 pub mod clock;
 pub mod datagen;
 pub mod delta_table;
+pub mod dynamodb;
 pub mod file;
 pub mod http;
 pub mod iceberg;

--- a/crates/feldera-types/src/transport/dynamodb.rs
+++ b/crates/feldera-types/src/transport/dynamodb.rs
@@ -1,0 +1,373 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Connectors by default start with 1 worker thread.
+/// Increasing the number of threads helps scale the encoding process; however, for
+/// DynamoDB, encoding is often not the bottleneck, writing to DynamoDB is.
+fn default_threads() -> usize {
+    1
+}
+
+/// Ten attempts with the ~13s backoff ceiling retries for roughly two minutes:
+/// enough to ride out transient throttling, bounded enough not to stall the
+/// pipeline forever. Set `max_retries` to `null` for unbounded.
+fn default_max_retries() -> Option<u8> {
+    Some(10)
+}
+
+fn default_max_buffer_size_bytes() -> usize {
+    1024 * 1024
+}
+
+/// Number of concurrent requests made to DynamoDB at any time.
+/// Increasing this may improve the throughput, but may also cause
+/// throttling and increase retries.
+///
+/// 64 concurrent requests mean at any time, we submit a maximum of:
+/// - 64 * 25 Batch items
+/// - 64 * 100 Transactional items
+fn default_max_concurrent_requests() -> usize {
+    64
+}
+
+/// Batch mode allows for higher throughput than transactional mode.
+fn default_write_mode() -> DynamoDBWriteMode {
+    DynamoDBWriteMode::Batch
+}
+
+fn default_allow_cross_step_write_overlap() -> bool {
+    false
+}
+
+/// DynamoDB write API used by the output connector.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DynamoDBWriteMode {
+    /// Use DynamoDB [`BatchWriteItem`].
+    ///
+    /// This is the high-throughput path. Each request writes up to 25 items,
+    /// and each item costs one write capacity unit (WCU). Writes are flushed at
+    /// batch end, but DynamoDB does not make the whole batch atomic: some items
+    /// in a request may succeed while others fail (and are retried).
+    ///
+    /// [`BatchWriteItem`]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
+    Batch,
+
+    /// Use DynamoDB [`TransactWriteItems`].
+    ///
+    /// This provides atomicity for each transaction chunk: either all items in
+    /// the request are written or none are. It is substantially slower than
+    /// `Batch` and is limited to 100 writes per request.
+    ///
+    /// [`TransactWriteItems`]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
+    Transactional,
+}
+
+/// DynamoDB output connector configuration.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct DynamoDBWriterConfig {
+    /// Name of the DynamoDB table to write to.
+    pub table: String,
+
+    /// AWS region.
+    pub region: String,
+
+    /// Optional endpoint URL, for example when using a local
+    /// DynamoDB-compatible service.
+    pub endpoint_url: Option<String>,
+
+    /// AWS access key ID.
+    ///
+    /// If both `aws_access_key_id` and `aws_secret_access_key` are specified,
+    /// the connector uses these static credentials. Otherwise it uses the
+    /// default AWS credential provider chain, including IAM Roles for Service
+    /// Accounts (IRSA) in EKS.
+    ///
+    /// Static credentials are treated as long-lived IAM keys: no session token
+    /// is sent, so STS-issued temporary credentials are not supported via these
+    /// fields. To use temporary credentials, rely on the default provider chain
+    /// instead (leave these unset).
+    pub aws_access_key_id: Option<String>,
+
+    /// AWS secret access key.
+    pub aws_secret_access_key: Option<String>,
+
+    /// Maximum number of write requests in one DynamoDB write call.
+    ///
+    /// DynamoDB supports at most 100 for `TransactWriteItems` and at most 25
+    /// for `BatchWriteItem`. If omitted, the connector uses the maximum for
+    /// the selected `write_mode`.
+    #[serde(default)]
+    pub batch_size: Option<usize>,
+
+    /// Write API to use when flushing records at batch end.
+    ///
+    /// The default is `batch`, where each worker bulk-writes its own split
+    /// using DynamoDB `BatchWriteItem`.
+    #[serde(default = "default_write_mode")]
+    #[schema(default = default_write_mode)]
+    pub write_mode: DynamoDBWriteMode,
+
+    /// Maximum number of bytes buffered by each worker before flushing writes.
+    ///
+    /// This is an approximate size based on encoded DynamoDB attributes.
+    #[serde(default = "default_max_buffer_size_bytes")]
+    #[schema(default = default_max_buffer_size_bytes)]
+    pub max_buffer_size_bytes: usize,
+
+    /// Maximum number of DynamoDB write requests in flight per worker thread.
+    ///
+    /// The total in-flight request count across the connector is
+    /// `threads × max_concurrent_requests`. Size this accordingly when
+    /// tuning against a provisioned-throughput table to avoid excessive
+    /// throttling.
+    #[serde(default = "default_max_concurrent_requests")]
+    #[schema(default = default_max_concurrent_requests)]
+    pub max_concurrent_requests: usize,
+
+    /// Number of worker threads used to encode and write disjoint key ranges.
+    #[serde(default = "default_threads")]
+    #[schema(default = default_threads)]
+    pub threads: usize,
+
+    /// Allow write requests from later DBSP steps to be submitted before all
+    /// write requests from previous steps have completed.
+    ///
+    /// The default is `false`, each `batch_end` waits until all writes for that
+    /// batch have drained before the next step can be encoded. Setting this to
+    /// `true` can increase throughput for small steps by keeping DynamoDB requests
+    /// in flight across step boundaries. This allows writes from different steps to
+    /// overlap; use it for insert-only or mostly disjoint-key workloads where cross-step
+    /// write ordering to the same DynamoDB item is not required.
+    #[serde(default = "default_allow_cross_step_write_overlap")]
+    #[schema(default = default_allow_cross_step_write_overlap)]
+    pub allow_cross_step_write_overlap: bool,
+
+    /// Maximum number of retries for a failed or partially-applied DynamoDB write chunk.
+    ///
+    /// For `batch` writes, `BatchWriteItem` may return some items as "unprocessed" in a
+    /// successful 200 response; those are re-submitted and counted as retries. For
+    /// `transactional` writes, a failed `TransactWriteItems` call is retried in full.
+    ///
+    /// Transient errors (throttling, network failures) are first handled transparently by the
+    /// AWS SDK. Only attempts that reach this connector's retry loop count against this limit.
+    /// Each retry waits longer than the previous one (exponential backoff), up to a ceiling
+    /// of roughly 13 seconds.
+    ///
+    /// Set to `null` to retry indefinitely. After the backoff ceiling is reached the connector
+    /// keeps retrying at that interval, providing backpressure until DynamoDB recovers.
+    /// Defaults to `10`.
+    #[serde(default = "default_max_retries")]
+    #[schema(default = default_max_retries)]
+    pub max_retries: Option<u8>,
+}
+
+impl DynamoDBWriterConfig {
+    pub fn effective_batch_size(&self) -> usize {
+        self.batch_size
+            .unwrap_or_else(|| self.write_mode.max_batch_size())
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.table.trim().is_empty() {
+            return Err("table cannot be empty".to_string());
+        }
+        if self.table.len() < 3 || self.table.len() > 255 {
+            return Err(format!(
+                "table name '{}' is {} character(s); DynamoDB requires 3–255 characters",
+                self.table,
+                self.table.len()
+            ));
+        }
+        if !self
+            .table
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+        {
+            return Err(format!(
+                "table name '{}' contains invalid characters; DynamoDB requires [a-zA-Z0-9_.-]",
+                self.table
+            ));
+        }
+        if self.region.trim().is_empty() {
+            return Err("region cannot be empty".to_string());
+        }
+        if let Some(batch_size) = self.batch_size {
+            let max_batch_size = self.write_mode.max_batch_size();
+            if batch_size == 0 || batch_size > max_batch_size {
+                return Err(format!(
+                    "batch_size must be between 1 and {max_batch_size} for {:?} write mode",
+                    self.write_mode
+                ));
+            }
+        }
+        if self.threads == 0 {
+            return Err("threads must be at least 1".to_string());
+        }
+        if self.max_buffer_size_bytes == 0 {
+            return Err("max_buffer_size_bytes must be greater than 0".to_string());
+        }
+        if self.max_concurrent_requests == 0 {
+            return Err("max_concurrent_requests must be greater than 0".to_string());
+        }
+        match (&self.aws_access_key_id, &self.aws_secret_access_key) {
+            (Some(_), Some(_)) | (None, None) => {}
+            _ => {
+                return Err(
+                    "aws_access_key_id and aws_secret_access_key must be specified together"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl DynamoDBWriteMode {
+    pub fn max_batch_size(self) -> usize {
+        match self {
+            Self::Batch => 25,
+            Self::Transactional => 100,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(write_mode: DynamoDBWriteMode, batch_size: Option<usize>) -> DynamoDBWriterConfig {
+        DynamoDBWriterConfig {
+            table: "test_table".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: None,
+            aws_access_key_id: None,
+            aws_secret_access_key: None,
+            batch_size,
+            write_mode,
+            max_buffer_size_bytes: 1024 * 1024,
+            max_concurrent_requests: 16,
+            threads: 1,
+            allow_cross_step_write_overlap: false,
+            max_retries: Some(10u8),
+        }
+    }
+
+    #[test]
+    fn default_batch_size_is_mode_specific() {
+        assert_eq!(
+            config(DynamoDBWriteMode::Batch, None).effective_batch_size(),
+            25
+        );
+        assert_eq!(
+            config(DynamoDBWriteMode::Transactional, None).effective_batch_size(),
+            100
+        );
+    }
+
+    #[test]
+    fn explicit_batch_size_is_validated_against_mode_limit() {
+        assert!(
+            config(DynamoDBWriteMode::Batch, Some(25))
+                .validate()
+                .is_ok()
+        );
+        assert!(
+            config(DynamoDBWriteMode::Batch, Some(26))
+                .validate()
+                .is_err()
+        );
+        assert!(
+            config(DynamoDBWriteMode::Transactional, Some(100))
+                .validate()
+                .is_ok()
+        );
+        assert!(
+            config(DynamoDBWriteMode::Transactional, Some(101))
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn table_name_validation() {
+        let base = config(DynamoDBWriteMode::Batch, None);
+
+        // too short
+        assert!(
+            DynamoDBWriterConfig {
+                table: "ab".to_string(),
+                ..base.clone()
+            }
+            .validate()
+            .is_err()
+        );
+        // minimum length
+        assert!(
+            DynamoDBWriterConfig {
+                table: "abc".to_string(),
+                ..base.clone()
+            }
+            .validate()
+            .is_ok()
+        );
+        // too long
+        assert!(
+            DynamoDBWriterConfig {
+                table: "a".repeat(256),
+                ..base.clone()
+            }
+            .validate()
+            .is_err()
+        );
+        // maximum length
+        assert!(
+            DynamoDBWriterConfig {
+                table: "a".repeat(255),
+                ..base.clone()
+            }
+            .validate()
+            .is_ok()
+        );
+        // invalid characters
+        assert!(
+            DynamoDBWriterConfig {
+                table: "my/table".to_string(),
+                ..base.clone()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            DynamoDBWriterConfig {
+                table: "my table".to_string(),
+                ..base.clone()
+            }
+            .validate()
+            .is_err()
+        );
+        // valid characters
+        assert!(
+            DynamoDBWriterConfig {
+                table: "my.table-name_1".to_string(),
+                ..base.clone()
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn null_max_retries_deserializes_as_unbounded() {
+        let json = r#"{"table":"t","region":"us-east-1","max_retries":null}"#;
+        let cfg: DynamoDBWriterConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.max_retries, None);
+    }
+
+    #[test]
+    fn omitted_max_retries_deserializes_as_default() {
+        let json = r#"{"table":"t","region":"us-east-1"}"#;
+        let cfg: DynamoDBWriterConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.max_retries, Some(10u8));
+    }
+}

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -404,6 +404,8 @@ It contains the following fields:
         feldera_types::transport::delta_table::DeltaTableWriteMode,
         feldera_types::transport::delta_table::DeltaTableReaderConfig,
         feldera_types::transport::delta_table::DeltaTableWriterConfig,
+        feldera_types::transport::dynamodb::DynamoDBWriteMode,
+        feldera_types::transport::dynamodb::DynamoDBWriterConfig,
         feldera_types::transport::iceberg::IcebergReaderConfig,
         feldera_types::transport::iceberg::IcebergIngestMode,
         feldera_types::transport::iceberg::IcebergCatalogType,

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -778,6 +778,7 @@ pub fn generate_program_info(
                 | TransportConfig::PostgresOutput(_)
                 | TransportConfig::KafkaOutput(_)
                 | TransportConfig::DeltaTableOutput(_)
+                | TransportConfig::DynamoDBOutput(_)
                 | TransportConfig::RedisOutput(_)
                 | TransportConfig::NullOutput => {}
                 _ => {

--- a/crates/rest-api/build.rs
+++ b/crates/rest-api/build.rs
@@ -132,6 +132,14 @@ fn type_replacement() -> Vec<(&'static str, &'static str)> {
             "DeltaTableWriterConfig",
             "feldera_types::transport::delta_table::DeltaTableWriterConfig",
         ),
+        (
+            "DynamoDBWriterConfig",
+            "feldera_types::transport::dynamodb::DynamoDBWriterConfig",
+        ),
+        (
+            "DynamoDBWriteMode",
+            "feldera_types::transport::dynamodb::DynamoDBWriteMode",
+        ),
         ("Chunk", "feldera_types::transport::http::Chunk"),
         (
             "JsonUpdateFormat",

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,12 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        - New DynamoDB output connector. It writes a SQL view to an Amazon
+          DynamoDB table, mapping inserts and updates to upserts and deletes to
+          deletes keyed by the table's primary key. See the
+          [connector documentation](/connectors/sinks/dynamodb) for configuration
+          details.
+
         - Pipeline name is now limited to 63 characters and must follow the Kubernetes
           label pattern (and be non-empty and contain no dots as before). The check is only enforced
           when the pipeline is being newly created, its `name` field is being PATCHed

--- a/docs.feldera.com/docs/connectors/sinks/dynamodb.md
+++ b/docs.feldera.com/docs/connectors/sinks/dynamodb.md
@@ -1,0 +1,189 @@
+# DynamoDB output connector
+
+:::caution Experimental feature
+DynamoDB support is an experimental feature of Feldera.
+:::
+
+Feldera allows you to output data from a SQL view to an Amazon DynamoDB table.
+
+:::important
+Only SQL views with [Uniqueness Constraints](/connectors/unique_keys) can output
+data to a DynamoDB table.
+
+The columns of the Feldera index must match the primary key of the DynamoDB
+table. If the table uses a composite primary key (partition key + sort key),
+the index must include both columns.
+:::
+
+## DynamoDB output configuration
+
+| Property                         | Type    | Default   | Description                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `table`\*                        | string  |           | Name of the DynamoDB table to write to. Must be between 3 and 255 characters and contain only letters, numbers, hyphens, underscores, and dots.                                                                                                                                                                                                                                                         |
+| `region`\*                       | string  |           | AWS region where the DynamoDB table resides, e.g., `"us-east-1"`.                                                                                                                                                                                                                                                                                                                                       |
+| `endpoint_url`                   | string  |           | Optional endpoint URL override, for example when using a local DynamoDB-compatible service such as [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html).                                                                                                                                                                                               |
+| `aws_access_key_id`              | string  |           | AWS access key ID for static credentials. Must be specified together with `aws_secret_access_key`. If both are omitted, the connector uses the default AWS credential provider chain (environment variables, `~/.aws/credentials`, IAM roles for Amazon EKS, and so forth).                                                                                                                             |
+| `aws_secret_access_key`          | string  |           | AWS secret access key for static credentials. Must be specified together with `aws_access_key_id`.                                                                                                                                                                                                                                                                                                      |
+| `write_mode`                     | string  | `batch`   | [Write mode](#write-modes) to use when flushing records (`"batch"` or `"transactional"`).                                                                                                                                                                                                                                                                                                               |
+| `batch_size`                     | integer |           | Maximum number of write requests per DynamoDB API call. Defaults to `25` for `batch` mode and `100` for `transactional` mode, which are the respective DynamoDB limits.                                                                                                                                                                                                                                 |
+| `max_buffer_size_bytes`          | integer | `1048576` | Maximum number of bytes buffered by each worker thread before flushing to DynamoDB. Default is 1 MiB (`1048576` bytes).                                                                                                                                                                                                                                                                                 |
+| `max_concurrent_requests`        | integer | `64`      | Maximum number of DynamoDB write requests in flight per worker thread at any one time. The connector blocks the encoding thread when this limit is reached, applying backpressure to the pipeline.                                                                                                                                                                                                      |
+| `threads`                        | integer | `1`       | Number of parallel worker threads used to encode and write disjoint key ranges. Each thread makes its own DynamoDB API calls. Increasing this value can improve throughput for large batches.                                                                                                                                                                                                           |
+| `allow_cross_step_write_overlap` | boolean | `false`   | Allow writes from later DBSP steps to be submitted before all writes from earlier steps have completed. This can improve throughput for small steps by keeping DynamoDB requests in flight across step boundaries. Use for mostly disjoint-key workloads where cross-step write ordering to the same DynamoDB item is not required.                                                                     |
+| `max_retries`                    | integer | `10`      | Maximum number of retries for a failed or partially-applied DynamoDB write. For `batch` mode, retries apply to items returned as unprocessed in a successful response. For `transactional` mode, retries apply to failed `TransactWriteItems` calls. Set to `null` to retry indefinitely. Transient errors such as throttling are handled separately by the AWS SDK and do not count toward this limit. |
+
+[*]: Required fields
+
+## Write modes
+
+The DynamoDB connector supports two write modes:
+
+### Batch mode (default)
+
+In batch mode (`"write_mode": "batch"`), the connector uses the
+[`BatchWriteItem`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html)
+API. This mode:
+
+- Provides high throughput by writing up to 25 items per API call
+- Does not make writes atomic across items in the same batch
+
+### Transactional mode
+
+In transactional mode (`"write_mode": "transactional"`), the connector uses the
+[`TransactWriteItems`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html)
+API. This mode:
+
+- Guarantees atomicity for each transaction chunk of up to 100 items
+- Is substantially slower than batch mode due to the overhead of ACID transactions
+
+## Item-size limit
+
+DynamoDB rejects any item larger than its 400 KB
+[item-size limit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-items).
+Because such an item can never be written, the connector drops it while encoding
+rather than sending it. This keeps an oversized record from failing the write
+chunk or transaction it would otherwise share, so the remaining records in the
+same batch are still written. Dropped records are reported through the
+`dynamodb_output_oversized_items_dropped_total` metric.
+
+## Performance
+
+The following samples were measured using a Feldera pipeline writing
+well-distributed records smaller than 1 KiB to a DynamoDB table provisioned with
+40k WCU.
+
+| `threads` | `max_concurrent_requests` | WCU/s without overlap | WCU/s with overlap |
+| --------- | ------------------------- | --------------------- | ------------------ |
+| 1         | 64                        | ~7.7k                 | ~16.9k             |
+| 1         | 128                       | ~27.2k                | ~37.1k             |
+
+Suggestions:
+
+- Enable `allow_cross_step_write_overlap` to keep DynamoDB requests in flight
+  across step boundaries instead of draining the entire write pipeline at every
+  `batch_end`; in these measurements, it more than doubled WCU/s at `threads=1`,
+  `max_concurrent_requests=64`.
+- Increase `max_concurrent_requests` when DynamoDB still has unused capacity.
+- If increasing `threads` or `max_concurrent_requests` does not improve
+  throughput, check whether the pipeline is stalling because output buffers are
+  full. In that case, increase the output connector's `max_queued_records` so
+  the pipeline can queue more completed records while DynamoDB writes are still
+  in flight.
+
+## AWS credentials
+
+If `aws_access_key_id` and `aws_secret_access_key` are both specified, the
+connector uses those static credentials. Otherwise it falls back to the default
+AWS credential provider chain, which checks (in order):
+
+1. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+2. The `~/.aws/credentials` file
+3. IAM Roles for Service Accounts (IRSA) when running in Amazon EKS
+
+## Data type mapping
+
+:::info
+The following table lists supported DynamoDB attribute types.
+Please [let us know](https://github.com/feldera/feldera/issues) if you need support for a specific type.
+:::
+
+| Feldera Type      | DynamoDB Attribute Type               | Comments                                          |
+| ----------------- | ------------------------------------- | ------------------------------------------------- |
+| BOOL              | Boolean (`BOOL`)                      |                                                   |
+| TINYINT           | Number (`N`)                          | Encoded as a numeric string.                      |
+| SMALLINT          | Number (`N`)                          | Encoded as a numeric string.                      |
+| INT               | Number (`N`)                          | Encoded as a numeric string.                      |
+| BIGINT            | Number (`N`)                          | Encoded as a numeric string.                      |
+| DECIMAL           | Number (`N`)                          | Encoded as a numeric string.                      |
+| REAL              | Number (`N`)                          | Encoded as a numeric string.                      |
+| DOUBLE            | Number (`N`)                          | Encoded as a numeric string.                      |
+| VARCHAR           | String (`S`)                          |                                                   |
+| TIME              | String (`S`)                          |                                                   |
+| DATE              | String (`S`)                          |                                                   |
+| TIMESTAMP         | String (`S`)                          |                                                   |
+| UUID              | String (`S`)                          |                                                   |
+| VARIANT           | `S`, `N`, `BOOL`, `NULL`, `M`, or `L` | Attribute type follows the underlying JSON value. |
+| VARBINARY         | Binary (`B`)                          |                                                   |
+| ARRAY             | List (`L`)                            |                                                   |
+| User Defined Type | Map (`M`)                             |                                                   |
+| MAP               | Map (`M`)                             |                                                   |
+| NULL values       | Null (`NULL`)                         |                                                   |
+
+## Example
+
+First, create a DynamoDB table with a composite key. The partition key must
+correspond to one of the index columns and the sort key to another.
+
+```sh
+aws dynamodb create-table \
+  --table-name feldera_out \
+  --attribute-definitions \
+      AttributeName=id,AttributeType=N \
+      AttributeName=sort,AttributeType=S \
+  --key-schema \
+      AttributeName=id,KeyType=HASH \
+      AttributeName=sort,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST \
+  --region us-east-1
+```
+
+Now output data to this table from a Feldera view.
+
+```sql
+-- Feldera SQL
+
+-- Create a table and fill it with 5 randomly generated records.
+CREATE TABLE t0 (id INT NOT NULL, sort VARCHAR NOT NULL, s VARCHAR) WITH (
+  'connectors' = '[{
+    "transport": {
+      "name": "datagen",
+      "config": {
+        "plan": [{ "rate": 1, "limit": 5 }]
+      }
+    }
+  }]'
+);
+
+-- Create a view and attach a DynamoDB output connector to it.
+CREATE MATERIALIZED VIEW v1 WITH (
+    'connectors' = '[{
+        "index": "v1_idx",
+        "transport": {
+            "name": "dynamodb_output",
+            "config": {
+                "table": "feldera_out",
+                "region": "us-east-1"
+            }
+        }
+    }]'
+) AS SELECT * FROM t0;
+
+-- Index v1 using (id, sort) as a composite key.
+-- Both columns must correspond to the DynamoDB table's key schema.
+CREATE INDEX v1_idx ON v1(id, sort);
+```
+
+:::important
+Column names in the Feldera SQL index and in the DynamoDB table key schema must
+match exactly.
+:::

--- a/docs.feldera.com/docs/sidebars.js
+++ b/docs.feldera.com/docs/sidebars.js
@@ -377,6 +377,11 @@ const connectors = {
                 },
                 {
                     type: 'doc',
+                    id: 'connectors/sinks/dynamodb',
+                    label: 'DynamoDB (experimental)'
+                },
+                {
+                    type: 'doc',
                     id: 'connectors/sinks/snowflake',
                     label: 'Snowflake (experimental)'
                 },

--- a/openapi.json
+++ b/openapi.json
@@ -8912,6 +8912,92 @@
           }
         ]
       },
+      "DynamoDBWriteMode": {
+        "type": "string",
+        "description": "DynamoDB write API used by the output connector.",
+        "enum": [
+          "batch",
+          "transactional"
+        ]
+      },
+      "DynamoDBWriterConfig": {
+        "type": "object",
+        "description": "DynamoDB output connector configuration.",
+        "required": [
+          "table",
+          "region"
+        ],
+        "properties": {
+          "allow_cross_step_write_overlap": {
+            "type": "boolean",
+            "description": "Allow write requests from later DBSP steps to be submitted before all\nwrite requests from previous steps have completed.\n\nThe default is `false`, each `batch_end` waits until all writes for that\nbatch have drained before the next step can be encoded. Setting this to\n`true` can increase throughput for small steps by keeping DynamoDB requests\nin flight across step boundaries. This allows writes from different steps to\noverlap; use it for insert-only or mostly disjoint-key workloads where cross-step\nwrite ordering to the same DynamoDB item is not required.",
+            "default": false
+          },
+          "aws_access_key_id": {
+            "type": "string",
+            "description": "AWS access key ID.\n\nIf both `aws_access_key_id` and `aws_secret_access_key` are specified,\nthe connector uses these static credentials. Otherwise it uses the\ndefault AWS credential provider chain, including IAM Roles for Service\nAccounts (IRSA) in EKS.\n\nStatic credentials are treated as long-lived IAM keys: no session token\nis sent, so STS-issued temporary credentials are not supported via these\nfields. To use temporary credentials, rely on the default provider chain\ninstead (leave these unset).",
+            "nullable": true
+          },
+          "aws_secret_access_key": {
+            "type": "string",
+            "description": "AWS secret access key.",
+            "nullable": true
+          },
+          "batch_size": {
+            "type": "integer",
+            "description": "Maximum number of write requests in one DynamoDB write call.\n\nDynamoDB supports at most 100 for `TransactWriteItems` and at most 25\nfor `BatchWriteItem`. If omitted, the connector uses the maximum for\nthe selected `write_mode`.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "endpoint_url": {
+            "type": "string",
+            "description": "Optional endpoint URL, for example when using a local\nDynamoDB-compatible service.",
+            "nullable": true
+          },
+          "max_buffer_size_bytes": {
+            "type": "integer",
+            "description": "Maximum number of bytes buffered by each worker before flushing writes.\n\nThis is an approximate size based on encoded DynamoDB attributes.",
+            "default": 1048576,
+            "minimum": 0
+          },
+          "max_concurrent_requests": {
+            "type": "integer",
+            "description": "Maximum number of DynamoDB write requests in flight per worker thread.\n\nThe total in-flight request count across the connector is\n`threads × max_concurrent_requests`. Size this accordingly when\ntuning against a provisioned-throughput table to avoid excessive\nthrottling.",
+            "default": 64,
+            "minimum": 0
+          },
+          "max_retries": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of retries for a failed or partially-applied DynamoDB write chunk.\n\nFor `batch` writes, `BatchWriteItem` may return some items as \"unprocessed\" in a\nsuccessful 200 response; those are re-submitted and counted as retries. For\n`transactional` writes, a failed `TransactWriteItems` call is retried in full.\n\nTransient errors (throttling, network failures) are first handled transparently by the\nAWS SDK. Only attempts that reach this connector's retry loop count against this limit.\nEach retry waits longer than the previous one (exponential backoff), up to a ceiling\nof roughly 13 seconds.\n\nSet to `null` to retry indefinitely. After the backoff ceiling is reached the connector\nkeeps retrying at that interval, providing backpressure until DynamoDB recovers.\nDefaults to `10`.",
+            "default": 10,
+            "nullable": true,
+            "minimum": 0
+          },
+          "region": {
+            "type": "string",
+            "description": "AWS region."
+          },
+          "table": {
+            "type": "string",
+            "description": "Name of the DynamoDB table to write to."
+          },
+          "threads": {
+            "type": "integer",
+            "description": "Number of worker threads used to encode and write disjoint key ranges.",
+            "default": 1,
+            "minimum": 0
+          },
+          "write_mode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DynamoDBWriteMode"
+              }
+            ],
+            "default": "batch"
+          }
+        }
+      },
       "ErrorResponse": {
         "type": "object",
         "description": "Information returned by REST API endpoints on error.",
@@ -13788,6 +13874,24 @@
                 "type": "string",
                 "enum": [
                   "delta_table_output"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/DynamoDBWriterConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "dynamodb_output"
                 ]
               }
             }


### PR DESCRIPTION
Adds an integrated output connector that writes output to a DynamoDB table.
The output view is materialized in the DynamoDB table.

Inserts and updates are treated as `PutItem` requests and deletes are
`DeleteItem`.

By default, we use the `BatchWriteItem` api. Transaction write mode is
supported as well, but the performance is typically worse for it, as it is a
more expensive operation.

This connector supports multithreading, but it isn't really beneficial as
encoding isn't the bottleneck, writing to DynamoDB is. The best way of
increasing throughput is to increase the `max_concurrent_requests` parameter.

Each DynamoDB worker thread, spawns `max_concurrent_requests` tokio tasks that
write to the DynamoDB table.
### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

-  [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

