### PR TITLE
[connector] CSV parser/encoder rejects unknown configuration options

### DIFF
--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -210,6 +210,72 @@ fn test_start_after() {
     controller.stop().unwrap();
 }
 
+// A typo in the CSV parser config (e.g. "header" instead of "headers") must
+// be reported as an error rather than silently using the default value.
+#[test]
+fn test_csv_input_config_unknown_field() {
+    init_test_logger();
+
+    let temp_input_file = NamedTempFile::new().unwrap();
+
+    let config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 4,
+        "inputs": {
+            "test_input1": {
+                "stream": "test_input1",
+                "transport": {
+                    "name": "file_input",
+                    "config": {
+                        "path": temp_input_file.path(),
+                        "follow": false
+                    }
+                },
+                "format": {
+                    "name": "csv",
+                    "config": {
+                        "header": true
+                    }
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    let Err(err) = Controller::with_test_config(
+        |circuit_config| {
+            Ok(test_circuit::<TestStruct>(
+                circuit_config,
+                &TestStruct::schema(),
+                &[None],
+            ))
+        },
+        &config,
+        Box::new(|e, _| panic!("error: {e}")),
+    ) else {
+        panic!("expected controller creation to fail due to unknown CSV config field 'header'")
+    };
+
+    let msg = err.to_string();
+    // Full error looks like:
+    //   invalid controller configuration: Error parsing format configuration
+    //   for input endpoint 'test_input1': unknown field `header`, expected
+    //   one of `delimiter`, `headers`, ...
+    //   Invalid configuration: {"header":true}
+    assert!(
+        msg.contains("Error parsing format configuration for input endpoint 'test_input1'"),
+        "error should identify the affected endpoint: {msg}"
+    );
+    assert!(
+        msg.contains("unknown field `header`"),
+        "error should name the unknown field: {msg}"
+    );
+    assert!(
+        msg.contains("`headers`"),
+        "error should suggest the correct field name: {msg}"
+    );
+}
+
 // TODO: Parameterize this with config string, so we can test different
 // input/output formats and transports when we support more than one.
 proptest! {

--- a/crates/adapters/src/format/csv.rs
+++ b/crates/adapters/src/format/csv.rs
@@ -836,4 +836,45 @@ true,bar,buzz"#;
         assert_eq!(rows[0].first, "foo");
         assert_eq!(rows[0].second, "bar");
     }
+
+    // ---- Config deserialization error tests ----
+
+    // A typo in a config field name ("header" instead of "headers") must
+    // produce an error rather than being silently ignored.
+    #[test]
+    fn parser_config_rejects_unknown_field() {
+        let bad = serde_json::json!({ "header": true });
+        let err = CsvParserConfig::deserialize(&bad)
+            .expect_err("expected error for unknown field 'header'")
+            .to_string();
+        // Serde names the offending key and lists all valid keys.
+        // Example: unknown field `header`, expected one of `delimiter`, `headers`, ...
+        assert!(
+            err.contains("unknown field `header`"),
+            "error should name the unknown field: {err}"
+        );
+        assert!(
+            err.contains("`headers`"),
+            "error should list 'headers' as a valid field: {err}"
+        );
+    }
+
+    #[test]
+    fn encoder_config_rejects_unknown_field() {
+        use feldera_types::format::csv::CsvEncoderConfig;
+        // intentional typo: "delimeter" instead of "delimiter"
+        let bad = serde_json::json!({ "delimeter": ";" });
+        let err = CsvEncoderConfig::deserialize(&bad)
+            .expect_err("expected error for unknown field 'delimeter'")
+            .to_string();
+        // Example: unknown field `delimeter`, expected `delimiter` or `buffer_size_records`
+        assert!(
+            err.contains("unknown field `delimeter`"),
+            "error should name the unknown field: {err}"
+        );
+        assert!(
+            err.contains("`delimiter`"),
+            "error should list 'delimiter' as a valid field: {err}"
+        );
+    }
 }

--- a/crates/feldera-types/src/format/csv.rs
+++ b/crates/feldera-types/src/format/csv.rs
@@ -19,7 +19,7 @@ pub enum CsvTrim {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, ToSchema, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct CsvParserConfig {
     /// Field delimiter (default `','`).
     ///
@@ -126,7 +126,7 @@ impl From<char> for CsvDelimiter {
 }
 
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct CsvEncoderConfig {
     /// Field delimiter (default `','`).
     ///


### PR DESCRIPTION
Fixes #4656 

The fix is to add `#[serde(deny_unknown_fields)]` to the connector config.
Should we do this for other connectors too?

## Checklist

- [x] Unit tests added/updated
