### PR TITLE
pipeline-manager: add `use_platform_compiler` program config option

### DIFF
--- a/crates/fda/src/debug.rs
+++ b/crates/fda/src/debug.rs
@@ -324,12 +324,14 @@ async fn unbundle_support_bundle(
                     .as_str()
                     .map(|s| s.to_string())
                     .or(runtime_version.clone()),
+                use_platform_compiler: false,
             })
         } else {
             Some(ProgramConfig {
                 cache: true,
                 profile: Some(CompilationProfile::Optimized),
                 runtime_version: runtime_version.clone(),
+                use_platform_compiler: false,
             })
         };
 

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -704,6 +704,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                             cache: true,
                             profile: Some(profile),
                             runtime_version,
+                            use_platform_compiler: false,
                         }),
                         runtime_config: None,
                     })
@@ -2512,6 +2513,7 @@ async fn program(format: OutputFormat, action: ProgramAction, client: Client) {
                     profile,
                     cache: true,
                     runtime_version,
+                    use_platform_compiler: false,
                 }),
                 runtime_config: None,
             };

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -49,6 +49,7 @@ fn extended_pipeline_1() -> ExtendedPipelineDescr {
             profile: Some(CompilationProfile::Optimized),
             cache: true,
             runtime_version: None,
+            use_platform_compiler: false,
         })
         .unwrap(),
         program_version: Version(2),
@@ -137,6 +138,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
             profile: Some(CompilationProfile::Unoptimized),
             cache: true,
             runtime_version: None,
+            use_platform_compiler: false,
         })
         .unwrap(),
         program_version: Version(1),
@@ -335,6 +337,7 @@ pub(crate) fn pipeline_post_put() -> PostPutPipeline {
             profile: Some(CompilationProfile::Optimized),
             cache: true,
             runtime_version: None,
+            use_platform_compiler: false,
         }),
     }
 }

--- a/crates/pipeline-manager/src/compiler/main.rs
+++ b/crates/pipeline-manager/src/compiler/main.rs
@@ -577,6 +577,7 @@ pub async fn compiler_precompile(
         profile: None, // The pre-compilation will use the compiler configuration default profile
         cache: false,
         runtime_version: None,
+        use_platform_compiler: false,
     };
     let program_config = serde_json::to_value(&program_config).map_err(|e| {
         CommonError::json_serialization_error(

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -515,17 +515,24 @@ pub(crate) async fn perform_sql_compilation(
     })?;
 
     let runtime_selector = program_config.runtime_version();
+    let use_platform_compiler =
+        program_config.use_platform_compiler && !runtime_selector.is_platform();
     assert!(has_unstable_feature("runtime_version") || runtime_selector.is_platform());
     let pipeline_name = pipeline_name.as_deref().unwrap_or("N/A");
     info!(
         pipeline_id = %pipeline_id,
         pipeline = pipeline_name,
-        "SQL compilation started (program version: {}{})",
+        "SQL compilation started (program version: {}{}{})",
         program_version,
         if !runtime_selector.is_platform() {
             format!(", runtime version: {runtime_selector}")
         } else {
             "".to_string()
+        },
+        if use_platform_compiler {
+            ", using platform compiler"
+        } else {
+            ""
         }
     );
 
@@ -565,8 +572,17 @@ pub(crate) async fn perform_sql_compilation(
         .join("stubs.rs");
 
     // SQL compiler executable
-    let sql_compiler_executable_file_path = determine_sql_compiler_path(config, &runtime_selector);
-    if has_unstable_feature("runtime_version") && !sql_compiler_executable_file_path.exists() {
+    // When use_platform_compiler is set with a non-platform runtime version, use
+    // the platform's SQL compiler JAR directly, bypassing the per-version download.
+    let sql_compiler_executable_file_path = if use_platform_compiler {
+        PathBuf::from(&config.sql_compiler_path)
+    } else {
+        determine_sql_compiler_path(config, &runtime_selector)
+    };
+    if !use_platform_compiler
+        && has_unstable_feature("runtime_version")
+        && !sql_compiler_executable_file_path.exists()
+    {
         fetch_sql_compiler(config, &runtime_selector).await?;
         // Either executable exists now or we error'd out
         assert!(sql_compiler_executable_file_path.exists());

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -353,6 +353,7 @@ fn map_val_to_limited_program_config(val: ProgramConfigPropVal) -> serde_json::V
             },
             cache: val.3,
             runtime_version: None,
+            use_platform_compiler: false,
         })
         .unwrap()
     }
@@ -852,6 +853,7 @@ async fn pipeline_retrieval() {
                     profile: Some(CompilationProfile::Unoptimized),
                     cache: true,
                     runtime_version: None,
+                    use_platform_compiler: false,
                 })
                 .unwrap(),
             },
@@ -895,6 +897,7 @@ async fn pipeline_retrieval() {
                     profile: Some(CompilationProfile::Unoptimized),
                     cache: false,
                     runtime_version: None,
+                    use_platform_compiler: false,
                 })
                 .unwrap(),
             },
@@ -1154,6 +1157,7 @@ async fn pipeline_versioning() {
         profile: Some(CompilationProfile::Dev),
         cache: false,
         runtime_version: None,
+        use_platform_compiler: false,
     })
     .unwrap();
     handle

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -465,6 +465,23 @@ pub struct ProgramConfig {
     /// If not set (null), the runtime version will be the same as the platform version.
     #[schema(value_type = Option<String>)]
     pub runtime_version: Option<RuntimeSelector>,
+
+    /// Use the platform SQL compiler when a non-platform `runtime_version` is specified.
+    ///
+    /// Warning: This setting is experimental and may change in the future.
+    /// Requires the platform to run with the unstable feature `runtime_version` enabled.
+    ///
+    /// When `false` (default), the SQL compiler matching the `runtime_version` is
+    /// downloaded and used. When `true`, the platform's SQL compiler is used instead.
+    ///
+    /// Setting this to `true` avoids downloading the runtime-version-specific SQL
+    /// compiler JAR (e.g., when network access is unavailable or slow), at the cost
+    /// of potentially using a mismatched SQL compiler. The Rust runtime sources are
+    /// still checked out and compiled from the requested `runtime_version`.
+    ///
+    /// Has no effect when `runtime_version` is not set or the platform does not have
+    /// the unstable feature `runtime_version` enabled.
+    pub use_platform_compiler: bool,
 }
 
 impl ProgramConfig {
@@ -489,6 +506,7 @@ impl Default for ProgramConfig {
             profile: None,
             cache: true,
             runtime_version: None,
+            use_platform_compiler: false,
         }
     }
 }

--- a/crates/pipeline-manager/src/db/types/utils.rs
+++ b/crates/pipeline-manager/src/db/types/utils.rs
@@ -442,6 +442,7 @@ mod tests {
             profile: Some(CompilationProfile::Unoptimized),
             cache: false,
             runtime_version: None,
+            use_platform_compiler: false,
         };
         let value = serde_json::to_value(program_config.clone()).unwrap();
         assert_eq!(

--- a/openapi.json
+++ b/openapi.json
@@ -633,7 +633,8 @@
                     "program_config": {
                       "profile": "optimized",
                       "cache": true,
-                      "runtime_version": null
+                      "runtime_version": null,
+                      "use_platform_compiler": false
                     },
                     "program_version": 2,
                     "program_status": "Pending",
@@ -724,7 +725,8 @@
                     "program_config": {
                       "profile": "unoptimized",
                       "cache": true,
-                      "runtime_version": null
+                      "runtime_version": null,
+                      "use_platform_compiler": false
                     },
                     "program_version": 1,
                     "program_status": "Pending",
@@ -845,7 +847,8 @@
                 "program_config": {
                   "profile": "optimized",
                   "cache": true,
-                  "runtime_version": null
+                  "runtime_version": null,
+                  "use_platform_compiler": false
                 }
               }
             }
@@ -919,7 +922,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -1105,7 +1109,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -1253,7 +1258,8 @@
                 "program_config": {
                   "profile": "optimized",
                   "cache": true,
-                  "runtime_version": null
+                  "runtime_version": null,
+                  "use_platform_compiler": false
                 }
               }
             }
@@ -1327,7 +1333,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -1428,7 +1435,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -1700,7 +1708,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -6637,7 +6646,8 @@
                   "program_config": {
                     "profile": "optimized",
                     "cache": true,
-                    "runtime_version": null
+                    "runtime_version": null,
+                    "use_platform_compiler": false
                   },
                   "program_version": 2,
                   "program_status": "Pending",
@@ -11902,6 +11912,11 @@
             "description": "Override runtime version of the pipeline being executed.\n\nWarning: This setting is experimental and may change in the future.\nRequires the platform to run with the unstable feature `runtime_version`\nenabled. Should only be used for testing purposes, and requires\nnetwork access.\n\nA runtime version can be specified in the form of a version\nor SHA taken from the `feldera/feldera` repository main branch.\n\nExamples: `v0.96.0` or `f4dcac0989ca0fda7d2eb93602a49d007cb3b0ae`\n\nA platform of version `0.x.y` may be capable of running future and past\nruntimes with versions `>=0.x.y` and `<=0.x.y` until breaking API changes happen,\nthe exact bounds for each platform version are unspecified until we reach a\nstable version. Compatibility is only guaranteed if platform and runtime version\nare exact matches.\n\nNote that any enterprise features are currently considered to be part of\nthe platform.\n\nIf not set (null), the runtime version will be the same as the platform version.",
             "default": null,
             "nullable": true
+          },
+          "use_platform_compiler": {
+            "type": "boolean",
+            "description": "Use the platform SQL compiler when a non-platform `runtime_version` is specified.\n\nWarning: This setting is experimental and may change in the future.\nRequires the platform to run with the unstable feature `runtime_version` enabled.\n\nWhen `false` (default), the SQL compiler matching the `runtime_version` is\ndownloaded and used. When `true`, the platform's SQL compiler is used instead.\n\nSetting this to `true` avoids downloading the runtime-version-specific SQL\ncompiler JAR (e.g., when network access is unavailable or slow), at the cost\nof potentially using a mismatched SQL compiler. The Rust runtime sources are\nstill checked out and compiled from the requested `runtime_version`.\n\nHas no effect when `runtime_version` is not set or the platform does not have\nthe unstable feature `runtime_version` enabled.",
+            "default": false
           }
         }
       },


### PR DESCRIPTION
When `runtime_version` is overridden, the pipeline manager normally downloads the matching SQL compiler JAR for that version. The new `use_platform_compiler: bool` field in `ProgramConfig` (default: false) skips this download and uses the platform's SQL compiler JAR instead.

This is useful when network access is unavailable or slow, or when testing a runtime version that is compatible with the platform compiler. The Rust runtime sources are still checked out and compiled from the requested `runtime_version`; only the SQL-to-DBSP compiler JAR selection is affected.

Written by claude.  Tested by me with a local cloud deployment.
