### PR TITLE
[web-console] Show a rendering progress bar over the ELK layout pass

### DIFF
--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -49,6 +49,9 @@
     /** Optional slot for a richer SQL panel; receives current highlight ranges */
     sqlPanel?: Snippet<[highlightRanges: SourcePositionRange[]]>
     onHighlightSourceRanges?: (ranges: SourcePositionRange[]) => void
+    /** Fired when the graph rendering enters or leaves its asynchronous layout phase.
+     */
+    onRenderingChange?: (rendering: boolean) => void
   }
 
   let {
@@ -63,7 +66,8 @@
     sqlPanelFullHeight = $bindable(),
     loadProfileControl,
     sqlPanel,
-    onHighlightSourceRanges
+    onHighlightSourceRanges,
+    onRenderingChange
   }: Props = $props()
 
   let profilerDiagram: ProfilerDiagram | undefined = $state()
@@ -168,6 +172,9 @@
       }
       highlightRanges = ranges
       onHighlightSourceRanges?.(ranges)
+    },
+    onRenderingChange: (rendering) => {
+      onRenderingChange?.(rendering)
     }
   }
 

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -425,6 +425,10 @@ export class CytographRendering {
     lastNode: Option<NodeId>;
     // Current node that has tooltip displayed (for refreshing on metadata changes)
     private currentTooltipNode: NodeId | null = null;
+    // True between `initiateLayout` and its matching `layoutComplete`. Used so `dispose()`
+    // can fire a final `onRenderingChange(false)` if the layout was still in flight when the
+    // visualizer is torn down — otherwise a consumer's progress bar would stick on screen.
+    private renderingInFlight = false;
 
     readonly graph_style: StylesheetJson = [
         {
@@ -777,11 +781,23 @@ export class CytographRendering {
         if (this.cy === null) {
             return;
         }
-        // This runs asynchronously
+        // The layout runs asynchronously; the `true` dispatched here is paired with the
+        // `false` dispatched from `layoutComplete()` on the `layoutstop` event. If `.run()`
+        // throws synchronously (bad options, cytoscape internal error), we'd never reach
+        // `layoutstop` and the consumer's progress bar would stick forever — so reset on the
+        // throw before rethrowing.
+        this.renderingInFlight = true;
+        this.callbacks.onRenderingChange?.(true);
         this.message("Computing layout...");
-        this.cy
-            .layout(options)
-            .run();
+        try {
+            this.cy
+                .layout(options)
+                .run();
+        } catch (e) {
+            this.renderingInFlight = false;
+            this.callbacks.onRenderingChange?.(false);
+            throw e;
+        }
     }
 
     /** Modify the rendered graph incrementally by applying a diff. */
@@ -890,8 +906,9 @@ export class CytographRendering {
     }
 
     layoutComplete() {
-        // console.log("layout complete");
         this.clearMessage();
+        this.renderingInFlight = false;
+        this.callbacks.onRenderingChange?.(false);
         this.cy.container()!.style.visibility = "visible";
         this.updateNavigator(this.navigator);
         if (this.lastNode.isSome()) {
@@ -1099,6 +1116,14 @@ export class CytographRendering {
      * Clean up resources when the rendering is no longer needed
      */
     dispose(): void {
+        // Destroying cytoscape mid-layout cancels the pending `layoutstop` event, so a
+        // consumer driving a progress bar from `onRenderingChange` would never see the
+        // matching `false`. Emit it explicitly here for the in-flight case.
+        if (this.renderingInFlight) {
+            this.renderingInFlight = false;
+            this.callbacks.onRenderingChange?.(false);
+        }
+
         // Destroy the Cytoscape instance
         if (this.cy) {
             this.cy.destroy();

--- a/js-packages/profiler-lib/src/profiler.ts
+++ b/js-packages/profiler-lib/src/profiler.ts
@@ -71,6 +71,12 @@ export interface ProfilerCallbacks {
 
     /** Called when a node is double-clicked. */
     onNodeDoubleClick?: (nodeId: string, type: 'group' | 'leaf') => void;
+
+    /** Called when the graph rendering enters or leaves its asynchronous layout phase.
+     *  `rendering = true` is dispatched immediately before the ELK layout starts (the cytoscape
+     *  container is hidden during this window); `rendering = false` follows the `layoutstop`
+     *  event when the graph is on screen and interactive. */
+    onRenderingChange?: (rendering: boolean) => void;
 }
 
 export interface VisualizerConfig {

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
@@ -51,6 +51,9 @@
       })
     | null = $state(null)
   let triageResults: TriageResults = $state(new TriageResults())
+  // `true` while ELK is running the layout pass on the current profile. The flag flips back
+  // to `false` once `layoutstop` fires inside profiler-lib.
+  let isRendering = $state(false)
 
   let collectNewData = $state(collect)
   let fileInput: HTMLInputElement | null = $state(null)
@@ -235,14 +238,28 @@
     {/snippet}
   </AppHeader>
 
-  <!-- Download progress bar -->
-  <div class="{nonNull(downloadProgress.percent) ? '' : 'h-0 opacity-0'} transition-opacity">
-    <Progress class="h-1" value={downloadProgress.percent ?? null} max={100}>
-      <Progress.Track>
-        <Progress.Range class="bg-primary-500" />
-      </Progress.Track>
-    </Progress>
-  </div>
+  <!-- Thin progress bar shown above the layout while a profile is loading or being drawn.
+       `percent === null` keeps it indeterminate (the layout engine has no progress signal,
+       so the "rendering" pass cannot report a fraction). `visible === false` collapses the
+       row to zero height instead of unmounting, so successive uses (download → render) flow
+       without layout jumps. -->
+  {#snippet progressBar(visible: boolean, percent: number | null)}
+    <div class=" px-4 {visible ? '' : 'h-0 opacity-0'} transition-opacity">
+      <Progress class="-mt-1 h-1" value={percent} max={100}>
+        <Progress.Track>
+          <Progress.Range class="bg-primary-500" />
+        </Progress.Track>
+      </Progress>
+    </div>
+  {/snippet}
+  <!-- Download takes precedence: while the bundle is still arriving there is nothing to
+       render yet, and once it has, `downloadProgress.percent` is reset to null and we display
+       the indeterminate rendering bar while the diagram layout is computed. -->
+  {#if nonNull(downloadProgress.percent)}
+    {@render progressBar(true, downloadProgress.percent ?? null)}
+  {:else}
+    {@render progressBar(isRendering, null)}
+  {/if}
 
   {#if isLoading && !getProfileData}
     <div class="flex flex-1 flex-col items-center justify-center gap-4">
@@ -264,7 +281,7 @@
     </div>
   {:else if getProfileData}
     {@const { profile, dataflow, sources, logText } = getProfileData()}
-    <div class="min-h-0 flex-1 px-2 pb-4 md:pr-8 md:pl-8 xl:pl-4">
+    <div class="min-h-0 flex-1 px-4 pb-4">
       <SupportBundleViewerLayout
         profileData={profile}
         dataflowData={dataflow}
@@ -275,6 +292,7 @@
         selectedTimestamp={selectedProfile}
         onSelectTimestamp={handleSelectTimestamp}
         bind:sqlPanelFullHeight={layoutSettings.sqlPanelFullHeight.value}
+        onRenderingChange={(rendering) => (isRendering = rendering)}
       >
         {#snippet loadProfileControl()}
           <Popup>


### PR DESCRIPTION
When a profile zip is downloaded fro a pipeline in the profiler layout, the download progress bar is displayed, but after it is downloaded there is synchronous step of computing the diagram layout, which had no progress indication. THis PR fixes this - uses the same progress bar to indicate the layout is loading. There is no text that describes what's happening.

Testing: manual, ~added unit test~