### PR TITLE
[DOCS] Remove INTERNED from the documentation (but not from the compiler)

### DIFF
--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -31,8 +31,13 @@ statement
   |   setOptionStatement
 
 columnDecl
-  :   column generalType [ INTERNED ]
+  :   column generalType
 ```
+
+<!--
+  TODO: interning is broken, restore this if it's supported
+  :   column generalType [ INTERNED ]
+-->
 
 ## Creating user-defined types
 
@@ -70,7 +75,6 @@ columnConstraint
   |   LATENESS expression
   |   WATERMARK expression
   |   DEFAULT expression
-  |   INTERNED
 
 tableConstraint
   :   [ CONSTRAINT name ]
@@ -89,6 +93,11 @@ keyValueList
 keyValue
   : stringLiteral '=' stringLiteral
 ```
+
+<!--
+ TODO: Removed INTERNED from columnConstraint, add when supported
+    |   INTERNED
+-->
 
 Columns that are part of a `PRIMARY KEY` cannot have nullable types.
 
@@ -181,6 +190,7 @@ instructs Feldera to also maintain the complete contents of the table.
 Such materialized tables can be browsed and queried at runtime.
 See [Materialized Tables and Views](materialized.md) for more details.
 
+<!--
 #### Interned strings
 
 The `INTERNED` annotation can be added to a column with type `VARCHAR`
@@ -193,6 +203,8 @@ the string value.  This works well if strings are only used for
 equality comparisons; when interned strings participate in other
 computations, or before being emitted to the output, they are
 converted back to their original values.
+
+-->
 
 #### Append-only tables
 


### PR DESCRIPTION
string interning has been broken for a while #5395 so we remove it from the list of supported features until this bug is fixed.