### PR TITLE
[web-console] Correctly show configured memory limit on multihost deployments

### DIFF
--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
@@ -15,7 +15,7 @@
   import { getThemeColor } from '$lib/functions/common/color'
   import { humanSize } from '$lib/functions/common/string'
   import { tuple } from '$lib/functions/common/tuple'
-  import { timeSeriesAxisMax } from '$lib/functions/pipelineMetrics'
+  import { multihostMemoryLimitMb, timeSeriesAxisMax } from '$lib/functions/pipelineMetrics'
   import type { Pipeline } from '$lib/services/pipelineManager'
   import type { TimeSeriesEntry } from '$lib/types/pipelineManager'
 
@@ -49,8 +49,14 @@
   const yMaxStep = $derived(2 ** Math.ceil(Math.log2(valueMax * 1.25)))
   const yMax = $derived(valueMax !== 0 ? yMaxStep : 1024 * 2048)
   const yMin = 0
+  // The reported memory metric (`m`) is the sum across all hosts in a multihost
+  // deployment, while `memory_mb_max` is the per-host limit. Scale the limit by
+  // the number of hosts.
   const maxMemoryMb = $derived(
-    pipeline.current.runtimeConfig?.resources?.memory_mb_max ?? undefined
+    multihostMemoryLimitMb(
+      pipeline.current.runtimeConfig?.resources?.memory_mb_max,
+      pipeline.current.runtimeConfig?.hosts
+    )
   )
 
   const primaryColor = getThemeColor('--color-primary-500').format('hex')
@@ -92,9 +98,7 @@
         {
           markline: {
             data: maxMemoryMb
-              ? [
-                  { yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } } // example 1
-                ]
+              ? [{ yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } }]
               : []
           }
         }
@@ -182,9 +186,7 @@
           symbol: ['none', 'none'],
           // svelte-ignore state_referenced_locally
           data: maxMemoryMb
-            ? [
-                { yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } } // example 1
-              ]
+            ? [{ yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } }]
             : []
         },
         triggerLineEvent: true

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TimeSeriesEntry } from '$lib/types/pipelineManager'
-import { timeSeriesAxisMax } from './pipelineMetrics'
+import { multihostMemoryLimitMb, timeSeriesAxisMax } from './pipelineMetrics'
 
 const sampleAt = (timeMs: number): TimeSeriesEntry => ({
   t: timeMs,
@@ -18,5 +18,29 @@ describe('timeSeriesAxisMax', () => {
 
   it('falls back to the supplied time source when there are no samples', () => {
     expect(timeSeriesAxisMax([], () => 4242)).toBe(4242)
+  })
+})
+
+describe('multihostMemoryLimitMb', () => {
+  it('returns the per-host limit unchanged for a single host', () => {
+    expect(multihostMemoryLimitMb(2048, 1)).toBe(2048)
+  })
+
+  it('scales the per-host limit by the number of hosts in a multihost deployment', () => {
+    // The reported memory metric sums RSS across all hosts, so the limit line
+    // must reflect the aggregate ceiling, not the per-host limit.
+    expect(multihostMemoryLimitMb(2048, 3)).toBe(3 * 2048)
+  })
+
+  it('treats a missing or non-positive host count as a single host', () => {
+    expect(multihostMemoryLimitMb(2048, undefined)).toBe(2048)
+    expect(multihostMemoryLimitMb(2048, null)).toBe(2048)
+    expect(multihostMemoryLimitMb(2048, 0)).toBe(2048)
+  })
+
+  it('returns undefined when no memory limit is configured', () => {
+    expect(multihostMemoryLimitMb(undefined, 3)).toBeUndefined()
+    expect(multihostMemoryLimitMb(null, 3)).toBeUndefined()
+    expect(multihostMemoryLimitMb(0, 3)).toBeUndefined()
   })
 })

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -215,6 +215,23 @@ export const timeSeriesAxisMax = (metrics: TimeSeriesEntry[], now: () => number 
   metrics.at(-1)?.t ?? now()
 
 /**
+ * Memory limit on a multi-host deployment, in MB.
+ *
+ * `memory_mb_max` is the individual host's limit, but the reported memory metric
+ * is the sum of resident memory across all hosts in a multihost deployment.
+ * To keep the limit line meaningful, multiply the per-host limit by the number of hosts.
+ *
+ * @param perHostMemoryMb - Per-host limit `runtimeConfig.resources.memory_mb_max`, in MB.
+ * @param hosts - Number of hosts `runtimeConfig.hosts`; treated as at least 1.
+ * @returns The aggregate limit in MB, or undefined when no limit is configured.
+ */
+export const multihostMemoryLimitMb = (
+  perHostMemoryMb: number | null | undefined,
+  hosts: number | null | undefined
+): number | undefined =>
+  perHostMemoryMb ? perHostMemoryMb * Math.max(hosts ?? 1, 1) : undefined
+
+/**
  * @returns Time series of throughput with smoothing window over 3 data intervals
  */
 export const calcPipelineThroughput = (metrics: TimeSeriesEntry[]) => {


### PR DESCRIPTION
The reported memory limit is simply multiplied by the reported number of hosts
Testing: added unit tests

Fix https://github.com/feldera/feldera/issues/6398