### PR TITLE
adapters: support column mapping in follow and CDC mode for delta input

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -7,7 +7,7 @@ use crate::util::JobQueue;
 use crate::{ControllerError, InputConsumer, InputReader, PipelineState};
 use anyhow::{Error as AnyError, Result as AnyResult, anyhow, bail};
 use arrow::array::BooleanArray;
-use arrow::datatypes::Schema as ArrowSchema;
+use arrow::datatypes::{FieldRef, Schema as ArrowSchema, SchemaRef};
 use chrono::{DateTime, Utc};
 use datafusion::catalog::TableProvider;
 use datafusion::common::DataFusionError;
@@ -19,10 +19,11 @@ use datafusion::datasource::listing::{
 use datafusion::physical_plan::{PhysicalExpr, displayable};
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use dbsp::circuit::tokio::TOKIO;
+use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
 use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::execution::context::SQLOptions;
 use deltalake::datafusion::logical_expr::SortExpr;
-use deltalake::datafusion::prelude::SessionContext;
+use deltalake::datafusion::prelude::{Expr, SessionContext, col};
 use deltalake::datafusion::sql::sqlparser::dialect::GenericDialect;
 use deltalake::datafusion::sql::sqlparser::parser::Parser;
 use deltalake::datafusion::sql::sqlparser::tokenizer::Token;
@@ -940,6 +941,20 @@ struct DeltaTableInputEndpointInner {
     /// even when marked unused, so the expressions can resolve them. Derived
     /// once from the immutable config.
     config_referenced_columns: OnceLock<ColumnNameSet>,
+
+    /// Table handle whose snapshot supplies the schema used to read the table's
+    /// data files. Set to the open table once it is loaded, so it is always
+    /// present before any data is read. The version it reflects only ever moves
+    /// forward (see [`schema_snapshot`](Self::schema_snapshot)):
+    ///
+    /// * Snapshot mode leaves it at the opened version.
+    /// * While following, each commit's data is read against the schema that was
+    ///   active when that commit was written: [`advance_schema`](Self::advance_schema)
+    ///   adopts the new schema whenever a commit carries a `metaData` action. A
+    ///   renamed column keeps its physical `col-<uuid>` name, a column added
+    ///   later null-fills for earlier commits, and a dropped column is ignored
+    ///   once gone.
+    schema_table: Mutex<Option<Arc<DeltaTable>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -989,6 +1004,7 @@ impl DeltaTableInputEndpointInner {
             catchup_follow_state: Mutex::new(CatchupFollowState::default()),
             used_sql_columns: OnceLock::new(),
             config_referenced_columns: OnceLock::new(),
+            schema_table: Mutex::new(None),
         }
     }
 
@@ -1206,9 +1222,9 @@ impl DeltaTableInputEndpointInner {
     ///
     /// Delta schemas carry no case-sensitivity information, so column names are
     /// matched both as-is and lowercased (see [`ColumnNameSet`]).
-    fn used_columns(&self, table: &DeltaTable) -> Vec<String> {
+    fn used_columns(&self) -> Vec<String> {
         let used = self.used_sql_columns();
-        table
+        self.schema_snapshot()
             .snapshot()
             .expect("Delta table snapshot must be loaded before computing used columns")
             .schema()
@@ -1218,8 +1234,8 @@ impl DeltaTableInputEndpointInner {
             .collect()
     }
 
-    fn used_column_list(&self, table: &DeltaTable) -> String {
-        let columns = self.used_columns(table);
+    fn used_column_list(&self) -> String {
+        let columns = self.used_columns();
 
         columns
             .iter()
@@ -1344,7 +1360,7 @@ impl DeltaTableInputEndpointInner {
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
     ) -> AnyResult<usize> {
-        let column_names = self.used_column_list(table);
+        let column_names = self.used_column_list();
 
         let mut snapshot_query = format!("select {column_names} from snapshot");
         if let Some(filter) = self.effective_snapshot_filter() {
@@ -1514,7 +1530,7 @@ impl DeltaTableInputEndpointInner {
             )
         })?;
 
-        let columns = self.used_columns(table);
+        let columns = self.used_columns();
         let column_names = columns
             .iter()
             .map(quote_sql_identifier)
@@ -1660,6 +1676,10 @@ impl DeltaTableInputEndpointInner {
 
         let table = Arc::new(table);
 
+        // The opened table is the schema source until following pins it to the
+        // latest version; this makes it available to the snapshot reads below.
+        *self.schema_table.lock().unwrap() = Some(Arc::clone(&table));
+
         if let Err(e) = self.prepare_snapshot_query(&table).await {
             let _ = init_status_sender.send(Err(e)).await;
             return;
@@ -1732,6 +1752,11 @@ impl DeltaTableInputEndpointInner {
 
         // Start following the table if required by the configuration.
         if self.config.follow() {
+            // The schema source stays at the version we opened at; each commit's
+            // schema change advances it as the loop reaches that commit (see
+            // `advance_schema`), so every commit's data is read against the
+            // schema that was active when it was written.
+
             // Log the appropriate message based on whether we just completed a snapshot
             if self.config.snapshot() && snapshot_incomplete {
                 // We just completed reading a snapshot, now switching to follow mode
@@ -2695,6 +2720,10 @@ impl DeltaTableInputEndpointInner {
             );
         }
 
+        // Adopt a schema change carried by this commit before reading its data,
+        // so the files are interpreted against the right schema.
+        self.advance_schema(new_version, actions).await?;
+
         // Use the time when we _started_ reading transaction data as the ingestion timestamp.
         let timestamp = Utc::now();
 
@@ -2712,7 +2741,7 @@ impl DeltaTableInputEndpointInner {
             // Compute the projected read set once for the whole transaction; each
             // `process_action` borrows the `&str` view rather than re-collecting it
             // per Add/Remove. `used_column_names` owns the strings the view points at.
-            let used_column_names = self.used_columns(table);
+            let used_column_names = self.used_columns();
             let used_columns: Vec<&str> = used_column_names.iter().map(String::as_str).collect();
 
             // TODO: consider processing all Add actions and all Remove actions in one
@@ -2891,21 +2920,163 @@ impl DeltaTableInputEndpointInner {
         Ok(())
     }
 
-    /// Create a table provider from a list of Parquet files.
-    async fn create_parquet_table(
-        &self,
-        table: &DeltaTable,
-        files: Vec<String>,
-        description: &str,
-    ) -> AnyResult<ListingTable> {
-        // `DeltaTable::snapshot()` returns the table state; calling `.snapshot()`
-        // on that state hands back the eager snapshot, which exposes the Arrow
-        // schema.
-        let schema = table
+    /// The table handle whose snapshot defines the current schema (see the
+    /// [`schema_table`](Self#structfield.schema_table) field). Set before any
+    /// data is read.
+    fn schema_snapshot(&self) -> Arc<DeltaTable> {
+        Arc::clone(
+            self.schema_table
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("schema table must be set before reading the table schema"),
+        )
+    }
+
+    /// Reload the table at `version` and adopt it as the schema source, unless
+    /// the current schema is already at `version`. Mirrors
+    /// [`open_table`](Self::open_table)'s storage configuration without its
+    /// resume/version-selection logic.
+    async fn pin_schema_to_version(&self, version: u64) -> AnyResult<()> {
+        if self.schema_snapshot().version() == Some(version) {
+            return Ok(());
+        }
+        let url = ensure_table_uri(&self.config.uri)
+            .map_err(|e| anyhow!("invalid Delta table uri '{}': {e}", &self.config.uri))?;
+        let table = self
+            .retry(
+                &format!("error loading Delta table schema at version {version}"),
+                Some("delta-schema-load"),
+                || async {
+                    // DeltaTableBuilder isn't Clone, so build it anew on each retry.
+                    DeltaTableBuilder::from_url(url.clone())
+                        .map_err(|e| anyhow!("invalid Delta table URL '{url}': {e}"))?
+                        .with_storage_options(self.config.object_store_config.clone())
+                        .with_io_runtime(IORuntime::RT(TOKIO_DEDICATED_IO.handle().clone()))
+                        .with_version(version)
+                        .load()
+                        .await
+                        .map_err(|e| anyhow!("{e}"))
+                },
+            )
+            .await?;
+        *self.schema_table.lock().unwrap() = Some(Arc::new(table));
+        Ok(())
+    }
+
+    /// Advance the schema source when a commit carries a schema change.
+    ///
+    /// A commit that changes the schema writes a `metaData` action holding the
+    /// schema effective from that commit on. We reload the table at that version
+    /// and adopt it, so this commit's data, and every later commit's, is read
+    /// against the schema that was active when it was written. Commits without a
+    /// `metaData` action leave the current schema in place. Moves forward only:
+    /// the guard skips a version we already hold (the opened or resumed snapshot
+    /// may already reflect it), since the schema never moves backward.
+    async fn advance_schema(&self, new_version: i64, actions: &[Action]) -> AnyResult<()> {
+        let changes_schema = actions.iter().any(|a| matches!(a, Action::Metadata(_)));
+        let current_version = self.schema_snapshot().version();
+        if !changes_schema || current_version.is_some_and(|v| new_version <= v as i64) {
+            return Ok(());
+        }
+        self.pin_schema_to_version(new_version as u64).await
+    }
+
+    /// Logical-to-physical column-name pairs under Delta column mapping.
+    ///
+    /// With `delta.columnMapping.mode = 'name'` or `'id'` each column lives on
+    /// disk under an opaque physical name (`col-<uuid>`, from the field's
+    /// `physicalName` metadata) while the SQL schema and connector expressions
+    /// use logical names. Returns one pair per renamed field; empty when mapping
+    /// is off, so callers skip remapping.
+    fn column_mapping(&self) -> AnyResult<Vec<(String, String)>> {
+        let schema_table = self.schema_snapshot();
+        let state = schema_table
+            .snapshot()
+            .map_err(|e| anyhow!("error accessing Delta table snapshot: {e}"))?;
+        Ok(state
+            .schema()
+            .fields()
+            .filter_map(|field| {
+                match field.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName) {
+                    Some(MetadataValue::String(physical)) if physical != field.name() => {
+                        Some((field.name().to_string(), physical.clone()))
+                    }
+                    _ => None,
+                }
+            })
+            .collect())
+    }
+
+    /// Returns the Arrow schema to use when reading the raw data files, named as
+    /// they appear on disk: the table's logical schema restricted to the columns
+    /// `keep` accepts (in schema order, so unions with another read side line
+    /// up), with each column-mapped field renamed to its physical (`col-<uuid>`)
+    /// name so DataFusion's by-name matching finds them. The same as the kept
+    /// logical schema when column mapping is off.
+    fn physical_read_schema(&self, keep: impl Fn(&str) -> bool) -> AnyResult<SchemaRef> {
+        let schema_table = self.schema_snapshot();
+        let logical = schema_table
             .snapshot()
             .map_err(|e| anyhow!("error accessing Delta table snapshot: {e}"))?
             .snapshot()
             .arrow_schema();
+        let pairs = self.column_mapping()?;
+        let to_physical: HashMap<&str, &str> = pairs
+            .iter()
+            .map(|(l, p)| (l.as_str(), p.as_str()))
+            .collect();
+        let fields: Vec<FieldRef> = logical
+            .fields()
+            .iter()
+            .filter(|f| keep(f.name()))
+            .map(|f| match to_physical.get(f.name().as_str()) {
+                Some(physical) => Arc::new(f.as_ref().clone().with_name(*physical)),
+                None => Arc::clone(f),
+            })
+            .collect();
+        Ok(Arc::new(
+            ArrowSchema::new(fields).with_metadata(logical.metadata().clone()),
+        ))
+    }
+
+    /// Renames a DataFrame's physical columns back to their logical names.
+    ///
+    /// Follow/CDC reads apply [`physical_read_schema`](Self::physical_read_schema),
+    /// so a column-mapped DataFrame arrives with physical (`col-<uuid>`) names,
+    /// while the rest of the pipeline expects logical names. Unmapped columns
+    /// (already logical, or Delta metadata like `__feldera_op`) pass through.
+    /// This function is a no-op when column mapping is off.
+    fn project_physical_to_logical(&self, df: DataFrame) -> AnyResult<DataFrame> {
+        let pairs = self.column_mapping()?;
+        if pairs.is_empty() {
+            return Ok(df);
+        }
+        let to_logical: HashMap<&str, &str> = pairs
+            .iter()
+            .map(|(l, p)| (p.as_str(), l.as_str()))
+            .collect();
+        let exprs: Vec<Expr> = df
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| match to_logical.get(f.name().as_str()) {
+                Some(logical) => col(f.name()).alias(*logical),
+                None => col(f.name()),
+            })
+            .collect();
+        df.select(exprs)
+            .map_err(|e| anyhow!("error remapping column-mapped names: {e}"))
+    }
+
+    async fn create_parquet_table(
+        &self,
+        files: Vec<String>,
+        description: &str,
+    ) -> AnyResult<ListingTable> {
+        // Use the on-disk (physical) schema so the reader matches each file's
+        // columns; `project_physical_to_logical` renames them back afterwards.
+        let schema = self.physical_read_schema(|_| true)?;
 
         let mut urls = Vec::with_capacity(files.len());
         for file in files.iter() {
@@ -2955,25 +3126,9 @@ impl DeltaTableInputEndpointInner {
             )
             .await?;
 
-        let snapshot_schema = table
-            .snapshot()
-            .map_err(|e| anyhow!("error accessing Delta table snapshot for {description}: {e}"))?
-            .snapshot()
-            .arrow_schema();
-
-        // Restrict the schema to the kept columns, preserving field order so
-        // unions with the unmasked side line up.
-        let fields: Vec<_> = snapshot_schema
-            .fields()
-            .iter()
-            .filter(|f| keep_column(f.name()))
-            .cloned()
-            .collect();
-        let logical_schema = if fields.len() == snapshot_schema.fields().len() {
-            snapshot_schema
-        } else {
-            Arc::new(ArrowSchema::new(fields))
-        };
+        // The provider declares the kept columns under their physical names so
+        // it lines up with the unmasked side; the caller renames them back.
+        let read_schema = self.physical_read_schema(keep_column)?;
 
         // `Add.path` is URL-encoded per the Delta spec; decode it into a
         // real object-store key.
@@ -2984,7 +3139,7 @@ impl DeltaTableInputEndpointInner {
             table.log_store().object_store(None),
             file_path,
             bitmap,
-            logical_schema,
+            read_schema,
         )
         .await
     }
@@ -3030,11 +3185,11 @@ impl DeltaTableInputEndpointInner {
                 .iter()
                 .map(|p| format!("{}{}", root_url.as_str(), p))
                 .collect();
-            let listing_table =
-                Arc::new(self.create_parquet_table(table, files, description).await?);
+            let listing_table = Arc::new(self.create_parquet_table(files, description).await?);
             let df = self.datafusion.read_table(listing_table).map_err(|e| {
                 anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet files: {e}")
             })?;
+            let df = self.project_physical_to_logical(df)?;
             // Drop unused columns when `skip_unused_columns` is set, so
             // DataFusion never reads them off disk.
             dfs.push(self.project_cdc_columns(df).map_err(|e| {
@@ -3055,9 +3210,10 @@ impl DeltaTableInputEndpointInner {
                     description,
                 )
                 .await?;
-            dfs.push(self.datafusion.read_table(provider).map_err(|e| {
+            let df = self.datafusion.read_table(provider).map_err(|e| {
                 anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading masked file '{path}': {e}")
-            })?);
+            })?;
+            dfs.push(self.project_physical_to_logical(df)?);
         }
 
         let mut dfs = dfs.into_iter();
@@ -3115,12 +3271,13 @@ impl DeltaTableInputEndpointInner {
         }
     }
 
-    // NOTE: Column projection (follow mode here, CDC mode in `process_cdc_transaction`) projects
-    // against the startup snapshot schema, which `create_parquet_table` forces onto every Parquet
-    // file we read. This assumes a stable schema across the log versions we follow. DataFusion's
-    // schema adapter handles additive evolution (new columns ignored, missing columns read as NULL);
-    // a renamed/dropped column also reads as NULL, and an uncastable type change errors at read time.
-    // Real per-version evolution would require reloading the table and re-deriving the column set.
+    // NOTE: Column projection (follow here, CDC in `process_cdc_transaction`) runs against the
+    // schema in `schema_table`, which `create_parquet_table` applies to every Parquet file we read.
+    // While following, that schema is the one active when the commit being read was written (see the
+    // field's docs and `advance_schema`). Column-mapped physical names are stable across a rename, so
+    // the reader handles each version's files against its own schema: DataFusion's schema adapter
+    // null-fills columns absent from a file and ignores ones the schema drops; a type change produces
+    // an error at read time when a value cannot be converted to the target type.
     #[allow(clippy::too_many_arguments)]
     async fn add_with_polarity(
         &self,
@@ -3155,21 +3312,20 @@ impl DeltaTableInputEndpointInner {
                 // don't use `object_store_url()` here.
                 let full_path = format!("{}{}", table.log_store().root_url().as_str(), path);
                 Arc::new(
-                    self.create_parquet_table(table, vec![full_path], &description)
+                    self.create_parquet_table(vec![full_path], &description)
                         .await?,
                 )
             };
 
-        let df = self
-            .datafusion
-            .read_table(provider)
-            .map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet file: {e}")
-            })?
-            .select_columns(used_columns)
-            .map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error selecting columns: {e}")
-            })?;
+        let df = self.datafusion.read_table(provider).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet file: {e}")
+        })?;
+        // Translate column-mapped physical names back to logical before any
+        // logical-name projection or filter.
+        let df = self.project_physical_to_logical(df)?;
+        let df = df.select_columns(used_columns).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error selecting columns: {e}")
+        })?;
 
         let df = if let Some(filter) = &self.config.filter {
             let expr = df

--- a/python/tests/platform/fixtures/column_mapping.py
+++ b/python/tests/platform/fixtures/column_mapping.py
@@ -2,7 +2,7 @@
 
 ``tests.utils.ensure_delta_spark_fixture`` runs this as a subprocess
 (``uv run --with "delta-spark>=4.2,<5" python column_mapping.py <output_dir>
-<mode>``), where ``<mode>`` is a ``delta.columnMapping.mode`` value: ``name``
+<mode>``). ``<mode>`` is a ``delta.columnMapping.mode`` value: ``name``
 (physical Parquet columns are renamed to ``col-<uuid>``) or ``id`` (columns are
 matched by Parquet field ID). PySpark is currently the only writer that can
 produce a Delta table with column mapping enabled *and* perform the rename /
@@ -26,9 +26,14 @@ The resulting table's history (one commit per step):
 * ``v5`` DROP COLUMN ``amount``
 * ``v6`` INSERT one row under the final ``(id, full_name, country)`` schema
 
-A snapshot read at the latest version must therefore return the final logical
-schema with ``amount`` gone, ``country`` NULL for the rows written before it
-existed, and every value resolved through column mapping.
+A snapshot read of the latest version returns the final logical schema with
+``amount`` gone, ``country`` NULL for the rows written before it existed, and
+every value resolved through column mapping. The follow/CDC paths instead read
+each commit's data file as raw Parquet against the schema active when that commit
+was written, exercising the connector's own physical-name resolution across the
+rename/add/drop history. A replay from v0 therefore differs from the snapshot on
+the pre-rename rows: rows 1 and 2 were written under the logical name ``name``,
+so ``full_name`` reads NULL for them (see ``_REPLAY_EXPECTED_ROWS`` in the test).
 """
 
 from __future__ import annotations
@@ -48,7 +53,8 @@ EXPECTED_ROWS = [
 
 
 def build(table_path: str, mode: str = "name") -> None:
-    """Create the column-mapped, schema-evolved table at ``table_path``.
+    """Create a column-mapped table at ``table_path`` with the rename/add/drop
+    history documented in the module docstring.
 
     :param mode: ``delta.columnMapping.mode`` for the table: ``name`` or ``id``.
     """
@@ -71,15 +77,15 @@ def build(table_path: str, mode: str = "name") -> None:
     spark.sparkContext.setLogLevel("ERROR")
     try:
         t = f"delta.`{table_path}`"
+        props = (
+            f"TBLPROPERTIES ('delta.columnMapping.mode' = '{mode}',"
+            "               'delta.minReaderVersion' = '2',"
+            "               'delta.minWriterVersion' = '5')"
+        )
 
         spark.sql(
-            f"""
-            CREATE TABLE {t} (id BIGINT, name STRING, amount DOUBLE)
-            USING delta
-            TBLPROPERTIES ('delta.columnMapping.mode' = '{mode}',
-                           'delta.minReaderVersion' = '2',
-                           'delta.minWriterVersion' = '5')
-            """
+            f"CREATE TABLE {t} (id BIGINT, name STRING, amount DOUBLE)"
+            f" USING delta {props}"
         )
         spark.sql(f"INSERT INTO {t} VALUES (1,'alice',10.0),(2,'bob',20.0)")
         spark.sql(f"ALTER TABLE {t} RENAME COLUMN name TO full_name")

--- a/python/tests/platform/test_delta_input_column_mapping.py
+++ b/python/tests/platform/test_delta_input_column_mapping.py
@@ -1,13 +1,20 @@
-"""Snapshot read of a column-mapped Delta table after schema evolution.
+"""Read a column-mapped, schema-evolved Delta table in every ingest mode.
 
 A table with ``delta.columnMapping.mode = 'name'`` stores opaque physical
 Parquet column names (``col-<uuid>``) that differ from the logical names; with
 ``mode = 'id'`` columns are matched by Parquet field ID instead. Either way, a
-correct snapshot read must resolve every value through the column-mapping
-metadata in the Delta log. PySpark seeds the fixture (it is currently the only
-writer that supports column-mapping rename/drop); the builder lives in
-``fixtures/column_mapping.py`` and runs via ``uv run --with delta-spark`` so
-the Spark/JVM wheels are only fetched on cache miss.
+correct read must resolve every value through the column-mapping metadata in
+the Delta log. snapshot reads let delta-rs resolve this against the latest
+schema; the follow and CDC paths read each commit's data file as raw Parquet and
+must resolve the physical names themselves, against the schema active when that
+commit was written. Because of that, replaying the rename/add/drop history from
+v0 does not converge to a snapshot of the latest table: rows written before a
+column was renamed resolve under the old logical name (NULL in the SQL relation).
+
+PySpark seeds the fixture (it is currently the only writer that supports
+column-mapping rename/drop); the builder lives in ``fixtures/column_mapping.py``
+and runs via ``uv run --with delta-spark`` so the Spark/JVM wheels are only
+fetched on cache miss.
 """
 
 from __future__ import annotations
@@ -26,32 +33,39 @@ from tests.utils import DeltaTestLocation, ensure_delta_spark_fixture
 TABLE = "t"
 CONNECTOR = "delta_in"
 # Bump to invalidate cached MinIO copies when the fixture definition changes.
-FIXTURE_VERSION = "v1"
+FIXTURE_VERSION = "v2"
 
 # Spark builder that writes the column-mapped, schema-evolved table. It runs in
 # a subprocess (see ensure_delta_spark_fixture) rather than being imported here.
 _FIXTURE_BUILDER = Path(__file__).parent / "fixtures" / "column_mapping.py"
 
 
-def _build_sql(loc: DeltaTestLocation) -> str:
+# The final, post-evolution logical columns. Used unless a test reads only part
+# of the history (see the end_version test, which sees the pre-drop schema).
+_FINAL_COLUMNS = "id BIGINT NOT NULL, full_name VARCHAR, country VARCHAR"
+
+
+def _build_sql(
+    loc: DeltaTestLocation,
+    extra_config: dict | None = None,
+    columns: str = _FINAL_COLUMNS,
+) -> str:
+    config = dict(loc.connector_config)
+    config.update(extra_config or {})
     connectors = json.dumps(
         [
             {
                 "name": CONNECTOR,
                 "transport": {
                     "name": "delta_table_input",
-                    "config": dict(loc.connector_config),
+                    "config": config,
                 },
             }
         ]
     ).replace("'", "''")
-    # The SQL schema declares the final, post-evolution logical columns.
     return (
-        f"CREATE TABLE {TABLE} ("
-        "id BIGINT NOT NULL,"
-        "full_name VARCHAR,"
-        "country VARCHAR"
-        f") WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
+        f"CREATE TABLE {TABLE} ({columns})"
+        f" WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
     )
 
 
@@ -66,18 +80,54 @@ def _snapshot_rows(pipeline) -> list[dict]:
     )
 
 
-def _run_column_mapping_snapshot_test(pipeline_name: str, mapping_mode: str) -> None:
-    """A snapshot read of a column-mapped, schema-evolved table returns the
-    final logical schema and correctly resolves physical column names.
+# Replay the whole fixture history (v0 CREATE through v6) in follow/CDC mode.
+# ``version`` is the already-consumed baseline (the empty v0 table), so the
+# connector applies every later commit: the three inserts and the interleaved
+# rename/add/drop.
+_REPLAY_CONFIG = {"version": 0, "end_version": 6}
 
-    Driven by one wrapper test per ``delta.columnMapping.mode`` (rather than
-    ``pytest.mark.parametrize``) so each case gets a distinct pipeline name —
-    the ``pipeline_name`` fixture derives the name from the test function, and
+
+# Follow/CDC read each commit's data against the schema active when that commit
+# was written, so a replay from v0 does NOT converge to a snapshot of the latest
+# table on renamed columns. The v1 rows (1, 2) were written under the original
+# logical name ``name``; at v1 the connector resolves them to ``name``, which the
+# SQL relation (``full_name``) does not have, so ``full_name`` is NULL for them.
+# Rows written at v4/v6 (after the v2 rename) carry ``full_name`` and resolve
+# normally. Contrast ``EXPECTED_ROWS``, which a snapshot read of v6 produces by
+# resolving the whole table against its final schema.
+_REPLAY_EXPECTED_ROWS = [
+    {"id": 1, "full_name": None, "country": None},
+    {"id": 2, "full_name": None, "country": None},
+    {"id": 3, "full_name": "carol", "country": "US"},
+    {"id": 4, "full_name": "dave", "country": "UK"},
+    {"id": 5, "full_name": "erin", "country": "FR"},
+]
+
+
+def _run_column_mapping_test(
+    pipeline_name: str,
+    mapping_mode: str,
+    *,
+    mode: str,
+    extra_config: dict | None = None,
+) -> None:
+    """Ingest the column-mapped table in ``mode`` and check that every value
+    resolves through the column-mapping metadata.
+
+    snapshot mode reads the latest version directly, resolving the whole table
+    against its final schema (``EXPECTED_ROWS``). follow/CDC replay the log from
+    v0 and read each commit against the schema active when it was written, so
+    the pre-rename rows surface their old logical name and ``full_name`` is NULL
+    for them (``_REPLAY_EXPECTED_ROWS``).
+
+    One wrapper test per (ingest mode, ``delta.columnMapping.mode``) pair rather
+    than ``pytest.mark.parametrize`` so each gets a distinct pipeline name — the
+    ``pipeline_name`` fixture derives the name from the test function, and
     parametrized cases sharing one name could collide under ``pytest -n``.
     """
     loc = DeltaTestLocation.create(
         pipeline_name,
-        mode="snapshot",
+        mode=mode,
         stable_subpath=f"column_mapping_{mapping_mode}_{FIXTURE_VERSION}",
     )
     try:
@@ -86,7 +136,7 @@ def _run_column_mapping_snapshot_test(pipeline_name: str, mapping_mode: str) -> 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
             pipeline_name,
-            sql=_build_sql(loc),
+            sql=_build_sql(loc, extra_config),
             runtime_config=RuntimeConfig(
                 workers=FELDERA_TEST_NUM_WORKERS,
                 hosts=FELDERA_TEST_NUM_HOSTS,
@@ -97,10 +147,12 @@ def _run_column_mapping_snapshot_test(pipeline_name: str, mapping_mode: str) -> 
         pipeline.wait_for_completion(force_stop=False, timeout_s=600)
 
         rows = _snapshot_rows(pipeline)
-        assert rows == EXPECTED_ROWS, (
-            "snapshot read must resolve column-mapped, schema-evolved data: "
-            "dropped 'amount' gone, 'country' NULL for pre-add rows; "
-            f"got {rows}"
+        expected = EXPECTED_ROWS if mode == "snapshot" else _REPLAY_EXPECTED_ROWS
+        assert rows == expected, (
+            f"{mode} read must resolve column-mapped, schema-evolved data: "
+            "dropped 'amount' gone, 'country' NULL for pre-add rows, and "
+            "(follow/CDC only) 'full_name' NULL for rows written before the "
+            f"rename; got {rows}"
         )
 
         pipeline.stop(force=True)
@@ -110,9 +162,221 @@ def _run_column_mapping_snapshot_test(pipeline_name: str, mapping_mode: str) -> 
 
 def test_delta_input_column_mapping_name_snapshot(pipeline_name):
     """Snapshot read with ``delta.columnMapping.mode = 'name'``."""
-    _run_column_mapping_snapshot_test(pipeline_name, "name")
+    _run_column_mapping_test(pipeline_name, "name", mode="snapshot")
 
 
 def test_delta_input_column_mapping_id_snapshot(pipeline_name):
     """Snapshot read with ``delta.columnMapping.mode = 'id'``."""
-    _run_column_mapping_snapshot_test(pipeline_name, "id")
+    _run_column_mapping_test(pipeline_name, "id", mode="snapshot")
+
+
+def test_delta_input_column_mapping_name_follow(pipeline_name):
+    """Follow a column-mapped (``mode = 'name'``) table across schema evolution.
+
+    The follow path reads each commit's data file as raw Parquet, resolving the
+    physical (``col-<uuid>``) names against the schema active when that commit
+    was written. The v1 rows predate the ``name`` -> ``full_name`` rename, so
+    they resolve to ``name`` and read NULL for the SQL ``full_name`` column;
+    rows written after the rename resolve normally (``_REPLAY_EXPECTED_ROWS``).
+    """
+    _run_column_mapping_test(
+        pipeline_name,
+        "name",
+        mode="snapshot_and_follow",
+        extra_config=_REPLAY_CONFIG,
+    )
+
+
+def test_delta_input_column_mapping_id_follow(pipeline_name):
+    """Follow a column-mapped (``mode = 'id'``) table across schema evolution."""
+    _run_column_mapping_test(
+        pipeline_name,
+        "id",
+        mode="snapshot_and_follow",
+        extra_config=_REPLAY_CONFIG,
+    )
+
+
+# CDC mode requires a delete filter and an order-by; the fixture has no
+# delete-marker column, so use an always-false predicate on a real logical
+# column. Every row stays an insert, and resolving the filter and order-by
+# against logical names confirms they survive the physical-name remap.
+_CDC_CONFIG = {
+    **_REPLAY_CONFIG,
+    "cdc_delete_filter": "id < 0",
+    "cdc_order_by": "id asc",
+}
+
+
+def test_delta_input_column_mapping_name_cdc(pipeline_name):
+    """CDC-replay a column-mapped (``mode = 'name'``) table across evolution."""
+    _run_column_mapping_test(
+        pipeline_name, "name", mode="cdc", extra_config=_CDC_CONFIG
+    )
+
+
+def test_delta_input_column_mapping_id_cdc(pipeline_name):
+    """CDC-replay a column-mapped (``mode = 'id'``) table across evolution."""
+    _run_column_mapping_test(pipeline_name, "id", mode="cdc", extra_config=_CDC_CONFIG)
+
+
+# Replaying a window that ends at v4 (after the rename and ADD country, before
+# the v5 DROP amount) reads each commit against its own schema. The v1 rows
+# (1, 2) were written under ``(id, name, amount)``: ``amount`` is present (10/20),
+# but the column is logically ``name`` there, so the SQL ``full_name`` is NULL
+# for them; ``country`` did not yet exist, so it is NULL too. The v4 rows (3, 4)
+# were written after the rename and ADD, so every column resolves. ``amount``
+# survives for all rows because it is dropped only at v5, past this window.
+_V4_COLUMNS = "id BIGINT NOT NULL, full_name VARCHAR, amount DOUBLE, country VARCHAR"
+_V4_EXPECTED_ROWS = [
+    {"id": 1, "full_name": None, "amount": 10.0, "country": None},
+    {"id": 2, "full_name": None, "amount": 20.0, "country": None},
+    {"id": 3, "full_name": "carol", "amount": 30.0, "country": "US"},
+    {"id": 4, "full_name": "dave", "amount": 40.0, "country": "UK"},
+]
+
+
+def test_delta_input_column_mapping_follow_end_version(pipeline_name):
+    """Follow a window ending at v4: each commit resolves against its own schema."""
+    loc = DeltaTestLocation.create(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        stable_subpath=f"column_mapping_name_{FIXTURE_VERSION}",
+    )
+    try:
+        ensure_delta_spark_fixture(loc, _FIXTURE_BUILDER, builder_args=("name",))
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=_build_sql(
+                loc,
+                extra_config={"version": 0, "end_version": 4},
+                columns=_V4_COLUMNS,
+            ),
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                logging="debug",
+            ),
+        ).create_or_replace()
+        pipeline.start()
+        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+        rows = sorted(
+            (
+                {
+                    "id": r["id"],
+                    "full_name": r["full_name"],
+                    "amount": r["amount"],
+                    "country": r["country"],
+                }
+                for r in pipeline.query(
+                    f"SELECT id, full_name, amount, country FROM {TABLE}"
+                )
+            ),
+            key=lambda r: r["id"],
+        )
+        assert rows == _V4_EXPECTED_ROWS, (
+            "replay up to v4 must read each commit against its own schema: "
+            "'amount' present (dropped only at v5), 'full_name' NULL for the "
+            f"pre-rename v1 rows; got {rows}"
+        )
+
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()
+
+
+# snapshot_and_follow from v2: snapshot the table as of v2, then follow later
+# commits. The v2 snapshot carries rows 1 and 2 (written pre-rename under
+# ``name``) with full_name resolved via column mapping; country is NULL, added
+# only at v3. Following v3..v6 then adds rows 3, 4, 5.
+_MID_HISTORY_EXPECTED_ROWS = [
+    {"id": 1, "full_name": "alice", "country": None},
+    {"id": 2, "full_name": "bob", "country": None},
+    {"id": 3, "full_name": "carol", "country": "US"},
+    {"id": 4, "full_name": "dave", "country": "UK"},
+    {"id": 5, "full_name": "erin", "country": "FR"},
+]
+
+
+def test_delta_input_column_mapping_resume_mid_history(pipeline_name):
+    """Snapshot at a non-zero version, then follow: the snapshot resolves the
+    pre-rename rows through column mapping and later commits are replayed."""
+    loc = DeltaTestLocation.create(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        stable_subpath=f"column_mapping_name_{FIXTURE_VERSION}",
+    )
+    try:
+        ensure_delta_spark_fixture(loc, _FIXTURE_BUILDER, builder_args=("name",))
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=_build_sql(loc, extra_config={"version": 2, "end_version": 6}),
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                logging="debug",
+            ),
+        ).create_or_replace()
+        pipeline.start()
+        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+        rows = _snapshot_rows(pipeline)
+        assert rows == _MID_HISTORY_EXPECTED_ROWS, (
+            "snapshot at v2 must resolve the pre-rename rows 1 and 2 through "
+            "column mapping (full_name populated, country NULL), then follow "
+            f"v3..v6 for rows 3, 4, 5; got {rows}"
+        )
+
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()
+
+
+# Pure follow (no snapshot) from v2: read only the commits after v2 as raw
+# Parquet. Rows 1 and 2 never appear (no snapshot, and their insert predates v2);
+# v3..v6 give rows 3, 4, 5, all post-rename so full_name and country resolve.
+_FOLLOW_FROM_VERSION_EXPECTED_ROWS = [
+    {"id": 3, "full_name": "carol", "country": "US"},
+    {"id": 4, "full_name": "dave", "country": "UK"},
+    {"id": 5, "full_name": "erin", "country": "FR"},
+]
+
+
+def test_delta_input_column_mapping_follow_from_version(pipeline_name):
+    """Pure follow from a non-zero version: replay only the commits after it."""
+    loc = DeltaTestLocation.create(
+        pipeline_name,
+        mode="follow",
+        stable_subpath=f"column_mapping_name_{FIXTURE_VERSION}",
+    )
+    try:
+        ensure_delta_spark_fixture(loc, _FIXTURE_BUILDER, builder_args=("name",))
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=_build_sql(loc, extra_config={"version": 2, "end_version": 6}),
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                logging="debug",
+            ),
+        ).create_or_replace()
+        pipeline.start()
+        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+        rows = _snapshot_rows(pipeline)
+        assert rows == _FOLLOW_FROM_VERSION_EXPECTED_ROWS, (
+            "pure follow from v2 must replay only v3..v6 as raw Parquet (no "
+            "snapshot, so rows 1 and 2 never appear), resolving full_name and "
+            f"country for rows 3, 4, 5 against each commit's schema; got {rows}"
+        )
+
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -310,6 +310,7 @@ def ensure_delta_spark_fixture(
     *,
     delta_spark_spec: str = "delta-spark>=4.2,<5",
     is_present: Callable[[DeltaTestLocation], bool] | None = None,
+    max_attempts: int = 3,
 ) -> None:
     """Ensure a PySpark-authored Delta fixture exists at ``loc`` (cached).
 
@@ -336,6 +337,11 @@ def ensure_delta_spark_fixture(
         primitives; ``None`` would become the literal string ``"None"``.
     :param is_present: Predicate deciding whether the fixture already exists;
         also re-checked after upload to catch partial uploads.
+    :param max_attempts: How many times to run the builder before giving up.
+        Spark resolves the delta-spark dependency tree from Maven Central on
+        this path; that download is prone to transient failures (0-byte
+        artifacts, half-written Ivy cache files, gateway timeouts) that clear on
+        a fresh attempt, so retry rather than fail the test on infra flakiness.
     """
     present = (
         is_present if is_present is not None else DeltaTestLocation.delta_log_exists
@@ -349,25 +355,39 @@ def ensure_delta_spark_fixture(
             f"(builder runs via `uv run --with {delta_spark_spec}`)."
         )
 
-    staging = pathlib.Path(tempfile.mkdtemp(prefix="feldera_delta_fixture_"))
-    try:
-        subprocess.run(
-            [
-                "uv",
-                "run",
-                "--no-project",
-                "--with",
-                delta_spark_spec,
-                "python",
-                str(builder_script),
-                str(staging),
-                *(str(arg) for arg in builder_args),
-            ],
-            check=True,
-        )
-        loc._place_tree(staging)
-    finally:
-        shutil.rmtree(staging, ignore_errors=True)
+    for attempt in range(1, max_attempts + 1):
+        # Fresh staging each attempt: a builder that died mid-write must not
+        # leak a partial tree into the next attempt or the upload.
+        staging = pathlib.Path(tempfile.mkdtemp(prefix="feldera_delta_fixture_"))
+        try:
+            subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "--no-project",
+                    "--with",
+                    delta_spark_spec,
+                    "python",
+                    str(builder_script),
+                    str(staging),
+                    *(str(arg) for arg in builder_args),
+                ],
+                check=True,
+            )
+            loc._place_tree(staging)
+            break
+        except subprocess.CalledProcessError:
+            if attempt == max_attempts:
+                raise
+            logging.warning(
+                "PySpark Delta fixture build failed (attempt %d/%d); retrying. "
+                "Usually a transient Maven/Ivy download failure.",
+                attempt,
+                max_attempts,
+            )
+            time.sleep(5 * attempt)
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
 
     if not present(loc):
         raise RuntimeError(


### PR DESCRIPTION
The follow/CDC paths read each commit's data file as raw Parquet, bypassing delta-rs's scan. That bypass also skips delta-rs's column-mapping translation, so a table with delta.columnMapping.mode = 'name' or 'id'
read wrong or missing columns: on disk the data lives under physical col-<uuid>
names while the SQL schema uses logical names.

Force the physical schema onto the reader, then rename columns back to their logical names after reading. Read each commit against the schema active when it was written: advance_schema adopts a new schema whenever a commit carries a metaData action. Physical names are stable across a rename, so a replayed commit resolves under whatever logical name it had at that version — a replay from v0 therefore diverges from a snapshot on renamed columns (pre-rename rows read NULL for the new name).

### Describe Manual Test Plan

Ran QA against it locally with the comprehensive workload.

## Checklist

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

This should not be a breaking change
