### PR TITLE
[SQL] Support INTERSECT/EXCEPT ALL by rewriting using the new `positive` operator

### DIFF
--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -337,7 +337,7 @@ query
       |   query UNION [ ALL | DISTINCT ] query
       |   query EXCEPT [ DISTINCT ] query
       |   query MINUS [ DISTINCT ] query
-      |   query INTERSECT [ DISTINCT ] query
+      |   query INTERSECT [ ALL | DISTINCT ] query
       }
       [ ORDER BY { ALL [ ASC | DESC ] [ NULLS FIRST | NULLS LAST ] | orderItem [, orderItem]* } ]
       [ LIMIT [ start, ] { count | ALL } ]
@@ -351,8 +351,7 @@ withItem
       AS '(' query ')'
 ```
 
-`MINUS` is equivalent to `EXCEPT`.  Note that `EXCEPT ALL` and
-`INTERSECT ALL` are currently not implemented.
+`MINUS` is equivalent to `EXCEPT`.
 
 <a id="values"></a>
 ```

--- a/docs.feldera.com/docs/sql/unsupported-operations.md
+++ b/docs.feldera.com/docs/sql/unsupported-operations.md
@@ -109,9 +109,6 @@ supported.
 columns. Refer to [PIVOT documentation](./aggregates.md#pivots) for
 example usage.  Dynamic `PIVOT` is not yet supported.
 
-## `INTERSECT ALL` and `EXCEPT ALL`
-`INTERSECT ALL` and `EXCEPT ALL` operations are not yet supported.
-
 ## `MULTISET` Data Type
 The `MULTISET` data type is not currently supported.
 

--- a/python/tests/runtime_aggtest/illarg_tests/test_grammar_tbl_fn.py
+++ b/python/tests/runtime_aggtest/illarg_tests/test_grammar_tbl_fn.py
@@ -356,7 +356,6 @@ class illarg_intersect_illegal(TstView):
 
 
 # INTERSECT ALL
-# Negative Test
 class illarg_intersect_all_illegal(TstView):
     def __init__(self):
         self.sql = """CREATE MATERIALIZED VIEW intersect_all_illegal AS SELECT
@@ -364,7 +363,7 @@ class illarg_intersect_all_illegal(TstView):
                       INTERSECT ALL
                       SELECT booll
                       FROM illegal_tbl"""
-        self.expected_error = "Not yet implemented"
+        self.data = [{"str": None}]
 
 
 # MINUS
@@ -381,14 +380,14 @@ class illarg_minus_illegal(TstView):
 
 # MINUS ALL
 # Negative Test
-class illarg_minus_all_illegal(TstView):
-    def __init__(self):
-        self.data = []
-        self.sql = """CREATE MATERIALIZED VIEW minus_all_illegal AS SELECT
-                      arr FROM illegal_tbl
-                      MINUS ALL
-                      SELECT arr FROM illegal_tbl"""
-        self.expected_error = "Not yet implemented"
+# class illarg_minus_all_illegal(TstView):
+#    def __init__(self):
+#        self.data = []
+#        self.sql = """CREATE MATERIALIZED VIEW minus_all_illegal AS SELECT
+#                      arr FROM illegal_tbl
+#                      MINUS ALL
+#                      SELECT arr FROM illegal_tbl"""
+#        self.expected_error = "Not yet implemented"
 
 
 # VALUES

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPositiveOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPositiveOperator.java
@@ -7,24 +7,16 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteEmptyRel;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
-import org.dbsp.sqlCompiler.ir.NonCoreIR;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-/** This operator does not exist in DBSP, it is purely used while computing monotonicity */
-@NonCoreIR
-public final class DBSPBinaryDistinctOperator extends DBSPBinaryOperator
+public final class DBSPPositiveOperator extends DBSPUnaryOperator
         implements IContainsIntegrator, IIncremental {
-    /** If true this is from a {@link DBSPPositiveOperator}, else it's from a {@link DBSPDistinctOperator}. */
-    public final boolean positive;
-
-    public DBSPBinaryDistinctOperator(CalciteRelNode node, OutputPort integral, OutputPort delta, boolean positive) {
-        super(node, "distinct_component", null, delta.outputType(), false, integral, delta);
-        this.positive = positive;
+    public DBSPPositiveOperator(CalciteRelNode node, OutputPort input) {
+        super(node, "positive", null, input.outputType(), false, input);
     }
 
     @Override
@@ -41,19 +33,16 @@ public final class DBSPBinaryDistinctOperator extends DBSPBinaryOperator
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2);
-            if (force || this.inputsDiffer(newInputs))
-                return new DBSPBinaryDistinctOperator(
-                        this.getRelNode(), newInputs.get(0), newInputs.get(1), this.positive).copyAnnotations(this);
+            return new DBSPPositiveOperator(
+                    this.getRelNode(), newInputs.get(0)).copyAnnotations(this);
         }
         return this;
     }
 
     @SuppressWarnings("unused")
-    public static DBSPBinaryDistinctOperator fromJson(JsonNode node, JsonDecoder decoder) {
+    public static DBSPPositiveOperator fromJson(JsonNode node, JsonDecoder decoder) {
         CommonInfo info = commonInfoFromJson(node, decoder);
-        boolean positive = Utilities.getBooleanProperty(node, "positive");
-        return new DBSPBinaryDistinctOperator(CalciteEmptyRel.INSTANCE, info.getInput(0), info.getInput(1), positive)
-                .addAnnotations(info.annotations(), DBSPBinaryDistinctOperator.class);
+        return new DBSPPositiveOperator(CalciteEmptyRel.INSTANCE, info.getInput(0))
+                .addAnnotations(info.annotations(), DBSPPositiveOperator.class);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -908,6 +908,26 @@ public class ToRustVisitor extends CircuitVisitor {
     }
 
     @Override
+    public VisitDecision preorder(DBSPPositiveOperator operator) {
+        // No "persistent" version
+        DBSPType streamType = this.streamType(operator);
+        this.writeComments(operator)
+                .append("let ")
+                .append(operator.getNodeName(this.preferHash))
+                .append(": ");
+        this.innerVisitor.setOperatorContext(operator);
+        streamType.accept(this.innerVisitor);
+        this.innerVisitor.setOperatorContext(null);
+        this.builder.append(" = ")
+                .append(this.getInputName(operator, 0))
+                .append(".")
+                .append(operator.operation)
+                .append("();");
+        this.tagStream(operator);
+        return VisitDecision.STOP;
+    }
+
+    @Override
     public VisitDecision preorder(DBSPControlledKeyFilterOperator operator) {
         // No need to use the Merkle Hash
         this.builder.append("let (")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -93,6 +93,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
@@ -1164,14 +1165,14 @@ public class CalciteToDBSPCompiler extends RelVisitor
 
     private void visitMinus(LogicalMinus minus) {
         IntermediateRel node = CalciteObject.create(minus);
-        boolean first = true;
         RelDataType rowType = minus.getRowType();
         DBSPTypeTuple outputType = this.convertType(node.getPositionRange(), rowType, false).to(DBSPTypeTuple.class);
-        List<OutputPort> inputs = new ArrayList<>();
         this.checkPermutation(node, minus.getInputs(), "EXCEPT");
 
+        boolean first = true;
+        List<OutputPort> inputs = new ArrayList<>(minus.getInputs().size());
         for (RelNode input : minus.getInputs()) {
-            DBSPSimpleOperator opInput = this.getInputAs(input, false);
+            DBSPSimpleOperator opInput = this.getInputAs(input, minus.all);
             if (!first) {
                 DBSPSimpleOperator neg = new DBSPNegateOperator(node, opInput.outputPort());
                 this.addOperator(neg);
@@ -1193,14 +1194,19 @@ public class CalciteToDBSPCompiler extends RelVisitor
             first = false;
         }
 
+        DBSPSumOperator sum = new DBSPSumOperator(node, inputs);
+        final DBSPSimpleOperator result;
+        this.addOperator(sum);
         if (minus.all) {
-            throw new UnimplementedException("EXCEPT/MINUS ALL", 5483, node);
+            DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(node, sum.outputPort());
+            this.addOperator(diff);
+            DBSPPositiveOperator pos = new DBSPPositiveOperator(node, diff.outputPort());
+            this.addOperator(pos);
+            result = new DBSPIntegrateOperator(node.getFinal(), pos.outputPort());
         } else {
-            DBSPSumOperator sum = new DBSPSumOperator(node, inputs);
-            this.addOperator(sum);
-            DBSPStreamDistinctOperator d = new DBSPStreamDistinctOperator(node.getFinal(), sum.outputPort());
-            this.assignOperator(minus, d);
+            result = new DBSPStreamDistinctOperator(node.getFinal(), sum.outputPort());
         }
+        this.assignOperator(minus, result);
     }
 
     void visitFilter(LogicalFilter filter) {
@@ -2429,40 +2435,67 @@ public class CalciteToDBSPCompiler extends RelVisitor
         return result;
     }
 
+    private DBSPSimpleOperator
+    except(IntermediateRel node, DBSPSimpleOperator left, DBSPSimpleOperator right, boolean all, boolean needsDistinct) {
+        List<OutputPort> inputs = new ArrayList<>(2);
+        inputs.add(left.outputPort());
+        DBSPSimpleOperator neg = new DBSPNegateOperator(node, right.outputPort());
+        this.addOperator(neg);
+        inputs.add(neg.outputPort());
+        DBSPSumOperator sum = new DBSPSumOperator(node, inputs);
+        this.addOperator(sum);
+        if (!needsDistinct)
+            return sum;
+
+        final DBSPSimpleOperator result;
+        if (all) {
+            DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(node, sum.outputPort());
+            this.addOperator(diff);
+            DBSPPositiveOperator pos = new DBSPPositiveOperator(node, diff.outputPort());
+            this.addOperator(pos);
+            result = new DBSPIntegrateOperator(node.getFinal(), pos.outputPort());
+        } else {
+            result = new DBSPStreamDistinctOperator(node.getFinal(), sum.outputPort());
+        }
+        this.addOperator(result);
+        return result;
+    }
+
     void visitIntersect(LogicalIntersect intersect) {
-        var node = CalciteObject.create(intersect);
-        // Intersect is a special case of join.
-        List<RelNode> inputs = intersect.getInputs();
-        RelNode input = intersect.getInput(0);
-        DBSPSimpleOperator previous = this.getInputAs(input, false);
-        this.checkPermutation(node, inputs, "INTERSECT");
+        // A INTERSECT B = A EXCEPT (A EXCEPT B)
+        // A INTERSECT ALL B = A EXCEPT ALL (A EXCEPT ALL B)
+        IntermediateRel node = CalciteObject.create(intersect);
+        RelDataType rowType = intersect.getRowType();
+        DBSPTypeTuple outputType = this.convertType(node.getPositionRange(), rowType, false).to(DBSPTypeTuple.class);
+        List<RelNode> relInputs = intersect.getInputs();
+        this.checkPermutation(node, relInputs, "INTERSECT");
 
-        if (inputs.isEmpty())
+        if (relInputs.isEmpty())
             throw new UnsupportedException(node);
-        if (intersect.all)
-            throw new UnimplementedException("INTERSECT ALL", node);
-        if (inputs.size() == 1) {
-            Utilities.putNew(this.nodeOperator, intersect, previous);
-            return;
+
+        DBSPSimpleOperator current = null;
+        for (RelNode input : intersect.getInputs()) {
+            DBSPSimpleOperator opInput = this.getInputAs(input, intersect.all);
+            DBSPTypeTuple inputRowType = opInput.getOutputZSetElementType().to(DBSPTypeTuple.class);
+            List<Integer> filterIndexes = new ArrayList<>();
+            for (int i = 0; i < outputType.size(); i++) {
+                if (inputRowType.getFieldType(i).mayBeNull && !outputType.getFieldType(i).mayBeNull)
+                    filterIndexes.add(i);
+            }
+
+            DBSPSimpleOperator filter =
+                    this.filterNonNullFields(node, CalciteObject.EMPTY, filterIndexes, opInput, false);
+            DBSPSimpleOperator next = this.castOutput(node, filter, outputType);
+            if (current == null)
+                current = next;
+            else {
+                DBSPSimpleOperator crtExceptNext = this.except(node, current, next, intersect.all, true);
+                current = this.except(node, current, crtExceptNext, intersect.all, false);
+            }
         }
 
-        DBSPTypeTuple resultType = this.convertType(node.getPositionRange(), intersect.getRowType(), false)
-                .to(DBSPTypeTuple.class);
-        DBSPMapIndexOperator previousIndex = this.indexEntireTuple(node, previous.outputPort(), resultType);
-
-        for (int i = 1; i < inputs.size(); i++) {
-            DBSPSimpleOperator inputI = this.getInputAs(intersect.getInput(i), false);
-            DBSPMapIndexOperator index = this.indexEntireTuple(node, inputI.outputPort(), resultType);
-            // Join with the current result
-            DBSPVariablePath l = DBSPTypeTuple.EMPTY.ref().var();
-            DBSPVariablePath r = DBSPTypeTuple.EMPTY.ref().var();
-            DBSPVariablePath k = resultType.ref().var();
-            DBSPClosureExpression closure = DBSPTupleExpression.flatten(k.deref()).closure(k, l, r);
-            previous = new DBSPStreamJoinOperator(node, TypeCompiler.makeZSet(resultType),
-                    closure, false, previousIndex.outputPort(), index.outputPort(), false);
-            this.addOperator(previous);
-        }
-        Utilities.putNew(this.nodeOperator, intersect, previous);
+        Utilities.enforce(current != null);
+        Utilities.putNew(this.nodeOperator, intersect, current);
     }
 
     /** If this is not null, the parent LogicalFilter should use this implementation

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
@@ -333,6 +333,12 @@ public class CalciteOptimizer implements IWritesLogs {
                 new InnerDecorrelator()));
         this.addStep(new SimpleOptimizerStep("Desugar EXCEPT", 2,
                 new ExceptOptimizerRule()));
+        this.addStep(new SimpleOptimizerStep("Rewrite INTERSECT/EXCEPT ALL", 0,
+                CoreRules.UNION_MERGE,
+                CoreRules.MINUS_MERGE,
+                CoreRules.INTERSECT_MERGE,
+                new ExceptAllFoldRule()
+        ));
         this.addStep(new CalciteOptimizerStep() {
             @Override
             public String getName() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ExceptAllFoldRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ExceptAllFoldRule.java
@@ -1,0 +1,68 @@
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.optimizer;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.tools.RelBuilder;
+
+import java.util.List;
+
+/**
+ * Rewrites an n-ary {@code EXCEPT ALL} (n &gt; 2 inputs) into a binary one by
+ * collapsing inputs 1..n-1 into a single {@code UNION ALL}.
+ *
+ * <p>The transformation is:
+ * <pre>{@code
+ * A EXCEPT ALL B1 EXCEPT ALL ... EXCEPT ALL Bn
+ *   =>
+ * A EXCEPT ALL (B1 UNION ALL ... UNION ALL Bn)
+ * }</pre>
+ *
+ * <p>This is semantically correct because the number of copies of value {@code v}
+ * retained by EXCEPT ALL is {@code max(0, count_A(v) - count_B1(v) - ... - count_Bn(v))},
+ * which equals the result obtained by subtracting the combined right-side multiplicity
+ * {@code count_B1(v) + ... + count_Bn(v)} in a single step.
+ */
+public class ExceptAllFoldRule
+        extends RelRule<DefaultOptRuleConfig<ExceptAllFoldRule>>
+        implements TransformationRule {
+
+    protected ExceptAllFoldRule() {
+        super(CONFIG);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Minus minus = call.rel(0);
+        assert minus.all;
+
+        List<RelNode> inputs = minus.getInputs();
+        assert inputs.size() > 2;
+
+        RelBuilder builder = call.builder();
+
+        // Push left side (input[0]).
+        builder.push(inputs.get(0));
+
+        // UNION ALL inputs[1..n-1] into a single right-side relation.
+        builder.push(inputs.get(1));
+        for (int i = 2; i < inputs.size(); i++) {
+            builder.push(inputs.get(i));
+            builder.union(true);  // UNION ALL
+        }
+
+        // Produce a binary EXCEPT ALL(input[0], union_all).
+        builder.minus(true);  // EXCEPT ALL
+
+        call.transformTo(builder.build());
+    }
+
+    public static final DefaultOptRuleConfig<ExceptAllFoldRule> CONFIG =
+            DefaultOptRuleConfig.<ExceptAllFoldRule>create()
+                    .withOperandSupplier(b ->
+                            b.operand(Minus.class)
+                             .predicate(m -> m.all && m.getInputs().size() > 2)
+                             .anyInputs());
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
@@ -17,6 +17,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRankOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRowNumberOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
@@ -162,6 +163,11 @@ public class AppendOnly extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPDistinctOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator node) {
         this.copy(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -459,6 +459,11 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
     }
 
     @Override
+    public void postorder(DBSPPositiveOperator operator) {
+        this.replace(operator);
+    }
+
+    @Override
     public void postorder(DBSPBinaryDistinctOperator operator) {
         this.replace(operator);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -346,6 +346,10 @@ public abstract class CircuitVisitor
         return this.preorder((DBSPUnaryOperator) node);
     }
 
+    public VisitDecision preorder(DBSPPositiveOperator node) {
+        return this.preorder((DBSPUnaryOperator) node);
+    }
+
     public VisitDecision preorder(DBSPBinaryDistinctOperator node) {
         return this.preorder((DBSPBinaryOperator) node);
     }
@@ -722,6 +726,10 @@ public abstract class CircuitVisitor
     }
 
     public void postorder(DBSPDistinctOperator node) {
+        this.postorder((DBSPUnaryOperator) node);
+    }
+
+    public void postorder(DBSPPositiveOperator node) {
         this.postorder((DBSPUnaryOperator) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
@@ -44,8 +44,14 @@ public class OptimizeDistinctVisitor extends CircuitCloneVisitor {
             !input.isMultiset()) {
             this.map(distinct.outputPort(), input, false);
             return;
-        }
-        if (input.node().is(DBSPStreamJoinOperator.class) ||
+        } else if (input.node().is(DBSPPositiveOperator.class)) {
+            // distinct(positive(x)) = distinct(x)
+            DBSPSimpleOperator newDistinct = distinct
+                    .withInputs(Linq.list(input.simpleNode().inputs.get(0)), false)
+                    .to(DBSPSimpleOperator.class);
+            this.map(distinct, newDistinct);
+            return;
+        } else if (input.node().is(DBSPStreamJoinOperator.class) ||
             input.node().is(DBSPMapOperator.class) ||
             input.node().is(DBSPSumOperator.class) ||
             input.node().is(DBSPAtomicSumOperator.class)) {
@@ -68,8 +74,21 @@ public class OptimizeDistinctVisitor extends CircuitCloneVisitor {
     }
 
     @Override
+    public void postorder(DBSPPositiveOperator operator) {
+        OutputPort input = this.mapped(operator.input());
+        if (input.node().is(DBSPPositiveOperator.class)
+            || input.node().is(DBSPDistinctOperator.class)) {
+            // positive(distinct(x)) = distinct(x);
+            // positive(positive(x)) = positive(X)
+            this.map(operator.outputPort(), input, false);
+            return;
+        }
+        super.postorder(operator);
+    }
+
+    @Override
     public void postorder(DBSPDistinctOperator distinct) {
-        // distinct (distinct) = distinct
+        // distinct (distinct(x)) = distinct(x)
         OutputPort input = this.mapped(distinct.input());
         if (input.node().is(DBSPStreamDistinctOperator.class) ||
             input.node().is(DBSPDistinctOperator.class) ||
@@ -82,7 +101,7 @@ public class OptimizeDistinctVisitor extends CircuitCloneVisitor {
                 input.node().is(DBSPSumOperator.class)) {
             boolean allDistinct = Linq.all(input.node().inputs, i -> i.node().is(DBSPStreamDistinctOperator.class));
             if (allDistinct) {
-                // distinct(map(distinct)) = distinct(map)
+                // distinct(map(distinct(x))) = distinct(map(x))
                 List<OutputPort> newInputs = Linq.map(input.node().inputs, i -> i.node().inputs.get(0));
                 DBSPSimpleOperator newInput = input.simpleNode()
                         .withInputs(newInputs, false)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
@@ -17,6 +17,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinOperator;
@@ -128,6 +129,12 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPDistinctOperator operator) {
+        if (this.replaceUnary(operator))
+            super.postorder(operator);
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator operator) {
         if (this.replaceUnary(operator))
             super.postorder(operator);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/DeltaExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/DeltaExpandOperators.java
@@ -24,6 +24,8 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
@@ -219,7 +221,18 @@ public class DeltaExpandOperators extends CircuitCloneVisitor {
         DBSPIntegrateOperator integrator = new DBSPIntegrateOperator(operator.getRelNode(), input);
         this.addOperator(integrator);
         DBSPBinaryDistinctOperator distinct =
-                new DBSPBinaryDistinctOperator(operator.getRelNode(), integrator.outputPort(), input);
+                new DBSPBinaryDistinctOperator(operator.getRelNode(), integrator.outputPort(), input, false);
+        this.addExpansion(operator, new DistinctDeltaExpansion(integrator, distinct));
+        this.map(operator, distinct);
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator operator) {
+        OutputPort input = this.mapped(operator.input());
+        DBSPIntegrateOperator integrator = new DBSPIntegrateOperator(operator.getRelNode(), input);
+        this.addOperator(integrator);
+        DBSPBinaryDistinctOperator distinct =
+                new DBSPBinaryDistinctOperator(operator.getRelNode(), integrator.outputPort(), input, true);
         this.addExpansion(operator, new DistinctDeltaExpansion(integrator, distinct));
         this.map(operator, distinct);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -809,21 +809,17 @@ public class InsertLimiters extends CircuitCloneVisitor {
         super.postorder(operator);
     }
 
-    @Override
-    public void postorder(DBSPDistinctOperator operator) {
+    // Handle DBSPDistinctOperator and DBSPPositiveOperator
+    boolean processDistinct(DBSPUnaryOperator operator) {
         OutputPort source = this.mapped(operator.input());
         OperatorDeltaExpansion expanded = this.expandedInto.get(operator);
         if (expanded == null) {
-            super.postorder(operator);
-            this.nonMonotone(operator);
-            return;
+            return false;
         }
         DistinctDeltaExpansion expansion = expanded.to(DistinctDeltaExpansion.class);
         OutputPort sourceLimiter = this.bound.get(operator.input());
         if (sourceLimiter == null) {
-            super.postorder(operator);
-            this.nonMonotone(operator);
-            return;
+            return false;
         }
 
         DBSPSimpleOperator result = operator.withInputs(Linq.list(source), false)
@@ -835,6 +831,25 @@ public class InsertLimiters extends CircuitCloneVisitor {
         this.markBound(expansion.distinct.outputPort(), sourceLimiter);
         this.markBound(operator.outputPort(), sourceLimiter);
         this.map(operator, result, true);
+        return true;
+    }
+
+    @Override
+    public void postorder(DBSPDistinctOperator operator) {
+        boolean monotone = this.processDistinct(operator);
+        if (!monotone) {
+            super.postorder(operator);
+            this.nonMonotone(operator);
+        }
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator operator) {
+        boolean monotone = this.processDistinct(operator);
+        if (!monotone) {
+            super.postorder(operator);
+            this.nonMonotone(operator);
+        }
     }
 
     /** Represents a join and the two inputs.  onLeft is true if a retainKeys operator was inserted on the left input */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/KeyPropagation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/KeyPropagation.java
@@ -11,6 +11,8 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
@@ -477,6 +479,11 @@ public class KeyPropagation extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPDistinctOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator source) {
         this.copy(source);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -21,6 +21,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
@@ -556,6 +557,11 @@ public class Monotonicity extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPDistinctOperator node) {
+        this.identity(node);
+    }
+
+    @Override
+    public void postorder(DBSPPositiveOperator node) {
         this.identity(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
@@ -10,6 +10,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPLagOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRankOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRowNumberOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
@@ -67,6 +68,7 @@ public class SeparateIntegrators extends CircuitCloneWithGraphsVisitor {
                 (operator.is(DBSPWindowOperator.class) && input == 0) ||
                 operator.is(DBSPPartitionedRollingAggregateOperator.class) ||
                 operator.is(DBSPDistinctOperator.class) ||
+                operator.is(DBSPPositiveOperator.class) ||
                 operator.is(DBSPAggregateOperator.class) ||
                 operator.is(DBSPIntegrateOperator.class) ||
                 operator.is(DBSPLagOperator.class) ||

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
@@ -32,6 +32,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPFailExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
@@ -165,8 +166,14 @@ public class DBSPTypeTuple extends DBSPTypeTupleBase {
             casts[i] = casts[i].call(var.deepCopy().deref().field(i).borrow());
         }
         DBSPExpression result = new DBSPTupleExpression(to.mayBeNull, casts);
-        if (this.mayBeNull)
-            result = new DBSPIfExpression(CalciteObject.EMPTY, var.deref().is_null(), to.none(), result);
+        if (this.mayBeNull) {
+            final DBSPExpression tup;
+            if (to.mayBeNull)
+                tup = to.none();
+            else
+                tup = new DBSPFailExpression(CalciteObject.EMPTY, to, "Cast to non-nullable value applied to NULL");
+            result = new DBSPIfExpression(CalciteObject.EMPTY, var.deref().is_null(), tup, result);
+        }
         return result.closure(var);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -496,6 +496,16 @@ public class EndToEndTests extends BaseSQLTests {
     }
 
     @Test
+    public void intersectAllTest() {
+        // Both rows in T have COL1=10, so SELECT COL1 is a multiset {10, 10}.
+        // INTERSECT ALL with itself returns the same multiset: {10, 10} (weight 2).
+        DBSPTupleExpression ten = new DBSPTupleExpression(new DBSPI32Literal(10));
+        this.testQuery(
+                "SELECT COL1 FROM T INTERSECT ALL SELECT COL1 FROM T",
+                new DBSPZSetExpression(ten, ten));
+    }
+
+    @Test
     public void plusNullTest() {
         String query = "SELECT T.COL1 + T.COL5 FROM T";
         this.testQuery(query,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -1324,16 +1324,16 @@ public class Regression1Tests extends SqlIoTest {
                 """
                  id | step | en   | ss | ts  | x |     y |     z
                 ---------------------------------------------------
-                 1 | true  | beta|      10 | 116 | 0 | false | true
-                 1 | true  | alpha|     10 | 590 | 47| true  | true
-                 1 | true  | alpha|     10 | 597 | 0 | true  | false
-                 1 | true  | gamma|     10 | 604 | 0 | true  | true
+                 1 | true  | beta|	10 | 116 | 0 | false | true
+                 1 | true  | alpha|	10 | 590 | 47| true  | true
+                 1 | true  | alpha|	10 | 597 | 0 | true  | false
+                 1 | true  | gamma|	10 | 604 | 0 | true  | true
                  1 | true  | delta| 20 | 618 | 1 | true  | false
-                 2 | false | beta|      10 | 593 | 0 | false | true
-                 2 | false | alpha|     25 | 600 | 0 | false | false
-                 2 | false | eta|       12 | 608 | 0 | false | false
-                 2 | false | gamma|     25 | 615 | 0 | false | false
-                 2 | false | gamma|     25 | 622 | 0 | false | false""");
+                 2 | false | beta|	10 | 593 | 0 | false | true
+                 2 | false | alpha|	25 | 600 | 0 | false | false
+                 2 | false | eta|	12 | 608 | 0 | false | false
+                 2 | false | gamma|	25 | 615 | 0 | false | false
+                 2 | false | gamma|	25 | 622 | 0 | false | false""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -41,28 +41,6 @@ public class Regression2Tests extends SqlIoTest {
     }
 
     @Test
-    public void issue5481() {
-        this.statementsFailingInCompilation("""
-                CREATE TABLE tbl(
-                str VARCHAR,
-                bin BINARY,
-                uuidd UUID,
-                arr VARCHAR ARRAY);
-                
-                CREATE MATERIALIZED VIEW v1 AS
-                SELECT str FROM tbl
-                EXCEPT ALL
-                SELECT arr[1] FROM tbl;""", "Not yet implemented: EXCEPT/MINUS ALL");
-    }
-
-    @Test
-    public void intersectAllTest() {
-        this.statementsFailingInCompilation("""
-                CREATE TABLE T(x INT);
-                CREATE VIEW V AS SELECT * FROM T INTERSECT ALL SELECT * FROM T;""", "Not yet implemented: INTERSECT ALL");
-    }
-
-    @Test
     public void issue5425() {
         this.statementsFailingInCompilation("""
                 CREATE TABLE  tbl(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SetOpTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SetOpTests.java
@@ -3,12 +3,25 @@ package org.dbsp.sqlCompiler.compiler.sql.simple;
 import org.dbsp.sqlCompiler.compiler.sql.quidem.ScottBaseTests;
 import org.junit.Test;
 
-/** End-to-end tests for SQL set operations: UNION, INTERSECT, EXCEPT.
+/** End-to-end tests for SQL set operations: UNION, UNION ALL, INTERSECT, INTERSECT ALL, EXCEPT.
  * Some tests are from set-op.iq */
 public class SetOpTests extends ScottBaseTests {
     @Test
     public void calciteIntersect() {
         this.qst("""
+             -- Intersect all
+            select * from
+            (select x, y from (values (1, 'a'), (1, 'a'), (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y))
+            intersect all
+            (select x, y from (values (1, 'a'), (1, 'a'), (2, 'c'), (4, 'x')) as t2(x, y));
+            +---+---+
+            | X | Y |
+            +---+---+
+            | 1 | a |
+            | 1 | a |
+            +---+---+
+            (2 rows)
+
             -- Intersect
             select * from
             (select x, y from (values (1, 'a'), (1, 'a'), (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y))
@@ -20,6 +33,21 @@ public class SetOpTests extends ScottBaseTests {
             | 1 | a |
             +---+---+
             (1 row)
+
+            -- Intersect all with null value rows
+            select * from
+            (select x, y from (values (cast(NULL as int), cast(NULL as varchar(1))),
+            (cast(NULL as int), cast(NULL as varchar(1))), (cast(NULL as int), cast(NULL as varchar(1)))) as t(x, y))
+            intersect all
+            (select x, y from (values (cast(NULL as int), cast(NULL as varchar(1))),
+            (cast(NULL as int), cast(NULL as varchar(1)))) as t2(x, y));
+            +----+----+
+            | X  | Y  |
+            +----+----+
+            |NULL|NULL|
+            |NULL|NULL|
+            +----+----+
+            (2 rows)
 
             -- Intersect with null value rows
             select * from
@@ -109,6 +137,21 @@ public class SetOpTests extends ScottBaseTests {
     @Test
     public void calciteExcept() {
         this.qst("""
+            -- Except all
+            select * from
+            (select x, y from (values (1, 'a'), (1, 'a'), (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y))
+            except all
+            (select x, y from (values (1, 'a'), (2, 'c'), (4, 'x')) as t2(x, y));
+            +---+---+
+            | X | Y |
+            +---+---+
+            | 1 | a |
+            | 1 | a |
+            | 2 | b |
+            | 3 | c |
+            +---+---+
+            (4 rows)
+
             -- Except
             select * from
             (select x, y from (values (1, 'a'), (1, 'a'), (1, 'a'), (2, 'b'), (3, 'c')) as t(x, y))
@@ -121,6 +164,20 @@ public class SetOpTests extends ScottBaseTests {
             | 3 | c |
             +---+---+
             (2 rows)
+
+            -- Except all with null value rows
+            select * from
+            (select x, y from (values (cast(NULL as int), cast(NULL as varchar(1))),
+            (cast(NULL as int), cast(NULL as varchar(1))), (cast(NULL as int), cast(NULL as varchar(1)))) as t(x, y))
+            except all
+            (select x, y from (values (cast(NULL as int), cast(NULL as varchar(1))),
+            (cast(NULL as int), cast(NULL as varchar(1)))) as t2(x, y));
+            +----+----+
+            | X  | Y  |
+            +----+----+
+            |NULL|NULL|
+            +----+----+
+            (1 row)
 
             -- Except with null value rows
             select * from
@@ -217,10 +274,6 @@ public class SetOpTests extends ScottBaseTests {
             (1 row)""");
     }
 
-    // -----------------------------------------------------------------------
-    // UNION / UNION ALL
-    // -----------------------------------------------------------------------
-
     @Test
     public void testUnionBasic() {
         this.qst("""
@@ -296,10 +349,6 @@ public class SetOpTests extends ScottBaseTests {
                 (4 rows)""");
     }
 
-    // -----------------------------------------------------------------------
-    // INTERSECT (distinct)
-    // -----------------------------------------------------------------------
-
     @Test
     public void testIntersectBasic() {
         this.qst("""
@@ -361,18 +410,113 @@ public class SetOpTests extends ScottBaseTests {
                 (1 row)""");
     }
 
-    /** INTERSECT: all 16 combinations of which column(s) hold NULL and on which side. */
     @Test
-    public void testIntersectNullTwoInts() {
-        for (boolean nullInFirst : new boolean[]{true, false}) {
-            for (boolean nullInSecond : new boolean[]{true, false}) {
-                for (boolean nullOnLeft : new boolean[]{true, false}) {
-                    for (boolean nullOnRight : new boolean[]{true, false}) {
-                        checkSetOpNullTwoInts("INTERSECT", nullInFirst, nullInSecond, nullOnLeft, nullOnRight);
-                    }
-                }
-            }
-        }
+    public void testIntersectAllBasic() {
+        // A = {1, 2, 2}  B = {2, 2, 3}
+        // Result = {2, 2}  (min(0,0)=0 for 1 and 3, min(2,2)=2 for 2)
+        this.qst("""
+                SELECT * FROM (VALUES (1), (2), (2)) AS T(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (2), (2), (3)) AS T(x);
+                 x
+                ---
+                 2
+                 2
+                (2 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllMinCounts() {
+        // A = {1, 1, 1}  B = {1, 1}
+        // Result = {1, 1}  (min(3, 2) = 2)
+        this.qst("""
+                SELECT * FROM (VALUES (1), (1), (1)) AS T(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (1), (1)) AS T(x);
+                 x
+                ---
+                 1
+                 1
+                (2 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllEmpty() {
+        // No common values: result is empty.
+        this.qst("""
+                SELECT * FROM (VALUES (1), (2)) AS T(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (3), (4)) AS T(x);
+                 x
+                ---
+                (0 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllNull() {
+        // A = {NULL, NULL, 1}  B = {NULL, 1, 1}
+        // Result = {NULL, 1}  (min(2,1)=1 for NULL, min(1,2)=1 for 1)
+        this.qst("""
+                SELECT * FROM (VALUES (CAST(NULL AS INT)), (CAST(NULL AS INT)), (1)) AS T(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (CAST(NULL AS INT)), (1), (1)) AS T(x);
+                 x
+                ------
+                 NULL
+                 1
+                (2 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllNullBothSides() {
+        // A = {NULL, NULL}  B = {NULL, NULL, NULL}
+        // Result = {NULL, NULL}  (min(2, 3) = 2)
+        this.qst("""
+                SELECT * FROM (VALUES (CAST(NULL AS INT)), (CAST(NULL AS INT))) AS T(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (CAST(NULL AS INT)), (CAST(NULL AS INT)), (CAST(NULL AS INT))) AS T(x);
+                 x
+                ------
+                 NULL
+                 NULL
+                (2 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllMultiColumn() {
+        // A = {(1,'a')x2, (2,NULL)x1, (NULL,'c')x1}
+        // B = {(1,'a')x1, (2,NULL)x2, (NULL,'c')x1}
+        // Result: each value appears min(count_A, count_B) times:
+        //   (1,'a'): min(2,1) = 1
+        //   (2,NULL): min(1,2) = 1
+        //   (NULL,'c'): min(1,1) = 1
+        this.qst("""
+                SELECT * FROM (VALUES (1, 'a'), (1, 'a'), (2, CAST(NULL AS VARCHAR)), (CAST(NULL AS INT), 'c')) AS T(x, s)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (1, 'a'), (2, CAST(NULL AS VARCHAR)), (2, CAST(NULL AS VARCHAR)), (CAST(NULL AS INT), 'c')) AS T(x, s);
+                 x    | s
+                ----------
+                 1    | a
+                 2    |NULL
+                NULL  | c
+                (3 rows)""");
+    }
+
+    @Test
+    public void testIntersectAllThreeWay() {
+        // A = {1, 1, 2, 3}  B = {1, 2, 2}  C = {1, 1, 1, 2}
+        // Result: 1 → min(2,1,3)=1;  2 → min(1,2,1)=1;  3 → min(1,0,0)=0
+        this.qst("""
+                SELECT * FROM (VALUES (1), (1), (2), (3)) AS A(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (1), (2), (2)) AS B(x)
+                INTERSECT ALL
+                SELECT * FROM (VALUES (1), (1), (1), (2)) AS C(x);
+                 x
+                ---
+                 1
+                 2
+                (2 rows)""");
     }
 
     @Test
@@ -484,7 +628,7 @@ public class SetOpTests extends ScottBaseTests {
         String ry = (nullOnRight && nullInSecond) ? "CAST(NULL AS INT)" : "10";
 
         boolean rowsMatch = lx.equals(rx) && ly.equals(ry);
-        boolean hasResult = op.equals("INTERSECT") ? rowsMatch : !rowsMatch;
+        boolean hasResult = op.equals("INTERSECT") == rowsMatch;
 
         String resultX = lx.contains("NULL") ? "NULL" : "10";
         String resultY = ly.contains("NULL") ? "NULL" : "10";
@@ -508,6 +652,20 @@ public class SetOpTests extends ScottBaseTests {
                 for (boolean nullOnLeft : new boolean[]{true, false}) {
                     for (boolean nullOnRight : new boolean[]{true, false}) {
                         checkSetOpNullTwoInts("EXCEPT", nullInFirst, nullInSecond, nullOnLeft, nullOnRight);
+                    }
+                }
+            }
+        }
+    }
+
+    /** INTERSECT: all 16 combinations of which column(s) hold NULL and on which side. */
+    @Test
+    public void testIntersectNullTwoInts() {
+        for (boolean nullInFirst : new boolean[]{true, false}) {
+            for (boolean nullInSecond : new boolean[]{true, false}) {
+                for (boolean nullOnLeft : new boolean[]{true, false}) {
+                    for (boolean nullOnRight : new boolean[]{true, false}) {
+                        checkSetOpNullTwoInts("INTERSECT", nullInFirst, nullInSecond, nullOnLeft, nullOnRight);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #6436
Fixes #5483 

`EXCEPT ALL` is implemented using the newly-merged DBSP `positive` operator.
`A INTERSECT ALL B` is rewritten as `A EXCEPT ALL (A EXCEPT ALL B)`. A similar rule is used for simple `INTERSECT` instead of synthesizing a join.

### Describe Manual Test Plan

Ran all the new Java tests.

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
