### PR TITLE
cli: Add pipeline copy command

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -342,6 +342,15 @@ pub enum PipelineAction {
         )]
         stdin: bool,
     },
+    /// Copy a pipeline's program and configuration into a new pipeline.
+    #[clap(aliases = &["clone"])]
+    Copy {
+        /// The name of the pipeline to copy from.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        source: String,
+        /// The name of the new pipeline.
+        destination: String,
+    },
     /// Start a pipeline.
     ///
     /// If the pipeline is compiling it will wait for the compilation to finish.

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -1057,7 +1057,7 @@ pub enum ConnectorAction {
 
 #[cfg(test)]
 mod tests {
-    use crate::cli::{Cli, Commands, ProgramAction};
+    use crate::cli::{Cli, Commands, PipelineAction, ProgramAction};
     use clap::Parser;
 
     /// [clap] will panic inside `try_parse` if it finds anything invalid in the
@@ -1075,9 +1075,25 @@ mod tests {
 
         assert!(matches!(
             cli.command,
-            Commands::Pipeline(crate::cli::PipelineAction::Program {
+            Commands::Pipeline(PipelineAction::Program {
                 action: ProgramAction::Errors { name }
             }) if name == "pipeline"
         ));
+    }
+
+    #[test]
+    fn parse_pipeline_copy_command_and_alias() {
+        for command in ["copy", "clone"] {
+            let cli = Cli::try_parse_from(["fda", command, "source", "destination"])
+                .expect("copy command should parse");
+
+            assert!(matches!(
+                cli.command,
+                Commands::Pipeline(PipelineAction::Copy {
+                    source,
+                    destination
+                }) if source == "source" && destination == "destination"
+            ));
+        }
     }
 }

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -844,6 +844,84 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 std::process::exit(1);
             }
         }
+        PipelineAction::Copy {
+            source,
+            destination,
+        } => {
+            let source_pipeline = client
+                .get_pipeline()
+                .pipeline_name(source.clone())
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to get source pipeline",
+                    1,
+                ))
+                .unwrap()
+                .into_inner();
+
+            let Some(program_code) = source_pipeline.program_code else {
+                eprintln!(
+                    "Source pipeline response did not include program code. {}",
+                    UPGRADE_NOTICE
+                );
+                std::process::exit(1);
+            };
+            let Some(runtime_config) = source_pipeline.runtime_config else {
+                eprintln!(
+                    "Source pipeline response did not include runtime configuration. {}",
+                    UPGRADE_NOTICE
+                );
+                std::process::exit(1);
+            };
+            let Some(program_config) = source_pipeline.program_config else {
+                eprintln!(
+                    "Source pipeline response did not include compilation configuration. {}",
+                    UPGRADE_NOTICE
+                );
+                std::process::exit(1);
+            };
+
+            let response = client
+                .post_pipeline()
+                .body(PostPutPipeline {
+                    description: source_pipeline.description,
+                    tags: source_pipeline.tags,
+                    name: destination.clone(),
+                    program_code,
+                    udf_rust: source_pipeline.udf_rust,
+                    udf_toml: source_pipeline.udf_toml,
+                    program_config: Some(program_config),
+                    runtime_config: Some(runtime_config),
+                })
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to copy pipeline",
+                    1,
+                ))
+                .unwrap();
+
+            match format {
+                OutputFormat::Text => {
+                    println!("Pipeline copied successfully.");
+                    debug!("{:#?}", response);
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&response.into_inner())
+                            .expect("Failed to serialize pipeline response")
+                    );
+                }
+                _ => {
+                    eprintln!("Unsupported output format: {}", format);
+                    std::process::exit(1);
+                }
+            }
+        }
         PipelineAction::Start {
             name,
             recompile,

--- a/crates/fda/test.bash
+++ b/crates/fda/test.bash
@@ -79,7 +79,7 @@ CREATE VIEW example_count WITH ('connectors' = '[{ "name": "c", "transport": { "
 EOF
 
 fda create p1 program.sql
-fda program get p1 | fda create p2 -s
+fda copy p1 p2
 compare_output "fda program get p1" "fda program get p2"
 fda program set-config p1 --profile dev
 fda program set-config p1 --profile optimized

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -249,10 +249,10 @@ CREATE VIEW example_count AS ( SELECT COUNT(*) AS num_rows FROM example );" > pr
 fda create p1 program.sql
 ```
 
-Retrieve the program for `p1` and create a new pipeline `p2` from it:
+Copy pipeline `p1` to a new pipeline `p2`:
 
 ```bash
-fda program get p1 | fda create p2 -s
+fda copy p1 p2
 ```
 
 Enable storage for `p1`:


### PR DESCRIPTION
Closes #6399

idk, manually cloning a pipeline by stitching together program and config commands feels easy to mess up. imo this belongs as a tiny CLI shortcut, since testing variants should not make you copy the same fields by hand.

Adds `fda copy SOURCE DESTINATION`, plus `clone` as an alias. It creates the new pipeline from the source pipeline's program, UDFs, runtime config, compilation config, description, and tags. ltm this is better as a boring built-in command than a shell recipe. lgtm for the testing workflow in the issue.
