### PR TITLE
[SQL] Optimization to pull filters above joins

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFilterOperator.java
@@ -42,6 +42,7 @@ public final class DBSPFilterOperator extends DBSPUnaryOperator implements ILine
     public DBSPFilterOperator(CalciteRelNode node, DBSPExpression condition, OutputPort input) {
         super(node, "filter", condition, input.outputType(), input.isMultiset(), input);
         this.checkResultType(condition, new DBSPTypeBool(CalciteEmptyRel.INSTANCE, false));
+        checkArgumentFunctionType(condition, input);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -92,7 +92,7 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
                         () -> "Replacing operator with type\n" + oldPort.outputType() +
                                 " with new type\n" + newPort.outputType());
             }
-            Logger.INSTANCE.belowLevel(this, 1)
+            Logger.INSTANCE.belowLevel(this, 2)
                     .appendSupplier(this::toString)
                     .append(":")
                     .appendSupplier(oldPort::toString)
@@ -591,7 +591,7 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
             DBSPNode.discardOuterNode(result);
             result = circuit;
         } else {
-            Logger.INSTANCE.belowLevel(this, 1)
+            Logger.INSTANCE.belowLevel(this, 2)
                     .append("Circuit has changed").newline();
         }
         this.map(circuit, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoinVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoinVisitor.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinFilterMapOperator;
@@ -11,12 +12,134 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.NoExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
+import org.dbsp.util.Logger;
+import org.dbsp.util.Maybe;
+import org.dbsp.util.Utilities;
 
-/** Combine a {@link DBSPJoinOperator} followed by a {@link DBSPFilterOperator} into a
- * {@link DBSPJoinFilterMapOperator}.  Similar expansion for {@link DBSPLeftJoinOperator}. */
+import java.util.List;
+
+/**
+ * Optimize a join followed by a filter:
+ * <ul>
+ * <li>For simple joins attempt to pull the filter on one or both sides of the join
+ * <li>Combine a {@link DBSPJoinOperator}, {@link DBSPLeftJoinOperator} or {@link DBSPStarJoinOperator}
+ *  followed by a {@link DBSPFilterOperator} into a JoinFilterMap version of the same operator.
+ * <uil> */
 public class FilterJoinVisitor extends CircuitCloneWithGraphsVisitor {
     public FilterJoinVisitor(DBSPCompiler compiler, CircuitGraphs graphs) {
         super(compiler, graphs);
+    }
+
+    /** Search if an expression contains NoExpression as a sub-expression */
+    static class ContainsNoExpression extends InnerVisitor {
+        boolean found = false;
+
+        public ContainsNoExpression(DBSPCompiler compiler) {
+            super(compiler);
+        }
+
+        @Override
+        public VisitDecision preorder(NoExpression expression) {
+            this.found = true;
+            return VisitDecision.STOP;
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPType type) {
+            return VisitDecision.STOP;
+        }
+
+        static boolean search(DBSPCompiler compiler, DBSPExpression expression) {
+            ContainsNoExpression cno = new ContainsNoExpression(compiler);
+            cno.apply(expression);
+            return cno.found;
+        }
+    }
+
+    /**
+     * Check if filter can be pushed to one input.  We use the following
+     * algorithm: we compute the function joinFunction \circ filterFunction
+     * and check whether it does not depend on one of the join inputs.
+     * For that purpose we apply it to a NoExpression on that input
+     * and check if the NoExpression appears in the resulting program.
+     * @param filter  Filter operator immediately after a join
+     * @param join  Join operator
+     * @param isLeft  True if we only try to pull on the left input (for left joins).
+     * @return        True if the predicate was pulled successfully.
+     */
+    boolean checkPredicatePull(DBSPFilterOperator filter, DBSPJoinBaseOperator join, boolean isLeft) {
+        DBSPClosureExpression joinFunction = join.getClosureFunction();
+        DBSPClosureExpression filterFunction = filter.getClosureFunction();
+        Utilities.enforce(joinFunction.parameters.length == 3);
+        OutputPort leftInput = null, rightInput = null;
+
+        final DBSPVariablePath left = new DBSPTypeRawTuple(
+                joinFunction.parameters[0].getType(),
+                joinFunction.parameters[1].getType()).var();
+        final DBSPClosureExpression leftProjection = joinFunction.call(
+                        left.field(0),
+                        left.field(1),
+                        new NoExpression(joinFunction.parameters[2].getType()))
+                .closure(left);
+        final DBSPClosureExpression leftFilterPredicate = filterFunction.applyAfter(compiler, leftProjection, Maybe.YES);
+        if (!ContainsNoExpression.search(this.compiler, leftFilterPredicate)) {
+            // Can pull predicate on the left side, since it does not
+            // depend on any field on the RHS
+            DBSPFilterOperator leftFilter = new DBSPFilterOperator(
+                    filter.getRelNode(),
+                    leftFilterPredicate,
+                    join.left());
+            this.addOperator(leftFilter);
+            leftInput = leftFilter.outputPort();
+            rightInput = join.right();
+        }
+
+        if (!isLeft) {
+            final DBSPVariablePath right = new DBSPTypeRawTuple(
+                    joinFunction.parameters[0].getType(),
+                    joinFunction.parameters[2].getType()).var();
+            final DBSPClosureExpression rightProjection = joinFunction.call(
+                            right.field(0),
+                            new NoExpression(joinFunction.parameters[1].getType()),
+                            right.field(1))
+                    .closure(right);
+            final DBSPClosureExpression rightFilterPredicate = filterFunction.applyAfter(compiler, rightProjection, Maybe.YES);
+            if (!ContainsNoExpression.search(this.compiler, rightFilterPredicate)) {
+                // Can pull predicate on the right side, since it does not
+                // depend on any field on the LHS
+                DBSPFilterOperator rightFilter = new DBSPFilterOperator(
+                        filter.getRelNode(),
+                        rightFilterPredicate,
+                        join.right());
+                this.addOperator(rightFilter);
+                rightInput = rightFilter.outputPort();
+                if (leftInput == null)
+                    leftInput = join.left();
+            }
+        }
+
+        // It is possible for a predicate to be pulled on both sides, if it only
+        // depends on the key
+        if (leftInput != null) {
+            DBSPSimpleOperator newJoin = join.withInputs(List.of(leftInput, rightInput), false)
+                    .to(DBSPSimpleOperator.class);
+            // No more filter after the join
+            this.map(filter, newJoin);
+            Logger.INSTANCE.belowLevel(this, 1)
+                    .append("Pulled predicate before join ")
+                    .appendSupplier(filterFunction::toString)
+                    .newline();
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -25,6 +148,10 @@ public class FilterJoinVisitor extends CircuitCloneWithGraphsVisitor {
         int inputFanout = this.getGraph().getFanout(operator.input().node());
         if (source.node().is(DBSPJoinOperator.class) && (inputFanout == 1)) {
             DBSPJoinOperator join = source.node().to(DBSPJoinOperator.class);
+
+            boolean pulled = this.checkPredicatePull(operator, join, false);
+            if (pulled) return;
+
             CalciteRelNode node = join.getRelNode().after(operator.getRelNode());
             DBSPSimpleOperator result =
                     new DBSPJoinFilterMapOperator(node, source.getOutputZSetType(),
@@ -35,6 +162,10 @@ public class FilterJoinVisitor extends CircuitCloneWithGraphsVisitor {
             return;
         } else if (source.node().is(DBSPLeftJoinOperator.class) && (inputFanout == 1)) {
             DBSPLeftJoinOperator join = source.node().to(DBSPLeftJoinOperator.class);
+
+            boolean pulled = this.checkPredicatePull(operator, join, true);
+            if (pulled) return;
+
             CalciteRelNode node = join.getRelNode().after(operator.getRelNode());
             DBSPSimpleOperator result =
                     new DBSPLeftJoinFilterMapOperator(node, source.getOutputZSetType(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
@@ -5,11 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dbsp.sqlCompiler.CompilerMain;
 import org.dbsp.sqlCompiler.compiler.backend.rust.multi.MultiCrates;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
-import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
@@ -1,7 +1,10 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
@@ -799,6 +802,133 @@ public class IncrementalRegression2Tests extends SqlIoTest {
             @Override
             public void endVisit() {
                 Assert.assertEquals(2, this.retains);
+            }
+        });
+    }
+
+    @Test
+    public void issue6279() {
+        // Results were validated using Postgres
+        String prefix = """
+                CREATE TABLE T(x INT, y INT);
+                CREATE TABLE S(x INT, z INT);
+                CREATE LOCAL VIEW V AS SELECT * FROM T JOIN S ON T.x = S.x;
+                """;
+
+        String insert = """
+                INSERT INTO T(x, y) VALUES
+                  (1, 5),
+                  (1, 12),
+                  (2, 3),
+                  (3, 20),
+                  (4, 7);
+                INSERT INTO S(x, z) VALUES
+                  (1, 100),
+                  (2, 200),
+                  (5, 300);""";
+
+        // Pull filter above left input of join
+        var ccs = this.getCCS(prefix + "CREATE VIEW W AS SELECT * FROM V WHERE y < 10;");
+        ccs.stepWeightOne(insert, """
+                 T.x | y | S.x | z
+                -----------------------
+                 1   | 5 | 1   | 100
+                 2   | 3 | 2   | 200""");
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            @Override
+            public void postorder(DBSPFilterOperator node) {
+                Assert.fail("Should have been eliminated");
+            }
+
+            @Override
+            public void postorder(DBSPJoinFilterMapOperator node) {
+                Assert.fail("Should not be present");
+            }
+        });
+
+        // Pull filter above right input of join
+        ccs = this.getCCS(prefix + "CREATE VIEW W AS SELECT * FROM V WHERE z > 10;");
+        ccs.stepWeightOne(insert, """
+                 T.x |  y | S.x | z
+                -----------------------
+                 1   |  5 | 1   | 100
+                 2   |  3 | 2   | 200
+                 1   | 12 | 1   | 100""");
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            @Override
+            public void postorder(DBSPFilterOperator node) {
+                Assert.fail("Should have been eliminated");
+            }
+
+            @Override
+            public void postorder(DBSPJoinFilterMapOperator node) {
+                Assert.fail("Should not be present");
+            }
+        });
+
+        // Pull filter above both input of join
+        ccs = this.getCCS(prefix + "CREATE VIEW W AS SELECT * FROM V WHERE x < 10;");
+        ccs.stepWeightOne(insert, """
+                 T.x |  y | S.x | z
+                -----------------------
+                 1   |  5 | 1   | 100
+                 2   |  3 | 2   | 200
+                 1   | 12 | 1   | 100""");
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            @Override
+            public void postorder(DBSPFilterOperator node) {
+                Assert.fail("Should have been eliminated");
+            }
+
+            @Override
+            public void postorder(DBSPJoinFilterMapOperator node) {
+                Assert.fail("Should not be present");
+            }
+        });
+
+        // Pull key filter only above left input of left join
+        ccs = this.getCCS(""" 
+                CREATE TABLE T(x INT, y INT);
+                CREATE TABLE S(x INT, z INT);
+                CREATE LOCAL VIEW V AS SELECT * FROM T LEFT JOIN S ON T.x = S.x;
+                CREATE VIEW W AS SELECT * FROM V WHERE x < 10;""");
+        ccs.stepWeightOne(insert, """
+                 T.x |  y | S.x | z
+                -----------------------
+                 1   |  5 | 1   | 100
+                 1   | 12 | 1   | 100
+                 2   |  3 | 2   | 200
+                 3   | 20 |NULL |NULL
+                 4   |  7 |NULL |NULL""");
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            @Override
+            public void postorder(DBSPFilterOperator node) {
+                Assert.fail("Should have been eliminated");
+            }
+
+            @Override
+            public void postorder(DBSPLeftJoinFilterMapOperator node) {
+                Assert.fail("Should not be present");
+            }
+        });
+
+        // Do not pull filter above right input of left join
+        ccs = this.getCCS(""" 
+                CREATE TABLE T(x INT, y INT);
+                CREATE TABLE S(x INT, z INT);
+                CREATE LOCAL VIEW V AS SELECT * FROM T LEFT JOIN S ON T.x = S.x;
+                CREATE VIEW W AS SELECT * FROM V WHERE z > 10;""");
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            int filters = 0;
+
+            @Override
+            public void postorder(DBSPLeftJoinFilterMapOperator node) {
+                this.filters++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(1, this.filters);
             }
         });
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -62,7 +62,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.Predicate;


### PR DESCRIPTION
Fixes #6279 

There are calcite optimizations to pull predicates above joins if they only depend on one side of a join. But Calcite optimizes each view separately. This PR introduces an optimization which operates on the graph produced by stitching all views together. It does find a few predicates that can be pulled, most of them of the shape "IS NOT NULL".

### Describe Manual Test Plan

Ran all Java tests manually.

## Checklist

- [x] Unit tests added/updated

