### PR TITLE
Implement auto-pause for Change Stream and Logs tabs

### DIFF
--- a/js-packages/common-ui/src/lib/LogList.svelte
+++ b/js-packages/common-ui/src/lib/LogList.svelte
@@ -55,6 +55,9 @@
      *  Hosts typically focus their search input here. When omitted, the browser's native
      *  find-in-page is left to handle the shortcut. */
     onSearchShortcut?: () => void
+    /** Fired whenever stick-to-bottom toggles: `true` when the view re-anchors to the
+     *  bottom, `false` when the user scrolls up off the bottom. */
+    onStickToBottomChange?: (stickToBottom: boolean) => void
   }
 
   let {
@@ -67,7 +70,8 @@
     style,
     header,
     getCopyContent,
-    onSearchShortcut
+    onSearchShortcut,
+    onStickToBottomChange
   }: Props = $props()
 
   // Reverse-scroll lives here (not in wrappers) so search behaviour and auto-scroll behaviour
@@ -82,7 +86,10 @@
   // svelte-ignore state_referenced_locally
   const reverseScroll = useReverseScrollContainer({
     observeContentElement: (e) => e.firstElementChild!,
-    initialStickToBottom: streaming
+    initialStickToBottom: streaming,
+    // Surface stick-to-bottom transitions (the signal that drives ScrollDownFab) to the host
+    // so a streaming feed can pause when the user scrolls up and resume on the way back.
+    onStickToBottomChange: (stickToBottom) => onStickToBottomChange?.(stickToBottom)
   })
 
   let scrollContainer: HTMLDivElement | undefined = $state()

--- a/js-packages/common-ui/src/lib/useReverseScrollContainer.svelte.ts
+++ b/js-packages/common-ui/src/lib/useReverseScrollContainer.svelte.ts
@@ -14,6 +14,9 @@ export const useReverseScrollContainer = (
      *  the bottom, re-stick as content grows). Pass `false` for static content that should
      *  start at the top and never auto-scroll on mount. */
     initialStickToBottom?: boolean
+    /** Fired on a stick-to-bottom transition: `true` when the view anchors to the bottom,
+     *  `false` when the user scrolls up off it. */
+    onStickToBottomChange?: (stickToBottom: boolean) => void
   }
 ) => {
   let ref = <HTMLDivElement>undefined!
@@ -52,6 +55,17 @@ export const useReverseScrollContainer = (
   }
 
   const debouncedStickToBottom = new Debounced(() => stickToBottom, 50)
+
+  // Notify the parent on stick-to-bottom transitions.
+  // The effect re-runs only when the debounced value actually changes.
+  let lastNotifiedStick = debouncedStickToBottom.current
+  $effect(() => {
+    const stick = debouncedStickToBottom.current
+    if (stick !== lastNotifiedStick) {
+      lastNotifiedStick = stick
+      params.onStickToBottomChange?.(stick)
+    }
+  })
 
   return {
     action: ((

--- a/js-packages/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -26,16 +26,25 @@
   import type { SQLValueJS } from '$lib/types/sql'
 
   let {
-    changeStream
+    changeStream,
+    onScrollPausedChange
   }: {
     changeStream: ChangeStreamData
+    /** Fired whenever scroll-pause toggles: `true` when the user scrolls up off the
+     *  bottom, `false` when the view sticks to the bottom again. */
+    onScrollPausedChange?: (paused: boolean) => void
   } = $props()
 
   let popupRef: HTMLElement | undefined = $state()
   let tooltip = usePopoverTooltip<SQLValueJS>(() => popupRef)
 
+  // Pause the stream when the view stops sticking to the bottom (scrolled up off it) and
+  // resume when it sticks again — the same threshold that toggles `ScrollDownFab`, so
+  // pause/resume and FAB visibility stay in lockstep. Driven by the scroll container's own
+  // notification rather than a reactive read, so the host callback always fires.
   const reverseScroll = useReverseScrollContainer({
-    observeContentSize: () => changeStream.rows.length
+    observeContentSize: () => changeStream.rows.length,
+    onStickToBottomChange: (stickToBottom) => onScrollPausedChange?.(!stickToBottom)
   })
 </script>
 

--- a/js-packages/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
@@ -12,13 +12,16 @@
   const {
     logs,
     search = emptySearchState,
-    onSearchShortcut
+    onSearchShortcut,
+    onStickToBottomChange
   }: {
     logs: { rows: string[]; totalSkippedBytes: number; firstRowIndex: number }
     /** Current search state (see {@link SearchState}), advanced by the host. */
     search?: SearchState
     /** Forwarded to {@link LogList}; invoked on Ctrl-F / Cmd-F inside the list. */
     onSearchShortcut?: () => void
+    /** Forwarded to {@link LogList}; fires when stick-to-bottom toggles. */
+    onStickToBottomChange?: (stickToBottom: boolean) => void
   } = $props()
 
   const getCopyContent = (slice: CopySlice) =>
@@ -33,6 +36,7 @@
   streaming
   {getCopyContent}
   {onSearchShortcut}
+  {onStickToBottomChange}
   class="bg-white-dark rounded pl-2"
 >
   {#snippet header()}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -39,7 +39,12 @@
   type ExtraType = {
     fields: Record<string, Field>
     selected: boolean
+    // Full teardown: stops the network read AND drops this relation's rows from the
+    // buffer (used when a relation is unchecked or the pipeline is torn down).
     cancelStream?: () => void
+    // Bare network stop used by scroll-pause: halts reading but keeps the rows already
+    // received so the paused view stays put. Resume re-establishes the stream.
+    stopStream?: () => void
   }
 
   let pipelinesRelations = $state<
@@ -82,9 +87,16 @@
     pipelineName: string,
     relationName: string
   ) => {
+    const clearStreamHandles = () => {
+      const relation = pipelinesRelations[tenantName]?.[pipelineName]?.[relationName]
+      if (relation) {
+        relation.cancelStream = undefined
+        relation.stopStream = undefined
+      }
+    }
     const request = api.relationEgressStream(pipelineName, relationName).then((result) => {
       if (result instanceof Error) {
-        pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = undefined
+        clearStreamHandles()
         return undefined
       }
 
@@ -142,7 +154,7 @@
             appendForRelation(rows as unknown as Row[], rows[0])
           },
           onParseEnded: () => {
-            pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = undefined
+            clearStreamHandles()
           }
         }
       )
@@ -150,10 +162,20 @@
         cancel()
       }
     })
-    return () => {
+    // Bare network stop: halt reading without removing already-received rows. Drives
+    // scroll-pause, where the paused view must keep showing the latest data.
+    pipelinesRelations[tenantName][pipelineName][relationName].stopStream = () => {
       request.then((cancel) => {
         cancel?.()
-        pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = undefined
+        clearStreamHandles()
+      })
+    }
+    // Full teardown: stop reading and drop this relation's rows from the buffer (used when a
+    // relation is unchecked or the pipeline is torn down).
+    pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = () => {
+      request.then((cancel) => {
+        cancel?.()
+        clearStreamHandles()
         ;({
           rows: changeStream[tenantName][pipelineName].rows,
           headers: changeStream[tenantName][pipelineName].headers
@@ -179,12 +201,40 @@
       if (pipelinesRelations[tenantName][pipelineName][relationName].cancelStream) {
         continue
       }
-      pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = startReadingStream(
-        api,
-        tenantName,
-        pipelineName,
-        relationName
-      )
+      startReadingStream(api, tenantName, pipelineName, relationName)
+    }
+    getChangeStream.current = changeStream
+  }
+  // Scroll-pause: stop reading every selected relation's stream without touching the
+  // buffer, so the view freezes on the rows already received and no new data arrives.
+  const pauseSelectedStreams = (tenantName: string, pipelineName: string) => {
+    const relations = pipelinesRelations[tenantName]?.[pipelineName]
+    if (!relations) {
+      return
+    }
+    for (const relation of Object.values(relations)) {
+      if (relation.selected) {
+        relation.stopStream?.()
+      }
+    }
+  }
+  // Scroll-resume: re-establish a stream for every selected relation that isn't already
+  // streaming. Unlike `startSelectedStreams`, the existing buffer is preserved — resuming
+  // continues the history rather than wiping it.
+  const resumeSelectedStreams = (
+    api: PipelineManagerApi,
+    tenantName: string,
+    pipelineName: string
+  ) => {
+    const relations = pipelinesRelations[tenantName]?.[pipelineName]
+    if (!relations) {
+      return
+    }
+    for (const [relationName, relation] of Object.entries(relations)) {
+      if (!relation.selected || relation.cancelStream) {
+        continue
+      }
+      startReadingStream(api, tenantName, pipelineName, relationName)
     }
     getChangeStream.current = changeStream
   }
@@ -439,8 +489,7 @@
           pipelinesRelations[tenantName][pipelineName][relation.relationName].selected = follow
           if (follow) {
             // If stream is stopped - the action will silently fail
-            pipelinesRelations[tenantName][pipelineName][relation.relationName].cancelStream =
-              startReadingStream(api, tenantName, pipelineName, relation.relationName)
+            startReadingStream(api, tenantName, pipelineName, relation.relationName)
           } else {
             pipelinesRelations[tenantName][pipelineName][relation.relationName].cancelStream?.()
             pipelinesRelations[tenantName][pipelineName][relation.relationName].cancelStream =
@@ -497,7 +546,16 @@
 {#snippet dataView()}
   {#if getChangeStream.current[tenantName]?.[pipelineName]?.rows?.length}
     {#key `${tenantName}::${pipelineName}`}
-      <ChangeStream changeStream={getChangeStream.current[tenantName][pipelineName]}></ChangeStream>
+      <ChangeStream
+        changeStream={getChangeStream.current[tenantName][pipelineName]}
+        onScrollPausedChange={(paused) => {
+          if (paused) {
+            pauseSelectedStreams(tenantName, pipelineName)
+          } else {
+            resumeSelectedStreams(api, tenantName, pipelineName)
+          }
+        }}
+      ></ChangeStream>
     {/key}
   {:else}
     <span class="p-2 text-surface-600-400">

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -83,20 +83,7 @@
     // Close log stream when leaving log tab, switching to another pipeline, or when readonly
     let oldPipelineName = pipelineName
     return () => {
-      if (streams[oldPipelineName]) {
-        if ('open' in streams[oldPipelineName].stream) {
-          streams[oldPipelineName].stream.stop()
-          return
-        }
-        if ('cancelRetry' in streams[oldPipelineName].stream) {
-          streams[oldPipelineName].stream.cancelRetry()
-          return
-        }
-        if ('cancelFetch' in streams[oldPipelineName].stream) {
-          streams[oldPipelineName].stream.cancelFetch()
-          return
-        }
-      }
+      stopLogStream(oldPipelineName)
     }
   })
   const bufferSize = 10000
@@ -159,6 +146,10 @@
         tryRestartStream(pipelineName, isServerOverloaded ? attempts + 1 : 0)
         return
       }
+      // Replace the previous connection's buffer only once fresh data is actually in hand,
+      // not the moment the fetch resolves. Otherwise a reconnect (scroll-resume, retry) blanks
+      // the view between connecting and the first byte. Until then the prior rows stay visible.
+      let freshConnection = true
       const { cancel } = parseStream<string>(
         result,
         newlineTextDecoder({
@@ -169,6 +160,13 @@
         }),
         {
           pushChanges: (changes: string[]) => {
+            if (freshConnection) {
+              freshConnection = false
+              streams[pipelineName].rows = []
+              streams[pipelineName].firstRowIndex = 0
+              streams[pipelineName].rowBoundaries = []
+              streams[pipelineName].totalSkippedBytes = 0
+            }
             const droppedNum = pushAsCircularBuffer(
               () => streams[pipelineName].rows,
               bufferSize,
@@ -177,7 +175,12 @@
             streams[pipelineName].firstRowIndex += droppedNum
           },
           onParseEnded: (reason) => {
-            if (!streams[pipelineName]) {
+            const current = streams[pipelineName]?.stream
+            // Ignore a callback from a stream we've already replaced: scroll-pause can stop
+            // this stream and scroll-resume can open a new one before this 'cancelled' callback
+            // lands. Acting on it would clobber the live stream's handle. Identify "still mine"
+            // by the open ReadableStream reference.
+            if (!current || !('open' in current) || current.open !== result.stream) {
               return
             }
             streams[pipelineName].stream = { closed: {} }
@@ -188,13 +191,9 @@
           }
         }
       )
-      streams[pipelineName] = {
-        firstRowIndex: 0,
-        stream: { open: result.stream, stop: cancel },
-        rows: [],
-        rowBoundaries: [],
-        totalSkippedBytes: 0
-      }
+      // Keep the existing rows in place — only swap in the live stream handle. The buffer is
+      // cleared on the first `pushChanges` above, so the view stays populated until then.
+      streams[pipelineName].stream = { open: result.stream, stop: cancel }
       getStreams.current = streams
     })
   }
@@ -215,6 +214,53 @@
         streams[pipelineName].stream = { closed: {} }
       },
       retryAtTimestamp: Date.now() + delayMs
+    }
+  }
+
+  // Stop the log feed whatever state it's in — an open stream, an in-flight connect, or a
+  // pending retry — and mark it closed. A clean stop reports 'cancelled' to `onParseEnded`,
+  // which deliberately does not auto-restart. Used by scroll-pause (so the user can read back
+  // through history with no "connection lost" banner) and by teardown when leaving the tab or
+  // switching pipelines.
+  const stopLogStream = (pipelineName: string) => {
+    const stream = streams[pipelineName]?.stream
+    if (!stream) {
+      return
+    }
+    if ('open' in stream) {
+      stream.stop()
+      // Mark closed now rather than waiting for the (delayed) onParseEnded tick, so a
+      // scroll-resume that arrives within the flush window sees a closed stream and reconnects.
+      streams[pipelineName].stream = { closed: {} }
+    } else if ('cancelFetch' in stream) {
+      stream.cancelFetch()
+    } else if ('cancelRetry' in stream) {
+      stream.cancelRetry()
+    }
+  }
+  // Scroll-resume: when the view sticks to the bottom again, reconnect the feed. Drop any
+  // pending retry first so we connect immediately rather than waiting out the backoff.
+  const resumeLogStream = (pipelineName: string) => {
+    const s = streams[pipelineName]?.stream
+    if (!s) {
+      return
+    }
+    if ('cancelRetry' in s) {
+      s.cancelRetry()
+    }
+    if ('open' in s || 'cancelFetch' in s) {
+      return
+    }
+    startStream(pipelineName, 0)
+  }
+  const onStickToBottomChange = (stickToBottom: boolean) => {
+    if (deleted) {
+      return
+    }
+    if (stickToBottom) {
+      resumeLogStream(pipelineName)
+    } else {
+      stopLogStream(pipelineName)
     }
   }
 
@@ -274,7 +320,11 @@
     <WarningBanner>Connecting to logs stream...</WarningBanner>
   {/if}
   {#key pipelineName}
-    <LogsStreamList logs={pipelineLogs} search={logSearch} onSearchShortcut={onLogSearchShortcut}
+    <LogsStreamList
+      logs={pipelineLogs}
+      search={logSearch}
+      onSearchShortcut={onLogSearchShortcut}
+      {onStickToBottomChange}
     ></LogsStreamList>
   {/key}
 </div>

--- a/js-packages/web-console/src/lib/functions/pipelines/changeStream.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/changeStream.spec.ts
@@ -164,6 +164,52 @@ describe('parseStream', () => {
     // JS Number would coerce this to 1e19; BigNumber preserves it verbatim.
     expect(values[0].v.toFixed()).toBe(huge)
   })
+
+  it('drops parsed-but-unflushed rows when cancelled (scroll-pause: no data after stop)', async () => {
+    // Regression guard for scroll-pause: when the consumer cancels, rows the decoder
+    // already parsed into the internal buffer but the flush timer hasn't emitted yet
+    // must be discarded, not delivered on the next tick. Without this, scrolling up to
+    // pause would still drip the already-buffered rows into the (frozen) view.
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+    const values: BigNumber[] = []
+    let endedReason: 'ended' | 'cancelled' | undefined
+    const parser = createBigNumberStreamParser<{ a: BigNumber }>({ paths: ['$'], separator: '' })
+
+    // A stream that yields one chunk then stays open forever, so the decode loop parks on
+    // its next `read()` — the only thing that stops it is the cancel under test.
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"a":1}\n{"a":2}\n{"a":3}\n'))
+      }
+    })
+
+    const { cancel } = parseStream<{ a: BigNumber }>(
+      { stream, cancel: () => {} },
+      newlineJsonDecoder(parser),
+      {
+        pushChanges: (vs) => values.push(...vs.map((v) => v.a)),
+        onParseEnded: (reason) => {
+          endedReason = reason
+        }
+      },
+      // Long flush interval: the three rows sit parsed-but-unflushed in the buffer when we cancel.
+      { flushIntervalMs: 500 }
+    )
+
+    // Let the decoder parse and admit all three rows into the internal buffer. The flush
+    // timer hasn't fired yet (500ms), so nothing has reached the consumer.
+    await sleep(100)
+    expect(values).toEqual([])
+
+    cancel()
+
+    // Wait past the flush interval: the post-cancel tick must emit nothing (buffer cleared)
+    // and then report the cancellation.
+    await sleep(600)
+    expect(values).toEqual([])
+    expect(endedReason).toBe('cancelled')
+  })
 })
 
 // Same shape as `runParseStream`, but drives `newlineTextDecoder` over the same

--- a/js-packages/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -229,6 +229,8 @@ export const parseStream = <T>(
     cancel: () => {
       cancelled = true
       closedReason = 'cancelled'
+      // Drop everything parsed-but-not-yet-flushed.
+      outBuffer.length = 0
       Promise.resolve(decoder.cancel?.())
         .catch(() => {})
         .finally(() => {


### PR DESCRIPTION
When the user scrolls up in either tabs the updates stop being processed and displayed, so the user can inspect all history without interruptions. When the user scrolls all the way down or presses the purple "scroll to bottom" button the streams resume

Also fixes related bug: Fix https://github.com/feldera/feldera/issues/6476

[Screencast from 2026-06-17 20-31-28.webm](https://github.com/user-attachments/assets/0bc36b9b-07d3-4e7c-956e-c139ba461f9d)
