### PR TITLE
deps(py): bump pyJWT and pyarrow versions

### DIFF
--- a/crates/iceberg/src/test/requirements.ci.txt
+++ b/crates/iceberg/src/test/requirements.ci.txt
@@ -1,7 +1,7 @@
 # Only include requirements used in CI (no s3 or glue pyiceberg features).
 numpy==2.2.0
 pandas==2.2.3
-pyarrow==17.0.0
-pyiceberg[sql-sqlite]==0.8.1
+pyarrow==23.0.1
+pyiceberg[sql-sqlite,pyiceberg-core]==0.11.1
 # Transitive dependency via pyiceberg.
-pydantic==2.11.10
+pydantic==2.13.4

--- a/crates/iceberg/src/test/requirements.txt
+++ b/crates/iceberg/src/test/requirements.txt
@@ -1,6 +1,6 @@
 numpy==2.2.0
 pandas==2.2.3
-pyarrow==17.0.0
-pyiceberg[s3fs,glue,sql-sqlite]==0.8.1
+pyarrow==23.0.1
+pyiceberg[s3fs,glue,sql-sqlite,pyiceberg-core]==0.11.1
 # Transitive dependency via pyiceberg.
-pydantic==2.11.10
+pydantic==2.13.4

--- a/python/dbt-feldera/uv.lock
+++ b/python/dbt-feldera/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-11T14:17:25.329850715Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -305,7 +305,7 @@ wheels = [
 
 [[package]]
 name = "dbt-feldera"
-version = "0.299.0"
+version = "0.313.0"
 source = { editable = "." }
 dependencies = [
     { name = "agate" },
@@ -1207,14 +1207,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numpy>=2.2.4",
     "pretty-errors",
     "ruff>=0.6.9",
-    "PyJWT>=2.12.0",
+    "PyJWT>=2.13.0",
     "tenacity>=9.1.4",
     "pyarrow>=24.0",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-16T05:50:17.266848806Z"
+exclude-newer = "2026-06-11T14:17:18.675358746Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -360,7 +360,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.1.2" },
     { name = "pretty-errors" },
     { name = "pyarrow", specifier = ">=24.0" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "requests" },
     { name = "ruff", specifier = ">=0.6.9" },
     { name = "tenacity", specifier = ">=9.1.4" },
@@ -885,14 +885,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps pyJWT to 2.13.0 in python packages, and pyarrow to 23.0.1 in iceberg test requirements.


