### PR TITLE
Testing API to block for compaction

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -1102,6 +1102,9 @@ pub trait Node: Any {
     /// Call [`Operator::start_compaction`](super::operator_traits::Operator::start_compaction) on the operator this node encapsulates.
     fn start_compaction(&mut self);
 
+    /// Call [`Operator::is_compaction_complete`](super::operator_traits::Operator::is_compaction_complete) on the operator this node encapsulates.
+    fn is_compaction_complete(&self) -> bool;
+
     /// Place operator in the replay mode.
     ///
     /// In the replay mode the operator streams its stored state to a temporary
@@ -1885,6 +1888,10 @@ pub trait CircuitBase: 'static {
     fn rebalance(&self);
 
     fn start_compaction(&self);
+
+    /// Returns `true` when all operators' background compaction has fully
+    /// converged.
+    fn is_compaction_complete(&self) -> bool;
 }
 
 /// The circuit interface.  All DBSP computation takes place within a circuit.
@@ -3595,6 +3602,15 @@ where
             Ok(())
         });
     }
+
+    fn is_compaction_complete(&self) -> bool {
+        let mut complete = true;
+        let _ = self.map_local_nodes(&mut |node| {
+            complete &= node.is_compaction_complete();
+            Ok(())
+        });
+        complete
+    }
 }
 
 impl<P, T> Circuit for ChildCircuit<P, T>
@@ -4775,6 +4791,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -4924,6 +4944,10 @@ where
 
     fn start_compaction(&mut self) {
         self.operator.start_compaction()
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
     }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
@@ -5091,6 +5115,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -5247,6 +5275,10 @@ where
 
     fn start_compaction(&mut self) {
         self.operator.start_compaction()
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
     }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
@@ -5464,6 +5496,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -5653,6 +5689,10 @@ where
 
     fn start_compaction(&mut self) {
         self.operator.start_compaction()
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
     }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
@@ -5870,6 +5910,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -6057,6 +6101,10 @@ where
 
     fn start_compaction(&mut self) {
         self.operator.start_compaction()
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
     }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
@@ -6269,6 +6317,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -6464,6 +6516,10 @@ where
         self.operator.start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.clear_state()
     }
@@ -6649,6 +6705,10 @@ where
         self.operator.borrow_mut().start_compaction()
     }
 
+    fn is_compaction_complete(&self) -> bool {
+        self.operator.borrow().is_compaction_complete()
+    }
+
     fn clear_state(&mut self) -> Result<(), DbspError> {
         self.operator.borrow_mut().clear_state()
     }
@@ -6815,6 +6875,10 @@ where
     }
 
     fn start_compaction(&mut self) {}
+
+    fn is_compaction_complete(&self) -> bool {
+        true
+    }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
         Ok(())
@@ -7046,6 +7110,10 @@ where
 
     fn start_compaction(&mut self) {
         self.circuit.start_compaction();
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.circuit.is_compaction_complete()
     }
 
     fn clear_state(&mut self) -> Result<(), DbspError> {
@@ -7838,6 +7906,10 @@ impl CircuitHandle {
 
     pub fn start_compaction(&self) {
         self.circuit.start_compaction()
+    }
+
+    pub fn is_compaction_complete(&self) -> bool {
+        self.circuit.is_compaction_complete()
     }
 }
 

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1771,15 +1771,18 @@ impl DBSPHandle {
     }
 
     /// Block until background compaction has fully converged on every worker,
-    /// or until `timeout` elapses.  This method is designed for use in tests.
+    /// or until `timeout` elapses.
     ///
     /// Polls [`is_compaction_complete`](Self::is_compaction_complete) with
     /// exponential back-off, starting at 1 ms and doubling each iteration up
     /// to a cap of 1 s.
     ///
-    /// Returns `Ok(())` when compaction is complete, or
-    /// `Err(`[`DbspError::Constructor`]`)` when the timeout expires.
-    pub fn wait_for_compaction(&mut self, timeout: std::time::Duration) -> Result<(), DbspError> {
+    /// Returns `Ok(())` when compaction is complete, or an error if the
+    /// circuit fails or the timeout expires.
+    pub fn wait_for_compaction(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<(), anyhow::Error> {
         use std::thread;
         use std::time::Instant;
 
@@ -1795,9 +1798,7 @@ impl DBSPHandle {
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                return Err(DbspError::Constructor(anyhow::anyhow!(
-                    "timed out after {timeout:?} waiting for compaction to complete"
-                )));
+                anyhow::bail!("timed out after {timeout:?} waiting for compaction to complete");
             }
             let sleep = std::time::Duration::from_millis(sleep_ms).min(remaining);
             thread::sleep(sleep);

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -883,6 +883,15 @@ impl Runtime {
                             return;
                         }
                     }
+                    Ok(Command::IsCompactionComplete) => {
+                        let complete = circuit.is_compaction_complete();
+                        if status_sender
+                            .send(Ok(Response::IsCompactionComplete(complete)))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
                     // Nothing to do: do some housekeeping and relinquish the CPU if there's none
                     // left.
                     Err(TryRecvError::Empty) => {
@@ -976,6 +985,7 @@ enum Command {
     Rebalance,
     SetAutoRebalance(bool),
     StartCompaction,
+    IsCompactionComplete,
 }
 
 impl Debug for Command {
@@ -1018,6 +1028,7 @@ impl Debug for Command {
                 f.debug_tuple("SetAutoRebalance").field(enable).finish()
             }
             Command::StartCompaction => write!(f, "StartCompaction"),
+            Command::IsCompactionComplete => write!(f, "IsCompactionComplete"),
         }
     }
 }
@@ -1027,6 +1038,7 @@ enum Response {
     Unit,
     CommitComplete(bool),
     BootstrapComplete(bool),
+    IsCompactionComplete(bool),
     CommitProgress(CommitProgress),
     ProfileDump(Graph),
     Profile(WorkerProfile),
@@ -1739,6 +1751,58 @@ impl DBSPHandle {
     pub fn start_compaction(&mut self) -> Result<(), DbspError> {
         self.broadcast_command(Command::StartCompaction, |_, _| {})?;
         Ok(())
+    }
+
+    /// Returns `true` when background compaction has fully converged on every
+    /// worker: all compaction requests have been processed, no merge is in
+    /// progress, and each spine has been reduced to at most one batch.
+    ///
+    /// This is a non-blocking point-in-time snapshot.  Callers that need to
+    /// wait for compaction to finish should call
+    /// [`wait_for_compaction`](Self::wait_for_compaction) or poll this method.
+    pub fn is_compaction_complete(&mut self) -> Result<bool, DbspError> {
+        let mut complete = true;
+        self.broadcast_command(Command::IsCompactionComplete, |_, response| {
+            if let Response::IsCompactionComplete(c) = response {
+                complete &= c;
+            }
+        })?;
+        Ok(complete)
+    }
+
+    /// Block until background compaction has fully converged on every worker,
+    /// or until `timeout` elapses.  This method is designed for use in tests.
+    ///
+    /// Polls [`is_compaction_complete`](Self::is_compaction_complete) with
+    /// exponential back-off, starting at 1 ms and doubling each iteration up
+    /// to a cap of 1 s.
+    ///
+    /// Returns `Ok(())` when compaction is complete, or
+    /// `Err(`[`DbspError::Constructor`]`)` when the timeout expires.
+    pub fn wait_for_compaction(&mut self, timeout: std::time::Duration) -> Result<(), DbspError> {
+        use std::thread;
+        use std::time::Instant;
+
+        const INITIAL_SLEEP_MS: u64 = 1;
+        const MAX_SLEEP_MS: u64 = 1_000;
+
+        let deadline = Instant::now() + timeout;
+        let mut sleep_ms = INITIAL_SLEEP_MS;
+
+        loop {
+            if self.is_compaction_complete()? {
+                return Ok(());
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(DbspError::Constructor(anyhow::anyhow!(
+                    "timed out after {timeout:?} waiting for compaction to complete"
+                )));
+            }
+            let sleep = std::time::Duration::from_millis(sleep_ms).min(remaining);
+            thread::sleep(sleep);
+            sleep_ms = (sleep_ms * 2).min(MAX_SLEEP_MS);
+        }
     }
 }
 
@@ -2650,5 +2714,75 @@ pub(crate) mod tests {
             checkpoint = Some(cpm.uuid);
             dbsp.kill().unwrap();
         }
+    }
+
+    /// `is_compaction_complete` / `wait_for_compaction` must converge after a
+    /// compaction sweep and verify actual merging occurred.
+    ///
+    /// Uses in-memory storage so the test finishes quickly.
+    #[test]
+    fn test_is_compaction_complete() {
+        use crate::circuit::GlobalNodeId;
+        use crate::circuit::metadata::{MetaItem, SPINE_BATCHES_COUNT};
+        use crate::utils::Tup2;
+        use std::time::Duration;
+
+        const BATCHES: usize = 30;
+        const RECORDS_PER_BATCH: i32 = 500;
+
+        let (mut dbsp, input_handle) =
+            Runtime::init_circuit(CircuitConfig::with_workers(2), |circuit| {
+                let (stream, handle) = circuit.add_input_indexed_zset::<i32, i32>();
+                stream.shard().integrate_trace();
+                Ok(handle)
+            })
+            .unwrap();
+
+        // Feed enough batches to give each spine more than one batch to merge.
+        for batch in 0..BATCHES as i32 {
+            let mut tuples: Vec<_> = (0..RECORDS_PER_BATCH)
+                .map(|r| Tup2(batch * RECORDS_PER_BATCH + r, Tup2(r, 1)))
+                .collect();
+            input_handle.append(&mut tuples);
+            dbsp.transaction().unwrap();
+        }
+
+        // Collect per-operator spine batch counts from the profile.
+        let batch_counts = |dbsp: &mut DBSPHandle| -> Vec<usize> {
+            let root = GlobalNodeId::root();
+            dbsp.retrieve_profile()
+                .unwrap()
+                .worker_profiles
+                .iter()
+                .flat_map(|p| p.attribute_profile(&SPINE_BATCHES_COUNT))
+                .filter_map(|(id, value)| {
+                    (id != root).then(|| match value {
+                        MetaItem::Count(n) => n,
+                        other => panic!("unexpected MetaItem: {other:?}"),
+                    })
+                })
+                .collect()
+        };
+
+        // Before compaction there must be at least one spine with more than one
+        // batch, confirming that actual merging work is needed.
+        let counts_before = batch_counts(&mut dbsp);
+        assert!(
+            counts_before.iter().any(|&n| n > 1),
+            "expected at least one spine with >1 batch before compaction, got {counts_before:?}"
+        );
+
+        // Request a full compaction and block until all spines converge.
+        dbsp.start_compaction().unwrap();
+        dbsp.wait_for_compaction(Duration::from_secs(60)).unwrap();
+
+        // After convergence every spine must have at most one batch.
+        let counts_after = batch_counts(&mut dbsp);
+        assert!(
+            counts_after.iter().all(|&n| n <= 1),
+            "expected all spines to have <=1 batch after compaction, got {counts_after:?}"
+        );
+
+        dbsp.kill().unwrap();
     }
 }

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -312,6 +312,12 @@ pub trait Operator: 'static {
     ///
     /// Only defined for operators that support compaction. No-op for all other operators.
     fn start_compaction(&mut self) {}
+
+    /// Returns `true` when the operator's background compaction has fully
+    /// converged.  Operators without a trace always return `true`.
+    fn is_compaction_complete(&self) -> bool {
+        true
+    }
 }
 
 /// A source operator that injects data from the outside world or from the

--- a/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
@@ -1107,6 +1107,12 @@ where
             trace.initiate_compaction()
         }
     }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.trace
+            .as_ref()
+            .is_none_or(|t| t.is_compaction_complete())
+    }
 }
 
 impl<C, B, T> StrictOperator<T> for AccumulateZ1Trace<C, B, T>

--- a/crates/dbsp/src/operator/dynamic/multijoin/match_keys.rs
+++ b/crates/dbsp/src/operator/dynamic/multijoin/match_keys.rs
@@ -867,6 +867,10 @@ where
 
     fn start_compaction(&mut self) {}
 
+    fn is_compaction_complete(&self) -> bool {
+        true
+    }
+
     fn eval<'a>(
         &'a mut self,
     ) -> Pin<Box<dyn Future<Output = Result<Option<Position>, SchedulerError>> + 'a>> {

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -1175,6 +1175,12 @@ where
             trace.initiate_compaction()
         }
     }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.trace
+            .as_ref()
+            .is_none_or(|t| t.is_compaction_complete())
+    }
 }
 
 impl<C, B, T> StrictOperator<T> for Z1Trace<C, B, T>

--- a/crates/dbsp/src/trace.rs
+++ b/crates/dbsp/src/trace.rs
@@ -335,6 +335,11 @@ pub trait Trace: BatchReader {
     fn metadata(&self, _meta: &mut OperatorMeta) {}
 
     fn initiate_compaction(&self);
+
+    /// Returns `true` when compaction has fully converged: all compaction
+    /// requests have been processed, no background merge is in progress, and
+    /// the trace has been reduced to at most one batch.
+    fn is_compaction_complete(&self) -> bool;
 }
 
 /// Where a batch is stored.

--- a/crates/dbsp/src/trace/spine_async.rs
+++ b/crates/dbsp/src/trace/spine_async.rs
@@ -438,6 +438,23 @@ where
         self.slots.iter().any(|slot| slot.merging_batches.is_some())
     }
 
+    /// Returns `true` if compaction has fully converged: all compaction
+    /// requests have been processed, no merge is in progress, and the spine
+    /// has been reduced to at most one batch.
+    ///
+    /// A single batch (or zero batches) is the desired steady state after a
+    /// compaction sweep completes.  Note that "ran out of fuel" is **not**
+    /// the same as complete: a spine with several batches and no pending work
+    /// may still need further merges once new batches arrive.
+    fn is_compaction_complete(&self) -> bool {
+        let all_requests_processed = self
+            .slots
+            .iter()
+            .all(|s| s.compaction_status == CompactionStatus::None);
+        let total_batches: usize = self.slots.iter().map(Slot::n_batches).sum();
+        all_requests_processed && !self.is_merging() && total_batches <= 1
+    }
+
     /// Finishes up the ongoing merge at the given `level`, which completed in
     /// `elapsed` time over `n_steps` steps, with `new_batch` at `new_level` as
     /// the result.
@@ -1079,6 +1096,10 @@ where
     fn initiate_compaction(&self) {
         let mut state = self.state.lock().unwrap();
         state.initiate_compaction();
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.state.lock().unwrap().is_compaction_complete()
     }
 }
 
@@ -2119,6 +2140,10 @@ where
 
     fn initiate_compaction(&self) {
         self.merger.initiate_compaction();
+    }
+
+    fn is_compaction_complete(&self) -> bool {
+        self.merger.is_compaction_complete()
     }
 }
 

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -1407,6 +1407,10 @@ where
     }
 
     fn initiate_compaction(&self) {}
+
+    fn is_compaction_complete(&self) -> bool {
+        true
+    }
 }
 
 /// Test random sampling methods.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HrBaseTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HrBaseTests.java
@@ -52,6 +52,13 @@ public class HrBaseTests extends SqlIoTest {
                 --(30, 'Marketing', ARRAY()),
                 --(40, 'HR', ARRAY[Employee(200, 20, 'Eric', 8000, 500)])
                 --;
+
+                -- Postgres syntax
+                --INSERT INTO Depts VALUES
+                --(10, 'Sales', ARRAY[ROW(100, 10, 'Bill', 10000, 1000)::Employee, ROW(150, 10, 'Sebastian', 7000, null)::Employee]),
+                --(30, 'Marketing', ARRAY[]::Employee ARRAY),
+                --(40, 'HR', ARRAY[ROW(200, 20, 'Eric', 8000, 500)::Employee])
+                --;
                 """);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
@@ -690,7 +690,6 @@ public class IncrementalRegression2Tests extends SqlIoTest {
         }
     }
 
-
     @Test
     public void testSumCase() {
         var ccs = this.getCCS("""
@@ -727,6 +726,32 @@ public class IncrementalRegression2Tests extends SqlIoTest {
                  0  | 0   | 0 | -1""");
     }
 
+    @Test
+    public void issue2808() {
+        // Check the API for blocking until compaction is completed
+        var ccs = this.getCCS("""
+                CREATE TABLE T(id INT, bid INT, ts TIMESTAMP, ts0 TIMESTAMP, s INT);
+                CREATE VIEW V AS
+                SELECT id, bid,
+                    SUM(
+                        CASE
+                            WHEN ts >= (ts0 - INTERVAL '180' DAY)
+                            AND NOT s IS NULL THEN 1
+                            ELSE 0
+                        END
+                    )
+                FROM T GROUP BY id, bid;
+                """);
+        ccs.stepWeightOne("", """
+                 id | bid | sum
+                ----------------""");
+        ccs.blockForCompaction();
+        ccs.stepWeightOne("INSERT INTO T VALUES(1, 1, 0, 0, 0);", """
+                 id | bid | sum
+                ----------------
+                 1  | 1   | 1""");
+        ccs.blockForCompaction();
+    }
 
     @Test
     public void issue6350a() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BlockForCompaction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BlockForCompaction.java
@@ -1,0 +1,9 @@
+package org.dbsp.sqlCompiler.compiler.sql.tools;
+
+/** Emit a command to block for compaction */
+public class BlockForCompaction implements IStreamCommand {
+    @Override
+    public boolean compatible(IStreamCommand other) {
+        return true;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/CompilerCircuitStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/CompilerCircuitStream.java
@@ -76,6 +76,13 @@ public class CompilerCircuitStream extends CompilerCircuit {
         this.stream.addPair(input, output);
     }
 
+    /**
+     * Block the circuit until compaction is finished.
+     */
+    public void blockForCompaction() {
+        this.stream.addBlockForCompaction();
+    }
+
     /** Like step, but every record in the output has weight one, and the
      * weight column is omitted for the expected output. */
     public void stepWeightOne(String script, String expected) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/IStreamCommand.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/IStreamCommand.java
@@ -1,0 +1,7 @@
+package org.dbsp.sqlCompiler.compiler.sql.tools;
+
+/** A command part of a stream of commands that a test supplies to a circuit */
+public interface IStreamCommand {
+    /** True if the two stream commands can be applied to the same circuit */
+    boolean compatible(IStreamCommand other);
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChange.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChange.java
@@ -2,7 +2,7 @@ package org.dbsp.sqlCompiler.compiler.sql.tools;
 
 /** A pair of changes, one for inputs and the expected corresponding outputs,
  * used in a test. */
-public class InputOutputChange {
+public class InputOutputChange implements IStreamCommand {
     /** An input value for every input table. */
     public final Change inputs;
     /** An expected output value for every output view. */
@@ -25,8 +25,11 @@ public class InputOutputChange {
         return this.outputs;
     }
 
-    public boolean compatible(InputOutputChange change) {
-        return this.inputs.compatible(change.inputs) &&
-                this.outputs.compatible(change.outputs);
+    public boolean compatible(IStreamCommand change) {
+        if (change instanceof InputOutputChange otherChange) {
+            return this.inputs.compatible(otherChange.inputs) &&
+                    this.outputs.compatible(otherChange.outputs);
+        }
+        return true;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChangeStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChangeStream.java
@@ -16,28 +16,35 @@ public class InputOutputChangeStream {
     /** If non-empty it may be used to permute changes.
      * In this case outputs changes correspond to the views. */
     public final List<String> outputTables;
-    public final List<InputOutputChange> changes;
+    public final List<IStreamCommand> commands;
 
     public InputOutputChangeStream(List<String> inputTables, List<String> outputTables) {
-        this.changes = new ArrayList<>();
+        this.commands = new ArrayList<>();
         this.inputTables = inputTables;
         this.outputTables = outputTables;
     }
 
     public InputOutputChangeStream() {
-        this.changes = new ArrayList<>();
+        this.commands = new ArrayList<>();
         this.inputTables = new ArrayList<>();
         this.outputTables = new ArrayList<>();
     }
 
+    public InputOutputChangeStream addBlockForCompaction() {
+        // We don't expect "block" to be the first command
+        Utilities.enforce(! this.commands.isEmpty());
+        this.commands.add(new BlockForCompaction());
+        return this;
+    }
+
     public InputOutputChangeStream addChange(InputOutputChange change) {
-        Utilities.enforce(this.changes.isEmpty() || this.changes.get(0).compatible(change),
+        Utilities.enforce(this.commands.isEmpty() || this.commands.get(0).compatible(change),
                 () -> "Incompatible change");
         Utilities.enforce(this.inputTables.isEmpty() || change.inputs.getSetCount() == this.inputTables.size(),
                 () -> "Change does not have the same number of input tables as specified");
         Utilities.enforce(this.outputTables.isEmpty() || change.outputs.getSetCount() == this.outputTables.size(),
                 () -> "Change does not have the same number of output tables as specified");
-        this.changes.add(change);
+        this.commands.add(change);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.sql.tools;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.TableData;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
@@ -10,21 +11,28 @@ import org.dbsp.sqlCompiler.ir.DBSPFunction;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyMethodExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPConstructorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
+import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeFP;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeUser;
 import org.dbsp.util.ExplicitShuffle;
 import org.dbsp.util.IdShuffle;
 import org.dbsp.util.Linq;
@@ -58,7 +66,7 @@ public class TestCase {
     }
 
     boolean hasData() {
-        return !this.ccs.stream.changes.isEmpty();
+        return !this.ccs.stream.commands.isEmpty();
     }
 
     /**
@@ -88,7 +96,6 @@ public class TestCase {
         DBSPLetStatement streams = new DBSPLetStatement("streams", cas.getVarReference().field(1));
         list.add(streams);
 
-        int pair = 0;
         List<String> inputOrder = this.ccs.stream.inputTables;
         Shuffle inputShuffle = new IdShuffle(this.ccs.circuit.getInputTables().size());
         if (!inputOrder.isEmpty()) {
@@ -103,119 +110,135 @@ public class TestCase {
             outputShuffle = ExplicitShuffle.computePermutation(outputOrder, outputs);
         }
 
-        for (InputOutputChange changes : this.ccs.stream.changes) {
-            Change inputs = changes.getInputs();
-            inputs = inputs.shuffle(inputShuffle);
-            // Use id before simplify
-            Long changeId = inputs.getId();
-            inputs = inputs.simplify(this.ccs.compiler);
+        int pair = 0;
+        for (IStreamCommand command : this.ccs.stream.commands) {
+            if (command instanceof BlockForCompaction) {
+                var compact = new DBSPApplyMethodExpression(
+                        "start_compaction", DBSPTypeAny.getDefault(), cas.getVarReference().field(0))
+                        .resultUnwrap();
+                list.add(new DBSPExpressionStatement(compact));
+                var durationType = new DBSPTypeUser(CalciteObject.EMPTY, DBSPTypeCode.USER, "std::time::Duration", false);
+                var deadline = durationType.constructor("from_secs", new DBSPU64Literal(CalciteObject.EMPTY, 60L, false));
+                var block = new DBSPApplyMethodExpression(
+                        "wait_for_compaction", DBSPTypeAny.getDefault(), cas.getVarReference().field(0), deadline)
+                        .resultUnwrap();
+                list.add(new DBSPExpressionStatement(block));
+            } else if (command instanceof InputOutputChange change) {
+                Change inputs = change.getInputs();
+                inputs = inputs.shuffle(inputShuffle);
+                // Use id before simplify
+                Long changeId = inputs.getId();
+                inputs = inputs.simplify(this.ccs.compiler);
 
-            TableData[] tableData = new TableData[inputs.getSetCount()];
-            for (int i = 0; i < inputs.getSetCount(); i++)
-                tableData[i] = inputs.getSet(i);
-            String functionName = "input" + changeId;
-            DBSPFunction inputFunction = TableData.createInputFunction(
-                    this.ccs.compiler, functionName, tableData, codeDirectory, executionDirectory);
-            if (!changeFunction.containsKey(changeId)) {
-                result.add(inputFunction);
-                changeFunction.put(changeId, inputFunction);
-            }
-
-            String inputName = "input" + pair;
-            DBSPLetStatement in = new DBSPLetStatement(inputName, inputFunction.call());
-            list.add(in);
-
-            if (!useHandles)
-                throw new UnimplementedException("Testing for circuits with handles not yet implemented");
-
-            for (int i = 0; i < tableData.length; i++) {
-                String function;
-                DBSPExpression[] args;
-                var td = tableData[i];
-                if (!td.hasPrimaryKey()) {
-                    function = "append_to_collection_handle";
-                    args = new DBSPExpression[2];
-                } else {
-                    function = "append_to_map_handle";
-                    args = new DBSPExpression[3];
-                    args[2] = td.keyFunction();
+                TableData[] tableData = new TableData[inputs.getSetCount()];
+                for (int i = 0; i < inputs.getSetCount(); i++)
+                    tableData[i] = inputs.getSet(i);
+                String functionName = "input" + changeId;
+                DBSPFunction inputFunction = TableData.createInputFunction(
+                        this.ccs.compiler, functionName, tableData, codeDirectory, executionDirectory);
+                if (!changeFunction.containsKey(changeId)) {
+                    result.add(inputFunction);
+                    changeFunction.put(changeId, inputFunction);
                 }
-                args[0] = in.getVarReference().field(i).borrow();
-                args[1] = streams.getVarReference().field(i).borrow();
-                list.add(new DBSPApplyExpression(function, DBSPTypeAny.getDefault(), args).toStatement());
-            }
-            DBSPLetStatement step =
-                    new DBSPLetStatement("_", new DBSPApplyMethodExpression(
-                    "transaction", DBSPTypeAny.getDefault(), cas.getVarReference().field(0)).resultUnwrap());
-            list.add(step);
 
-            boolean skipSystemViews = changes.outputs.getSetCount() < this.ccs.circuit.getOutputCount();
-            int skippedOutputs = 0;
-            List<DBSPSinkOperator> sinks = Linq.list(this.ccs.circuit.sinkOperators.values());
-            for (int i = 0; i < changes.outputs.getSetCount(); i++) {
-                for (;;) {
-                    DBSPSinkOperator sink = sinks.get(i + skippedOutputs);
-                    // Skip over system views if we are not checking these
-                    if (!sink.metadata.system || !skipSystemViews)
-                        break;
-                    skippedOutputs++;
+                String inputName = "input" + pair;
+                DBSPLetStatement in = new DBSPLetStatement(inputName, inputFunction.call());
+                list.add(in);
+
+                if (!useHandles)
+                    throw new UnimplementedException("Testing for circuits with handles not yet implemented");
+
+                for (int i = 0; i < tableData.length; i++) {
+                    String function;
+                    DBSPExpression[] args;
+                    var td = tableData[i];
+                    if (!td.hasPrimaryKey()) {
+                        function = "append_to_collection_handle";
+                        args = new DBSPExpression[2];
+                    } else {
+                        function = "append_to_map_handle";
+                        args = new DBSPExpression[3];
+                        args[2] = td.keyFunction();
+                    }
+                    args[0] = in.getVarReference().field(i).borrow();
+                    args[1] = streams.getVarReference().field(i).borrow();
+                    list.add(new DBSPApplyExpression(function, DBSPTypeAny.getDefault(), args).toStatement());
                 }
-                String message = System.lineSeparator() +
-                        "mvn test -Dtest=" + this.javaTestName +
-                        System.lineSeparator() + this.name;
+                DBSPLetStatement step =
+                        new DBSPLetStatement("_", new DBSPApplyMethodExpression(
+                                "transaction", DBSPTypeAny.getDefault(), cas.getVarReference().field(0)).resultUnwrap());
+                list.add(step);
 
-                Change outputs = changes.getOutputs().shuffle(outputShuffle).simplify(this.ccs.compiler);
-                DBSPType rowType = outputs.getSetElementType(i);
-                boolean foundFp = false;
-                DBSPExpression[] converted = null;
-                DBSPVariablePath var = null;
-                if (rowType.is(DBSPTypeTuple.class)) {
-                    // Convert FP values to strings to ensure deterministic comparisons
-                    DBSPTypeTuple tuple = rowType.to(DBSPTypeTuple.class);
-                    converted = new DBSPExpression[tuple.size()];
-                    var = new DBSPVariablePath("t", tuple.ref());
-                    for (int index = 0; index < tuple.size(); index++) {
-                        DBSPType fieldType = tuple.getFieldType(index);
-                        if (fieldType.is(DBSPTypeFP.class)) {
-                            String converterFunction = "to_string_" + fieldType.to(DBSPTypeFP.class).shortName() +
-                                    fieldType.nullableUnderlineSuffix();
-                            converted[index] = new DBSPApplyExpression(
-                                    converterFunction, DBSPTypeString.varchar(fieldType.mayBeNull),
-                                    var.deref().field(index));
-                            foundFp = true;
-                        } else {
-                            converted[index] = var.deref().field(index).applyCloneIfNeeded();
+                boolean skipSystemViews = change.outputs.getSetCount() < this.ccs.circuit.getOutputCount();
+                int skippedOutputs = 0;
+                List<DBSPSinkOperator> sinks = Linq.list(this.ccs.circuit.sinkOperators.values());
+                for (int i = 0; i < change.outputs.getSetCount(); i++) {
+                    for (;;) {
+                        DBSPSinkOperator sink = sinks.get(i + skippedOutputs);
+                        // Skip over system views if we are not checking these
+                        if (!sink.metadata.system || !skipSystemViews)
+                            break;
+                        skippedOutputs++;
+                    }
+                    String message = System.lineSeparator() +
+                            "mvn test -Dtest=" + this.javaTestName +
+                            System.lineSeparator() + this.name;
+
+                    Change outputs = change.getOutputs().shuffle(outputShuffle).simplify(this.ccs.compiler);
+                    DBSPType rowType = outputs.getSetElementType(i);
+                    boolean foundFp = false;
+                    DBSPExpression[] converted = null;
+                    DBSPVariablePath var = null;
+                    if (rowType.is(DBSPTypeTuple.class)) {
+                        // Convert FP values to strings to ensure deterministic comparisons
+                        DBSPTypeTuple tuple = rowType.to(DBSPTypeTuple.class);
+                        converted = new DBSPExpression[tuple.size()];
+                        var = new DBSPVariablePath("t", tuple.ref());
+                        for (int index = 0; index < tuple.size(); index++) {
+                            DBSPType fieldType = tuple.getFieldType(index);
+                            if (fieldType.is(DBSPTypeFP.class)) {
+                                String converterFunction = "to_string_" + fieldType.to(DBSPTypeFP.class).shortName() +
+                                        fieldType.nullableUnderlineSuffix();
+                                converted[index] = new DBSPApplyExpression(
+                                        converterFunction, DBSPTypeString.varchar(fieldType.mayBeNull),
+                                        var.deref().field(index));
+                                foundFp = true;
+                            } else {
+                                converted[index] = var.deref().field(index).applyCloneIfNeeded();
+                            }
                         }
                     }
-                }
-                // else: TODO: handle Vec<> values with FP values inside.
-                // Currently we don't have any tests with this case.
+                    // else: TODO: handle Vec<> values with FP values inside.
+                    // Currently we don't have any tests with this case.
 
-                TableData expected = outputs.getSet(i);
-                DBSPExpression viewContents = expected.createOutput(this.ccs.compiler, "out" + testNumber,
-                        codeDirectory, executionDirectory);
-                DBSPExpression actual = new DBSPApplyExpression("read_output_spine", DBSPTypeAny.getDefault(),
-                        streams.getVarReference().field(changes.inputs.getSetCount() + i + skippedOutputs).borrow());
-                var produced = new DBSPLetStatement("produced_result", actual);
-                list.add(produced);
-                list.add(new DBSPComment("println!(\"result={:?}\", produced_result);"));
-                actual = produced.getVarReference();
+                    TableData expected = outputs.getSet(i);
+                    DBSPExpression viewContents = expected.createOutput(this.ccs.compiler, "out" + testNumber,
+                            codeDirectory, executionDirectory);
+                    DBSPExpression actual = new DBSPApplyExpression("read_output_spine", DBSPTypeAny.getDefault(),
+                            streams.getVarReference().field(change.inputs.getSetCount() + i + skippedOutputs).borrow());
+                    var produced = new DBSPLetStatement("produced_result", actual);
+                    list.add(produced);
+                    list.add(new DBSPComment("println!(\"result={:?}\", produced_result);"));
+                    actual = produced.getVarReference();
 
-                if (foundFp) {
-                    DBSPExpression convertedValue = new DBSPTupleExpression(converted);
-                    DBSPExpression converter = convertedValue.closure(var);
-                    DBSPVariablePath converterVar = new DBSPVariablePath("converter", DBSPTypeAny.getDefault());
-                    list.add(new DBSPLetStatement(converterVar.variable, converter));
-                    viewContents = new DBSPApplyExpression("zset_map", convertedValue.getType(), viewContents.borrow(), converterVar);
-                    actual = new DBSPApplyExpression("zset_map", convertedValue.getType(), actual.borrow(), converterVar);
+                    if (foundFp) {
+                        DBSPExpression convertedValue = new DBSPTupleExpression(converted);
+                        DBSPExpression converter = convertedValue.closure(var);
+                        DBSPVariablePath converterVar = new DBSPVariablePath("converter", DBSPTypeAny.getDefault());
+                        list.add(new DBSPLetStatement(converterVar.variable, converter));
+                        viewContents = new DBSPApplyExpression("zset_map", convertedValue.getType(), viewContents.borrow(), converterVar);
+                        actual = new DBSPApplyExpression("zset_map", convertedValue.getType(), actual.borrow(), converterVar);
+                    }
+                    DBSPStatement compare =
+                            new DBSPApplyExpression("assert!", DBSPTypeVoid.INSTANCE,
+                                    new DBSPApplyExpression("must_equal",
+                                            new DBSPTypeBool(CalciteObject.EMPTY, false),
+                                            actual.borrow(), viewContents.borrow()),
+                                    new DBSPStrLiteral(message, true)).toStatement();
+                    list.add(compare);
                 }
-                DBSPStatement compare =
-                        new DBSPApplyExpression("assert!", DBSPTypeVoid.INSTANCE,
-                                new DBSPApplyExpression("must_equal",
-                                        new DBSPTypeBool(CalciteObject.EMPTY, false),
-                                        actual.borrow(), viewContents.borrow()),
-                                new DBSPStrLiteral(message, true)).toStatement();
-                list.add(compare);
+            } else {
+                throw new InternalCompilerError("Unexpected test command");
             }
             pair++;
         }


### PR DESCRIPTION
Fixes #2808

Adds a new DBSP-level API for a circuit to wait for compaction to terminate in all workers.
Adds SQL compiler support for writing tests using this API. I expect all tests that relate to GC will use this API heavily.

### Describe Manual Test Plan

Tested the new Java test

## Checklist

- [x] Unit tests added/updated
