### PR TITLE
pipeline-manager: API type of `schema` is again `ProgramSchema`

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -29,6 +29,7 @@ use chrono::{DateTime, Utc};
 use feldera_types::adapter_stats::PipelineStatsErrorsResponse;
 use feldera_types::config::{InputEndpointConfig, OutputEndpointConfig, RuntimeConfig};
 use feldera_types::error::ErrorResponse;
+use feldera_types::program_schema::ProgramSchema;
 use feldera_types::runtime_status::{
     BootstrapConfig, BootstrapPolicy, RuntimeDesiredStatus, RuntimeStatus,
 };
@@ -49,7 +50,7 @@ pub mod pipeline_events;
 #[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
 pub struct PartialProgramInfo {
     /// Schema of the compiled SQL.
-    pub schema: serde_json::Value,
+    pub schema: ProgramSchema,
 
     /// Generated user defined function (UDF) stubs Rust code: stubs.rs
     pub udf_stubs: String,

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -199,7 +199,8 @@ fn pipeline_info_internal_to_external(pipeline: PipelineInfoInternal) -> Pipelin
             let program_info = validate_program_info(&v)
                 .expect("example must have a valid program_info if specified");
             PartialProgramInfo {
-                schema: program_info.schema,
+                schema: serde_json::from_value(program_info.schema)
+                    .expect("example should have a valid program_info.schema if specified"),
                 udf_stubs: program_info.udf_stubs,
                 input_connectors: program_info.input_connectors,
                 output_connectors: program_info.output_connectors,
@@ -260,7 +261,8 @@ fn pipeline_selected_info_internal_to_external(
                 let program_info = validate_program_info(&v)
                     .expect("example must have a valid program_info if specified");
                 PartialProgramInfo {
-                    schema: program_info.schema,
+                    schema: serde_json::from_value(program_info.schema)
+                        .expect("example should have a valid program_info.schema if specified"),
                     udf_stubs: program_info.udf_stubs,
                     input_connectors: program_info.input_connectors,
                     output_connectors: program_info.output_connectors,

--- a/openapi.json
+++ b/openapi.json
@@ -10594,7 +10594,7 @@
             }
           },
           "schema": {
-            "description": "Schema of the compiled SQL."
+            "$ref": "#/components/schemas/ProgramSchema"
           },
           "udf_stubs": {
             "type": "string",


### PR DESCRIPTION
The `program_info` is already stored as JSON and served as such through the API. This restores that the OpenAPI spec continues to indicate that the type of the `program_info.schema` field is `ProgramSchema` such that clients (such as Web Console) can use the spec directly without having to make an exception to parse it as such.

**PR information**
- Backward compatible