### PR TITLE
pipeline-manager: fix row locking

### DIFF
--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -16,7 +16,7 @@ use feldera_types::error::ErrorResponse;
 use refinery::Error as RefineryError;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{backtrace::Backtrace, borrow::Cow, error::Error as StdError, fmt, fmt::Display};
-use tokio_postgres::error::Error as PgError;
+use tokio_postgres::error::{Error as PgError, SqlState};
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
@@ -256,6 +256,8 @@ pub enum DBError {
         event_id: PipelineMonitorEventId,
     },
     NoPipelineMonitorEventsAvailable,
+    LockTookTooLong,
+    DeadlockDetected,
 }
 
 impl DBError {
@@ -394,6 +396,13 @@ where
 
 impl From<PgError> for DBError {
     fn from(error: PgError) -> Self {
+        if let Some(error) = error.as_db_error() {
+            if matches!(error.code(), &SqlState::LOCK_NOT_AVAILABLE) {
+                return DBError::LockTookTooLong;
+            } else if matches!(error.code(), &SqlState::T_R_DEADLOCK_DETECTED) {
+                return DBError::DeadlockDetected;
+            }
+        }
         Self::PostgresError {
             error: Box::new(error),
             backtrace: Backtrace::capture(),
@@ -812,6 +821,12 @@ impl Display for DBError {
             DBError::NoPipelineMonitorEventsAvailable => {
                 write!(f, "There are not yet any pipeline monitor events recorded")
             }
+            DBError::LockTookTooLong => {
+                write!(f, "The lock required for this operation took too long to acquire. Try this operation again later.")
+            }
+            DBError::DeadlockDetected => {
+                write!(f, "A deadlock was detected while performing the operation. Try this operation again later. Please also file a bug report, as this error should not happen.")
+            }
         }
     }
 }
@@ -931,6 +946,8 @@ impl DetailedError for DBError {
             }
             Self::UnknownPipelineMonitorEvent { .. } => Cow::from("UnknownPipelineMonitorEvent"),
             Self::NoPipelineMonitorEventsAvailable => Cow::from("NoPipelineMonitorEventsAvailable"),
+            Self::LockTookTooLong => Cow::from("LockTookTooLong"),
+            Self::DeadlockDetected => Cow::from("DeadlockDetected"),
         }
     }
 }
@@ -1014,6 +1031,8 @@ impl ResponseError for DBError {
             Self::UnnecessaryResourcesStatusTransition { .. } => StatusCode::BAD_REQUEST,
             Self::UnknownPipelineMonitorEvent { .. } => StatusCode::NOT_FOUND,
             Self::NoPipelineMonitorEventsAvailable => StatusCode::NOT_FOUND,
+            Self::LockTookTooLong => StatusCode::SERVICE_UNAVAILABLE,
+            Self::DeadlockDetected => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -38,6 +38,12 @@ use tokio_postgres::Row;
 use tracing::warn;
 use uuid::Uuid;
 
+/// This expression converts the first 8 bytes of the pipeline UUID to a BIGINT,
+/// and takes its absolute value. It is used to determine which compiler server
+/// worker the pipeline is assigned to.
+const PIPELINE_ID_SQL_HASH_FUNCTION_CALL: &str =
+    "abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint)";
+
 pub(crate) async fn list_pipelines(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
@@ -78,17 +84,25 @@ pub(crate) async fn list_pipelines_for_monitoring(
     Ok(result)
 }
 
+/// Retrieve pipeline complete descriptor by its name.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 pub(crate) async fn get_pipeline(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     name: &str,
+    row_lock: bool,
 ) -> Result<ExtendedPipelineDescr, DBError> {
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT {PIPELINE_COLUMNS_ALL}
              FROM pipeline AS p
              WHERE p.tenant_id = $1 AND p.name = $2
-            "
+             {}
+            ",
+            if row_lock { "FOR UPDATE" } else { "" }
         ))
         .await?;
     let row = txn.query_opt(&stmt, &[&tenant_id.0, &name]).await?.ok_or(
@@ -99,17 +113,25 @@ pub(crate) async fn get_pipeline(
     parse_pipeline_row_all(&row)
 }
 
+/// Retrieve pipeline monitoring descriptor (only contains status-related fields) by its name.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 pub(crate) async fn get_pipeline_for_monitoring(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     name: &str,
+    row_lock: bool,
 ) -> Result<ExtendedPipelineDescrMonitoring, DBError> {
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT {PIPELINE_COLUMNS_MONITORING}
              FROM pipeline AS p
              WHERE p.tenant_id = $1 AND p.name = $2
-            "
+             {}
+            ",
+            if row_lock { "FOR UPDATE" } else { "" }
         ))
         .await?;
     let row = txn.query_opt(&stmt, &[&tenant_id.0, &name]).await?.ok_or(
@@ -120,18 +142,27 @@ pub(crate) async fn get_pipeline_for_monitoring(
     parse_pipeline_row_monitoring(&row)
 }
 
+/// Retrieve pipeline by its identifier; internal helper that allows specifying which `fields`
+/// to retrieve.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 async fn internal_get_pipeline_by_id(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     pipeline_id: PipelineId,
     fields: &'static str,
+    row_lock: bool,
 ) -> Result<Row, DBError> {
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT {fields}
              FROM pipeline AS p
              WHERE p.tenant_id = $1 AND p.id = $2
-            "
+             {}
+            ",
+            if row_lock { "FOR UPDATE" } else { "" }
         ))
         .await?;
     txn.query_opt(&stmt, &[&tenant_id.0, &pipeline_id.0])
@@ -139,33 +170,65 @@ async fn internal_get_pipeline_by_id(
         .ok_or(DBError::UnknownPipeline { pipeline_id })
 }
 
+/// Retrieve pipeline complete descriptor by its identifier.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 pub async fn get_pipeline_by_id(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     pipeline_id: PipelineId,
+    row_lock: bool,
 ) -> Result<ExtendedPipelineDescr, DBError> {
     let row =
-        internal_get_pipeline_by_id(txn, tenant_id, pipeline_id, PIPELINE_COLUMNS_ALL).await?;
+        internal_get_pipeline_by_id(txn, tenant_id, pipeline_id, PIPELINE_COLUMNS_ALL, row_lock)
+            .await?;
     parse_pipeline_row_all(&row)
 }
 
+/// Retrieve pipeline monitoring descriptor (only contains status-related fields) by its identifier.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 pub async fn get_pipeline_by_id_for_monitoring(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     pipeline_id: PipelineId,
+    row_lock: bool,
 ) -> Result<ExtendedPipelineDescrMonitoring, DBError> {
-    let row = internal_get_pipeline_by_id(txn, tenant_id, pipeline_id, PIPELINE_COLUMNS_MONITORING)
-        .await?;
+    let row = internal_get_pipeline_by_id(
+        txn,
+        tenant_id,
+        pipeline_id,
+        PIPELINE_COLUMNS_MONITORING,
+        row_lock,
+    )
+    .await?;
     parse_pipeline_row_monitoring(&row)
 }
 
+/// Retrieve pipeline descriptor by its identifier, getting only the fields needed to construct
+/// an event.
+///
+/// Set `row_lock` to `true` when using the retrieved row in the decision logic in the
+/// rest of the transaction (for example, whether/how to update its fields). It will
+/// acquire a FOR UPDATE lock on the retrieved row in that case.
 pub async fn get_pipeline_by_id_for_event_info(
     txn: &Transaction<'_>,
     tenant_id: TenantId,
     pipeline_id: PipelineId,
+    row_lock: bool,
 ) -> Result<ExtendedPipelineDescrEventInfo, DBError> {
-    let row = internal_get_pipeline_by_id(txn, tenant_id, pipeline_id, PIPELINE_COLUMNS_EVENT_INFO)
-        .await?;
+    let row = internal_get_pipeline_by_id(
+        txn,
+        tenant_id,
+        pipeline_id,
+        PIPELINE_COLUMNS_EVENT_INFO,
+        row_lock,
+    )
+    .await?;
     parse_pipeline_row_event_info(&row)
 }
 
@@ -367,7 +430,7 @@ pub(crate) async fn update_pipeline(
 
     // Fetch current pipeline to decide how to update.
     // This will also return an error if the pipeline does not exist.
-    let current = get_pipeline(txn, tenant_id, original_name).await?;
+    let current = get_pipeline(txn, tenant_id, original_name, true).await?;
 
     // Build the current client metadata and merge the patch into it to get the
     // new value. `current.client_metadata()` uses an exhaustive `ClientMetadata`
@@ -655,7 +718,7 @@ pub(crate) async fn delete_pipeline(
     tenant_id: TenantId,
     name: &str,
 ) -> Result<PipelineId, DBError> {
-    let current = get_pipeline(txn, tenant_id, name).await?;
+    let current = get_pipeline(txn, tenant_id, name, true).await?;
 
     // Pipeline deletion is only possible if it is fully stopped
     if current.deployment_resources_status != ResourcesStatus::Stopped
@@ -696,7 +759,7 @@ pub(crate) async fn set_program_status(
     new_program_binary_integrity_checksum: &Option<String>,
     new_program_info_integrity_checksum: &Option<String>,
 ) -> Result<(), DBError> {
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     // Only if the program whose status is being transitioned is the same one can it be updated
     if current.program_version != program_version_guard {
@@ -959,7 +1022,7 @@ pub(crate) async fn dismiss_deployment_error(
     tenant_id: TenantId,
     pipeline_name: &str,
 ) -> Result<(), DBError> {
-    let current = get_pipeline(txn, tenant_id, pipeline_name).await?;
+    let current = get_pipeline(txn, tenant_id, pipeline_name, true).await?;
 
     // If an error has to be cleared, then it is only possible if it is fully stopped
     if (current.deployment_resources_status != ResourcesStatus::Stopped
@@ -997,7 +1060,7 @@ pub(crate) async fn set_deployment_resources_desired_status(
     bootstrap_config: Option<BootstrapConfig>,
     dismiss_error: bool,
 ) -> Result<PipelineId, DBError> {
-    let current = get_pipeline(txn, tenant_id, pipeline_name).await?;
+    let current = get_pipeline(txn, tenant_id, pipeline_name, true).await?;
 
     // Deployment error will be automatically dismissed if this is wanted
     let final_deployment_error = if dismiss_error {
@@ -1139,7 +1202,7 @@ async fn check_version_guard_and_transition_deployment_resources_status(
     new_deployment_resources_status: ResourcesStatus,
     remain: bool,
 ) -> Result<ExtendedPipelineDescrMonitoring, DBError> {
-    let current = get_pipeline_by_id_for_monitoring(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id_for_monitoring(txn, tenant_id, pipeline_id, true).await?;
 
     // Use the version guard to check that the deployment is the intended one
     if current.version != version_guard {
@@ -1209,7 +1272,7 @@ pub(crate) async fn set_deployment_resources_status_stopped(
         false,
     )
     .await?;
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     set_deployment_resources_status(
         txn,
@@ -1285,7 +1348,7 @@ pub(crate) async fn set_deployment_resources_status_provisioning(
         false,
     )
     .await?;
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     set_deployment_resources_status(
         txn,
@@ -1358,7 +1421,7 @@ pub(crate) async fn set_deployment_resources_status_provisioned(
         false,
     )
     .await?;
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     set_deployment_resources_status(
         txn,
@@ -1432,7 +1495,7 @@ pub(crate) async fn set_deployment_resources_status_stopping(
         false,
     )
     .await?;
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     set_deployment_resources_status(
         txn,
@@ -1655,7 +1718,7 @@ pub(crate) async fn set_storage_status(
     pipeline_id: PipelineId,
     new_storage_status: StorageStatus,
 ) -> Result<(), DBError> {
-    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id).await?;
+    let current = get_pipeline_by_id(txn, tenant_id, pipeline_id, true).await?;
 
     // Check that the transition is permitted
     validate_storage_status_transition(
@@ -1771,6 +1834,104 @@ pub(crate) async fn list_pipelines_across_all_tenants_for_monitoring(
     Ok(result)
 }
 
+/// Retrieves a list of pipelines across all tenants that belong to the worker ID which are
+/// `Stopped` and are either:
+/// - of the same platform version and are `CompilingSql`
+/// - of a different platform version and are either `Pending` or `CompilingSql`
+///
+/// The SQL compiler worker will use the result of this to reset the compilation of those
+/// pipelines in the database, before picking up its next job.
+pub(crate) async fn list_pipelines_across_all_tenants_needing_sql_compilation_clear(
+    txn: &Transaction<'_>,
+    platform_version: &str,
+    worker_id: usize,
+    total_workers: usize,
+) -> Result<Vec<(TenantId, ExtendedPipelineDescrMonitoring)>, DBError> {
+    let stmt = txn
+        .prepare_cached(&format!(
+            "SELECT p.tenant_id, {PIPELINE_COLUMNS_MONITORING}
+             FROM pipeline AS p
+             WHERE p.deployment_resources_status = 'stopped'
+                   AND (
+                      (p.platform_version = $1 AND p.program_status = 'compiling_sql')
+                      OR
+                      (p.platform_version != $1 AND (p.program_status = 'pending' OR p.program_status = 'compiling_sql'))
+                   )
+                   AND ({PIPELINE_ID_SQL_HASH_FUNCTION_CALL} % $2) = $3
+             ORDER BY p.id ASC
+             FOR UPDATE
+            "
+        ))
+        .await?;
+    let rows: Vec<Row> = txn
+        .query(
+            &stmt,
+            &[
+                &platform_version.to_string(),
+                &(total_workers as i64),
+                &(worker_id as i64),
+            ],
+        )
+        .await?;
+    let mut result = Vec::with_capacity(rows.len());
+    for row in rows {
+        result.push((
+            TenantId(row.get("tenant_id")),
+            parse_pipeline_row_monitoring(&row)?,
+        ));
+    }
+    Ok(result)
+}
+
+/// Retrieves a list of pipelines across all tenants that belong to the worker ID which are
+/// `Stopped` and are either:
+/// - of the same platform version and are `CompilingRust`
+/// - of a different platform version and are either `SqlCompiled` or `CompilingRust`
+///
+/// The Rust compiler worker will use the result of this to reset the compilation of those
+/// pipelines in the database, before picking up its next job.
+pub(crate) async fn list_pipelines_across_all_tenants_needing_rust_compilation_clear(
+    txn: &Transaction<'_>,
+    platform_version: &str,
+    worker_id: usize,
+    total_workers: usize,
+) -> Result<Vec<(TenantId, ExtendedPipelineDescrMonitoring)>, DBError> {
+    let stmt = txn
+        .prepare_cached(&format!(
+            "SELECT p.tenant_id, {PIPELINE_COLUMNS_MONITORING}
+             FROM pipeline AS p
+             WHERE p.deployment_resources_status = 'stopped'
+                   AND (
+                      (p.platform_version = $1 AND p.program_status = 'compiling_rust')
+                      OR
+                      (p.platform_version != $1 AND (p.program_status = 'sql_compiled' OR p.program_status = 'compiling_rust'))
+                   )
+                   AND ({PIPELINE_ID_SQL_HASH_FUNCTION_CALL} % $2) = $3
+             ORDER BY p.id ASC
+             FOR UPDATE
+            "
+        ))
+        .await?;
+    let rows: Vec<Row> = txn
+        .query(
+            &stmt,
+            &[
+                &platform_version.to_string(),
+                &(total_workers as i64),
+                &(worker_id as i64),
+            ],
+        )
+        .await?;
+    let mut result = Vec::with_capacity(rows.len());
+    for row in rows {
+        result.push((
+            TenantId(row.get("tenant_id")),
+            parse_pipeline_row_monitoring(&row)?,
+        ));
+    }
+    Ok(result)
+}
+
 /// Retrieves the pipeline which is stopped, whose program status has been Pending
 /// for the longest, and is of the current platform version. Returns `None` if none is found.
 pub(crate) async fn get_next_sql_compilation(
@@ -1779,9 +1940,6 @@ pub(crate) async fn get_next_sql_compilation(
     worker_id: usize,
     total_workers: usize,
 ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
-    // The expression `abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3`
-    // converts the first 8 bytes of the UUID to a bigint, takes its absolute value,
-    // and computes the modulo with the total number of workers.
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT p.tenant_id, {PIPELINE_COLUMNS_ALL}
@@ -1789,7 +1947,7 @@ pub(crate) async fn get_next_sql_compilation(
              WHERE p.deployment_resources_status = 'stopped'
                    AND p.program_status = 'pending'
                    AND p.platform_version = $1
-                   AND (abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3
+                   AND ({PIPELINE_ID_SQL_HASH_FUNCTION_CALL} % $2) = $3
              ORDER BY p.program_status_since ASC, p.id ASC
              LIMIT 1
             "
@@ -1822,9 +1980,6 @@ pub(crate) async fn get_next_rust_compilation(
     worker_id: usize,
     total_workers: usize,
 ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
-    // The expression `abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3`
-    // converts the first 8 bytes of the UUID to a bigint, takes its absolute value,
-    // and computes the modulo with the total number of workers.
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT p.tenant_id, {PIPELINE_COLUMNS_ALL}
@@ -1832,7 +1987,7 @@ pub(crate) async fn get_next_rust_compilation(
              WHERE p.deployment_resources_status = 'stopped'
                    AND p.program_status = 'sql_compiled'
                    AND p.platform_version = $1
-                   AND (abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3
+                   AND ({PIPELINE_ID_SQL_HASH_FUNCTION_CALL} % $2) = $3
              ORDER BY p.program_status_since ASC, p.id ASC
              LIMIT 1
             "

--- a/crates/pipeline-manager/src/db/operations/pipeline_monitor.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline_monitor.rs
@@ -25,7 +25,7 @@ pub(crate) async fn get_pipeline_monitor_event_short(
     pipeline_name: String,
     event_id: PipelineMonitorEventId,
 ) -> Result<PipelineMonitorEvent, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -51,7 +51,7 @@ pub(crate) async fn get_pipeline_monitor_event_extended(
     pipeline_name: String,
     event_id: PipelineMonitorEventId,
 ) -> Result<ExtendedPipelineMonitorEvent, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -76,7 +76,7 @@ pub(crate) async fn get_latest_pipeline_monitor_event_short(
     tenant_id: TenantId,
     pipeline_name: String,
 ) -> Result<PipelineMonitorEvent, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -103,7 +103,7 @@ pub(crate) async fn get_latest_pipeline_monitor_event_extended(
     tenant_id: TenantId,
     pipeline_name: String,
 ) -> Result<ExtendedPipelineMonitorEvent, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -130,7 +130,7 @@ pub(crate) async fn list_pipeline_monitor_events_short(
     tenant_id: TenantId,
     pipeline_name: String,
 ) -> Result<Vec<PipelineMonitorEvent>, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -157,7 +157,7 @@ pub(crate) async fn list_pipeline_monitor_events_extended(
     tenant_id: TenantId,
     pipeline_name: String,
 ) -> Result<Vec<ExtendedPipelineMonitorEvent>, DBError> {
-    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name)
+    let pipeline_id = get_pipeline_for_monitoring(txn, tenant_id, &pipeline_name, false)
         .await?
         .id;
 
@@ -185,7 +185,7 @@ pub(crate) async fn new_pipeline_monitor_event(
     pipeline_id: PipelineId,
     new_event_id: Uuid,
 ) -> Result<(), DBError> {
-    let pipeline = get_pipeline_by_id_for_event_info(txn, tenant_id, pipeline_id).await?;
+    let pipeline = get_pipeline_by_id_for_event_info(txn, tenant_id, pipeline_id, true).await?;
 
     let stmt = txn
         .prepare_cached(

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -30,28 +30,32 @@ use deadpool_postgres::{Manager, Pool, RecyclingMethod};
 use feldera_types::config::{PipelineConfig, RuntimeConfig};
 use feldera_types::error::ErrorResponse;
 use feldera_types::runtime_status::{BootstrapConfig, RuntimeDesiredStatus, RuntimeStatus};
-use tokio_postgres::Row;
+use tokio_postgres::{IsolationLevel, Row};
 use tracing::{debug, info};
 use uuid::Uuid;
 
-// Convert PipelineId UUID to u64 to match PostgreSQL's behavior.
-// This uses the first 8 bytes of the UUID converted to a big-endian u64.
-// This ensures consistent worker assignment between Rust and SQL implementations.
-fn pipline_uuid_to_u64(pipeline_id: PipelineId) -> u64 {
+/// Converts PipelineId UUID to u64 to mostly match PostgreSQL's behavior.
+/// This uses the first 8 bytes of the UUID converted to a big-endian i64,
+/// of which the absolute value is taken. Unlike the SQL implementation,
+/// this implementation does not error when it is a `i64::MIN`.
+#[cfg(test)] // Only used in the database behavioral model test
+fn pipeline_uuid_to_u64(pipeline_id: PipelineId) -> u64 {
     let bytes = pipeline_id.0.as_bytes();
-    u64::from_be_bytes([
+    i64::from_be_bytes([
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
     ])
+    .unsigned_abs()
 }
 
 /// Determine if a pipeline is assigned to a specific worker based on its ID.
 /// Uses modulo operation to distribute pipelines across workers.
+#[cfg(test)] // Only used in the database behavioral model test
 pub(crate) fn is_pipeline_assigned_to_worker(
     pipeline_id: PipelineId,
     worker_index: u64,
     total_workers: u64,
 ) -> bool {
-    let hash = pipline_uuid_to_u64(pipeline_id);
+    let hash = pipeline_uuid_to_u64(pipeline_id);
     (hash % total_workers) == worker_index
 }
 
@@ -189,7 +193,7 @@ impl Storage for StoragePostgres {
     ) -> Result<ExtendedPipelineDescr, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        let pipeline = operations::pipeline::get_pipeline(&txn, tenant_id, name).await?;
+        let pipeline = operations::pipeline::get_pipeline(&txn, tenant_id, name, false).await?;
         txn.commit().await?;
         Ok(pipeline)
     }
@@ -202,7 +206,7 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipeline =
-            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, name).await?;
+            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, name, false).await?;
         txn.commit().await?;
         Ok(pipeline)
     }
@@ -215,7 +219,7 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipeline =
-            operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline_id).await?;
+            operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline_id, false).await?;
         txn.commit().await?;
         Ok(pipeline)
     }
@@ -227,9 +231,13 @@ impl Storage for StoragePostgres {
     ) -> Result<ExtendedPipelineDescrMonitoring, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        let pipeline =
-            operations::pipeline::get_pipeline_by_id_for_monitoring(&txn, tenant_id, pipeline_id)
-                .await?;
+        let pipeline = operations::pipeline::get_pipeline_by_id_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_id,
+            false,
+        )
+        .await?;
         txn.commit().await?;
         Ok(pipeline)
     }
@@ -242,10 +250,19 @@ impl Storage for StoragePostgres {
         provision_called: bool,
     ) -> Result<ExtendedPipelineDescrRunner, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
-        let pipeline_monitoring =
-            operations::pipeline::get_pipeline_by_id_for_monitoring(&txn, tenant_id, pipeline_id)
-                .await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
+        let pipeline_monitoring = operations::pipeline::get_pipeline_by_id_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_id,
+            false,
+        )
+        .await?;
         let is_ready_compiled = pipeline_monitoring.program_status == ProgramStatus::Success
             && is_supported_runtime(platform_version, &pipeline_monitoring.platform_version);
         let pipeline_result = if matches!(
@@ -268,7 +285,8 @@ impl Storage for StoragePostgres {
             ),
         ) {
             ExtendedPipelineDescrRunner::Complete(
-                operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline_id).await?,
+                operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline_id, false)
+                    .await?,
             )
         } else {
             ExtendedPipelineDescrRunner::Monitoring(pipeline_monitoring)
@@ -299,7 +317,7 @@ impl Storage for StoragePostgres {
 
         // Fetch newly created pipeline
         let extended_pipeline =
-            operations::pipeline::get_pipeline(&txn, tenant_id, &pipeline.name).await?;
+            operations::pipeline::get_pipeline(&txn, tenant_id, &pipeline.name, false).await?;
 
         txn.commit().await?;
         Ok(extended_pipeline)
@@ -318,7 +336,8 @@ impl Storage for StoragePostgres {
         let txn = client.transaction().await?;
 
         // Check if pipeline exists
-        let current = operations::pipeline::get_pipeline(&txn, tenant_id, original_name).await;
+        let current =
+            operations::pipeline::get_pipeline(&txn, tenant_id, original_name, true).await;
         let is_new: bool = match current {
             Ok(_) => {
                 // Pipeline already exists, as such update it. For a full
@@ -370,7 +389,7 @@ impl Storage for StoragePostgres {
 
         // Fetch new or updated pipeline
         let extended_pipeline =
-            operations::pipeline::get_pipeline(&txn, tenant_id, &pipeline.name).await?;
+            operations::pipeline::get_pipeline(&txn, tenant_id, &pipeline.name, false).await?;
 
         txn.commit().await?;
         Ok((is_new, extended_pipeline))
@@ -387,7 +406,7 @@ impl Storage for StoragePostgres {
 
         // Check if pipeline exists
         let current =
-            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name)
+            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name, true)
                 .await?;
 
         if current.deployment_resources_status != ResourcesStatus::Stopped {
@@ -398,12 +417,15 @@ impl Storage for StoragePostgres {
             .prepare_cached(
                 "UPDATE pipeline
                      SET platform_version = $1
-                     WHERE id = $2",
+                     WHERE tenant_id = $2 AND id = $3",
             )
             .await?;
 
         let rows_affected = txn
-            .execute(&stmt_update, &[&platform_version, &current.id.0])
+            .execute(
+                &stmt_update,
+                &[&platform_version, &tenant_id.0, &current.id.0],
+            )
             .await?;
 
         assert_eq!(rows_affected, 1);
@@ -462,7 +484,7 @@ impl Storage for StoragePostgres {
         // Fetch updated pipeline
         let final_name = name.clone().unwrap_or(original_name.to_string());
         let extended_pipeline =
-            operations::pipeline::get_pipeline(&txn, tenant_id, &final_name).await?;
+            operations::pipeline::get_pipeline(&txn, tenant_id, &final_name, false).await?;
 
         txn.commit().await?;
         Ok(extended_pipeline)
@@ -771,7 +793,7 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipeline =
-            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name)
+            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name, true)
                 .await?;
         let was_set = if pipeline.deployment_resources_status != ResourcesStatus::Provisioned {
             operations::pipeline::set_deployment_resources_desired_status(
@@ -804,9 +826,13 @@ impl Storage for StoragePostgres {
         let txn = client.transaction().await?;
         // If the pipeline currently is already Stopped and is desired to be Stopped,
         // then there is no need to transition to Provisioning
-        let pipeline =
-            operations::pipeline::get_pipeline_by_id_for_monitoring(&txn, tenant_id, pipeline_id)
-                .await?;
+        let pipeline = operations::pipeline::get_pipeline_by_id_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_id,
+            true,
+        )
+        .await?;
         if pipeline.deployment_resources_status == ResourcesStatus::Stopped
             && pipeline.deployment_resources_desired_status == ResourcesDesiredStatus::Stopped
         {
@@ -925,9 +951,13 @@ impl Storage for StoragePostgres {
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        let pipeline =
-            operations::pipeline::get_pipeline_by_id_for_monitoring(&txn, tenant_id, pipeline_id)
-                .await?;
+        let pipeline = operations::pipeline::get_pipeline_by_id_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_id,
+            true,
+        )
+        .await?;
         // If the pipeline currently is already Stopped and is desired to be Stopped,
         // then there is no need to transition to Stopping
         if pipeline.deployment_resources_status == ResourcesStatus::Stopped
@@ -1013,9 +1043,13 @@ impl Storage for StoragePostgres {
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        let pipeline =
-            operations::pipeline::get_pipeline_by_id_for_monitoring(&txn, tenant_id, pipeline_id)
-                .await?;
+        let pipeline = operations::pipeline::get_pipeline_by_id_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_id,
+            true,
+        )
+        .await?;
         operations::pipeline::set_deployment_resources_desired_status(
             &txn,
             tenant_id,
@@ -1046,7 +1080,7 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipeline =
-            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name)
+            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name, true)
                 .await?;
         if pipeline.storage_status != StorageStatus::Cleared {
             // If it is already cleared, it does not have to transition to clearing
@@ -1123,55 +1157,49 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipelines =
-            operations::pipeline::list_pipelines_across_all_tenants_for_monitoring(&txn).await?;
+            operations::pipeline::list_pipelines_across_all_tenants_needing_sql_compilation_clear(
+                &txn,
+                platform_version,
+                worker_id,
+                total_workers,
+            )
+            .await?;
         for (tenant_id, pipeline) in pipelines {
-            // skip the pipelines that are not assigned to this worker
-            if !is_pipeline_assigned_to_worker(pipeline.id, worker_id as u64, total_workers as u64)
-            {
-                continue;
-            }
-
-            if pipeline.deployment_resources_status == ResourcesStatus::Stopped {
-                if pipeline.platform_version == platform_version {
-                    if pipeline.program_status == ProgramStatus::CompilingSql {
-                        operations::pipeline::set_program_status(
-                            &txn,
-                            tenant_id,
-                            pipeline.id,
-                            pipeline.program_version,
-                            &ProgramStatus::Pending,
-                            &None,
-                            &None,
-                            &None,
-                            &None,
-                            &None,
-                            &None,
-                            &None,
-                        )
-                        .await?;
-                    }
-                } else if pipeline.program_status == ProgramStatus::Pending
-                    || pipeline.program_status == ProgramStatus::CompilingSql
-                {
-                    operations::pipeline::update_pipeline(
-                        &txn,
-                        true, // Done by compiler
-                        tenant_id,
-                        &pipeline.name,
-                        &operations::pipeline::PipelineFieldUpdates {
-                            name: &None,
-                            client_metadata: &PatchClientMetadata::default(),
-                            runtime_config: &None,
-                            program_code: &None,
-                            udf_rust: &None,
-                            udf_toml: &None,
-                            program_config: &None,
-                        },
-                        platform_version,
-                        true,
-                    )
-                    .await?;
-                }
+            if pipeline.platform_version == platform_version {
+                operations::pipeline::set_program_status(
+                    &txn,
+                    tenant_id,
+                    pipeline.id,
+                    pipeline.program_version,
+                    &ProgramStatus::Pending,
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                    &None,
+                )
+                .await?;
+            } else {
+                operations::pipeline::update_pipeline(
+                    &txn,
+                    true, // Done by compiler
+                    tenant_id,
+                    &pipeline.name,
+                    &operations::pipeline::PipelineFieldUpdates {
+                        name: &None,
+                        client_metadata: &PatchClientMetadata::default(),
+                        runtime_config: &None,
+                        program_code: &None,
+                        udf_rust: &None,
+                        udf_toml: &None,
+                        program_config: &None,
+                    },
+                    platform_version,
+                    true,
+                )
+                .await?;
             }
         }
         txn.commit().await?;
@@ -1206,63 +1234,55 @@ impl Storage for StoragePostgres {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
         let pipelines =
-            operations::pipeline::list_pipelines_across_all_tenants_for_monitoring(&txn).await?;
+            operations::pipeline::list_pipelines_across_all_tenants_needing_rust_compilation_clear(
+                &txn,
+                platform_version,
+                worker_id,
+                total_workers,
+            )
+            .await?;
 
         for (tenant_id, pipeline) in pipelines {
-            // skip the pipelines that are not assigned to this worker
-            if !is_pipeline_assigned_to_worker(pipeline.id, worker_id as u64, total_workers as u64)
-            {
-                continue;
-            }
-
-            if pipeline.deployment_resources_status == ResourcesStatus::Stopped {
-                if pipeline.platform_version == platform_version {
-                    if pipeline.program_status == ProgramStatus::CompilingRust {
-                        // Because `program_info` can be rather large, it is only fetched when
-                        // the program status needs to be reset to `SqlCompiled`
-                        let pipeline_complete =
-                            operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline.id)
-                                .await?;
-                        operations::pipeline::set_program_status(
-                            &txn,
-                            tenant_id,
-                            pipeline.id,
-                            pipeline.program_version,
-                            &ProgramStatus::SqlCompiled,
-                            &Some(pipeline_complete.program_error.sql_compilation.clone().expect("program_error.sql_compilation must be present if current status is CompilingRust")),
-                            &None,
-                            &None,
-                            &Some(pipeline_complete.program_info.clone().expect(
-                                "program_info must be present if current status is CompilingRust",
-                            )),
-                            &None,
-                            &None,
-                            &None,
-                        )
+            if pipeline.platform_version == platform_version {
+                let pipeline_complete =
+                    operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline.id, true)
                         .await?;
-                    }
-                } else if pipeline.program_status == ProgramStatus::SqlCompiled
-                    || pipeline.program_status == ProgramStatus::CompilingRust
-                {
-                    operations::pipeline::update_pipeline(
-                        &txn,
-                        true, // Done by compiler
-                        tenant_id,
-                        &pipeline.name,
-                        &operations::pipeline::PipelineFieldUpdates {
-                            name: &None,
-                            client_metadata: &PatchClientMetadata::default(),
-                            runtime_config: &None,
-                            program_code: &None,
-                            udf_rust: &None,
-                            udf_toml: &None,
-                            program_config: &None,
-                        },
-                        platform_version,
-                        true,
-                    )
-                    .await?;
-                }
+                operations::pipeline::set_program_status(
+                    &txn,
+                    tenant_id,
+                    pipeline.id,
+                    pipeline.program_version,
+                    &ProgramStatus::SqlCompiled,
+                    &Some(pipeline_complete.program_error.sql_compilation.clone().expect("program_error.sql_compilation must be present if current status is CompilingRust")),
+                    &None,
+                    &None,
+                    &Some(pipeline_complete.program_info.clone().expect(
+                        "program_info must be present if current status is CompilingRust",
+                    )),
+                    &None,
+                    &None,
+                    &None,
+                )
+                .await?;
+            } else {
+                operations::pipeline::update_pipeline(
+                    &txn,
+                    true, // Done by compiler
+                    tenant_id,
+                    &pipeline.name,
+                    &operations::pipeline::PipelineFieldUpdates {
+                        name: &None,
+                        client_metadata: &PatchClientMetadata::default(),
+                        runtime_config: &None,
+                        program_code: &None,
+                        udf_rust: &None,
+                        udf_toml: &None,
+                        program_config: &None,
+                    },
+                    platform_version,
+                    true,
+                )
+                .await?;
             }
         }
         txn.commit().await?;
@@ -1315,10 +1335,19 @@ impl Storage for StoragePostgres {
         how_many: u64,
     ) -> Result<(ExtendedPipelineDescrMonitoring, Vec<SupportBundleData>), DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
-        let pipeline =
-            operations::pipeline::get_pipeline_for_monitoring(&txn, tenant_id, pipeline_name)
-                .await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
+        let pipeline = operations::pipeline::get_pipeline_for_monitoring(
+            &txn,
+            tenant_id,
+            pipeline_name,
+            false,
+        )
+        .await?;
         let bundle_data =
             operations::pipeline::get_support_bundle_data(&txn, pipeline.id, how_many).await?;
         txn.commit().await?;
@@ -1413,7 +1442,12 @@ impl Storage for StoragePostgres {
         pipeline_name: String,
     ) -> Result<Vec<PipelineMonitorEvent>, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let events = operations::pipeline_monitor::list_pipeline_monitor_events_short(
             &txn,
             tenant_id,
@@ -1430,7 +1464,12 @@ impl Storage for StoragePostgres {
         pipeline_name: String,
     ) -> Result<Vec<ExtendedPipelineMonitorEvent>, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let events = operations::pipeline_monitor::list_pipeline_monitor_events_extended(
             &txn,
             tenant_id,
@@ -1448,7 +1487,12 @@ impl Storage for StoragePostgres {
         event_id: PipelineMonitorEventId,
     ) -> Result<PipelineMonitorEvent, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let event = operations::pipeline_monitor::get_pipeline_monitor_event_short(
             &txn,
             tenant_id,
@@ -1467,7 +1511,12 @@ impl Storage for StoragePostgres {
         event_id: PipelineMonitorEventId,
     ) -> Result<ExtendedPipelineMonitorEvent, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let event = operations::pipeline_monitor::get_pipeline_monitor_event_extended(
             &txn,
             tenant_id,
@@ -1485,7 +1534,12 @@ impl Storage for StoragePostgres {
         pipeline_name: String,
     ) -> Result<PipelineMonitorEvent, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let event = operations::pipeline_monitor::get_latest_pipeline_monitor_event_short(
             &txn,
             tenant_id,
@@ -1502,7 +1556,12 @@ impl Storage for StoragePostgres {
         pipeline_name: String,
     ) -> Result<ExtendedPipelineMonitorEvent, DBError> {
         let mut client = self.pool.get().await?;
-        let txn = client.transaction().await?;
+        let txn = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .await?;
         let event = operations::pipeline_monitor::get_latest_pipeline_monitor_event_extended(
             &txn,
             tenant_id,
@@ -1561,7 +1620,13 @@ impl StoragePostgres {
         db_config: &DatabaseConfig,
         #[cfg(feature = "postgresql_embedded")] pg_inst: Option<postgresql_embedded::PostgreSQL>,
     ) -> Result<Self, DBError> {
-        let config = db_config.tokio_postgres_config()?;
+        let mut config = db_config.tokio_postgres_config()?;
+        let new_options = if let Some(options) = config.get_options() {
+            format!("{options} -c lock_timeout=10000")
+        } else {
+            "-c lock_timeout=10000".to_string()
+        };
+        config.options(new_options);
         debug!(
             "Opening Postgres connection with configuration: {:?}",
             config

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2,6 +2,7 @@ use crate::api::support_data_collector::SupportBundleData;
 use crate::auth::{generate_api_key, TenantRecord};
 use crate::db::error::DBError;
 use crate::db::error::DBError::InvalidResourcesStatusNotRemain;
+use crate::db::operations::pipeline::get_pipeline_by_id_for_monitoring;
 use crate::db::storage::{ExtendedPipelineDescrRunner, Storage};
 use crate::db::storage_postgres::{is_pipeline_assigned_to_worker, StoragePostgres};
 use crate::db::types::api_key::{ApiKeyDescr, ApiKeyId, ApiPermission};
@@ -52,9 +53,10 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::vec;
-use tokio::sync::Mutex;
+use tokio::spawn;
+use tokio::sync::{oneshot, Mutex};
 use tokio::time::sleep;
 use tracing::info;
 use uuid::Uuid;
@@ -2965,6 +2967,169 @@ async fn pipeline_client_metadata_update_while_running() {
         .unwrap();
     assert_eq!(unchanged.version, before.version);
     assert_eq!(unchanged.refresh_version, before.refresh_version);
+}
+
+#[tokio::test]
+async fn pipeline_concurrent_access_stall() {
+    let handle = test_setup().await;
+    let tenant_id = TenantRecord::default().id;
+
+    // Create pipeline
+    let pipeline = handle
+        .db
+        .new_pipeline(
+            tenant_id,
+            Uuid::now_v7(),
+            "v0",
+            PipelineDescr {
+                name: "example1".to_string(),
+                description: "d1".to_string(),
+                tags: vec!["t1".to_string()],
+                runtime_config: json!({}),
+                program_code: "c1".to_string(),
+                udf_rust: "r1".to_string(),
+                udf_toml: "t2".to_string(),
+                program_config: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Client to create transactions with
+    let mut client1 = handle.db.pool.get().await.unwrap();
+    let mut client2 = handle.db.pool.get().await.unwrap();
+
+    // Non-conflicting
+    for (row_lock1, row_lock2) in [(false, false), (true, false), (false, true)] {
+        let txn1 = client1.transaction().await.unwrap();
+        let txn2 = client2.transaction().await.unwrap();
+        get_pipeline_by_id_for_monitoring(&txn1, tenant_id, pipeline.id, row_lock1)
+            .await
+            .unwrap();
+        get_pipeline_by_id_for_monitoring(&txn2, tenant_id, pipeline.id, row_lock2)
+            .await
+            .unwrap();
+        txn1.commit().await.unwrap();
+        txn2.commit().await.unwrap();
+    }
+
+    // Conflicting
+    let txn1 = client1.transaction().await.unwrap();
+    let txn2 = client2.transaction().await.unwrap();
+    get_pipeline_by_id_for_monitoring(&txn1, tenant_id, pipeline.id, true)
+        .await
+        .unwrap();
+    // The lock timeout has been set globally via an option. As such, the below is not needed.
+    // This test does take some time as a consequence (the actual timeout used: 10 seconds).
+    // However, this is an important check to make sure that when the system is deployed,
+    // the lock timeout is enforced.
+    // txn2.execute("SET LOCAL lock_timeout = 10000", &[]).await.unwrap();
+    let ts_start = Instant::now();
+    let error = get_pipeline_by_id_for_monitoring(&txn2, tenant_id, pipeline.id, true)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, DBError::LockTookTooLong),
+        "got {error:?} instead of {:?}",
+        DBError::LockTookTooLong
+    );
+    let elapsed = ts_start.elapsed();
+    assert!(elapsed >= Duration::from_millis(8000) && elapsed <= Duration::from_millis(30000));
+    txn1.commit().await.unwrap();
+    txn2.commit().await.unwrap();
+}
+
+#[tokio::test]
+async fn pipeline_concurrent_access_deadlock() {
+    let handle = test_setup().await;
+    let tenant_id = TenantRecord::default().id;
+
+    // Create pipeline 1
+    let pipeline1 = handle
+        .db
+        .new_pipeline(
+            tenant_id,
+            Uuid::now_v7(),
+            "v0",
+            PipelineDescr {
+                name: "example1".to_string(),
+                description: "d1".to_string(),
+                tags: vec!["t1".to_string()],
+                runtime_config: json!({}),
+                program_code: "c1".to_string(),
+                udf_rust: "r1".to_string(),
+                udf_toml: "t2".to_string(),
+                program_config: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Create pipeline 2
+    let pipeline2 = handle
+        .db
+        .new_pipeline(
+            tenant_id,
+            Uuid::now_v7(),
+            "v0",
+            PipelineDescr {
+                name: "example2".to_string(),
+                description: "d1".to_string(),
+                tags: vec!["t1".to_string(), "t2".to_string()],
+                runtime_config: json!({}),
+                program_code: "c1".to_string(),
+                udf_rust: "r1".to_string(),
+                udf_toml: "t2".to_string(),
+                program_config: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Deadlock:
+    // - T2 locks pipeline 2
+    // - T1 locks pipeline 1
+    // - T1 tries to lock pipeline 2 -> waits or deadlock
+    // - T2 tries to lock pipeline 1 -> waits or deadlock
+    let mut client1 = handle.db.pool.get().await.unwrap();
+    let mut client2 = handle.db.pool.get().await.unwrap();
+    let txn2 = client2.transaction().await.unwrap();
+    get_pipeline_by_id_for_monitoring(&txn2, tenant_id, pipeline2.id, true)
+        .await
+        .unwrap();
+    let (tx, rx) = oneshot::channel::<()>();
+    let join_handle = spawn(async move {
+        let txn1 = client1.transaction().await.unwrap();
+        get_pipeline_by_id_for_monitoring(&txn1, tenant_id, pipeline1.id, true)
+            .await
+            .unwrap();
+        tx.send(()).unwrap();
+        if let Err(e) =
+            get_pipeline_by_id_for_monitoring(&txn1, tenant_id, pipeline2.id, true).await
+        {
+            return Some(e);
+        }
+        txn1.commit().await.unwrap();
+        return None;
+    });
+    rx.await.unwrap();
+    let t2_error = if let Err(e) =
+        get_pipeline_by_id_for_monitoring(&txn2, tenant_id, pipeline1.id, true).await
+    {
+        Some(e)
+    } else {
+        None
+    };
+    let t1_error = join_handle.await.unwrap();
+    assert!(!(t1_error.is_some() && t2_error.is_some()));
+    let error = t1_error.unwrap_or_else(|| {
+        t2_error.expect("neither transaction errored whereas exactly one was expected to")
+    });
+    assert!(
+        matches!(error, DBError::DeadlockDetected),
+        "got {error:?} instead of {:?}",
+        DBError::DeadlockDetected
+    );
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -186,7 +186,7 @@ def test_pipeline_deleted_during_program_compilation(pipeline_name):
 
 
 @gen_pipeline_name
-def test_pipeline_stop_force_after_start(pipeline_name):
+def test_pipeline_stop_with_force_after_start(pipeline_name):
     """
     Start and then force stop after varying short delays.
     """
@@ -195,15 +195,10 @@ def test_pipeline_stop_force_after_start(pipeline_name):
     ).create_or_replace()
 
     for delay_sec in [0, 0.1, 0.5, 1, 3, 10, 20]:
-        print(f"Testing with {delay_sec} second delay")
-
-        # Issue non-blocking start
         pipeline.start(wait=False)
-
-        # Shortly wait for the pipeline to transition to next state(s)
         time.sleep(delay_sec)
-
-        # Stop force and clear the pipeline
+        pipeline.stop(force=True)
+        pipeline.start(wait=False)
         pipeline.stop(force=True)
         pipeline.clear_storage()
 
@@ -215,73 +210,85 @@ def test_pipeline_stop_with_force(pipeline_name):
     """
     create_pipeline(pipeline_name, "")
 
-    # Already stopped force
+    # Already stopped
     stop_pipeline(pipeline_name, force=True)
 
-    # Start then immediate stop (force)
-    #
-    # We do not wait for the pipeline to start, but we do wait for it
-    # to transition away from "Stopped".  Otherwise, there is a race:
-    #
-    # - Request start.
-    #
-    # - Request force stop.
-    #
-    # - Check for "stopped" status succeeds because starting up is
-    #   taking a little while, so we move along to
-    #   start_pipeline_as_paused().
-    #
-    # - Pipeline transitions to "stopping".
-    #
-    # - start_pipeline_as_paused() fails with "Cannot restart the
-    #   pipeline while it is stopping. Wait until it is stopped before
-    #   starting the pipeline again."
+    # Start (don't wait), immediately stop
     start_pipeline(pipeline_name, wait=False)
-    pipeline = Pipeline.get(pipeline_name, TEST_CLIENT)
-    wait_for_condition(
-        f"{pipeline_name} no longer stopped",
-        lambda: pipeline.status() != PipelineStatus.STOPPED,
-        timeout_s=30.0,
-        poll_interval_s=0.2,
-    )
     stop_pipeline(pipeline_name, force=True)
 
-    # Start paused then stop (simulate by pausing immediately)
+    # Start (wait for running), stop
+    start_pipeline(pipeline_name)
+    stop_pipeline(pipeline_name, force=True)
+
+    # Start (wait for paused), stop
     start_pipeline_as_paused(pipeline_name)
     stop_pipeline(pipeline_name, force=True)
 
-    # Start, stop (without waiting), then stop again
+    # Start (wait for running), stop twice in a row
     start_pipeline(pipeline_name)
     stop_pipeline(pipeline_name, force=True, wait=False)
     stop_pipeline(pipeline_name, force=True)
+
+    # Stopping must complete before starting again.
+    #
+    # It is possible that the stopping happens very quickly, as such only if an error occurs,
+    # is it checked that it is the correct error code.
+    start_pipeline(pipeline_name)
+    stop_pipeline(pipeline_name, force=True, wait=False)
+    error = None
+    try:
+        start_pipeline(pipeline_name)
+    except FelderaAPIError as e:
+        error = e
+    if error is not None:
+        assert error.error_code == "IllegalPipelineAction"
+    stop_pipeline(pipeline_name, force=True, wait=False)
+
+
+@enterprise_only
+@gen_pipeline_name
+def test_pipeline_stop_without_force_after_start(pipeline_name):
+    """
+    Start and then stop after varying short delays.
+    """
+    pipeline = PipelineBuilder(
+        TEST_CLIENT, pipeline_name, "CREATE TABLE t1(c1 INTEGER);"
+    ).create_or_replace()
+
+    for delay_sec in [0, 0.1, 0.5, 1, 3, 10, 20]:
+        pipeline.start(wait=False)
+        time.sleep(delay_sec)
+        pipeline.stop(force=False)
+        pipeline.start(wait=False)
+        pipeline.stop(force=False)
+        pipeline.clear_storage()
 
 
 @enterprise_only
 @gen_pipeline_name
 def test_pipeline_stop_without_force(pipeline_name):
     """
-    Same sequences but without force (Enterprise only).
+    Sequences of starting/stopping without force (Enterprise only).
     """
     create_pipeline(pipeline_name, "")
 
     # Already stopped
     stop_pipeline(pipeline_name, force=False)
 
-    # Start then stop (non-force)
-    #
-    # See test_pipeline_stop_with_force() for notes.
+    # Start (don't wait), immediately stop
     start_pipeline(pipeline_name, wait=False)
     stop_pipeline(pipeline_name, force=False)
 
-    # Start, wait for running, stop
+    # Start (wait for running), stop
     start_pipeline(pipeline_name)
     stop_pipeline(pipeline_name, force=False)
 
-    # Start paused (pause right away), stop
+    # Start (wait for paused), stop
     start_pipeline_as_paused(pipeline_name)
     stop_pipeline(pipeline_name, force=False)
 
-    # Start, stop twice in a row
+    # Start (wait for running), stop twice in a row
     start_pipeline(pipeline_name)
     stop_pipeline(pipeline_name, force=False, wait=False)
     stop_pipeline(pipeline_name, force=False)

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -698,7 +698,7 @@ def test_refresh_version_due_to_status_changes(pipeline_name):
         TEST_CLIENT.http.get(f"/pipelines/{pipeline_name}?selector=status")[
             "refresh_version"
         ]
-        <= 10
+        <= 15
     )
     pipeline.stop(force=True)
     pipeline.clear_storage()
@@ -706,7 +706,7 @@ def test_refresh_version_due_to_status_changes(pipeline_name):
         TEST_CLIENT.http.get(f"/pipelines/{pipeline_name}?selector=status")[
             "refresh_version"
         ]
-        <= 15
+        <= 25
     )
 
 


### PR DESCRIPTION
When a table row is retrieved for update purposes, the row itself is now locked by adding `FOR UPDATE` to the query. Although the current global lock mechanism on the database connection of the API server prevents concurrent access, the runner can separately access/change the rows (although, only certain fields when they are in its domain). One such concurrent one is setting of the desired resources status, and the transition of current resources status based on it.

A lock timeout of 10 seconds is added along with two custom error types `LockTookTooLong` and `DeadlockDetected`. Both correspond to HTTP error code 503, indicating to the client it should retry.

One example of concurrent access:
1. Assume a pipeline is fully compiled
2. User: calls `pipeline.start(wait=False)`
3. API server: `/start` is called -> sets desired status to `Provisioned` -> returns
4. User: call returns as `wait=False`
5. Runner: tasked with transitioning the current status towards `Provisioned`
6. Runner: starts transaction
7. Runner: retrieves the pipeline to check that the current status is `Stopped` and desired status is not `Stopped`, as otherwise it will not still transition toward `Provisioned`. This is not the case.
8. User calls `pipeline.stop(wait=True)`
9. API server: `/stop` is called -> sets desired status to `Stopped` -> returns
10. API server: `GET pipeline` is called -> returns
11. User call returns: sees current and desired status is `Stopped`
12. Runner: transitions the status to Provisioning (as check at step (7) passed)
13. Runner: commits transaction
14. Runner: tasked with transitioning the current status towards `Stopped`, and performs that operation. Current status: `Stopping`.
15. User: calls `pipeline.start()`
16. API server: `/start` is called -> desired status is right now `Stopped`, and current status is `Stopping`, so setting desired status to `Provisioned` is not allowed -> returns error `IllegalPipelineAction`
17. User: `FelderaAPIError` exception is raised

This fixes it by having the runner take an FOR UPDATE lock at step (7), and as such the API server at step (9) will be forced to wait until the runner is finished before being able to acquire the lock itself. After which, at step (11) the user will get back that the current status is not yet `Stopped` and will continue to poll until it is. As such, the user starting the pipeline again (step (15)) only happens once the pipeline is truly stopped, and will succeed.

**PR information**
- Unit tests added
- Integration tests updated
- No backward incompatible changes
