### PR TITLE
[python] Enable previously-disabled test which needed a new runtime

### DIFF
--- a/python/tests/runtime/test_postprocessor.py
+++ b/python/tests/runtime/test_postprocessor.py
@@ -68,9 +68,6 @@ def _consume_all(topic: str, timeout_s: float = 30.0) -> list[dict]:
 # Kafka lets us verify the scaled values it wrote.
 class TestPostprocessor(PipelineTestCase):
     def test_postprocessor(self):
-        if True:
-            # Disabled https://github.com/feldera/feldera/issues/6460
-            return
         admin = AdminClient({"bootstrap.servers": KAFKA_BOOTSTRAP})
         output_topic = _random_topic("postprocessor-out")
         _create_topic(admin, output_topic)


### PR DESCRIPTION
Fixes #6460 

This test could not be merged until the platform was updated, and the cloud build was broken.