### PR TITLE
[SQL] Emit source positions in --jit representation

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.backend;
 
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.DBSPFunction;
@@ -109,6 +110,14 @@ public class ToJsonInnerVisitor extends InnerVisitor {
             this.property("id");
             this.stream.append(node.getId());
             this.serialized.add(node.getId());
+
+            if (this.verbosity > 0) {
+                SourcePositionRange range = node.getNode().getPositionRange();
+                if (range.isValid()) {
+                    this.property("position");
+                    this.stream.append(range);
+                }
+            }
         }
         super.push(node);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/JsonStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/JsonStream.java
@@ -1,5 +1,8 @@
 package org.dbsp.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +25,20 @@ public class JsonStream {
         this.stream = stream;
     }
 
+    public JsonStream append(SourcePositionRange range) {
+        this.beginObject();
+        this.label("start_line_number");
+        this.append(range.start.line);
+        this.label("start_column");
+        this.append(range.start.column);
+        this.label("end_line_number");
+        this.append(range.end.line);
+        this.label("end_column");
+        this.append(range.end.column);
+        this.endObject();
+        return this;
+    }
+    
     public JsonStream append(String string) {
         this.value();
         try {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -482,6 +482,9 @@ public class MetadataTests extends BaseSQLTests {
         CompilerMain.execute("--jit", "-o", json.getPath(), file.getPath());
         ObjectMapper mapper = Utilities.deterministicObjectMapper();
         JsonNode parsed = mapper.readTree(json);
+        String contents = Utilities.readFile(json.getPath());
+        // File contains source position information
+        Assert.assertTrue(contents.contains("position"));
         DBSPCompiler compiler = new DBSPCompiler(new CompilerOptions());
         JsonDecoder decoder = new JsonDecoder(compiler.sqlToRelCompiler.typeFactory);
         DBSPCircuit result = decoder.decodeOuter(parsed, DBSPCircuit.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
@@ -5,11 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dbsp.sqlCompiler.CompilerMain;
 import org.dbsp.sqlCompiler.compiler.backend.rust.multi.MultiCrates;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
-import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;


### PR DESCRIPTION
### Describe Manual Test Plan

Checked the json output produced, here is a little sample:

```
       "class": "DBSPBinaryExpression","id": 17311,"position": {
        "start_line_number": 80,"start_column": 10,"end_line_number": 80,"end_column": 21
       },"type": {
        "node": 401
       },"left": {
         ...
       },"right": {
         ...
       },"opcode": "GT"
```

## Checklist

- [x] Unit tests added/updated
