### PR TITLE
[web-console] Implement pipeline tags UI

### DIFF
--- a/js-packages/web-console/src/lib/components/common/SlidingPanels.svelte
+++ b/js-packages/web-console/src/lib/components/common/SlidingPanels.svelte
@@ -1,0 +1,73 @@
+<script lang="ts" generics="K extends string">
+  import { fly } from 'svelte/transition'
+  import type { Snippet } from '$lib/types/svelte'
+
+  /**
+   * Shows one "page" at a time and slides between them, like the panels of a phone
+   * settings screen. `pages` is a fixed, ordered list of named panels and `current`
+   * names the one on screen; changing `current` is the "navigation" that animates
+   * the swap.
+   *
+   * The caller never requests "forward" or "back": navigation is assumed to be linear,
+   * and the slide direction is derived from each page's index in `pages`. Moving to
+   * a larger index the new page enters from the right, moving to a smaller index
+   * slides the page from the left. Comparing indices is a lightweight stand-in
+   * for an actual navigation-history stack, which has not been needed in web-console.
+   * `pages` must be ordered from the outermost page (root, index 0) to the deepest.
+   *
+   */
+  let {
+    current,
+    pages,
+    width = 220,
+    duration = 200,
+    class: className = ''
+  }: {
+    /** Key of the page currently shown. Must match one of `pages[].key`. */
+    current: K
+    /** The panels, ordered outermost-first: index 0 is the root, later entries are deeper. */
+    pages: { key: K; content: Snippet }[]
+    /** How far a page slides as it enters or leaves, in pixels. */
+    width?: number
+    /** Slide duration, in milliseconds. */
+    duration?: number
+    class?: string
+  } = $props()
+
+  const indexOf = (key: K) => pages.findIndex((page) => page.key === key)
+
+  // Which way the latest navigation slides: +1 toward a nested page (later in
+  // `pages`), -1 toward a "previous" one. We compare the new page's position with
+  // the previous page's (`lastKey`) — position alone decides the direction, so no
+  // navigation history is kept. `$effect.pre` runs before the DOM is updated, so
+  // `direction` is already current when the entering and leaving pages mount and
+  // read it for their slide transitions.
+  let direction = $state(1)
+  let lastKey = current
+  $effect.pre(() => {
+    const delta = indexOf(current) - indexOf(lastKey)
+    if (delta !== 0) {
+      direction = Math.sign(delta)
+    }
+    lastKey = current
+  })
+</script>
+
+<!-- Every page occupies the same single grid cell (row 1, column 1), so the
+     leaving and entering pages overlap and slide across each other rather than
+     pushing the layout around. Both move along the same `direction`: the entering
+     page flies in from one edge while the leaving page flies out the opposite
+     edge, reading as one continuous sweep. -->
+<div class="grid {className}">
+  {#each pages as page (page.key)}
+    {#if page.key === current}
+      <div
+        in:fly={{ x: direction * width, duration }}
+        out:fly={{ x: -direction * width, duration }}
+        class="col-start-1 row-start-1 flex flex-col"
+      >
+        {@render page.content()}
+      </div>
+    {/if}
+  {/each}
+</div>

--- a/js-packages/web-console/src/lib/components/pipelines/Table.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/Table.svelte
@@ -7,6 +7,7 @@
   import ThSort from '$lib/components/pipelines/table/ThSort.svelte'
   import { useElapsedTime } from '$lib/compositions/common/useElapsedTime'
   import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
+  import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { dateMax } from '$lib/functions/common/date'
   import { matchesSubstring } from '$lib/functions/common/string'
   import { type NamesInUnion, unionName } from '$lib/functions/common/union'
@@ -17,6 +18,7 @@
   } from '$lib/services/pipelineManager'
   import type { Snippet } from '$lib/types/svelte'
   import PipelineVersion from './table/PipelineVersion.svelte'
+  import Tags from './table/Tags.svelte'
 
   let {
     pipelines,
@@ -82,6 +84,20 @@
   const pipelinesFiltered = $derived(
     pipelinesWithLastChange.filter((p) => matchesSubstring(p.name, nameSearch))
   )
+
+  // `knownTags` is the union of tags over every pipeline — the pool the per-row
+  // tag picker chooses from.
+  const knownTags = $derived.by(() => {
+    const tags = new Set<string>()
+    for (const pipeline of pipelines) {
+      for (const tag of pipeline.tags) {
+        tags.add(tag)
+      }
+    }
+    return tags
+  })
+
+  const api = usePipelineManager()
 
   const { formatElapsedTime } = useElapsedTime()
   const td = 'py-1 text-base border-t-[0.5px]'
@@ -156,6 +172,14 @@
           <th class="px-1 py-1 text-left"
             ><span class="text-base font-normal text-surface-950-50">Message</span></th
           >
+          <th class="px-1 py-1 text-left"
+            ><span class="text-base font-normal text-surface-950-50">Tags</span></th
+          >
+          <ThSort {table} class="w-20 px-1 py-1 xl:w-32" field="platformVersion">
+            <span class="text-base font-normal text-surface-950-50">
+              Runtime <span class="hidden xl:!inline">version</span>
+            </span>
+          </ThSort>
           <ThSort
             {table}
             class="w-20 py-1 pr-4 text-right xl:w-32"
@@ -247,11 +271,9 @@
                 {/if}
               </span>
             </td>
-            <td class="{td} border-surface-100-900 pr-4 group-hover:bg-surface-50-950">
-              <div class="text-right text-nowrap">
-                {pipeline.connectors?.numErrors ?? '-'}
-              </div>
-            </td>
+            <td class="pr-2 {td} w-36 border-surface-100-900 group-hover:bg-surface-50-950"
+              ><Tags pipelineName={pipeline.name} tags={pipeline.tags} {knownTags} {api}></Tags></td
+            >
             <td class="{td} relative border-surface-100-900 group-hover:bg-surface-50-950">
               <div class="flex w-full flex-nowrap items-center gap-2 text-nowrap">
                 <PipelineVersion
@@ -260,6 +282,11 @@
                   baseRuntimeVersion={page.data.feldera!.version}
                   configuredRuntimeVersion={pipeline.programConfig.runtime_version}
                 ></PipelineVersion>
+              </div>
+            </td>
+            <td class="{td} border-surface-100-900 pr-4 group-hover:bg-surface-50-950">
+              <div class="text-right text-nowrap">
+                {pipeline.connectors?.numErrors ?? '-'}
               </div>
             </td>
             <td class="{td} relative w-28 border-surface-100-900 group-hover:bg-surface-50-950">

--- a/js-packages/web-console/src/lib/components/pipelines/Table.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/Table.svelte.spec.ts
@@ -11,8 +11,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-svelte'
-import type { PipelineThumb } from '$lib/services/pipelineManager'
 import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
+import type { PipelineThumb } from '$lib/services/pipelineManager'
 
 const SORT_KEY = 'layout/pipelines/table/sort'
 
@@ -47,6 +47,7 @@ const thumb = (name: string): PipelineThumb =>
   ({
     name,
     description: '',
+    tags: [],
     status: 'Stopped',
     storageStatus: 'Cleared',
     deploymentStatusSince: lastChange[name],

--- a/js-packages/web-console/src/lib/components/pipelines/editor/DownloadSupportBundle.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/DownloadSupportBundle.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Tooltip } from 'common-ui'
-  import { fly, slide } from 'svelte/transition'
+  import { slide } from 'svelte/transition'
   import Popup from '$lib/components/common/Popup.svelte'
+  import SlidingPanels from '$lib/components/common/SlidingPanels.svelte'
   import DownloadProgressDisplay from '$lib/components/dialogs/DownloadProgressDisplay.svelte'
   import GenericDialog from '$lib/components/dialogs/GenericDialog.svelte'
   import { useGlobalDialog } from '$lib/compositions/layout/useGlobalDialog.svelte'
@@ -163,60 +164,54 @@
       transition:slide={{ duration: 100 }}
       class="bg-white-dark absolute top-10 right-0 z-30 flex min-w-[220px] flex-col overflow-hidden rounded shadow-md"
     >
-      <!-- Grid with both pages in (1,1) so they overlap during the transition
-           and slide past each other like carousel slides. Each page has a fixed
-           direction (page 1 left, page 2 right) so forward/back animate as
-           mirrored sweeps without tracking direction state. -->
-      <div class="grid">
-        {#if pickedFile}
-          <!-- Confirmation view: opens the viewer tab on a direct click so the
-               browser preserves user activation through window.open. -->
-          <div
-            in:fly={{ x: 220, duration: 200 }}
-            out:fly={{ x: 220, duration: 200 }}
-            class="col-start-1 row-start-1 flex flex-col"
-          >
-            <div class="flex items-center gap-2 px-2 py-2">
-              <button class="btn-icon h-7 w-7" onclick={resetUpload} aria-label="Back" title="Back">
-                <span class="fd fd-chevron-left text-[20px]"></span>
-              </button>
-              <span class="min-w-0 flex-1 truncate text-sm" title={pickedFile.name}>
-                {pickedFile.name}
-              </span>
-            </div>
-            <div class="px-2 pb-2">
-              <button
-                class="btn h-8! w-full preset-filled-primary-500"
-                onclick={() => {
-                  confirmOpenViewer()
-                  close()
-                }}
-                data-testid="btn-confirm-view-profile"
-              >
-                <span class="fd fd-file-search text-[18px]"></span>
-                <span>View profile</span>
-              </button>
-            </div>
-          </div>
-        {:else}
-          <div
-            in:fly={{ x: -220, duration: 200 }}
-            out:fly={{ x: -220, duration: 200 }}
-            class="col-start-1 row-start-1 flex flex-col"
-          >
-            <SupportBundleMenu
-              bind:collectNewData={collectNewData.value}
-              onDownload={() => {
-                downloadData = { ...defaultData, collect: collectNewData.value }
-                globalDialog.dialog = supportBundleDialog
-                close()
-              }}
-              onFilePicked={handleFilePicked}
-            />
-          </div>
-        {/if}
-      </div>
+      <SlidingPanels
+        current={pickedFile ? 'confirm' : 'menu'}
+        pages={[
+          { key: 'menu', content: menuPage },
+          { key: 'confirm', content: confirmPage }
+        ]}
+      />
     </div>
+
+    {#snippet menuPage()}
+      <SupportBundleMenu
+        bind:collectNewData={collectNewData.value}
+        onDownload={() => {
+          downloadData = { ...defaultData, collect: collectNewData.value }
+          globalDialog.dialog = supportBundleDialog
+          close()
+        }}
+        onFilePicked={handleFilePicked}
+      />
+    {/snippet}
+
+    <!-- Confirmation view: opens the viewer tab on a direct click so the browser
+         preserves user activation through window.open. -->
+    {#snippet confirmPage()}
+      {#if pickedFile}
+        <div class="flex items-center gap-2 px-2 py-2">
+          <button class="btn-icon h-7 w-7" onclick={resetUpload} aria-label="Back" title="Back">
+            <span class="fd fd-chevron-left text-[20px]"></span>
+          </button>
+          <span class="min-w-0 flex-1 truncate text-sm" title={pickedFile.name}>
+            {pickedFile.name}
+          </span>
+        </div>
+        <div class="px-2 pb-2">
+          <button
+            class="btn h-8! w-full preset-filled-primary-500"
+            onclick={() => {
+              confirmOpenViewer()
+              close()
+            }}
+            data-testid="btn-confirm-view-profile"
+          >
+            <span class="fd fd-file-search text-[18px]"></span>
+            <span>View profile</span>
+          </button>
+        </div>
+      {/if}
+    {/snippet}
   {/snippet}
 </Popup>
 <Tooltip placement="top" class="w-[240px] text-wrap">

--- a/js-packages/web-console/src/lib/components/pipelines/table/Tags.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/table/Tags.svelte
@@ -1,0 +1,524 @@
+<script lang="ts">
+  import { Tooltip } from 'common-ui'
+  import { slide } from 'svelte/transition'
+  import Popup from '$lib/components/common/Popup.svelte'
+  import SlidingPanels from '$lib/components/common/SlidingPanels.svelte'
+  import {
+    usePipelineList,
+    useUpdatePipelineList
+  } from '$lib/compositions/pipelines/usePipelineList.svelte'
+  import type { PipelineManagerApi } from '$lib/compositions/usePipelineManager.svelte'
+  import { useToast } from '$lib/compositions/useToastNotification'
+  import { partition } from '$lib/functions/common/array'
+  import { promisePool } from '$lib/functions/common/promise'
+  import {
+    parseTag,
+    tagColorOf,
+    tagColorPalette,
+    tagDisplayName,
+    tagWithColor,
+    validateTag
+  } from '$lib/functions/pipelines/tags'
+  import { patchPipeline } from '$lib/services/pipelineManager'
+
+  let {
+    pipelineName,
+    tags,
+    knownTags,
+    api
+  }: {
+    /** Name of the pipeline these tags belong to. */
+    pipelineName: string
+    /** Tags currently applied to this pipeline. */
+    tags: string[]
+    /** Every tag known across all pipelines — the pool the popup picks from. */
+    knownTags: ReadonlySet<string>
+    /** Pipeline Manager client used to persist tag edits. */
+    api: PipelineManagerApi
+  } = $props()
+
+  // API returns tags already sorted - every client sorts before writing, so a
+  // pipeline's stored tag list is stable regardless of insertion order.
+  // This comparator is used only to
+  // (1) re-establish that order when writing edited tags and
+  // (2) order the combined assigned/unassigned picker,
+  // which is built from the unordered cross-pipeline tag pool.
+  const byText = (a: string, b: string) => a.localeCompare(b)
+
+  // Tag edits update the pipeline optimistically and patch the server; the next
+  // list refresh reconciles with the server, which owns `tags`.
+  const { updatePipeline, discardPendingListRefresh } = useUpdatePipelineList()
+  const pipelineList = usePipelineList()
+  const { toastError } = useToast()
+
+  // Sort the edited tags to store them in the backend,
+  // cache that same order optimistically, and return it as the patch body.
+  // This is the one place the client orders tags; readers trust the result.
+  const applyTagsLocally = (pipelineName: string, next: string[]) => {
+    const sorted = [...next].sort(byText)
+    updatePipeline(pipelineName, (p) => ({ ...p, tags: sorted }))
+    return sorted
+  }
+
+  // Persist a single pipeline's tags.
+  // `api.patchPipeline` reports errors that may arise to the users in a toast popup.
+  const setPipelineTags = (name: string, next: string[]) => {
+    api.patchPipeline(name, { tags: applyTagsLocally(name, next) })
+  }
+  const setTags = (next: string[]) => {
+    discardPendingListRefresh()
+    setPipelineTags(pipelineName, next)
+  }
+
+  // Patch the pipelines through a fixed-size pool of concurrent requests, so a tag shared by
+  // hundreds of pipelines doesn't fire hundreds of requests at once. These
+  // patches use the bare service call rather than `api.patchPipeline` so we
+  // control how failures surface: the first couple of failures toast
+  // individually as they land, but the moment we reach `PATCH_FAILURE_TOAST_LIMIT`
+  // failures we give up - skip the remaining pipelines, let the in-flight requests
+  // settle, then raise one toast covering the remaining failures plus
+  // every skipped update.
+  const PATCH_CONCURRENCY = 16
+  const PATCH_FAILURE_TOAST_LIMIT = 3
+  const setManyPipelineTags = async (
+    tagName: string,
+    updates: { name: string; tags: string[] }[]
+  ) => {
+    discardPendingListRefresh()
+    let failures = 0
+    let limitFailureBody = ''
+    let stopped = false
+    const outcomes = await promisePool(updates, PATCH_CONCURRENCY, async ({ name, tags }) => {
+      // Once we've given up, skip without issuing a request. The pool still
+      // visits the remaining items cheaply; we count the skips below.
+      if (stopped) {
+        return 'skipped' as const
+      }
+      try {
+        await patchPipeline(name, { tags: applyTagsLocally(name, tags) })
+        return 'ok' as const
+      } catch (error) {
+        // Toast each failure as it lands, up to the limit. The error that
+        // reaches the limit is carried into the aggregate toast below; later
+        // failures are only counted.
+        failures += 1
+        if (failures < PATCH_FAILURE_TOAST_LIMIT) {
+          toastError('')(new Error(`Failed to update tag “${tagName}” on pipeline “${name}”`))
+        } else if (failures === PATCH_FAILURE_TOAST_LIMIT) {
+          limitFailureBody = error instanceof Error ? error.message : String(error)
+          stopped = true
+        }
+        return 'failed' as const
+      }
+    })
+    if (failures >= PATCH_FAILURE_TOAST_LIMIT) {
+      // The first `PATCH_FAILURE_TOAST_LIMIT - 1` failures toasted individually;
+      // fold the failures past that point together with every update we skipped
+      // into one count — annotated with the error that hit the limit.
+      const skipped = outcomes.filter((outcome) => outcome === 'skipped').length
+      const count = failures - (PATCH_FAILURE_TOAST_LIMIT - 1) + skipped
+      toastError('')(
+        new Error(
+          `Failed to update tag "${tagName}" on ${count} pipeline${count === 1 ? '' : 's'}:\n${limitFailureBody}`
+        )
+      )
+    }
+  }
+  const toggleTag = (tag: string) => {
+    if (tags.includes(tag)) {
+      setTags(tags.filter((t) => t !== tag))
+      return
+    }
+    // Assigning a tag drops every other color variant of the same name, so a
+    // pipeline never carries two variants. This also cleans up a pipeline that
+    // another client gave several variants: checking one unassigns the rest.
+    const name = tagDisplayName(tag)
+    setTags([...tags.filter((t) => tagDisplayName(t) !== name), tag])
+  }
+  const createTag = (tag: string) => {
+    // Like `toggleTag`, drop any other color variant of the same name so the
+    // pipeline never ends up carrying two variants of one tag.
+    const name = tagDisplayName(tag)
+    setTags([...tags.filter((t) => tagDisplayName(t) !== name), tag])
+  }
+
+  // At most two tags fit in the row; the rest collapse into a "+N" chip.
+  const inlineTags = $derived(tags.slice(0, 2))
+  const overflowCount = $derived(Math.max(0, tags.length - 2))
+
+  let page = $state<'list' | 'create' | 'edit' | 'delete'>('list')
+  let search = $state('')
+  let newTagName = $state('')
+  // The '#rrggbb' color the user has chosen for the tag being created or edited;
+  // encoded as a '|rrggbb' suffix on submit (see `tagWithColor`). Defaults to the
+  // first palette entry so a freshly created tag always has a color.
+  let newTagColor = $state<string>(tagColorPalette[0].color)
+  // The exact tag string being edited (with its color suffix), or null when the
+  // form is in "create" mode.
+  let editingTag = $state<string | null>(null)
+
+  const matchesSearch = (text: string) =>
+    tagDisplayName(text).toLowerCase().includes(search.trim().toLowerCase())
+
+  // Selected tags float to the top; both groups are sorted a–z (see design).
+  const [selectedTags, unselectedTags] = $derived(
+    partition([...knownTags].filter(matchesSearch), (t) => tags.includes(t)).map((group) =>
+      group.sort(byText)
+    )
+  )
+
+  // In create mode, a name matching an existing tag must reuse that tag's color;
+  // otherwise we would create two tags with the same name but different colors.
+  const existingSameName = $derived(
+    [...knownTags].find((tag) => tagDisplayName(tag) === newTagName.trim())
+  )
+  // The existing tag's actual color, if it has one. An uncolored same-name tag
+  // leaves this undefined, so the picker stays open and the user can give the tag
+  // a color rather than being locked to the default.
+  const createLockedColor = $derived(
+    existingSameName === undefined ? undefined : parseTag(existingSameName).color
+  )
+
+  // The tag the create page would produce, with the color encoded as a suffix. A
+  // tag that already exists (same name *and* same color) is applied rather than
+  // created — hence the button reads "Assign" instead of "Create".
+  const candidateTag = $derived(tagWithColor(newTagName.trim(), createLockedColor ?? newTagColor))
+  const candidateExists = $derived(knownTags.has(candidateTag))
+
+  // Validate the encoded tag against the backend's rules so a bad name is caught
+  // here, before the request. Only meaningful once the user has typed a name; an
+  // empty name is already handled by disabling submit.
+  const candidateError = $derived(newTagName.trim() ? validateTag(candidateTag) : null)
+
+  const submitCreate = () => {
+    if (!newTagName.trim()) {
+      return
+    }
+    createTag(candidateTag)
+    closeForm()
+  }
+
+  const openCreate = (tag: string) => {
+    editingTag = null
+    newTagName = tagDisplayName(tag)
+    newTagColor = parseTag(tag).color ?? tagColorPalette[0].color
+    page = 'create'
+  }
+
+  const openEdit = (tag: string) => {
+    editingTag = tag
+    newTagName = tagDisplayName(tag)
+    newTagColor = parseTag(tag).color ?? tagColorPalette[0].color
+    page = 'edit'
+  }
+
+  // Apply an edit to an existing tag. When the tag string changes (a new color or
+  // name), every pipeline that carries the old tag is migrated to the new one. The
+  // pipeline list is captured up front so a concurrent poll refresh can't change
+  // what we iterate over mid-migration.
+  const submitEdit = () => {
+    const oldTag = editingTag
+    if (!oldTag || !newTagName.trim()) {
+      return
+    }
+    const newTag = tagWithColor(newTagName.trim(), newTagColor)
+    if (newTag !== oldTag) {
+      const pipelines = pipelineList.pipelines ?? []
+      setManyPipelineTags(
+        tagDisplayName(newTag),
+        pipelines
+          .filter((pipeline) => pipeline.tags.includes(oldTag))
+          .map((pipeline) => ({
+            name: pipeline.name,
+            // Drop the old tag (and any pre-existing copy of the new one) before
+            // adding the new tag, so a pipeline that already had both never ends
+            // up with the new tag twice.
+            tags: [...pipeline.tags.filter((t) => t !== oldTag && t !== newTag), newTag]
+          }))
+      )
+    }
+    closeForm()
+  }
+
+  // How many pipelines currently carry the tag being edited — surfaced in the
+  // delete confirmation so the user knows the blast radius.
+  const editingTagUsageCount = $derived.by(() => {
+    if (editingTag === null) {
+      return 0
+    }
+    const tag = editingTag
+    return (pipelineList.pipelines ?? []).filter((p) => p.tags.includes(tag)).length
+  })
+
+  // Delete the tag being edited: drop it from every pipeline that carries it. As
+  // with editing, the pipeline list is captured up front so a concurrent poll
+  // refresh can't change what we iterate over mid-deletion.
+  const submitDelete = () => {
+    const tag = editingTag
+    if (!tag) {
+      return
+    }
+    const pipelines = pipelineList.pipelines ?? []
+    setManyPipelineTags(
+      tagDisplayName(tag),
+      pipelines
+        .filter((pipeline) => pipeline.tags.includes(tag))
+        .map((pipeline) => ({
+          name: pipeline.name,
+          tags: pipeline.tags.filter((t) => t !== tag)
+        }))
+    )
+    closeForm()
+  }
+
+  // Return the form to a clean list view. Also used when the popup (re)opens.
+  const closeForm = () => {
+    page = 'list'
+    search = ''
+    newTagName = ''
+    editingTag = null
+  }
+</script>
+
+<Popup>
+  {#snippet trigger(toggle)}
+    {@const open = () => {
+      closeForm()
+      toggle()
+    }}
+    <div class="flex flex-nowrap items-center gap-1">
+      {#each inlineTags as tag (tag)}
+        {@render chip(tag, open)}
+      {/each}
+      {#if overflowCount > 0}
+        <button
+          class="px-1 text-sm text-surface-600-400 hover:text-surface-950-50"
+          onclick={open}
+          aria-label="Show all tags"
+        >
+          +{overflowCount}
+        </button>
+        <Tooltip placement="top" class="max-w-[240px] text-wrap"
+          >{tags.map(tagDisplayName).join(', ')}</Tooltip
+        >
+      {/if}
+      {#if tags.length === 0}
+        <button
+          class="flex h-5 items-center gap-1 rounded border border-dashed border-surface-500 px-2 text-sm text-surface-800-200 hover:border-surface-950-50 hover:text-surface-950-50"
+          onclick={open}
+        >
+          <span class="fd fd-plus text-[16px]"></span>
+          Tag
+        </button>
+      {/if}
+    </div>
+  {/snippet}
+  {#snippet content()}
+    <div
+      transition:slide={{ duration: 100 }}
+      class="bg-white-dark absolute top-8 left-0 z-30 flex w-[304px] flex-col overflow-hidden rounded shadow-md"
+    >
+      <SlidingPanels
+        current={page}
+        width={280}
+        pages={[
+          { key: 'list', content: listPage },
+          { key: 'create', content: createPage },
+          { key: 'edit', content: editPage },
+          { key: 'delete', content: deletePage }
+        ]}
+      />
+    </div>
+
+    {#snippet listPage()}
+      <div class="p-2">
+        <input class="input h-9 w-full" type="search" placeholder="Search" bind:value={search} />
+      </div>
+      <div class="scrollbar flex max-h-[280px] flex-col overflow-y-auto pb-1">
+        {#each selectedTags as tag (tag)}
+          {@render tagRow(tag, true)}
+        {/each}
+        {#each unselectedTags as tag (tag)}
+          {@render tagRow(tag, false)}
+        {/each}
+      </div>
+      <button
+        class="flex items-center gap-2 border-t border-surface-100-900 px-3 py-2 text-left text-sm hover:bg-surface-50-950"
+        onclick={() => openCreate(search)}
+      >
+        <span class="fd fd-plus text-[16px]"></span>
+        Create a new tag
+      </button>
+    {/snippet}
+
+    {#snippet createPage()}
+      {@render tagForm({
+        title: 'Create a new tag',
+        submitLabel: candidateExists ? 'Assign' : 'Create',
+        submitDisabled: !newTagName.trim() || candidateError !== null,
+        lockedColor: createLockedColor,
+        validationError: candidateError,
+        onSubmit: submitCreate
+      })}
+    {/snippet}
+
+    {#snippet editPage()}
+      {@render tagForm({
+        title: 'Edit tag',
+        submitLabel: 'Save',
+        submitDisabled: !newTagName.trim() || candidateError !== null,
+        validationError: candidateError,
+        onSubmit: submitEdit,
+        onDelete: () => (page = 'delete')
+      })}
+    {/snippet}
+
+    {#snippet deletePage()}
+      <div class="flex items-center gap-2 px-2 py-2">
+        <button
+          class="btn-icon h-7 w-7"
+          onclick={() => (page = 'edit')}
+          aria-label="Back"
+          title="Back"
+        >
+          <span class="fd fd-chevron-left text-[20px]"></span>
+        </button>
+        <span class="text-sm font-medium">Delete tag</span>
+      </div>
+      <div class="flex flex-col gap-3 px-3 pb-3">
+        <p class="">
+          The tag “{tagDisplayName(editingTag ?? '')}” will be removed from
+          {editingTagUsageCount}
+          {editingTagUsageCount === 1 ? 'pipeline' : 'pipelines'} it's currently assigned to.
+          <br />
+          This cannot be undone.
+        </p>
+        <div class="flex gap-2">
+          <button class="btn flex-1 preset-tonal-surface" onclick={() => (page = 'edit')}>
+            Cancel
+          </button>
+          <button class="btn flex-1 preset-filled-error-500" onclick={submitDelete}>
+            Delete
+          </button>
+        </div>
+      </div>
+    {/snippet}
+  {/snippet}
+</Popup>
+
+{#snippet chip(tag: string, open: () => void)}
+  <button
+    class="flex h-5 items-center gap-1.5 rounded border border-surface-200-800 px-2 text-sm whitespace-nowrap hover:bg-surface-50-950"
+    onclick={open}
+  >
+    <span class="h-2 w-2 rounded-full" style="background-color: {tagColorOf(tag)}"></span>
+    {tagDisplayName(tag)}
+  </button>
+{/snippet}
+
+{#snippet tagRow(tag: string, selected: boolean)}
+  <div class="group/row flex items-center hover:bg-surface-50-950">
+    <button
+      class="flex flex-1 items-center gap-2 py-1.5 pl-3 text-left text-sm"
+      onclick={() => toggleTag(tag)}
+    >
+      <input
+        class="pointer-events-none checkbox"
+        type="checkbox"
+        checked={selected}
+        tabindex="-1"
+      />
+      <span class="h-2.5 w-2.5 shrink-0 rounded-full" style="background-color: {tagColorOf(tag)}"
+      ></span>
+      <span class="truncate">{tagDisplayName(tag)}</span>
+    </button>
+    <button
+      class="invisible flex h-7 w-7 shrink-0 items-center justify-center text-surface-600-400 group-hover/row:visible hover:text-surface-950-50"
+      onclick={() => openEdit(tag)}
+      aria-label="Edit tag"
+      title="Edit tag"
+    >
+      <span class="fd fd-settings text-[16px]"></span>
+    </button>
+  </div>
+{/snippet}
+
+{#snippet tagForm(opts: {
+  title: string
+  submitLabel: string
+  submitDisabled: boolean
+  lockedColor?: string
+  validationError?: string | null
+  onSubmit: () => void
+  onDelete?: () => void
+})}
+  {@const selectedColor = opts.lockedColor ?? newTagColor}
+  {@const colorName = tagColorPalette.find((c) => c.color === selectedColor)?.name ?? 'Custom'}
+  <div class="flex items-center gap-2 px-2 py-2">
+    <button class="btn-icon h-7 w-7" onclick={() => (page = 'list')} aria-label="Back" title="Back">
+      <span class="fd fd-chevron-left text-[20px]"></span>
+    </button>
+    <span class="text-sm font-medium">{opts.title}</span>
+    {#if opts.onDelete}
+      <button
+        class="ml-auto btn-icon h-7 w-7 text-surface-600-400 hover:text-error-500"
+        onclick={opts.onDelete}
+        aria-label="Delete tag"
+        title="Delete tag"
+      >
+        <span class="fd fd-trash-2 text-[18px]"></span>
+      </button>
+    {/if}
+  </div>
+  <div class="flex flex-col gap-3 px-3 pb-3">
+    <label class="flex flex-col gap-1 text-sm font-medium">
+      Tag name
+      <input
+        class="input h-9 w-full"
+        class:border-error-500={!!opts.validationError}
+        type="text"
+        bind:value={newTagName}
+        placeholder="Tag name"
+      />
+      {#if opts.validationError}
+        <span class="text-xs font-normal text-error-500">{opts.validationError}</span>
+      {/if}
+    </label>
+    <div class="flex flex-col gap-1 text-sm font-medium">
+      <span class="flex items-center gap-2">
+        Label color
+        <span class="font-normal text-surface-500">{colorName}</span>
+      </span>
+      <div class="flex flex-wrap gap-2 py-1">
+        {#each tagColorPalette as paletteColor (paletteColor.name)}
+          <button
+            type="button"
+            disabled={opts.lockedColor !== undefined}
+            class="flex h-6 w-6 items-center justify-center rounded-full transition-transform hover:scale-110 disabled:cursor-not-allowed disabled:opacity-40"
+            style="background-color: {paletteColor.color}"
+            title={paletteColor.name}
+            aria-label={paletteColor.name}
+            aria-pressed={paletteColor.color === selectedColor}
+            onclick={() => (newTagColor = paletteColor.color)}
+          >
+            {#if paletteColor.color !== selectedColor}
+              <span class="bg-white-dark block h-4 w-4 rounded-full opacity-80"></span>
+            {/if}
+          </button>
+        {/each}
+      </div>
+    </div>
+    <button
+      class="btn h-9! w-full preset-filled-primary-500"
+      disabled={opts.submitDisabled}
+      onclick={opts.onSubmit}
+    >
+      {opts.submitLabel}
+    </button>
+    {#if opts.lockedColor !== undefined}
+      <p class="">
+        The tag “{newTagName.trim()}” already exists.
+      </p>
+    {/if}
+  </div>
+{/snippet}

--- a/js-packages/web-console/src/lib/components/pipelines/table/Tags.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/table/Tags.svelte.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-svelte'
+import type { PipelineManagerApi } from '$lib/compositions/usePipelineManager.svelte'
+import Tags from './Tags.svelte'
+
+// A stub Pipeline Manager client: only `patchPipeline` is exercised by the
+// single-pipeline edit paths this component triggers. The cast keeps the test
+// from having to fill in the dozens of unrelated client methods.
+const makeApi = () => {
+  const patchPipeline = vi.fn().mockResolvedValue(undefined)
+  return { api: { patchPipeline } as unknown as PipelineManagerApi, patchPipeline }
+}
+
+const renderTags = (props: { tags: string[]; knownTags?: string[] }) => {
+  const { api, patchPipeline } = makeApi()
+  const result = render(Tags, {
+    pipelineName: 'test-pipeline',
+    tags: props.tags,
+    knownTags: new Set(props.knownTags ?? props.tags),
+    api
+  })
+  return { ...result, patchPipeline }
+}
+
+describe('Tags.svelte', () => {
+  describe('chips', () => {
+    it('renders each assigned tag as a chip by display name, stripping the color', async () => {
+      renderTags({ tags: ['dev', 'prod|ef4444'] })
+      await expect.element(page.getByRole('button', { name: 'dev' })).toBeVisible()
+      const prod = page.getByRole('button', { name: 'prod' })
+      await expect.element(prod).toBeVisible()
+      // The chip's color dot uses the encoded color (#ef4444 -> rgb).
+      expect(prod.element().querySelector('span')).toHaveStyle({
+        backgroundColor: 'rgb(239, 68, 68)'
+      })
+    })
+
+    it('collapses the tags beyond the first two into a "+N" control', async () => {
+      renderTags({ tags: ['a', 'b', 'c', 'd'] })
+      await expect
+        .element(page.getByRole('button', { name: 'Show all tags' }))
+        .toHaveTextContent('+2')
+    })
+
+    it('shows an add-tag affordance when the pipeline has no tags', async () => {
+      renderTags({ tags: [] })
+      await expect.element(page.getByRole('button', { name: 'Tag' })).toBeVisible()
+    })
+  })
+
+  describe('picker', () => {
+    it('lists assigned and unassigned tags, the assigned one checked', async () => {
+      renderTags({ tags: ['prod|ef4444'], knownTags: ['prod|ef4444', 'dev'] })
+      await page.getByRole('button', { name: 'prod' }).click()
+
+      // Both names appear in the list (selected first, then unselected).
+      await expect.element(page.getByText('dev')).toBeVisible()
+      const checkboxes = page.getByRole('checkbox').elements()
+      expect(checkboxes).toHaveLength(2)
+      const checked = checkboxes.filter((c) => (c as HTMLInputElement).checked)
+      expect(checked).toHaveLength(1)
+    })
+
+    it('assigning an unselected tag patches the pipeline with it added, kept sorted', async () => {
+      const { patchPipeline } = renderTags({
+        tags: ['prod|ef4444'],
+        knownTags: ['prod|ef4444', 'dev']
+      })
+      await page.getByRole('button', { name: 'prod' }).click()
+      await page.getByRole('button', { name: 'dev' }).click()
+
+      expect(patchPipeline).toHaveBeenCalledWith('test-pipeline', {
+        tags: ['dev', 'prod|ef4444']
+      })
+    })
+
+    it('unassigning an assigned tag patches the pipeline with it removed', async () => {
+      const { patchPipeline } = renderTags({
+        tags: ['dev', 'prod|ef4444'],
+        knownTags: ['dev', 'prod|ef4444']
+      })
+      // Open via the overflow-free chip, then click the matching row to untoggle.
+      await page.getByRole('button', { name: 'dev' }).first().click()
+      // After opening, the same name exists as a chip and a row; the row is the
+      // second match. Click it to unassign.
+      await page.getByRole('button', { name: 'dev' }).last().click()
+
+      expect(patchPipeline).toHaveBeenCalledWith('test-pipeline', {
+        tags: ['prod|ef4444']
+      })
+    })
+  })
+
+  describe('create form validation', () => {
+    it('blocks an invalid name and surfaces the reason; a valid name is color-encoded', async () => {
+      const { patchPipeline } = renderTags({ tags: [] })
+      await page.getByRole('button', { name: 'Tag' }).click()
+      await page.getByRole('button', { name: 'Create a new tag' }).click()
+
+      const nameInput = page.getByPlaceholder('Tag name')
+      const createButton = page.getByRole('button', { name: 'Create' })
+
+      // A character outside the allowed set is rejected up front.
+      await nameInput.fill('a;b')
+      await expect.element(page.getByText(/may contain only/)).toBeVisible()
+      await expect.element(createButton).toBeDisabled()
+      expect(patchPipeline).not.toHaveBeenCalled()
+
+      // A valid name enables submit; the default palette color is encoded as a
+      // "|rrggbb" suffix (first palette entry is red, #ef4444).
+      await nameInput.fill('qa')
+      await expect.element(createButton).toBeEnabled()
+      await createButton.click()
+
+      expect(patchPipeline).toHaveBeenCalledWith('test-pipeline', {
+        tags: ['qa|ef4444']
+      })
+    })
+  })
+})

--- a/js-packages/web-console/src/lib/functions/common/promise.spec.ts
+++ b/js-packages/web-console/src/lib/functions/common/promise.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+import { promisePool } from './promise'
+
+/** A promise whose resolution the test controls explicitly. */
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/**
+ * Drain the microtask queue so resumed workers run to their next `await`.
+ * Resolving a promise and resuming its awaiter spans a few microtask turns, so
+ * yield several times rather than once.
+ */
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('promisePool', () => {
+  it('returns results in input order regardless of completion order', async () => {
+    const results = await promisePool([1, 2, 3, 4], 2, async (n) => n * 10)
+    expect(results).toEqual([10, 20, 30, 40])
+  })
+
+  it('passes the item and its index to the worker', async () => {
+    const seen: [string, number][] = []
+    await promisePool(['a', 'b', 'c'], 2, async (item, index) => {
+      seen.push([item, index])
+    })
+    expect(seen.sort((x, y) => x[1] - y[1])).toEqual([
+      ['a', 0],
+      ['b', 1],
+      ['c', 2]
+    ])
+  })
+
+  it('runs at most `concurrency` workers at once', async () => {
+    let inFlight = 0
+    let peak = 0
+    const gates = Array.from({ length: 6 }, () => deferred<void>())
+    const pool = promisePool(gates, 2, async (gate) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await gate.promise
+      inFlight--
+    })
+    // Release the gates one at a time, letting the pool refill its slots.
+    for (const gate of gates) {
+      await flush()
+      gate.resolve()
+    }
+    await pool
+    expect(peak).toBe(2)
+  })
+
+  it('slides the window: a slow item never stalls an idle slot', async () => {
+    const started: number[] = []
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>(), deferred<void>()]
+    const pool = promisePool([0, 1, 2, 3], 2, async (n) => {
+      started.push(n)
+      await gates[n].promise
+    })
+
+    // Slots 0 and 1 start immediately; 2 and 3 wait for a free slot.
+    await flush()
+    expect(started).toEqual([0, 1])
+
+    // Finish item 1 (the second slot); item 2 should take its place at once,
+    // even though item 0 is still running.
+    gates[1].resolve()
+    await flush()
+    expect(started).toEqual([0, 1, 2])
+
+    gates[0].resolve()
+    await flush()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    gates[2].resolve()
+    gates[3].resolve()
+    await pool
+  })
+
+  it('handles an empty input without invoking the worker', async () => {
+    const fn = vi.fn(async (n: number) => n)
+    const results = await promisePool([], 4, fn)
+    expect(results).toEqual([])
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('caps workers at the item count when concurrency exceeds it', async () => {
+    let inFlight = 0
+    let peak = 0
+    await promisePool([1, 2], 10, async (n) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await flush()
+      inFlight--
+      return n
+    })
+    expect(peak).toBe(2)
+  })
+
+  it('clamps non-positive concurrency to a single worker', async () => {
+    let inFlight = 0
+    let peak = 0
+    const results = await promisePool([1, 2, 3], 0, async (n) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await flush()
+      inFlight--
+      return n
+    })
+    expect(peak).toBe(1)
+    expect(results).toEqual([1, 2, 3])
+  })
+
+  it('rejects when a worker rejects, and starts no further items', async () => {
+    const started: number[] = []
+    await expect(
+      promisePool([0, 1, 2, 3, 4, 5], 2, async (n) => {
+        started.push(n)
+        if (n === 1) {
+          throw new Error('boom')
+        }
+        // Item 0 never settles on its own, so the only progress past the first
+        // two is whatever the failing worker would have pulled next — and it
+        // must pull nothing once the pool is rejecting.
+        await new Promise<void>(() => {})
+      })
+    ).rejects.toThrow('boom')
+    // Only the initial two items ever started; no third item was claimed.
+    expect(started).toEqual([0, 1])
+  })
+})

--- a/js-packages/web-console/src/lib/functions/common/promise.ts
+++ b/js-packages/web-console/src/lib/functions/common/promise.ts
@@ -2,6 +2,46 @@ import { clearTimeout as clearWorkerTimeout, setTimeout as setWorkerTimeout } fr
 
 export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
+/**
+ * Map over `items` with a bounded number of concurrent workers — a sliding
+ * window rather than fixed batches. At most `concurrency` calls to `fn` are in
+ * flight at once; as each settles, the next item starts immediately.
+ *
+ * Results are returned in input order, like `Promise.all`. `fn` receives the
+ * item and its index. A rejection from `fn` rejects the whole pool (again like
+ * `Promise.all`), and no further items are started; callers that want to finish
+ * the rest should catch inside `fn`.
+ *
+ * The "workers" are not threads: everything runs on the single main JS thread,
+ * so this is concurrency, not parallelism. It only helps when `fn` spends its
+ * time awaiting (a network request, a timer) - those waits overlap. CPU-bound
+ * `fn`s gain nothing, since the thread still runs them one at a time.
+ *
+ * @param items       Items to process.
+ * @param concurrency Maximum number of `fn` calls in flight at once (clamped to ≥ 1).
+ * @param fn          Async worker invoked once per item.
+ * @returns Results in the same order as `items`.
+ */
+export const promisePool = async <T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> => {
+  const results = new Array<R>(items.length)
+  let next = 0
+  // Each worker pulls the next unclaimed index until the list is drained;
+  // `next++` is atomic between awaits, so no two workers claim the same item.
+  const worker = async () => {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await fn(items[index], index)
+    }
+  }
+  const workerCount = Math.max(1, Math.min(concurrency, items.length))
+  await Promise.all(Array.from({ length: workerCount }, worker))
+  return results
+}
+
 const hasDocument = typeof document !== 'undefined'
 const isHidden = () => hasDocument && document.hidden
 const clearWorkerTimeoutSafely = (timeout: number) => {

--- a/js-packages/web-console/src/lib/functions/pipelines/tags.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/tags.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultTagColor,
+  maximumTagLength,
+  parseTag,
+  tagColorOf,
+  tagColorPalette,
+  tagDisplayName,
+  tagWithColor,
+  validateTag
+} from './tags'
+
+describe('parseTag', () => {
+  it('splits a name and its color', () => {
+    expect(parseTag('prod|ef4444')).toEqual({ name: 'prod', color: '#ef4444' })
+  })
+
+  it('re-adds the "#" the stored form omits', () => {
+    expect(parseTag('x|22c55e').color).toBe('#22c55e')
+  })
+
+  it('rejects uppercase hex, keeping it as part of the name', () => {
+    expect(parseTag('prod|ABCDEF')).toEqual({ name: 'prod|ABCDEF' })
+    expect(parseTag('prod|EF4444')).toEqual({ name: 'prod|EF4444' })
+  })
+
+  it('returns no color for a bare name', () => {
+    expect(parseTag('prod')).toEqual({ name: 'prod' })
+  })
+
+  it('keeps a "|" that is not followed by a six-digit hex color', () => {
+    expect(parseTag('a|b')).toEqual({ name: 'a|b' })
+    expect(parseTag('env|staging')).toEqual({ name: 'env|staging' })
+    expect(parseTag('prod|fff')).toEqual({ name: 'prod|fff' })
+    expect(parseTag('prod|gggggg')).toEqual({ name: 'prod|gggggg' })
+  })
+
+  it('treats only the final "|" segment as the color', () => {
+    expect(parseTag('a|b|ef4444')).toEqual({ name: 'a|b', color: '#ef4444' })
+  })
+})
+
+describe('tagDisplayName', () => {
+  it('strips a color suffix', () => {
+    expect(tagDisplayName('prod|ef4444')).toBe('prod')
+    expect(tagDisplayName('team billing|22c55e')).toBe('team billing')
+  })
+
+  it('returns a bare name unchanged', () => {
+    expect(tagDisplayName('prod')).toBe('prod')
+    expect(tagDisplayName('')).toBe('')
+  })
+
+  it('keeps a non-color "|" suffix', () => {
+    expect(tagDisplayName('a|b')).toBe('a|b')
+  })
+})
+
+describe('tagColorOf', () => {
+  it('returns the encoded color as a CSS value', () => {
+    expect(tagColorOf('prod|ef4444')).toBe('#ef4444')
+  })
+
+  it('falls back to the default color when uncolored', () => {
+    expect(tagColorOf('prod')).toBe(defaultTagColor)
+    expect(tagColorOf('a|b')).toBe(defaultTagColor)
+  })
+})
+
+describe('tagWithColor', () => {
+  it('encodes a color, dropping the leading "#"', () => {
+    expect(tagWithColor('prod', '#ef4444')).toBe('prod|ef4444')
+  })
+
+  it('replaces an existing suffix so re-coloring is idempotent', () => {
+    expect(tagWithColor('prod|ef4444', '#22c55e')).toBe('prod|22c55e')
+    expect(tagWithColor(tagWithColor('prod', '#ef4444'), '#ef4444')).toBe('prod|ef4444')
+  })
+
+  it('yields a bare name for a null or undefined color', () => {
+    expect(tagWithColor('prod|ef4444', null)).toBe('prod')
+    expect(tagWithColor('prod', undefined)).toBe('prod')
+  })
+
+  it('round-trips through parseTag', () => {
+    expect(parseTag(tagWithColor('prod', '#ef4444'))).toEqual({ name: 'prod', color: '#ef4444' })
+    // A name that itself contains "|" survives the round-trip.
+    expect(parseTag(tagWithColor('a|b', '#ef4444'))).toEqual({ name: 'a|b', color: '#ef4444' })
+  })
+
+  it('lowercases an uppercase CSS color so it stays recognizable', () => {
+    expect(tagWithColor('prod', '#ABCDEF')).toBe('prod|abcdef')
+    expect(parseTag(tagWithColor('prod', '#ABCDEF'))).toEqual({ name: 'prod', color: '#abcdef' })
+  })
+
+  it('uses every palette color as a valid encoded tag', () => {
+    for (const { color } of tagColorPalette) {
+      const tag = tagWithColor('prod', color)
+      expect(validateTag(tag)).toBeNull()
+      expect(tagColorOf(tag)).toBe(color)
+    }
+  })
+})
+
+describe('validateTag', () => {
+  it('accepts a plain name', () => {
+    expect(validateTag('prod')).toBeNull()
+  })
+
+  it('accepts the allowed punctuation', () => {
+    expect(validateTag('Mixed-1_2/3|4.5:6=7 8')).toBeNull()
+  })
+
+  it('accepts a fully encoded colored tag', () => {
+    expect(validateTag('prod|ef4444')).toBeNull()
+  })
+
+  it('accepts a tag exactly at the length limit', () => {
+    expect(validateTag('a'.repeat(maximumTagLength))).toBeNull()
+  })
+
+  it('rejects an empty tag', () => {
+    expect(validateTag('')).not.toBeNull()
+  })
+
+  it('rejects a tag over the length limit', () => {
+    expect(validateTag('a'.repeat(maximumTagLength + 1))).not.toBeNull()
+  })
+
+  it('rejects characters outside the allowed set', () => {
+    expect(validateTag('a;b')).not.toBeNull()
+    expect(validateTag('a#b')).not.toBeNull()
+    expect(validateTag('a,b')).not.toBeNull()
+    expect(validateTag('café')).not.toBeNull()
+    expect(validateTag('emoji😀')).not.toBeNull()
+  })
+})
+
+describe('palette', () => {
+  it('is non-empty and every entry is a lowercase #rrggbb hex color', () => {
+    expect(tagColorPalette.length).toBeGreaterThan(0)
+    for (const { color } of tagColorPalette) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+})

--- a/js-packages/web-console/src/lib/functions/pipelines/tags.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/tags.ts
@@ -1,0 +1,103 @@
+/**
+ * Pipeline tag colors.
+ *
+ * The backend stores a tag as an opaque string, validates it against a fixed
+ * character set (`PATTERN_VALID_TAG` in the pipeline manager), and knows nothing
+ * about color. A tag's color is therefore encoded into the string itself as a
+ * suffix drawn only from that character set: the visible name, then a `|`
+ * separator, then a six-digit `rrggbb` hex color — no leading `#`, which the
+ * backend disallows. For example `"prod|ef4444"`. The suffix is optional; a bare
+ * `"prod"` is an uncolored tag, shown in a default color.
+ *
+ * A tag's *identity* is its name alone — the text before the color suffix — so
+ * `"prod|ef4444"` and `"prod|22c55e"` are the same tag in two colors; assigning
+ * one to a pipeline replaces the other. The suffix is recognized only when the
+ * text after the last `|` is exactly six hex digits, so a name that itself
+ * contains `|` (without a trailing color) is preserved intact.
+ */
+
+/** The fixed palette of tag label colors (see design). */
+export const tagColorPalette = [
+  { name: 'Red', color: '#ef4444' },
+  { name: 'Purple', color: '#a855f7' },
+  { name: 'Pink', color: '#ec4899' },
+  { name: 'Orange', color: '#f97316' },
+  { name: 'Yellow', color: '#eab308' },
+  { name: 'Green', color: '#22c55e' },
+  { name: 'Teal', color: '#14b8a6' },
+  { name: 'Blue', color: '#3b82f6' },
+  { name: 'Dark blue', color: '#1d4ed8' }
+] as const
+
+export type TagColor = (typeof tagColorPalette)[number]
+
+/** The color shown for a tag that carries no color suffix. */
+export const defaultTagColor = '#9ca3af'
+
+/**
+ * The stored color suffix: a `|` followed by exactly six lowercase hex digits at
+ * the end of the string. No `#`, which the backend's tag character set disallows.
+ * Lowercase is the one canonical form (the palette below is lowercase); uppercase
+ * hex is not recognized as a color and stays part of the name.
+ */
+const storedColorSuffix = /\|([0-9a-f]{6})$/
+
+/**
+ * Split a tag into its name and optional color. The suffix is recognized only
+ * when the text after the last `|` is exactly six hex digits, so a name that
+ * contains `|` but no trailing color is returned whole and uncolored. The
+ * returned color is a CSS `#rrggbb` value, with the `#` the stored form omits.
+ */
+export const parseTag = (tag: string): { name: string; color?: string } => {
+  const match = storedColorSuffix.exec(tag)
+  if (match) {
+    return { name: tag.slice(0, match.index), color: `#${match[1]}` }
+  }
+  return { name: tag }
+}
+
+/** The visible text of a tag, with any color suffix removed. */
+export const tagDisplayName = (tag: string): string => parseTag(tag).name
+
+/** A tag's color as a CSS `#rrggbb` value, or {@link defaultTagColor} when none. */
+export const tagColorOf = (tag: string): string => parseTag(tag).color ?? defaultTagColor
+
+/**
+ * Encode `color` (a CSS `#rrggbb` value) into a tag as a `|rrggbb` suffix,
+ * dropping the leading `#` the backend disallows and replacing any existing
+ * suffix first so re-coloring is idempotent. The hex is lowercased so the result
+ * is recognized as a color even when given an uppercase CSS value. A null or
+ * undefined color yields the bare name.
+ */
+export const tagWithColor = (tag: string, color?: string | null): string => {
+  const name = tagDisplayName(tag)
+  return color ? `${name}|${color.replace(/^#/, '').toLowerCase()}` : name
+}
+
+/** Maximum length of a single stored tag, mirroring the backend. */
+export const maximumTagLength = 50
+
+/**
+ * Characters a tag may contain, mirroring the backend's `PATTERN_VALID_TAG`
+ * (crates/pipeline-manager/src/db/types/utils.rs).
+ * The color suffix is a subset of this character set.
+ */
+export const tagPattern = /^[a-zA-Z0-9 ._/|\\:=-]+$/
+
+/**
+ * Check a fully encoded tag against the same rules the backend enforces, so the
+ * UI can reject a bad tag up front instead of waiting for the API to fail.
+ * Returns a human-readable reason, or null when the tag is valid.
+ */
+export const validateTag = (tag: string): string | null => {
+  if (tag.length === 0) {
+    return 'A tag cannot be empty.'
+  }
+  if (tag.length > maximumTagLength) {
+    return `A tag may be at most ${maximumTagLength} characters; this one is ${tag.length}.`
+  }
+  if (!tagPattern.test(tag)) {
+    return 'A tag may contain only letters, numbers, spaces, and the characters . _ / | \\ : = -'
+  }
+  return null
+}

--- a/js-packages/web-console/src/lib/services/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/services/pipelineManager.ts
@@ -36,6 +36,7 @@ import {
   listClusterEvents,
   listPipelineEvents,
   listPipelines,
+  type PatchPipeline,
   type PipelineSelectedInfo,
   type PostPutPipeline,
   type ProgramError,

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1468,6 +1468,10 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
     def tags(self) -> List[str]:
         """
         Return the tags of the pipeline.
+
+        Tags are returned verbatim, including the ``|rrggbb`` color suffix the web
+        console uses to encode a tag's color. Use :func:`feldera.tags.tag_display_name`
+        to obtain the tag's text label.
         """
 
         self.refresh(PipelineFieldSelector.STATUS)

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -18,6 +18,7 @@ from feldera.rest.config import Config
 from feldera.rest.errors import FelderaAPIError, FelderaTimeoutError
 from feldera.rest.feldera_config import FelderaConfig
 from feldera.rest.pipeline import Pipeline
+from feldera.tags import _normalize_tags
 from feldera.rest.retry import RetryConfig
 
 logger = logging.getLogger(__name__)
@@ -332,7 +333,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             "program_config": pipeline.program_config,
             "runtime_config": pipeline.runtime_config,
             "description": pipeline.description or "",
-            "tags": pipeline.tags,
+            "tags": _normalize_tags(pipeline.tags),
         }
 
         self.http.post(
@@ -365,7 +366,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             "program_config": pipeline.program_config,
             "runtime_config": pipeline.runtime_config,
             "description": pipeline.description or "",
-            "tags": pipeline.tags,
+            "tags": _normalize_tags(pipeline.tags),
         }
 
         self.http.put(
@@ -398,6 +399,10 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         stored one, and a field left as ``None`` is omitted from the request and
         leaves the stored value untouched. To clear the description or tags, pass
         an empty string or empty list, respectively.
+
+        Tags, when provided, are normalized before being sent: color variants of
+        the same display name are collapsed and the result is stored in API server database
+        in lexicographic order (see :mod:`feldera.tags`).
         """
 
         self.http.patch(
@@ -409,7 +414,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
                 "program_config": program_config,
                 "runtime_config": runtime_config,
                 "description": description,
-                "tags": tags,
+                "tags": _normalize_tags(tags) if tags is not None else None,
             },
         )
 

--- a/python/feldera/tags.py
+++ b/python/feldera/tags.py
@@ -1,0 +1,51 @@
+"""
+Pipeline tag conventions.
+
+The backend stores a tag as an opaque string and validates it against an allowed
+character set. The web console encodes a tag's color into the string itself
+as a suffix that character set permits: the visible name, then a ``|`` separator,
+then a six-digit ``rrggbb`` hex color -- e.g. ``"prod|ef4444"``. The suffix
+is optional, so a bare ``"prod"`` is an uncolored tag; ``"prod|ef4444"`` and
+``"prod|22c55e"`` are considered a tag collision which can but should not occur.
+
+To stay consistent with the web console, the SDK treats a tag's *display name* --
+its name with any color suffix removed -- as the tag's identity, and enforces two
+invariants whenever a pipeline's tags are written:
+
+* **Variant exclusivity.** A pipeline carries at most one tag per display name.
+  When a list holds several color variants of the same name, the last one wins.
+* **Lexicographic order.** Tags are sorted lexicographically by the SDK
+  before sending to the API server.
+"""
+
+import re
+from typing import Iterable, List
+
+# A tag's color suffix: a ``|`` followed by exactly six lowercase hex digits at
+# the end of the string (no ``#``, which the backend's tag character set
+# disallows). Lowercase is the one canonical form; uppercase hex is therefore
+# not recognized as a color and stays part of the name.
+# Recognized only in this exact form, so a name that itself contains
+# ``|`` (without a trailing color) keeps its full text.
+_COLOR_SUFFIX = re.compile(r"\|[0-9a-f]{6}$")
+
+
+def tag_display_name(tag: str) -> str:
+    """Return a tag's visible text: its name with any color suffix removed."""
+
+    return _COLOR_SUFFIX.sub("", tag)
+
+
+def _normalize_tags(tags: Iterable[str]) -> List[str]:
+    """
+    Collapse color variants of the same tag and sort the result.
+
+    Tags that share a display name are deduplicated, keeping the last occurrence,
+    and the survivors are returned in lexicographic order. The color suffix that
+    encodes a tag's color is preserved.
+    """
+
+    by_display_name: dict[str, str] = {}
+    for tag in tags:
+        by_display_name[tag_display_name(tag)] = tag
+    return sorted(by_display_name.values())

--- a/python/tests/platform/test_pipeline_builder.py
+++ b/python/tests/platform/test_pipeline_builder.py
@@ -101,6 +101,13 @@ class TestPipelineBuilder(PipelineTestCase):
         pipeline.modify(tags=[])
         assert pipeline.tags() == []
 
+        # The SDK normalizes tags before storing them, matching the web console:
+        # tags are saved in sorted order, and color variants of the same name
+        # (the same text with different "|rrggbb" color suffixes) are collapsed to
+        # the last one supplied. The surviving variant keeps its color.
+        pipeline.modify(tags=["prod", "alpha", "prod|ef4444"])
+        assert pipeline.tags() == ["alpha", "prod|ef4444"]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/unit/test_tags.py
+++ b/python/tests/unit/test_tags.py
@@ -1,0 +1,67 @@
+"""Unit tests for the pipeline tag conventions in :mod:`feldera.tags`."""
+
+from feldera.tags import _normalize_tags, tag_display_name
+
+
+def test_display_name_strips_color_suffix():
+    # A trailing "|rrggbb" suffix is removed; everything else is the visible name.
+    assert tag_display_name("prod") == "prod"
+    assert tag_display_name("prod|ef4444") == "prod"
+    assert tag_display_name("team billing|22c55e") == "team billing"
+    # Only lowercase hex is a color; uppercase hex stays part of the name.
+    assert tag_display_name("prod|ef4444") == "prod"
+    assert tag_display_name("prod|ABCDEF") == "prod|ABCDEF"
+    assert tag_display_name("prod|EF4444") == "prod|EF4444"
+    # A name containing "|" but no valid trailing color is returned whole.
+    assert tag_display_name("a|b") == "a|b"
+    assert tag_display_name("env|staging") == "env|staging"
+    # Wrong-length or malformed suffixes are not colors.
+    assert tag_display_name("prod|fff") == "prod|fff"
+    assert tag_display_name("prod|gggggg") == "prod|gggggg"
+    # Only the final "|" segment is the color; an inner "|" stays in the name.
+    assert tag_display_name("a|b|ef4444") == "a|b"
+    assert tag_display_name("") == ""
+
+
+def test_normalize_sorts_lexicographically():
+    assert _normalize_tags(["prod", "dev", "staging"]) == ["dev", "prod", "staging"]
+
+
+def test_normalize_is_idempotent():
+    once = _normalize_tags(["beta", "alpha", "alpha|ef4444"])
+    assert _normalize_tags(once) == once
+
+
+def test_normalize_empty():
+    assert _normalize_tags([]) == []
+
+
+def test_normalize_collapses_color_variants_keeping_last():
+    # "prod" and "prod|ef4444" share a display name, so only one survives, and it
+    # is the last one supplied -- mirroring the console, where assigning a tag
+    # drops the other color variants of the same name.
+    assert _normalize_tags(["prod", "prod|ef4444"]) == ["prod|ef4444"]
+    assert _normalize_tags(["prod|ef4444", "prod"]) == ["prod"]
+
+
+def test_normalize_preserves_color_of_survivor():
+    # The surviving variant keeps its color suffix, so its color is not lost.
+    result = _normalize_tags(["dev", "prod|ef4444", "qa"])
+    assert result == ["dev", "prod|ef4444", "qa"]
+
+
+def test_normalize_distinct_names_with_colors_all_kept():
+    # Different display names never collide, regardless of color.
+    assert _normalize_tags(["b|ef4444", "a|22c55e", "c"]) == [
+        "a|22c55e",
+        "b|ef4444",
+        "c",
+    ]
+
+
+def test_normalize_accepts_any_iterable():
+    assert _normalize_tags(iter(["b", "a"])) == ["a", "b"]
+    assert _normalize_tags(("staging", "prod", "staging|22c55e")) == [
+        "prod",
+        "staging|22c55e",
+    ]


### PR DESCRIPTION
Testing: manual, added fda and python SDK tests, and web-console component test

I implemented the tag colors using a `|RRGGBB` suffix for the tag name. pipeline-manager stores tags as opaque strings, clients ensure tags are unique by the text label, not the entire text string.

Web-console can batch-update the pipelines (as per design) - so a tag can be deleted from all pipelines, and re-named and re-colored across all pipelines (one HTTP request per pipeline), in batches of 20 to avoid spamming too many HTTP calls at once.

The pipeline-manager allows duplication of colors for the same tag text label, so in the case this occurs web-console handles it gracefully and the user does not experience issues - they can just delete/re-color the offending color variant.

[Screencast from 2026-06-23 17-52-21.webm](https://github.com/user-attachments/assets/367cb173-f007-4556-a8de-4be07213108d)
