### PR TITLE
[DO NOT MERGE] [SQL] Prevent some incorrect Calcite filter rewrites

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -705,7 +705,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
             if (circuit == null)
                 return null;
             if (this.getDebugLevel() > 0)
-                ToDot.dump(this, "initial.png", this.getDebugLevel(), "png", circuit);
+                ToDot.dump(this, "initial.svg", this.getDebugLevel(), "svg", circuit);
 
             this.validateForeignKeys(circuit, foreignKeys);
             if (!this.options.ioOptions.inputCircuit)
@@ -887,7 +887,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
             System.out.println("Compilation took " + elapsedTimeInMs() + "ms");
 
         if (this.getDebugLevel() > 0 && !temporary && circuit != null) {
-            ToDot.dump(this, "final.png", this.getDebugLevel(), "png", circuit);
+            ToDot.dump(this, "final.svg", this.getDebugLevel(), "svg", circuit);
         }
         Logger.INSTANCE.belowLevel(this, 2)
                 .appendSupplier(() -> InnerVisitor.profiles.toString("Inner", 10))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
@@ -189,6 +189,7 @@ public class CalciteOptimizer implements IWritesLogs {
                     rel = optimized;
                 }
             } catch (Throwable ex) {
+                // System.out.println("CALCITE OPTIMIZER THREW " + ex.getClass().getSimpleName() + " in " + step.getName());
                 this.reporter.reportWarning(
                         SourcePositionRange.INVALID, "Calcite optimizer exception caught",
                         "Calcite optimizer failed during '" + step.getName() +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
@@ -75,6 +75,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dbsp.util.Utilities;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -132,9 +133,20 @@ public abstract class ReduceExpressionsRule<C extends org.apache.calcite.rel.rul
                     mq.getPulledUpPredicates(filter.getInput());
             if (reduceExpressions(filter, expList, predicates, true,
                     config.matchNullability(), config.treatDynamicCallsAsConstant())) {
-                assert expList.size() == 1;
-                newConditionExp = expList.get(0);
-                reduced = true;
+                Utilities.enforce(expList.size() == 1);
+                // Kludge workaroud for https://issues.apache.org/jira/browse/CALCITE-7619
+                // Attempting to build a filter with this expression will actually
+                // trip an assertion failure in Calcite, in Filter.isValid, but unfortunately assertions
+                // are disabled in release builds, so the filter is built with the wrong
+                // expression anyway.
+                boolean isValid = !RexUtil.isNullabilityCast(filter.getCluster().getTypeFactory(), expList.get(0));
+                if (isValid) {
+                    newConditionExp = expList.get(0);
+                    reduced = true;
+                } else {
+                    newConditionExp = filter.getCondition();
+                    reduced = false;
+                }
             } else {
                 // No reduction, but let's still test the original
                 // predicate to see if it was already a constant,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
@@ -7,7 +7,6 @@ import org.dbsp.sqlCompiler.compiler.TestUtil;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class Regression3Tests extends SqlIoTest {
@@ -716,5 +715,16 @@ public class Regression3Tests extends SqlIoTest {
                 );
                 
                 CREATE VIEW Z AS SELECT b, r.b, t.b FROM T;""");
+    }
+
+    @Test
+    public void testNullableIsFalse() {
+        // Test case exercising https://issues.apache.org/jira/browse/CALCITE-7619
+        var ccs = this.getCCS("""
+                CREATE TABLE T(x INT, b BOOLEAN);
+                CREATE VIEW V AS SELECT x FROM T WHERE b IS FALSE;""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(0, NULL);", """
+                 r
+                ---""");
     }
 }


### PR DESCRIPTION
I have filed a bug for Calcite which incorrectly simplifies some Boolean expressions: 
https://issues.apache.org/jira/browse/CALCITE-7619

Until a fix is submitted and merged, a partial workaround is to detect incorrect optimizations (in one place, there may be others!) and to skip them.