### PR TITLE
Remove artificial columns 'min' and 'max' from the per-worker data

### DIFF
--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -3,7 +3,7 @@
 import cytoscape, { type EdgeCollection, type EdgeDefinition, type ElementsDefinition, type EventObject, type NodeDefinition, type NodeSingular, type StylesheetJson } from 'cytoscape';
 import dblclick from 'cytoscape-dblclick';
 import { assert, Graph, OMap, Option, type EncodableAsString, NumericRange, Edge } from './util.js';
-import { CircuitProfile, NodeAndMetric, PropertyValue, MissingValue, type NodeId } from './profile.js';
+import { CircuitProfile, NodeAndMetric, PropertyValue, type NodeId } from './profile.js';
 import { CircuitSelection } from './selection.js';
 import elk from 'cytoscape-elk';
 import { Sources } from './dataflow.js';
@@ -677,9 +677,9 @@ export class CytographRendering {
     /** Compute the attributes for all cytograph nodes based on the circuit profile and current selection. */
     computeAttributes(profile: CircuitProfile, selection: MetadataSelection) {
         let workers = selection.workersVisible.getSelectedElements(profile.getWorkerNames());
-        let columnNames = [...workers.map(w => w.toString())];
-        columnNames.push("Min");
-        columnNames.push("Max");
+        // One column per visible worker. Aggregates such as min/max are not produced here:
+        // consumers that want them compute them from the per-worker values themselves.
+        let columnNames = workers.map(w => w.toString());
         for (const node of this.currentGraph!.nodes) {
             let profileNode = profile.getNode(node.getId()).unwrap();
             let data = new Map<string, Array<SerializedMeasurement>>();
@@ -690,25 +690,9 @@ export class CytographRendering {
                 let metrics = profileNode.getMeasurements(metric);
                 let selected = selection.workersVisible.getSelectedElements(metrics);
                 let measurements: Array<SerializedMeasurement> = [];
-                let min: PropertyValue = MissingValue.INSTANCE;
-                let max: PropertyValue = MissingValue.INSTANCE;
                 for (const m of selected) {
                     measurements.push(CytographRendering.toMeasurement(m, range));
                 }
-                // Compute min and max over all metrics, including the ones not selected
-                for (const m of metrics) {
-                    if (min instanceof MissingValue ||
-                        (m.getNumericValue().isSome() && min.getNumericValue().unwrap() > m.getNumericValue().unwrap())) {
-                        min = m;
-                    }
-                    if (max instanceof MissingValue ||
-                        (m.getNumericValue().isSome() && max.getNumericValue().unwrap() < m.getNumericValue().unwrap())) {
-                        max = m;
-                    }
-                }
-
-                measurements.push(CytographRendering.toMeasurement(min, range));
-                measurements.push(CytographRendering.toMeasurement(max, range));
                 data.set(metric, measurements);
             }
             // additional key-value per node attributes


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/6467

The issue was the profiler-lib was unconditionally augmenting the per-worker metrics with a min and max value for the statistic. This was originally done as a way to provide an overview of the metrics - and aggregation for the purposes of overview is now coordinated in the consumer of profiler-lib (profiler-layout).

The artificial `min` and `max` column are not an intrinsic part of reporting the per-worker metrics, so I decided to remove computing these columns in the first place, rather than e.g. just filtering them out or making them optional.

Testing: manual