### PR TITLE
ci: pin download-artifact to v7 to fix intermittent failures on self-hosted runners

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -96,7 +96,7 @@ jobs:
     needs: build-docker-ci-dev
     steps:
       - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -52,19 +52,19 @@ jobs:
 
       - name: Download fda
         id: binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: fda-${{ matrix.rust_target }}
           path: build
 
       - name: Download pipeline-manager
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: pipeline-manager-${{ matrix.rust_target }}
           path: build
 
       - name: Download Compiler Binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: feldera-sql-compiler
           path: build
@@ -141,7 +141,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: feldera-test-binaries-x86_64-unknown-linux-gnu
           path: build

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -234,7 +234,7 @@ jobs:
           CI_K8S_MINIO_SECRET_ACCESS_KEY: ${{ secrets.CI_K8S_MINIO_TEST_BUCKET_SECRET_ACCESS_KEY }}
 
       - name: Download fda binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: fda-${{ matrix.target }}
           path: build

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -33,13 +33,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
 
       - name: Download Compiler Binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: feldera-sql-compiler
           path: sql-build


### PR DESCRIPTION
v8 of actions/download-artifact introduced a regression that causes frequent download failures on self-hosted (ARM64) runners. The download redirects to Azure Blob Storage and fails after 5 retries with "Unable to download and extract artifact."

Pinning to v7, which is stable and matches the upload-artifact version already in use across these workflows.

Affects 8 usages across build-docker.yml, build-docker-dev.yml, test-unit.yml, test-adapters.yml, test-integration-platform.yml.

Closes #6390
