### PR TITLE
adapters: dynamodb-output: remove cross step overlapping

### DIFF
--- a/crates/adapters/src/integrated/dynamodb/output.rs
+++ b/crates/adapters/src/integrated/dynamodb/output.rs
@@ -76,7 +76,6 @@ pub(crate) struct DynamoDBWorker {
     controller: Weak<ControllerInner>,
     table: String,
     write_mode: DynamoDBWriteMode,
-    allow_cross_step_write_overlap: bool,
     batch_size: usize,
     max_retries: Option<u8>,
     client: Client,
@@ -143,7 +142,6 @@ impl DynamoDBWorker {
             controller,
             table: config.table.clone(),
             write_mode: config.write_mode,
-            allow_cross_step_write_overlap: config.allow_cross_step_write_overlap,
             batch_size: config.effective_batch_size(),
             max_retries: config.max_retries,
             client,
@@ -209,11 +207,7 @@ impl DynamoDBWorker {
     pub(crate) fn batch_end_inner(&mut self) -> AnyResult<u64> {
         let flush_result = self.flush();
 
-        let (total_retries, mut errors) = if self.allow_cross_step_write_overlap {
-            self.drain_completed_writes()
-        } else {
-            self.drain_pending_writes()
-        };
+        let (total_retries, mut errors) = self.drain_pending_writes();
 
         if let Err(e) = flush_result {
             errors.push(e);
@@ -274,9 +268,6 @@ impl DynamoDBWorker {
         let table = self.table.clone();
         let write_mode = self.write_mode;
         let max_retries: Option<usize> = self.max_retries.map(|n| n as usize);
-        let allow_cross_step_write_overlap = self.allow_cross_step_write_overlap;
-        let endpoint_id = self.endpoint_id;
-        let task_controller = self.controller.clone();
         self.metrics.record_write_chunk();
         let task_metrics = self.metrics.clone();
         let task_records_written = self.records_written.clone();
@@ -328,34 +319,9 @@ impl DynamoDBWorker {
                         task_records_written.fetch_add(rows as u64, Ordering::Relaxed);
                         task_bytes_written.fetch_add(bytes as u64, Ordering::Relaxed);
                         task_metrics.record_retries(retries);
-                        if allow_cross_step_write_overlap
-                            && let Some(controller) = task_controller.upgrade()
-                        {
-                            controller.status.output_buffer(endpoint_id, bytes, rows);
-                        }
                         Ok(retries)
                     }
-                    Err(error) => {
-                        if allow_cross_step_write_overlap {
-                            if let Some(controller) = task_controller.upgrade() {
-                                controller.output_transport_error(
-                                    endpoint_id,
-                                    &endpoint_name,
-                                    false,
-                                    error,
-                                    Some("dynamodb_async_write"),
-                                );
-                            } else {
-                                warn!(
-                                    endpoint = %endpoint_name,
-                                    "dynamodb: write failed after endpoint shutdown"
-                                );
-                            }
-                            Ok(0)
-                        } else {
-                            Err(error)
-                        }
-                    }
+                    Err(error) => Err(error),
                 }
             },
             TOKIO.handle(),
@@ -751,9 +717,7 @@ impl OutputConsumer for DynamoDBOutputEndpoint {
                 let num_rows = self.records_written.load(Ordering::Relaxed);
                 let num_bytes = self.bytes_written.load(Ordering::Relaxed);
 
-                if !self.config.allow_cross_step_write_overlap
-                    && let Some(controller) = self.controller.upgrade()
-                {
+                if let Some(controller) = self.controller.upgrade() {
                     controller.status.output_buffer(
                         self.endpoint_id,
                         num_bytes as usize,

--- a/crates/adapters/src/integrated/dynamodb/test.rs
+++ b/crates/adapters/src/integrated/dynamodb/test.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::thread::sleep;
@@ -19,6 +20,7 @@ use feldera_macros::IsNone;
 use feldera_sqllib::{
     ByteArray, Date, F32, F64, SqlDecimal, SqlString, Time, Timestamp, Uuid, Variant,
 };
+use feldera_types::config::PipelineConfig;
 use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
 use feldera_types::transport::dynamodb::{DynamoDBWriteMode, DynamoDBWriterConfig};
 use feldera_types::{
@@ -26,13 +28,16 @@ use feldera_types::{
 };
 use rand::Rng;
 use rand::distributions::Alphanumeric;
+use serde_json::json;
 use size_of::SizeOf;
+use tempfile::NamedTempFile;
 
+use crate::Controller;
 use crate::catalog::RecordFormat;
 use crate::controller::EndpointId;
 use crate::format::Encoder;
 use crate::static_compile::seroutput::SerBatchImpl;
-use crate::test::TestStruct;
+use crate::test::{TestStruct, test_circuit_with_index, wait};
 
 use super::helpers::make_client;
 use super::metrics::DynamoDBOutputMetrics;
@@ -317,7 +322,6 @@ fn config(batch_size: usize) -> DynamoDBWriterConfig {
         max_buffer_size_bytes: 1024 * 1024,
         max_concurrent_requests: 16,
         threads: 1,
-        allow_cross_step_write_overlap: false,
         max_retries: Some(10),
     }
 }
@@ -346,7 +350,6 @@ fn endpoint_config(
         max_buffer_size_bytes: 1024 * 1024,
         max_concurrent_requests: 16,
         threads,
-        allow_cross_step_write_overlap: false,
         max_retries: Some(10),
     }
 }
@@ -658,6 +661,35 @@ fn encoder_flushes_when_record_threshold_is_reached() {
     stage_batch(&mut worker, &batch);
     // Reaching the record threshold drains `pending` via a mid-encode flush.
     assert!(worker.pending.is_empty());
+}
+
+#[test]
+fn encoder_pending_never_buffers_whole_batch() {
+    // `push_request` flushes every `batch_size` records, so a batch far larger
+    // than `batch_size` is never buffered whole in `pending`: only the
+    // sub-`batch_size` remainder stays staged until `batch_end`.
+    const BATCH_SIZE: usize = 10;
+    const RECORDS: i32 = 25;
+
+    let mut config = config(BATCH_SIZE);
+    // Enough permits that no flush blocks, and `usize::MAX` bytes so the
+    // count-based flush is exercised in isolation from the byte-based one.
+    config.max_concurrent_requests = 64;
+    config.max_buffer_size_bytes = usize::MAX;
+    let mut worker = worker_with_config(config);
+
+    let batch = build_batch(
+        (0..RECORDS)
+            .map(|id| (record(id, "bulk", Some(id as i64), "r"), 1))
+            .collect(),
+    );
+    stage_batch(&mut worker, &batch);
+
+    // The 25 records flush at 10 and 20; only the trailing 5 remain staged, so
+    // `pending` holds the remainder rather than the entire batch.
+    assert_eq!(worker.pending.len(), RECORDS as usize % BATCH_SIZE);
+    assert!(worker.pending.len() < BATCH_SIZE);
+    assert!(worker.pending.len() < RECORDS as usize);
 }
 
 #[test]
@@ -1298,6 +1330,79 @@ fn dynamodb_endpoint(
     .unwrap()
 }
 
+fn write_raw_json_input(records: &[TestRecord]) -> NamedTempFile {
+    let mut input_file = NamedTempFile::new().unwrap();
+    for record in records {
+        input_file
+            .as_file_mut()
+            .write_all(&serde_json::to_vec(record).unwrap())
+            .unwrap();
+        input_file.write_all(b"\n").unwrap();
+    }
+    input_file
+}
+
+fn dynamodb_buffered_output_pipeline(
+    table: &str,
+    endpoint_url: Option<&str>,
+    input_file: &NamedTempFile,
+    max_output_buffer_size_records: usize,
+    max_output_buffer_time_millis: u64,
+) -> Controller {
+    let output_config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), 1);
+    let config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 1,
+        "inputs": {
+            "test_input1": {
+                "stream": "test_input1",
+                "transport": {
+                    "name": "file_input",
+                    "config": { "path": input_file.path() }
+                },
+                "format": {
+                    "name": "json",
+                    "config": { "update_format": "raw" }
+                }
+            }
+        },
+        "outputs": {
+            "test_output1": {
+                "stream": "test_output1",
+                "index": "idx1",
+                "enable_output_buffer": true,
+                "max_output_buffer_size_records": max_output_buffer_size_records,
+                "max_output_buffer_time_millis": max_output_buffer_time_millis,
+                "transport": {
+                    "name": "dynamodb_output",
+                    "config": output_config
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    let schema = value_relation().fields;
+    Controller::with_test_config(
+        move |workers| {
+            Ok(test_circuit_with_index::<TestRecord, TestKey, _>(
+                workers,
+                &schema,
+                &[SqlIdentifier::from("id"), SqlIdentifier::from("sort")],
+                |x: &TestRecord| TestKey {
+                    id: x.id,
+                    sort: x.sort.clone(),
+                },
+                &[None],
+                false,
+            ))
+        },
+        &config,
+        Box::new(move |e, _| panic!("dynamodb output buffer test: error: {e}")),
+    )
+    .unwrap()
+}
+
 fn dynamodb_all_types_endpoint(table: &str, endpoint_url: Option<&str>) -> DynamoDBOutputEndpoint {
     let config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), 2);
     DynamoDBOutputEndpoint::new(
@@ -1420,6 +1525,49 @@ fn dynamodb_all_supported_sql_types_round_trip() {
     let rows = scan_table(&client, &table);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0], expected_all_types_item());
+}
+
+#[test]
+fn dynamodb_output_buffer_flushes_by_size() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("output_buffer_size");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let input_file = write_raw_json_input(&[
+        record(1, "a", Some(10), "one"),
+        record(2, "b", Some(20), "two"),
+        record(3, "c", Some(30), "three"),
+    ]);
+    let controller =
+        dynamodb_buffered_output_pipeline(&table, endpoint_url.as_deref(), &input_file, 3, 60_000);
+
+    controller.start();
+    wait(|| scan_table(&client, &table).len() == 3, 60_000)
+        .expect("timeout waiting for size-triggered output buffer flush");
+    controller.stop().unwrap();
+}
+
+#[test]
+fn dynamodb_output_buffer_flushes_by_time() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("output_buffer_time");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+    let input_file = write_raw_json_input(&[
+        record(1, "a", Some(10), "one"),
+        record(2, "b", Some(20), "two"),
+    ]);
+    let controller =
+        dynamodb_buffered_output_pipeline(&table, endpoint_url.as_deref(), &input_file, 1_000, 200);
+
+    controller.start();
+    wait(|| scan_table(&client, &table).len() == 2, 60_000)
+        .expect("timeout waiting for time-triggered output buffer flush");
+    controller.stop().unwrap();
 }
 
 /// Encodes a batch holding two normal-sized records and one record that exceeds

--- a/crates/feldera-types/src/transport/dynamodb.rs
+++ b/crates/feldera-types/src/transport/dynamodb.rs
@@ -35,10 +35,6 @@ fn default_write_mode() -> DynamoDBWriteMode {
     DynamoDBWriteMode::Batch
 }
 
-fn default_allow_cross_step_write_overlap() -> bool {
-    false
-}
-
 /// DynamoDB write API used by the output connector.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -129,19 +125,6 @@ pub struct DynamoDBWriterConfig {
     #[serde(default = "default_threads")]
     #[schema(default = default_threads)]
     pub threads: usize,
-
-    /// Allow write requests from later DBSP steps to be submitted before all
-    /// write requests from previous steps have completed.
-    ///
-    /// The default is `false`, each `batch_end` waits until all writes for that
-    /// batch have drained before the next step can be encoded. Setting this to
-    /// `true` can increase throughput for small steps by keeping DynamoDB requests
-    /// in flight across step boundaries. This allows writes from different steps to
-    /// overlap; use it for insert-only or mostly disjoint-key workloads where cross-step
-    /// write ordering to the same DynamoDB item is not required.
-    #[serde(default = "default_allow_cross_step_write_overlap")]
-    #[schema(default = default_allow_cross_step_write_overlap)]
-    pub allow_cross_step_write_overlap: bool,
 
     /// Maximum number of retries for a failed or partially-applied DynamoDB write chunk.
     ///
@@ -248,7 +231,6 @@ mod tests {
             max_buffer_size_bytes: 1024 * 1024,
             max_concurrent_requests: 16,
             threads: 1,
-            allow_cross_step_write_overlap: false,
             max_retries: Some(10u8),
         }
     }

--- a/docs.feldera.com/docs/connectors/sinks/dynamodb.md
+++ b/docs.feldera.com/docs/connectors/sinks/dynamodb.md
@@ -29,7 +29,6 @@ the index must include both columns.
 | `max_buffer_size_bytes`          | integer | `1048576` | Maximum number of bytes buffered by each worker thread before flushing to DynamoDB. Default is 1 MiB (`1048576` bytes).                                                                                                                                                                                                                                                                                 |
 | `max_concurrent_requests`        | integer | `64`      | Maximum number of DynamoDB write requests in flight per worker thread at any one time. The connector blocks the encoding thread when this limit is reached, applying backpressure to the pipeline.                                                                                                                                                                                                      |
 | `threads`                        | integer | `1`       | Number of parallel worker threads used to encode and write disjoint key ranges. Each thread makes its own DynamoDB API calls. Increasing this value can improve throughput for large batches.                                                                                                                                                                                                           |
-| `allow_cross_step_write_overlap` | boolean | `false`   | Allow writes from later DBSP steps to be submitted before all writes from earlier steps have completed. This can improve throughput for small steps by keeping DynamoDB requests in flight across step boundaries. Use for mostly disjoint-key workloads where cross-step write ordering to the same DynamoDB item is not required.                                                                     |
 | `max_retries`                    | integer | `10`      | Maximum number of retries for a failed or partially-applied DynamoDB write. For `batch` mode, retries apply to items returned as unprocessed in a successful response. For `transactional` mode, retries apply to failed `TransactWriteItems` calls. Set to `null` to retry indefinitely. Transient errors such as throttling are handled separately by the AWS SDK and do not count toward this limit. |
 
 [*]: Required fields
@@ -68,21 +67,27 @@ same batch are still written. Dropped records are reported through the
 
 ## Performance
 
+:::note
+
+The connector waits for every write request of a DBSP step to complete before it
+starts the next step. This serialization can limit write throughput, especially
+for pipelines that produce many small steps. To reduce its impact, enable the
+[output buffer](/connectors#configuring-the-output-buffer) so the pipeline
+accumulates more changes into each step before writing them to DynamoDB.
+
+:::
+
 The following samples were measured using a Feldera pipeline writing
 well-distributed records smaller than 1 KiB to a DynamoDB table provisioned with
 40k WCU.
 
-| `threads` | `max_concurrent_requests` | WCU/s without overlap | WCU/s with overlap |
-| --------- | ------------------------- | --------------------- | ------------------ |
-| 1         | 64                        | ~7.7k                 | ~16.9k             |
-| 1         | 128                       | ~27.2k                | ~37.1k             |
+| `threads` | `max_concurrent_requests` | WCU/s   |
+| --------- | ------------------------- | ------- |
+| 1         | 64                        | ~7.7k   |
+| 1         | 128                       | ~27.2k  |
 
 Suggestions:
 
-- Enable `allow_cross_step_write_overlap` to keep DynamoDB requests in flight
-  across step boundaries instead of draining the entire write pipeline at every
-  `batch_end`; in these measurements, it more than doubled WCU/s at `threads=1`,
-  `max_concurrent_requests=64`.
 - Increase `max_concurrent_requests` when DynamoDB still has unused capacity.
 - If increasing `threads` or `max_concurrent_requests` does not improve
   throughput, check whether the pipeline is stalling because output buffers are

--- a/openapi.json
+++ b/openapi.json
@@ -8928,11 +8928,6 @@
           "region"
         ],
         "properties": {
-          "allow_cross_step_write_overlap": {
-            "type": "boolean",
-            "description": "Allow write requests from later DBSP steps to be submitted before all\nwrite requests from previous steps have completed.\n\nThe default is `false`, each `batch_end` waits until all writes for that\nbatch have drained before the next step can be encoded. Setting this to\n`true` can increase throughput for small steps by keeping DynamoDB requests\nin flight across step boundaries. This allows writes from different steps to\noverlap; use it for insert-only or mostly disjoint-key workloads where cross-step\nwrite ordering to the same DynamoDB item is not required.",
-            "default": false
-          },
           "aws_access_key_id": {
             "type": "string",
             "description": "AWS access key ID.\n\nIf both `aws_access_key_id` and `aws_secret_access_key` are specified,\nthe connector uses these static credentials. Otherwise it uses the\ndefault AWS credential provider chain, including IAM Roles for Service\nAccounts (IRSA) in EKS.\n\nStatic credentials are treated as long-lived IAM keys: no session token\nis sent, so STS-issued temporary credentials are not supported via these\nfields. To use temporary credentials, rely on the default provider chain\ninstead (leave these unset).",


### PR DESCRIPTION
Removes the cross step overlapping feature in the DynamoDB output connector.
Cross step overlapping would allow the connector to start writing batches in a new step when some of the batches from previous step are still being written.

While this increased the throughput, it also introduces correctness issues.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))

### Describe Incompatible Changes

Removes the overlapping feature and its config flag from the DynamoDB output connector.