### PR TITLE
[web-console] Add memory pressure indicator to memory graph

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 				"biomejs.biome"
 			],
 			"settings": {
-				"editor.formatOnSave": true,
+				"editor.formatOnSave": false,
 				"terminal.integrated.defaultProfile.linux": "bash",
 				"files.exclude": {
 					"**/CODE_OF_CONDUCT.md": true,

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
@@ -16,6 +16,7 @@
   import { humanSize } from '$lib/functions/common/string'
   import { tuple } from '$lib/functions/common/tuple'
   import { multihostMemoryLimitMb, timeSeriesAxisMax } from '$lib/functions/pipelineMetrics'
+  import type { MemoryPressure } from '$lib/services/manager'
   import type { Pipeline } from '$lib/services/pipelineManager'
   import type { TimeSeriesEntry } from '$lib/types/pipelineManager'
 
@@ -23,13 +24,23 @@
     pipeline,
     metrics,
     refetchMs,
-    keepMs
+    keepMs,
+    memoryPressure
   }: {
     pipeline: { current: Pipeline }
     metrics: TimeSeriesEntry[]
     refetchMs: number
     keepMs: number
+    memoryPressure?: MemoryPressure
   } = $props()
+
+  const pressureChips: Record<MemoryPressure, { label: string; class: string }> = {
+    low: { label: '', class: 'hidden' },
+    moderate: { label: 'Moderate pressure', class: 'bg-warning-100-900' },
+    high: { label: 'High pressure', class: 'bg-error-50-950' },
+    critical: { label: 'Critical pressure', class: 'bg-error-50-950' }
+  }
+  const pressureChip = $derived(memoryPressure ? pressureChips[memoryPressure] : undefined)
   use([
     LineChart,
     GridComponent,
@@ -209,8 +220,13 @@
 </script>
 
 <div class="absolute h-full w-full py-4">
-  <div class="px-4 pb-2">
-    Used memory: {humanSize(metrics.at(-1)?.m ?? 0)}
+  <div class="flex items-center justify-between gap-2 px-4 pb-2">
+    <span>Used memory: {humanSize(metrics.at(-1)?.m ?? 0)}</span>
+    {#if pressureChip}
+      <div class="pointer-events-none flex h-5 rounded px-2 text-sm {pressureChip.class}">
+        {pressureChip.label}
+      </div>
+    {/if}
   </div>
   {#key pipelineName}
     <Chart init={(dom, theme, opts) => (ref = init(dom, theme, opts))} {options} />

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -140,6 +140,13 @@
 
   const connectorsWithErrorsCount = $derived(numConnectorsWithProblems(metrics.current))
 
+  const memoryPressureErrorCount = $derived.by(() => {
+    const memoryPressure = metrics.current.global?.memory_pressure
+    return memoryPressure === 'high' || memoryPressure === 'critical' ? 1 : 0
+  })
+
+  const runtimeErrorsCount = $derived(connectorsWithErrorsCount + memoryPressureErrorCount)
+
   // Local input binding. The committed search (what the list actually runs) lives in
   // `logSearch` and only advances on Enter — so typing doesn't search as-you-type.
   let logSearchInput = $state('')
@@ -187,9 +194,9 @@
 
 {#snippet TabControlPerformance()}
   {@render TabPerformance.Label()}
-  {#if connectorsWithErrorsCount > 0}
+  {#if runtimeErrorsCount > 0}
     <span class="ml-1 inline-block min-w-6 rounded preset-filled-error-50-950 px-1 font-medium">
-      {connectorsWithErrorsCount}
+      {runtimeErrorsCount}
     </span>
   {/if}
 {/snippet}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -306,7 +306,12 @@
             ></PipelineThroughputGraph>
           </div>
           <div class="bg-white-dark relative h-52 w-full max-w-[700px] rounded">
-            <PipelineMemoryGraph {pipeline} metrics={timeSeries} refetchMs={1000} keepMs={60 * 1000}
+            <PipelineMemoryGraph
+              {pipeline}
+              metrics={timeSeries}
+              refetchMs={1000}
+              keepMs={60 * 1000}
+              memoryPressure={global.memory_pressure}
             ></PipelineMemoryGraph>
           </div>
           <div class="bg-white-dark relative h-52 w-full max-w-[700px] rounded">

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -228,8 +228,7 @@ export const timeSeriesAxisMax = (metrics: TimeSeriesEntry[], now: () => number 
 export const multihostMemoryLimitMb = (
   perHostMemoryMb: number | null | undefined,
   hosts: number | null | undefined
-): number | undefined =>
-  perHostMemoryMb ? perHostMemoryMb * Math.max(hosts ?? 1, 1) : undefined
+): number | undefined => (perHostMemoryMb ? perHostMemoryMb * Math.max(hosts ?? 1, 1) : undefined)
 
 /**
  * @returns Time series of throughput with smoothing window over 3 data intervals


### PR DESCRIPTION
High and Critical memory pressure adds to the "Runtime" tab label error count

Fix https://github.com/feldera/feldera/issues/6309

Testing: manual. Unit test is unnecessary

<img width="1746" height="648" alt="image" src="https://github.com/user-attachments/assets/5b4018ec-4b8e-49b5-b111-00bc144e150a" />
<img width="2344" height="893" alt="image" src="https://github.com/user-attachments/assets/29e9f0ed-deb5-4785-9ec2-820af13dcdcc" />
