### PR TITLE
adapters: do not skip columns used in config

### DIFF
--- a/crates/adapterlib/src/utils/datafusion.rs
+++ b/crates/adapterlib/src/utils/datafusion.rs
@@ -8,15 +8,18 @@ use datafusion::execution::memory_pool::FairSpillPool;
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::logical_expr::sqlparser::parser::ParserError;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
+use datafusion::sql::sqlparser::ast::{Expr, visit_expressions};
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Token;
 use feldera_types::config::PipelineConfig;
 use feldera_types::constants::DATAFUSION_TEMP_DIR;
 use feldera_types::program_schema::{ColumnType, Field, Relation, SqlType};
+use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::fs::{create_dir_all, read_dir, remove_dir_all, remove_file};
 use std::io::Error as IoError;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::warn;
@@ -309,6 +312,58 @@ pub fn validate_sql_order_by(order_by: &str) -> Result<(), ParserError> {
     Ok(())
 }
 
+/// Collect into `columns` every column name an expression's AST references,
+/// walking nested sub-expressions. For a compound reference such as `t.c` only
+/// the trailing part (`c`) is taken, since that is the column; leading parts are
+/// table qualifiers.
+///
+/// Over-collecting is harmless for the callers here -- it merely keeps a column
+/// from being pruned -- but under-collecting would drop a column the connector
+/// needs, so an identifier is kept whenever it could name a column.
+fn collect_referenced_columns(expr: &Expr, columns: &mut BTreeSet<String>) {
+    let _: ControlFlow<()> = visit_expressions(expr, |e| {
+        match e {
+            Expr::Identifier(ident) => {
+                columns.insert(ident.value.clone());
+            }
+            Expr::CompoundIdentifier(parts) => {
+                if let Some(column) = parts.last() {
+                    columns.insert(column.value.clone());
+                }
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    });
+}
+
+/// Column names referenced by a scalar SQL expression, e.g. a connector's
+/// `filter` or `cdc_delete_filter`. Names are returned verbatim; the caller
+/// case-folds when matching them against a schema.
+///
+/// Returns an error if the expression does not parse. Used when pruning
+/// "unused" columns, to keep the columns a connector expression depends on.
+pub fn columns_referenced_by_expression(expr: &str) -> Result<BTreeSet<String>, ParserError> {
+    let mut parser = Parser::new(&GenericDialect).try_with_sql(expr)?;
+    let parsed = parser.parse_expr()?;
+    let mut columns = BTreeSet::new();
+    collect_referenced_columns(&parsed, &mut columns);
+    Ok(columns)
+}
+
+/// Like [`columns_referenced_by_expression`], but for the comma-separated key
+/// list of an ORDER BY clause, e.g. a connector's `cdc_order_by`.
+pub fn columns_referenced_by_order_by(order_by: &str) -> Result<BTreeSet<String>, ParserError> {
+    let mut parser = Parser::new(&GenericDialect).try_with_sql(order_by)?;
+    let keys = parser.parse_comma_separated(Parser::parse_order_by_expr)?;
+    parser.expect_token(&Token::EOF)?;
+    let mut columns = BTreeSet::new();
+    for key in &keys {
+        collect_referenced_columns(&key.expr, &mut columns);
+    }
+    Ok(columns)
+}
+
 /// Convert a value of the timestamp column returned by a SQL query into a valid
 /// SQL expression.
 pub fn timestamp_to_sql_expression(column_type: &ColumnType, expr: &str) -> String {
@@ -405,10 +460,14 @@ pub async fn validate_timestamp_column(
 
 #[cfg(test)]
 mod tests {
-    use super::{create_runtime_env, create_session_context};
+    use super::{
+        columns_referenced_by_expression, columns_referenced_by_order_by, create_runtime_env,
+        create_session_context,
+    };
     use datafusion::execution::memory_pool::MemoryLimit;
     use feldera_types::config::{PipelineConfig, ResourceConfig, RuntimeConfig, StorageConfig};
     use feldera_types::constants::DATAFUSION_TEMP_DIR;
+    use std::collections::BTreeSet;
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -780,5 +839,57 @@ mod tests {
             "validation failures:\n{}",
             failures.join("\n")
         );
+    }
+
+    fn columns(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn expression_columns_are_collected() {
+        for (expr, expected) in [
+            ("__is_deleted = true", columns(&["__is_deleted"])),
+            ("deleted_at is not null", columns(&["deleted_at"])),
+            (
+                "__is_deleted = true OR deleted_at is not null",
+                columns(&["__is_deleted", "deleted_at"]),
+            ),
+            // Function arguments are walked; the function name is not a column.
+            ("lower(status) = 'gone'", columns(&["status"])),
+            // A compound reference resolves to its trailing (column) part.
+            ("t.deleted = true", columns(&["deleted"])),
+            // A predicate over no columns yields the empty set.
+            ("1 = 1", columns(&[])),
+        ] {
+            assert_eq!(
+                columns_referenced_by_expression(expr).unwrap(),
+                expected,
+                "columns of '{expr}'"
+            );
+        }
+    }
+
+    #[test]
+    fn order_by_columns_are_collected() {
+        assert_eq!(
+            columns_referenced_by_order_by("ts asc, lsn desc").unwrap(),
+            columns(&["ts", "lsn"]),
+        );
+        assert_eq!(
+            columns_referenced_by_order_by("coalesce(ts, created_at) asc").unwrap(),
+            columns(&["ts", "created_at"]),
+        );
+        // ASC/DESC and NULLS FIRST/LAST modifiers parse but are not columns.
+        assert_eq!(
+            columns_referenced_by_order_by("ts desc nulls last, lsn asc").unwrap(),
+            columns(&["ts", "lsn"]),
+        );
+    }
+
+    #[test]
+    fn malformed_expressions_error() {
+        assert!(columns_referenced_by_expression("a =").is_err());
+        // A trailing key past the first must still fail rather than be dropped.
+        assert!(columns_referenced_by_order_by("ts asc,").is_err());
     }
 }

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -924,11 +924,6 @@ struct DeltaTableInputEndpointInner {
     /// is a member. Derived once from the immutable SQL schema.
     used_sql_columns: OnceLock<ColumnNameSet>,
 
-    /// SQL columns the SQL program does not need, i.e. not read from the table.
-    /// A delta column is dropped iff it is a member. Derived once from the
-    /// immutable SQL schema.
-    skippable_sql_columns: OnceLock<ColumnNameSet>,
-
     /// SQL columns named by the connector's own expressions -- `filter`,
     /// `snapshot_filter`, `cdc_delete_filter`, `cdc_order_by`. These are kept
     /// even when marked unused, so the expressions can resolve them. Derived
@@ -982,7 +977,6 @@ impl DeltaTableInputEndpointInner {
             metrics,
             catchup_follow_state: Mutex::new(CatchupFollowState::default()),
             used_sql_columns: OnceLock::new(),
-            skippable_sql_columns: OnceLock::new(),
             config_referenced_columns: OnceLock::new(),
         }
     }
@@ -1196,21 +1190,6 @@ impl DeltaTableInputEndpointInner {
         })
     }
 
-    /// SQL columns the SQL program does not need (skippable unused columns),
-    /// matched case-insensitively against Delta column names. Derived once from
-    /// the immutable SQL schema and cached.
-    fn skippable_sql_columns(&self) -> &ColumnNameSet {
-        self.skippable_sql_columns.get_or_init(|| {
-            ColumnNameSet::from_names(
-                self.schema
-                    .fields
-                    .iter()
-                    .filter(|f| self.can_skip_column(f))
-                    .map(|f| f.name.name()),
-            )
-        })
-    }
-
     /// Compute the subset of columns in the Delta table schema that occur in the SQL
     /// table declaration.
     ///
@@ -1287,28 +1266,35 @@ impl DeltaTableInputEndpointInner {
                 .contains(&field.name.name())
     }
 
-    /// Project `df` to the columns the connector reads when `skip_unused_columns`
-    /// is set: drop skippable unused columns, keep everything else -- including
-    /// Delta metadata columns absent from the SQL schema (e.g. `__feldera_op`,
-    /// `__feldera_ts`) and SQL columns named by `cdc_order_by`/`cdc_delete_filter`/
-    /// `filter`, all of which those expressions must be able to resolve.
+    /// Project `df` to the columns the connector needs when `skip_unused_columns`
+    /// is set, mirroring the snapshot path's `SELECT <used_columns>`: keep a
+    /// column iff the circuit reads it (`used_sql_columns`) or a connector
+    /// expression names it (`config_referenced_columns`). The latter covers Delta
+    /// metadata columns absent from the SQL schema, e.g. `__feldera_op` /
+    /// `__feldera_ts`, which `cdc_delete_filter` / `cdc_order_by` test, so those
+    /// expressions can resolve. A Delta table may carry far more physical columns
+    /// than the SQL table maps; this keeps the connector from reading the rest
+    /// off disk.
     fn project_cdc_columns(&self, df: DataFrame) -> AnyResult<DataFrame> {
         if !self.skip_unused_columns() {
             return Ok(df);
         }
 
-        // Skippable SQL set is cached; the Delta column list comes from `df`'s
-        // own schema each call, so projection stays correct if column mapping
-        // ever makes the read schema vary across versions.
-        let skippable = self.skippable_sql_columns();
+        let used = self.used_sql_columns();
+        let referenced = self.config_referenced_columns();
 
-        // Own the kept names before consuming `df`: `select_columns` takes `df`
-        // by value, so the `df.schema()` borrow must end first.
+        // Filter `df`'s own field list (not the SQL schema) so the projection
+        // tracks the read schema if column mapping ever varies it across
+        // versions, and preserves on-disk column order: the order the
+        // `cdc_delete_filter` `PhysicalExpr` binds by index in
+        // `extract_delete_filter_expr`. Own the kept names before consuming `df`;
+        // `select_columns` takes `df` by value, so the `df.schema()` borrow must
+        // end first.
         let kept: Vec<String> = df
             .schema()
             .fields()
             .iter()
-            .filter(|f| !skippable.contains(f.name()))
+            .filter(|f| used.contains(f.name()) || referenced.contains(f.name()))
             .map(|f| f.name().to_string())
             .collect();
         let kept: Vec<&str> = kept.iter().map(String::as_str).collect();

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -31,7 +31,8 @@ use feldera_adapterlib::format::{ParseError, StagedInputBuffer};
 use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{InputQueueEntry, Resume, Watermark, parse_resume_info};
 use feldera_adapterlib::utils::datafusion::{
-    array_to_string, create_session_context_with, execute_query_collect, execute_singleton_query,
+    array_to_string, columns_referenced_by_expression, columns_referenced_by_order_by,
+    create_session_context_with, execute_query_collect, execute_singleton_query,
     timestamp_to_sql_expression, validate_sql_expression, validate_sql_order_by,
     validate_timestamp_column,
 };
@@ -927,6 +928,12 @@ struct DeltaTableInputEndpointInner {
     /// A delta column is dropped iff it is a member. Derived once from the
     /// immutable SQL schema.
     skippable_sql_columns: OnceLock<ColumnNameSet>,
+
+    /// SQL columns named by the connector's own expressions -- `filter`,
+    /// `snapshot_filter`, `cdc_delete_filter`, `cdc_order_by`. These are kept
+    /// even when marked unused, so the expressions can resolve them. Derived
+    /// once from the immutable config.
+    config_referenced_columns: OnceLock<ColumnNameSet>,
 }
 
 #[derive(Debug, Clone)]
@@ -976,6 +983,7 @@ impl DeltaTableInputEndpointInner {
             catchup_follow_state: Mutex::new(CatchupFollowState::default()),
             used_sql_columns: OnceLock::new(),
             skippable_sql_columns: OnceLock::new(),
+            config_referenced_columns: OnceLock::new(),
         }
     }
 
@@ -1182,7 +1190,7 @@ impl DeltaTableInputEndpointInner {
                 self.schema
                     .fields
                     .iter()
-                    .filter(|f| !self.skip_unused_columns() || !Self::is_skippable(f))
+                    .filter(|f| !self.skip_unused_columns() || !self.can_skip_column(f))
                     .map(|f| f.name.name()),
             )
         })
@@ -1197,7 +1205,7 @@ impl DeltaTableInputEndpointInner {
                 self.schema
                     .fields
                     .iter()
-                    .filter(|f| Self::is_skippable(f))
+                    .filter(|f| self.can_skip_column(f))
                     .map(|f| f.name.name()),
             )
         })
@@ -1230,20 +1238,60 @@ impl DeltaTableInputEndpointInner {
             .join(", ")
     }
 
-    /// True if a table column can be skipped: no user-visible result depends on
-    /// it, and omitting it lets us substitute NULL or its default value (it is
-    /// nullable or has a default).
+    /// True if a column's *shape* allows omitting it: no user-visible result
+    /// depends on it (`unused`), and omitting it lets us substitute NULL or its
+    /// default value (it is nullable or has a default).
     ///
-    /// The read paths that keep these columns and those that drop them share
-    /// this one predicate, so they stay in sync.
-    fn is_skippable(field: &Field) -> bool {
+    /// This is the shape-only rule; [`can_skip_column`](Self::can_skip_column)
+    /// adds the connector-config check before a column is actually skipped.
+    fn is_unused_and_omittable(field: &Field) -> bool {
         field.unused && (field.columntype.nullable || field.default.is_some())
+    }
+
+    /// SQL columns named by the connector's own expressions (`filter`,
+    /// `snapshot_filter`, `cdc_delete_filter`, `cdc_order_by`), case-folded for
+    /// matching. Derived once and cached.
+    ///
+    /// These strings are validated during configuration, so they parse here; a
+    /// parse error is therefore unreachable and contributes no columns rather
+    /// than failing the connector a second time.
+    fn config_referenced_columns(&self) -> &ColumnNameSet {
+        self.config_referenced_columns.get_or_init(|| {
+            let mut columns = BTreeSet::new();
+            for expr in [
+                &self.config.filter,
+                &self.config.snapshot_filter,
+                &self.config.cdc_delete_filter,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                columns.extend(columns_referenced_by_expression(expr).unwrap_or_default());
+            }
+            if let Some(order_by) = &self.config.cdc_order_by {
+                columns.extend(columns_referenced_by_order_by(order_by).unwrap_or_default());
+            }
+            ColumnNameSet::from_names(columns)
+        })
+    }
+
+    /// True if a column may actually be skipped: its shape permits omitting it
+    /// ([`is_unused_and_omittable`](Self::is_unused_and_omittable)) *and* no
+    /// connector expression references it. A referenced column must be read and
+    /// must survive projection, or expressions like `cdc_delete_filter` cannot
+    /// resolve it.
+    fn can_skip_column(&self, field: &Field) -> bool {
+        Self::is_unused_and_omittable(field)
+            && !self
+                .config_referenced_columns()
+                .contains(&field.name.name())
     }
 
     /// Project `df` to the columns the connector reads when `skip_unused_columns`
     /// is set: drop skippable unused columns, keep everything else -- including
     /// Delta metadata columns absent from the SQL schema (e.g. `__feldera_op`,
-    /// `__feldera_ts`) that `cdc_order_by`/`cdc_delete_filter`/`filter` reference.
+    /// `__feldera_ts`) and SQL columns named by `cdc_order_by`/`cdc_delete_filter`/
+    /// `filter`, all of which those expressions must be able to resolve.
     fn project_cdc_columns(&self, df: DataFrame) -> AnyResult<DataFrame> {
         if !self.skip_unused_columns() {
             return Ok(df);
@@ -3080,28 +3128,24 @@ mod is_skippable_tests {
 
     #[test]
     fn skippable_only_when_unused_and_safely_omittable() {
-        // A used column is never skippable, whatever its type.
-        assert!(!DeltaTableInputEndpointInner::is_skippable(&field(
-            false, true, None
-        )));
-        assert!(!DeltaTableInputEndpointInner::is_skippable(&field(
-            false,
-            false,
-            Some("0")
-        )));
+        // A used column is never omittable, whatever its type.
+        assert!(!DeltaTableInputEndpointInner::is_unused_and_omittable(
+            &field(false, true, None)
+        ));
+        assert!(!DeltaTableInputEndpointInner::is_unused_and_omittable(
+            &field(false, false, Some("0"))
+        ));
 
-        // An unused column is skippable only if omitting it is well-defined:
-        // it is nullable, or it carries a default.
-        assert!(DeltaTableInputEndpointInner::is_skippable(&field(
-            true, true, None
-        )));
-        assert!(DeltaTableInputEndpointInner::is_skippable(&field(
-            true,
-            false,
-            Some("0")
-        )));
-        assert!(!DeltaTableInputEndpointInner::is_skippable(&field(
-            true, false, None
-        )));
+        // An unused column is omittable only if substituting for it is
+        // well-defined: it is nullable, or it carries a default.
+        assert!(DeltaTableInputEndpointInner::is_unused_and_omittable(
+            &field(true, true, None)
+        ));
+        assert!(DeltaTableInputEndpointInner::is_unused_and_omittable(
+            &field(true, false, Some("0"))
+        ));
+        assert!(!DeltaTableInputEndpointInner::is_unused_and_omittable(
+            &field(true, false, None)
+        ));
     }
 }


### PR DESCRIPTION
compiler do not know about columns used in config options like cdc_delete_filter, hence we have to parse the config and make sure we aren't skipping these columns

Fix #6449 

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated

## Breaking Changes?

No
