### PR TITLE
[profiler] Display global pipeline stats in profiler

### DIFF
--- a/js-packages/common-ui/src/lib/TabsPanel.svelte
+++ b/js-packages/common-ui/src/lib/TabsPanel.svelte
@@ -15,6 +15,9 @@
     panel: Component<T>
     keepAlive: boolean
     tabBarEnd?: Snippet
+    /** When true, the trigger is rendered but cannot be selected. Use for tabs whose data the
+     *  loaded profile does not carry. */
+    disabled?: boolean
   }
 
   /** Visual style of the tab strip:
@@ -53,7 +56,9 @@
   // Segment items only need a `value`; the visual label is rendered via the `segmentLabel`
   // snippet, which dispatches back to each TabSpec's own `label` snippet so a tab definition
   // stays the single source of truth regardless of the chosen variant.
-  const segmentItems = $derived<SegmentedItem<string>[]>(tabs.map((t) => ({ value: t.id })))
+  const segmentItems = $derived<SegmentedItem<string>[]>(
+    tabs.map((t) => ({ value: t.id, disabled: t.disabled }))
+  )
 </script>
 
 {#snippet defaultTabContainer(tab: Snippet, hidden: boolean)}
@@ -113,12 +118,15 @@
          minimum width on the surrounding Pane. `min-w-0` on the row + a row gap keeps the
          wrapped rows visually grouped. -->
     <Tabs.List class="flex w-full min-w-0 flex-wrap items-center gap-0 pb-0 mb-0 {headerClass}">
-      {#each tabs as { id, label }}
+      {#each tabs as { id, label, disabled }}
         <Tabs.Trigger
           value={id}
+          {disabled}
           class="btn h-9 font-medium whitespace-nowrap {id === currentTab
             ? 'border-surface-950-50 '
-            : 'rounded hover:bg-surface-100-900/50'}"
+            : 'rounded hover:bg-surface-100-900/50'} {disabled
+            ? 'cursor-not-allowed opacity-40'
+            : ''}"
         >
           {@render label()}
         </Tabs.Trigger>

--- a/js-packages/profiler-app/src/App.svelte
+++ b/js-packages/profiler-app/src/App.svelte
@@ -2,6 +2,7 @@
   import {
     createLoadGuard,
     getSuitableProfiles,
+    type GlobalMetrics,
     processProfileFiles,
     SupportBundleViewerLayout,
     type ZipItem
@@ -23,6 +24,7 @@
     dataflow: Dataflow | undefined
     sources: string[] | undefined
     logText: string | undefined
+    globalMetrics: GlobalMetrics | undefined
   } | null = $state(null)
 
   let fileInput: HTMLInputElement | null = $state(null)
@@ -44,7 +46,8 @@
       profile: data.profile,
       dataflow: data.dataflow,
       sources: data.sources,
-      logText: data.logText
+      logText: data.logText,
+      globalMetrics: data.globalMetrics
     }
   }
 
@@ -111,6 +114,7 @@
       dataflowData={profileData.dataflow}
       programCode={profileData.sources}
       logText={profileData.logText}
+      globalMetrics={profileData.globalMetrics}
       triageResults={new TriageResults()}
       {profileFiles}
       {selectedTimestamp}

--- a/js-packages/profiler-app/src/App.svelte
+++ b/js-packages/profiler-app/src/App.svelte
@@ -25,6 +25,7 @@
     sources: string[] | undefined
     logText: string | undefined
     globalMetrics: GlobalMetrics | undefined
+    runtimeConfig: unknown
   } | null = $state(null)
 
   let fileInput: HTMLInputElement | null = $state(null)
@@ -47,7 +48,8 @@
       dataflow: data.dataflow,
       sources: data.sources,
       logText: data.logText,
-      globalMetrics: data.globalMetrics
+      globalMetrics: data.globalMetrics,
+      runtimeConfig: data.runtimeConfig
     }
   }
 
@@ -115,6 +117,7 @@
       programCode={profileData.sources}
       logText={profileData.logText}
       globalMetrics={profileData.globalMetrics}
+      runtimeConfig={profileData.runtimeConfig}
       triageResults={new TriageResults()}
       {profileFiles}
       {selectedTimestamp}

--- a/js-packages/profiler-layout/src/lib/components/ConfigView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ConfigView.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  interface Props {
+    /** Pipeline runtime configuration, as parsed from `pipeline_config.json`. */
+    runtimeConfig: unknown
+  }
+
+  let { runtimeConfig }: Props = $props()
+
+  // Pretty-print the config for a read-only view.
+  const formatted = $derived(
+    runtimeConfig === undefined ? '' : JSON.stringify(runtimeConfig, null, 2)
+  )
+</script>
+
+<div class="absolute inset-0 overflow-auto scrollbar bg-white-dark rounded">
+  {#if formatted === ''}
+    <div class="flex h-full items-center justify-center font-mono text-sm text-surface-600-400">
+      No runtime configuration available in this bundle
+    </div>
+  {:else}
+    <pre class="p-4 font-mono text-sm text-surface-900-100">{formatted}</pre>
+  {/if}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
@@ -28,8 +28,10 @@
 
 <script lang="ts">
   import type { TooltipData } from './ProfilerTooltip.svelte'
+  import KeyValueBlock from './metrics/blocks/KeyValueBlock.svelte'
   import MetricsDistributionBlock from './metrics/blocks/MetricsDistributionBlock.svelte'
   import { buildBlocks, type RenderableBlock } from './metrics/dispatch'
+  import { buildGlobalMetrics, type GlobalMetrics } from '../functions/globalMetrics'
   import type { LookupCoordinator } from '../functions/lookup'
 
   interface Props {
@@ -37,6 +39,8 @@
     tooltipData: TooltipData | null
     /** The loaded profile's toplevel node id, used to recognise overview data. */
     rootNodeId: string | undefined
+    /** Cumulative pipeline-wide metrics from `stats.json`; shown as a tile atop the overview. */
+    globalMetrics?: GlobalMetrics
     /** When true, metrics flagged `advanced` in the profile metadata are included. */
     showAdvanced: boolean
     /** Lookup coordinator; the view registers an imperative handler so each Enter on the
@@ -47,7 +51,14 @@
     onSearchNode?: (query: string) => void
   }
 
-  const { mode, tooltipData, rootNodeId, showAdvanced, lookup, onSearchNode }: Props = $props()
+  const { mode, tooltipData, rootNodeId, globalMetrics, showAdvanced, lookup, onSearchNode }: Props =
+    $props()
+
+  // Pipeline-wide totals for the overview's "Global stats" tile. Empty (so the tile is hidden) on
+  // any non-overview view or when the bundle carried no stats.
+  const globalMetricEntries = $derived(
+    mode === 'overview' ? buildGlobalMetrics(globalMetrics) : []
+  )
 
   const nodeAttributes = $derived(
     tooltipData && 'nodeAttributes' in tooltipData ? tooltipData.nodeAttributes : null
@@ -131,7 +142,7 @@
 </script>
 
 {#snippet attributesView()}
-  {#if !nodeAttributes}
+  {#if !nodeAttributes && globalMetricEntries.length === 0}
     <div class="flex flex-1 items-center justify-center text-sm text-surface-600-400">
       {#if mode === 'node'}
         Click a node in the graph to see its metrics.
@@ -140,7 +151,7 @@
       {/if}
     </div>
   {:else}
-    {#if isNodeView}
+    {#if nodeAttributes && isNodeView}
       <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-base">
         <button
           type="button"
@@ -160,6 +171,14 @@
          otherwise one column. CSS multi-column flow auto-distributes blocks; the column
          count is driven by the ResizeObserver on the scroll container. -->
     <div class="gap-3" style="column-count: {useTwoColumns ? 2 : 1};">
+      <!-- Overview-only cumulative pipeline metrics from `stats.json`, tiled alongside the node
+           blocks. Driven by the bundle's global metrics, not the selected node, so it shows in the
+           overview even when the root node carries no attributes and no node tooltip is produced. -->
+      {#if globalMetricEntries.length > 0}
+        <div class="mb-3 break-inside-avoid">
+          <KeyValueBlock id="global-metrics" title="Global stats" entries={globalMetricEntries} />
+        </div>
+      {/if}
       {#each blocks as b (b.id)}
         <div class="mb-3 break-inside-avoid">
           <MetricsDistributionBlock id={b.id} title={b.title} entries={b.entries} />

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -21,6 +21,7 @@
   } from 'profiler-lib'
   import { type Snippet, untrack } from 'svelte'
   import type { TriageResults } from 'triage-types'
+  import type { GlobalMetrics } from '../functions/globalMetrics'
   import { createLookupCoordinator } from '../functions/lookup'
   import { type AnalysisView, isNodeView, metricsModeOf } from '../functions/metricsMode'
   import { severityLabel, uniqueCategories, uniqueSeverities } from '../functions/triage'
@@ -41,6 +42,8 @@
     dataflowData: Dataflow | undefined
     programCode: string[] | undefined
     logText?: string
+    /** Cumulative pipeline-wide metrics from the bundle's `stats.json`; shown in the overview. */
+    globalMetrics?: GlobalMetrics
     triageResults: TriageResults
     profileFiles: [Date, ZipItem[]][]
     selectedTimestamp: Date | null
@@ -61,6 +64,7 @@
     dataflowData,
     programCode,
     logText,
+    globalMetrics,
     triageResults,
     profileFiles,
     selectedTimestamp,
@@ -261,6 +265,7 @@
     metricsMode,
     tooltipData,
     rootNodeId: diagramRootNodeId,
+    globalMetrics,
     showAdvancedMetrics,
     lookup,
     logText,

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -29,12 +29,13 @@
   import ProfilerDiagram from './ProfilerDiagram.svelte'
   import type { TooltipData } from './ProfilerTooltip.svelte'
   import ProfileTimestampSelector from './ProfileTimestampSelector.svelte'
+  import ConfigTab from './tabs/ConfigTab.svelte'
   import IssuesTab from './tabs/IssuesTab.svelte'
   import LogsTab from './tabs/LogsTab.svelte'
   import MetricsTab, { type AnalysisTabProps } from './tabs/MetricsTab.svelte'
   import SqlTab, { type SqlTabProps } from './tabs/SqlTab.svelte'
 
-  const TABS = ['Metrics', 'Logs', 'Issues'] as const
+  const TABS = ['Metrics', 'Logs', 'Config', 'Issues'] as const
   type AnalysisTab = (typeof TABS)[number]
 
   interface Props {
@@ -44,6 +45,9 @@
     logText?: string
     /** Cumulative pipeline-wide metrics from the bundle's `stats.json`; shown in the overview. */
     globalMetrics?: GlobalMetrics
+    /** Pipeline runtime configuration from the bundle's `pipeline_config.json`; shown in the Config
+     *  tab. Absent when the bundle carried no config. */
+    runtimeConfig?: unknown
     triageResults: TriageResults
     profileFiles: [Date, ZipItem[]][]
     selectedTimestamp: Date | null
@@ -65,6 +69,7 @@
     programCode,
     logText,
     globalMetrics,
+    runtimeConfig,
     triageResults,
     profileFiles,
     selectedTimestamp,
@@ -266,6 +271,7 @@
     tooltipData,
     rootNodeId: diagramRootNodeId,
     globalMetrics,
+    runtimeConfig,
     showAdvancedMetrics,
     lookup,
     logText,
@@ -289,6 +295,14 @@
       panel: LogsTab,
       keepAlive: true,
       tabBarEnd: commonTabBarEnd
+    },
+    {
+      id: 'Config',
+      label: configLabel,
+      panel: ConfigTab,
+      keepAlive: true,
+      // No runtime config in the bundle → nothing to show, so the tab is present but unselectable.
+      disabled: runtimeConfig === undefined
     },
     {
       id: 'Issues',
@@ -360,6 +374,7 @@
 <!-- ── Analysis panel labels and tab-bar-end snippets ────────────────────────── -->
 {#snippet metricsLabel()}Metrics{/snippet}
 {#snippet logsLabel()}Logs{/snippet}
+{#snippet configLabel()}Config{/snippet}
 {#snippet issuesLabel()}
   Issues &amp; Suggestions
   {#if triageResults.results.length > 0}

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/KeyValueBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/KeyValueBlock.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { GlobalMetricEntry } from '../../../functions/globalMetrics'
+
+  interface Props {
+    id: string
+    title?: string
+    /** Rows to print, each already carrying a formatted `PropertyValue`. */
+    entries: GlobalMetricEntry[]
+  }
+  const { id, title, entries }: Props = $props()
+</script>
+
+<!-- A plain text tile: one "label … value" row per metric. Unlike the distribution block it
+     has no per-worker bars — these are single pipeline-wide figures — so the value is rendered
+     straight from `PropertyValue.toString()`, reusing the same unit-aware formatting. -->
+<div class="rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
+  {#if title}
+    <h3 class="mb-2 text-base font-semibold text-surface-900-100">{title}</h3>
+  {/if}
+  <dl class="grid grid-cols-[1fr_auto] items-baseline gap-x-6 gap-y-2">
+    {#each entries as entry (entry.key)}
+      <dt class="truncate text-sm text-surface-700-300">{entry.label}</dt>
+      <dd class="text-right text-sm font-medium tabular-nums text-surface-900-100">
+        {entry.value.toString()}
+      </dd>
+    {/each}
+  </dl>
+</div>

--- a/js-packages/profiler-layout/src/lib/components/tabs/ConfigTab.svelte
+++ b/js-packages/profiler-layout/src/lib/components/tabs/ConfigTab.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import ConfigView from '../ConfigView.svelte'
+  import type { AnalysisTabProps } from './MetricsTab.svelte'
+
+  let { runtimeConfig }: AnalysisTabProps = $props()
+</script>
+
+<div class="relative min-h-0 flex-1">
+  <ConfigView {runtimeConfig} />
+</div>

--- a/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
+++ b/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" module>
   import type { TriageResults } from 'triage-types'
+  import type { GlobalMetrics } from '../../functions/globalMetrics'
   import type { LookupCoordinator } from '../../functions/lookup'
   import type { MetricsMode } from '../MetricsView.svelte'
   import type { TooltipData } from '../ProfilerTooltip.svelte'
@@ -12,6 +13,9 @@
     /** Id of the loaded profile's toplevel node, so the Metrics view can tell the overview from a
      *  single operator. `undefined` until a profile is loaded. */
     rootNodeId: string | undefined
+    /** Cumulative pipeline-wide metrics from `stats.json`, shown as a tile in the overview.
+     *  `undefined` when the bundle carried no stats. */
+    globalMetrics: GlobalMetrics | undefined
     /** When true, metrics flagged `advanced` in the profile metadata are shown too. */
     showAdvancedMetrics: boolean
     lookup: LookupCoordinator
@@ -34,6 +38,7 @@
     metricsMode,
     tooltipData,
     rootNodeId,
+    globalMetrics,
     showAdvancedMetrics,
     lookup,
     onSearchNode
@@ -44,6 +49,7 @@
   mode={metricsMode}
   {tooltipData}
   {rootNodeId}
+  {globalMetrics}
   showAdvanced={showAdvancedMetrics}
   {lookup}
   {onSearchNode}

--- a/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
+++ b/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
@@ -16,6 +16,9 @@
     /** Cumulative pipeline-wide metrics from `stats.json`, shown as a tile in the overview.
      *  `undefined` when the bundle carried no stats. */
     globalMetrics: GlobalMetrics | undefined
+    /** Pipeline runtime configuration shown in the Config tab. `undefined` when the bundle carried
+     *  no `pipeline_config.json` */
+    runtimeConfig: unknown
     /** When true, metrics flagged `advanced` in the profile metadata are shown too. */
     showAdvancedMetrics: boolean
     lookup: LookupCoordinator

--- a/js-packages/profiler-layout/src/lib/functions/globalMetrics.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/globalMetrics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { buildGlobalMetrics, type GlobalMetrics } from './globalMetrics.js'
+
+/** A fully-populated stats payload, including current gauges that the tile must drop. */
+function fullMetrics(): GlobalMetrics & Record<string, number> {
+  return {
+    total_input_records: 1500,
+    total_input_bytes: 2048,
+    total_processed_records: 1400,
+    total_processed_bytes: 1024,
+    total_completed_records: 1300,
+    total_initiated_steps: 7,
+    total_completed_steps: 6,
+    cpu_msecs: 5000,
+    runtime_elapsed_msecs: 12_000,
+    uptime_msecs: 90_000,
+    // Current gauges — must be excluded from the overview tile.
+    rss_bytes: 999_999,
+    storage_bytes: 888_888,
+    buffered_input_records: 42,
+    buffered_input_bytes: 64
+  }
+}
+
+describe('buildGlobalMetrics', () => {
+  it('returns an empty list when no stats are present', () => {
+    expect(buildGlobalMetrics(undefined)).toEqual([])
+    expect(buildGlobalMetrics({})).toEqual([])
+  })
+
+  it('excludes current gauges such as rss_bytes and storage_bytes', () => {
+    const keys = buildGlobalMetrics(fullMetrics()).map((e) => e.key)
+    expect(keys).not.toContain('rss_bytes')
+    expect(keys).not.toContain('storage_bytes')
+    expect(keys).not.toContain('buffered_input_records')
+    expect(keys).not.toContain('buffered_input_bytes')
+  })
+
+  it('emits the cumulative metrics in a stable presentation order', () => {
+    const keys = buildGlobalMetrics(fullMetrics()).map((e) => e.key)
+    expect(keys).toEqual([
+      'total_input_records',
+      'total_input_bytes',
+      'total_processed_records',
+      'total_processed_bytes',
+      'total_completed_records',
+      'total_initiated_steps',
+      'total_completed_steps',
+      'cpu_msecs',
+      'runtime_elapsed_msecs',
+      'uptime_msecs'
+    ])
+  })
+
+  it('formats each value with the matching unit', () => {
+    const byKey = new Map(buildGlobalMetrics(fullMetrics()).map((e) => [e.key, e.value.toString()]))
+    expect(byKey.get('total_input_records')).toBe('1.5K') // count, base 1000
+    expect(byKey.get('total_input_bytes')).toBe('2KiB') // bytes, base 1024
+    expect(byKey.get('cpu_msecs')).toBe('5s') // milliseconds rendered as seconds
+  })
+
+  it('skips fields that are absent or not finite numbers', () => {
+    const entries = buildGlobalMetrics({
+      total_input_records: 10,
+      total_input_bytes: Number.NaN,
+      total_processed_records: Number.POSITIVE_INFINITY,
+      // A stray non-numeric value (e.g. from a hand-edited stats file) is ignored, not rendered.
+      cpu_msecs: '5000' as unknown as number
+    })
+    expect(entries.map((e) => e.key)).toEqual(['total_input_records'])
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/globalMetrics.ts
+++ b/js-packages/profiler-layout/src/lib/functions/globalMetrics.ts
@@ -1,0 +1,81 @@
+// Builds the key/value entries shown in the overview tile from a pipeline's `stats.json`.
+//
+// `stats.json` is the `/stats` response (`ControllerStatus`); its `global_metrics` object
+// mixes two kinds of readings:
+//   - cumulative totals that describe the whole run (records processed, CPU time, …), and
+//   - "current" point-in-time gauges (`rss_bytes`, `storage_bytes`, buffered input, …).
+//
+// The overview tile reports a profile of the run, so only the cumulative readings are
+// meaningful here — a momentary RSS or storage figure says nothing about the profile as a
+// whole. We therefore select from an explicit allowlist; the current gauges are left out by
+// omission rather than by a fragile deny-list that new fields could slip past.
+
+import { BytesValue, CountValue, PropertyValue, TimeValue } from 'profiler-lib'
+
+/** The subset of `global_metrics` fields the overview tile reads. All are optional so a stats
+ *  file from an older or partial pipeline still yields whatever it does carry. */
+export interface GlobalMetrics {
+  total_input_records?: number
+  total_input_bytes?: number
+  total_processed_records?: number
+  total_processed_bytes?: number
+  total_completed_records?: number
+  total_initiated_steps?: number
+  total_completed_steps?: number
+  cpu_msecs?: number
+  runtime_elapsed_msecs?: number
+  uptime_msecs?: number
+}
+
+/** One row of the overview tile: a human label and a formatted value. */
+export interface GlobalMetricEntry {
+  /** The `global_metrics` field name, used as a stable list key. */
+  key: string
+  label: string
+  /** Wrapped so the tile reuses `PropertyValue.toString()` for unit-aware formatting. */
+  value: PropertyValue
+}
+
+/** Wraps a raw reading into the `PropertyValue` kind that formats it correctly. */
+type ToValue = (raw: number) => PropertyValue
+
+const millisecondsToTime: ToValue = (ms) => new TimeValue(ms / 1000)
+
+/** The cumulative metrics to display, in presentation order. Each descriptor names a
+ *  `global_metrics` field and the value kind that formats it. Current gauges (`rss_bytes`,
+ *  `storage_bytes`, `buffered_input_*`, …) are intentionally absent — see the file header. */
+const DESCRIPTORS: { key: keyof GlobalMetrics; label: string; toValue: ToValue }[] = [
+  { key: 'total_input_records', label: 'Input records', toValue: CountValue.fromNumber },
+  { key: 'total_input_bytes', label: 'Input bytes', toValue: BytesValue.fromNumber },
+  { key: 'total_processed_records', label: 'Processed records', toValue: CountValue.fromNumber },
+  { key: 'total_processed_bytes', label: 'Processed bytes', toValue: BytesValue.fromNumber },
+  { key: 'total_completed_records', label: 'Completed records', toValue: CountValue.fromNumber },
+  { key: 'total_initiated_steps', label: 'Initiated steps', toValue: CountValue.fromNumber },
+  { key: 'total_completed_steps', label: 'Completed steps', toValue: CountValue.fromNumber },
+  { key: 'cpu_msecs', label: 'CPU time', toValue: millisecondsToTime },
+  { key: 'runtime_elapsed_msecs', label: 'Runtime elapsed', toValue: millisecondsToTime },
+  { key: 'uptime_msecs', label: 'Uptime', toValue: millisecondsToTime }
+]
+
+/**
+ * Select and format the cumulative global metrics for the overview tile.
+ *
+ * Only fields that are present and finite are included, so a partial or older `stats.json`
+ * still produces a clean (possibly shorter) tile instead of rows reading "N/A".
+ *
+ * @param metrics The `global_metrics` object from `stats.json`, or `undefined` when the bundle
+ *                carried no stats. Returns an empty array in that case.
+ */
+export function buildGlobalMetrics(metrics: GlobalMetrics | undefined): GlobalMetricEntry[] {
+  if (!metrics) {
+    return []
+  }
+  const entries: GlobalMetricEntry[] = []
+  for (const { key, label, toValue } of DESCRIPTORS) {
+    const raw = metrics[key]
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      entries.push({ key, label, value: toValue(raw) })
+    }
+  }
+  return entries
+}

--- a/js-packages/profiler-layout/src/lib/functions/globalMetrics.ts
+++ b/js-packages/profiler-layout/src/lib/functions/globalMetrics.ts
@@ -1,14 +1,6 @@
 // Builds the key/value entries shown in the overview tile from a pipeline's `stats.json`.
 //
-// `stats.json` is the `/stats` response (`ControllerStatus`); its `global_metrics` object
-// mixes two kinds of readings:
-//   - cumulative totals that describe the whole run (records processed, CPU time, …), and
-//   - "current" point-in-time gauges (`rss_bytes`, `storage_bytes`, buffered input, …).
-//
-// The overview tile reports a profile of the run, so only the cumulative readings are
-// meaningful here — a momentary RSS or storage figure says nothing about the profile as a
-// whole. We therefore select from an explicit allowlist; the current gauges are left out by
-// omission rather than by a fragile deny-list that new fields could slip past.
+// Only the cumulative steats are meaningful in the overview tile - so we only pick those to display.
 
 import { BytesValue, CountValue, PropertyValue, TimeValue } from 'profiler-lib'
 
@@ -41,9 +33,7 @@ type ToValue = (raw: number) => PropertyValue
 
 const millisecondsToTime: ToValue = (ms) => new TimeValue(ms / 1000)
 
-/** The cumulative metrics to display, in presentation order. Each descriptor names a
- *  `global_metrics` field and the value kind that formats it. Current gauges (`rss_bytes`,
- *  `storage_bytes`, `buffered_input_*`, …) are intentionally absent — see the file header. */
+/** The cumulative metrics to display. */
 const DESCRIPTORS: { key: keyof GlobalMetrics; label: string; toValue: ToValue }[] = [
   { key: 'total_input_records', label: 'Input records', toValue: CountValue.fromNumber },
   { key: 'total_input_bytes', label: 'Input bytes', toValue: BytesValue.fromNumber },
@@ -59,9 +49,6 @@ const DESCRIPTORS: { key: keyof GlobalMetrics; label: string; toValue: ToValue }
 
 /**
  * Select and format the cumulative global metrics for the overview tile.
- *
- * Only fields that are present and finite are included, so a partial or older `stats.json`
- * still produces a clean (possibly shorter) tile instead of rows reading "N/A".
  *
  * @param metrics The `global_metrics` object from `stats.json`, or `undefined` when the bundle
  *                carried no stats. Returns an empty array in that case.

--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.test.ts
@@ -1,0 +1,41 @@
+import type { ZipItem } from 'but-unzip'
+import { describe, expect, it } from 'vitest'
+import { processProfileFiles } from './processZipBundle.js'
+
+/** Build a ZipItem whose `read()` returns the UTF-8 bytes of `text`. */
+function file(filename: string, text: string): ZipItem {
+  return { filename, comment: '', read: () => new TextEncoder().encode(text) }
+}
+
+const TIMESTAMP = '2026-05-25T12-34-56.789Z'
+
+/** A minimal circuit profile; `processProfileFiles` requires this file to exist. */
+function circuitProfile(): ZipItem {
+  return file(`${TIMESTAMP}/circuit_profile.json`, JSON.stringify({ nodes: [] }))
+}
+
+/** A `pipeline_config.json` with the given extra top-level fields alongside `program_code`. */
+function pipelineConfig(extra: Record<string, unknown>): ZipItem {
+  return file(
+    `${TIMESTAMP}/pipeline_config.json`,
+    JSON.stringify({ program_code: 'SELECT 1;', name: 'p', ...extra })
+  )
+}
+
+describe('processProfileFiles runtimeConfig', () => {
+  it('extracts runtime_config from pipeline_config.json', async () => {
+    const runtime_config = { workers: 8, storage: { backend: { name: 'default' } } }
+    const result = await processProfileFiles([circuitProfile(), pipelineConfig({ runtime_config })])
+    expect(result.runtimeConfig).toEqual(runtime_config)
+  })
+
+  it('leaves runtimeConfig undefined when the config lacks runtime_config', async () => {
+    const result = await processProfileFiles([circuitProfile(), pipelineConfig({})])
+    expect(result.runtimeConfig).toBeUndefined()
+  })
+
+  it('leaves runtimeConfig undefined when the bundle has no pipeline_config.json', async () => {
+    const result = await processProfileFiles([circuitProfile()])
+    expect(result.runtimeConfig).toBeUndefined()
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
@@ -2,11 +2,13 @@ import { unzip, type ZipItem } from 'but-unzip'
 import type { Dataflow, JsonProfiles } from 'profiler-lib'
 import sortOn from 'sort-on'
 import { groupBy } from './array'
+import type { GlobalMetrics } from './globalMetrics'
 
 const circuitProfileRegex = /circuit_profile\.json$/
 const dataflowGraphRegex = /dataflow_graph\.json$/
 const pipelineConfigRegex = /pipeline_config\.json$/
 const logsRegex = /logs\.txt$/
+const statsRegex = /stats\.json$/
 
 // New bundle layout (since support-bundle metadata_version 1): each collection
 // lives under a directory named after its timestamp, e.g.
@@ -45,6 +47,8 @@ export interface ProcessedProfile {
   sources?: string[]
   logText?: string
   pipelineName?: string
+  /** Cumulative pipeline-wide metrics from `stats.json`, when the bundle includes it. */
+  globalMetrics?: GlobalMetrics
 }
 
 /**
@@ -112,11 +116,28 @@ export async function processProfileFiles(files: ZipItem[]): Promise<ProcessedPr
     logText = decoder.decode(await logsFile.read())
   }
 
+  // `stats.json` is the `/stats` response; the overview tile only needs its `global_metrics`.
+  // A malformed or missing file leaves `globalMetrics` undefined rather than failing the load,
+  // since the stats are supplementary to the profile.
+  const statsFile = files.find((file) => statsRegex.test(file.filename))
+  let globalMetrics: GlobalMetrics | undefined
+  if (statsFile) {
+    try {
+      const stats = JSON.parse(decoder.decode(await statsFile.read())) as {
+        global_metrics?: GlobalMetrics
+      }
+      globalMetrics = stats.global_metrics
+    } catch {
+      globalMetrics = undefined
+    }
+  }
+
   return {
     profile,
     dataflow,
     sources,
     logText,
-    pipelineName
+    pipelineName,
+    globalMetrics
   }
 }

--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
@@ -47,8 +47,11 @@ export interface ProcessedProfile {
   sources?: string[]
   logText?: string
   pipelineName?: string
-  /** Cumulative pipeline-wide metrics from `stats.json`, when the bundle includes it. */
+  /** Cumulative pipeline-wide metrics from `stats.json`, when the bundle includes them. */
   globalMetrics?: GlobalMetrics
+  /** Pipeline runtime configuration (`runtime_config` from `pipeline_config.json`), when the
+   *  bundle includes it. */
+  runtimeConfig?: unknown
 }
 
 /**
@@ -101,13 +104,16 @@ export async function processProfileFiles(files: ZipItem[]): Promise<ProcessedPr
   const configFile = files.find((file) => pipelineConfigRegex.test(file.filename))
   let sources: string[] | undefined
   let pipelineName: string | undefined
+  let runtimeConfig: unknown
   if (configFile) {
     const pipelineConfig = JSON.parse(decoder.decode(await configFile.read())) as unknown as {
       program_code: string
       name?: string
+      runtime_config?: unknown
     }
     sources = pipelineConfig.program_code.split('\n')
     pipelineName = pipelineConfig.name || undefined
+    runtimeConfig = pipelineConfig.runtime_config ?? undefined
   }
 
   const logsFile = files.find((file) => logsRegex.test(file.filename))
@@ -138,6 +144,7 @@ export async function processProfileFiles(files: ZipItem[]): Promise<ProcessedPr
     sources,
     logText,
     pipelineName,
-    globalMetrics
+    globalMetrics,
+    runtimeConfig
   }
 }

--- a/js-packages/profiler-layout/src/lib/index.ts
+++ b/js-packages/profiler-layout/src/lib/index.ts
@@ -20,3 +20,8 @@ export { createLoadGuard } from './functions/loadGuard'
 export { createLookupCoordinator, type LookupCoordinator } from './functions/lookup'
 export type { ProcessedProfile } from './functions/processZipBundle'
 export { getSuitableProfiles, processProfileFiles } from './functions/processZipBundle'
+export {
+  buildGlobalMetrics,
+  type GlobalMetricEntry,
+  type GlobalMetrics
+} from './functions/globalMetrics'

--- a/js-packages/profiler-lib/src/index.ts
+++ b/js-packages/profiler-lib/src/index.ts
@@ -19,6 +19,10 @@ export {
     CircuitProfile,
     PropertyValue,
     MissingValue,
+    BytesValue,
+    CountValue,
+    TimeValue,
+    BooleanValue,
     type JsonProfiles
 } from './profile.js';
 export { type Dataflow, type SourcePositionRange } from './dataflow.js';

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -941,6 +941,9 @@ export class Measurement {
                 return [new Measurement(metric_id, Option.some(perc))];
             }
             case "seconds": {
+                if (metric.value === undefined) {
+                    return []
+                }
                 let s = metric.value as DurationMetricValue;
                 let duration = TimeValue.fromDurationMetric(s);
                 return [new Measurement(metric_id, Option.some(duration))];

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
@@ -4,6 +4,7 @@
   import {
     createLoadGuard,
     getSuitableProfiles,
+    type GlobalMetrics,
     processProfileFiles,
     SupportBundleViewerLayout,
     type ZipItem
@@ -48,6 +49,7 @@
         dataflow: Dataflow | undefined
         sources: string[] | undefined
         logText: string | undefined
+        globalMetrics: GlobalMetrics | undefined
       })
     | null = $state(null)
   let triageResults: TriageResults = $state(new TriageResults())
@@ -101,7 +103,8 @@
       profile: processed.profile,
       dataflow: processed.dataflow,
       sources: processed.sources,
-      logText: processed.logText
+      logText: processed.logText,
+      globalMetrics: processed.globalMetrics
     })
   }
 
@@ -280,13 +283,14 @@
       {/if}
     </div>
   {:else if getProfileData}
-    {@const { profile, dataflow, sources, logText } = getProfileData()}
+    {@const { profile, dataflow, sources, logText, globalMetrics } = getProfileData()}
     <div class="min-h-0 flex-1 px-4 pb-4">
       <SupportBundleViewerLayout
         profileData={profile}
         dataflowData={dataflow}
         programCode={sources}
         {logText}
+        {globalMetrics}
         {triageResults}
         profileFiles={getProfileFiles()}
         selectedTimestamp={selectedProfile}

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
@@ -3,8 +3,8 @@
   import { Progress } from '@skeletonlabs/skeleton-svelte'
   import {
     createLoadGuard,
-    getSuitableProfiles,
     type GlobalMetrics,
+    getSuitableProfiles,
     processProfileFiles,
     SupportBundleViewerLayout,
     type ZipItem
@@ -50,6 +50,7 @@
         sources: string[] | undefined
         logText: string | undefined
         globalMetrics: GlobalMetrics | undefined
+        runtimeConfig: unknown
       })
     | null = $state(null)
   let triageResults: TriageResults = $state(new TriageResults())
@@ -104,7 +105,8 @@
       dataflow: processed.dataflow,
       sources: processed.sources,
       logText: processed.logText,
-      globalMetrics: processed.globalMetrics
+      globalMetrics: processed.globalMetrics,
+      runtimeConfig: processed.runtimeConfig
     })
   }
 
@@ -283,7 +285,8 @@
       {/if}
     </div>
   {:else if getProfileData}
-    {@const { profile, dataflow, sources, logText, globalMetrics } = getProfileData()}
+    {@const { profile, dataflow, sources, logText, globalMetrics, runtimeConfig } =
+      getProfileData()}
     <div class="min-h-0 flex-1 px-4 pb-4">
       <SupportBundleViewerLayout
         profileData={profile}
@@ -291,6 +294,7 @@
         programCode={sources}
         {logText}
         {globalMetrics}
+        {runtimeConfig}
         {triageResults}
         profileFiles={getProfileFiles()}
         selectedTimestamp={selectedProfile}


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/6492: Profiler should show pipeline config

Testing: manual, added unit tests for extracting global metrics and pipeline config from the profile

<img width="2887" height="1369" alt="image" src="https://github.com/user-attachments/assets/6569b7e5-7397-4174-ba5e-bc7dc064e1cf" />
<img width="2887" height="1369" alt="image" src="https://github.com/user-attachments/assets/f56bf69d-3483-4d09-8b1b-208864125c0b" />

When the config not present in the bundle:
<img width="1840" height="728" alt="image" src="https://github.com/user-attachments/assets/0ea43994-3bdd-4125-a428-132bb52eb077" />
