### PR TITLE
[config] Move bloom_false_positive_rate from dev_tweaks to storage

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -1076,6 +1076,23 @@ impl Runtime {
             .unwrap_or_else(|| f(&DEFAULT))
     }
 
+    /// Returns the configured Bloom filter false-positive rate.
+    ///
+    /// Prefers `storage.bloom_false_positive_rate` when set; falls back to
+    /// the deprecated `dev_tweaks.bloom_false_positive_rate`.
+    pub fn bloom_false_positive_rate() -> f64 {
+        let from_storage: Option<f64> = RUNTIME.with(|rt| {
+            rt.borrow()
+                .as_ref()?
+                .inner()
+                .storage
+                .as_ref()?
+                .options
+                .bloom_false_positive_rate
+        });
+        from_storage.unwrap_or_else(|| Self::with_dev_tweaks(|dt| dt.bloom_false_positive_rate()))
+    }
+
     pub fn get_mode(&self) -> Mode {
         self.inner().mode
     }

--- a/crates/dbsp/src/storage/file/filter.rs
+++ b/crates/dbsp/src/storage/file/filter.rs
@@ -266,11 +266,11 @@ where
         // batch bounds we cannot safely decide that min-offset roaring
         // encoding will fit, and we do not allow switching filters after
         // writing has started.
+        let bloom_rate = Runtime::bloom_false_positive_rate();
         let (enable_roaring, bloom_false_positive_rate) = Runtime::with_dev_tweaks(|dev_tweaks| {
-            let rate = dev_tweaks.bloom_false_positive_rate();
             (
                 dev_tweaks.enable_roaring(),
-                (rate > 0.0 && rate < 1.0).then_some(rate),
+                (bloom_rate > 0.0 && bloom_rate < 1.0).then_some(bloom_rate),
             )
         });
         static LOG_FILTER_CONFIG: Once = Once::new();

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -317,7 +317,7 @@ impl StorageCacheConfig {
 }
 
 /// Storage configuration for a pipeline.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(default)]
 pub struct StorageOptions {
     /// How to connect to the underlying storage.
@@ -359,7 +359,29 @@ pub struct StorageOptions {
     /// background threads. If unset, each foreground or background thread cache
     /// is limited to 256 MiB.
     pub cache_mib: Option<usize>,
+
+    /// False-positive rate for Bloom filters on batches on storage, as a
+    /// fraction f, where 0 < f < 1.
+    ///
+    /// The false-positive rate trades off between the amount of memory used by
+    /// Bloom filters and how frequently storage needs to be searched for keys
+    /// that are not actually present.  Typical false-positive rates and their
+    /// corresponding memory costs are:
+    ///
+    /// - 0.1: 4.8 bits per key
+    /// - 0.01: 9.6 bits per key
+    /// - 0.001: 14.4 bits per key
+    /// - 0.0001: 19.2 bits per key (default)
+    ///
+    /// Values outside the valid range, such as 0.0, disable Bloom filters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, deserialize_with = "crate::serde_via_value::deserialize")]
+    pub bloom_false_positive_rate: Option<f64>,
 }
+
+// `f64` does not implement `Eq`, but `bloom_false_positive_rate` is always
+// finite, so `PartialEq` is an equivalence relation here.
+impl Eq for StorageOptions {}
 
 /// Backend storage configuration.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -1264,7 +1286,7 @@ mod test {
     use super::deserialize_fault_tolerance;
     use crate::config::{
         ConnectorConfig, DEFAULT_DATAFUSION_MEMORY_MB_CEILING, FtConfig, FtModel, PipelineConfig,
-        ResourceConfig, RuntimeConfig, TransportConfig,
+        ResourceConfig, RuntimeConfig, StorageOptions, TransportConfig,
     };
     use serde::{Deserialize, Serialize};
     use serde_json::json;
@@ -1464,6 +1486,49 @@ mod test {
                 model: Some(FtModel::default()),
                 checkpoint_interval_secs: None
             }
+        );
+    }
+
+    /// Regression test: `Option<f64>` fields inside `StorageOptions` must
+    /// survive a JSON-string round-trip through `PipelineConfig`, which uses
+    /// `#[serde(flatten)]` on `RuntimeConfig`.
+    #[test]
+    fn storage_options_f64_roundtrip_through_pipeline_config() {
+        let pc = PipelineConfig {
+            global: RuntimeConfig {
+                storage: Some(StorageOptions {
+                    bloom_false_positive_rate: Some(0.01),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            multihost: None,
+            name: Some("test-pipeline".into()),
+            given_name: None,
+            storage_config: None,
+            secrets_dir: None,
+            inputs: Default::default(),
+            outputs: Default::default(),
+            program_ir: None,
+        };
+
+        // JSON string round-trip (the path the pipeline process takes).
+        let json = serde_json::to_string_pretty(&pc).unwrap();
+        let pc2: PipelineConfig = serde_json::from_str(&json).expect(
+            "JSON string round-trip of PipelineConfig with f64 StorageOptions must succeed",
+        );
+        assert_eq!(
+            pc2.global.storage.unwrap().bloom_false_positive_rate,
+            Some(0.01)
+        );
+
+        // serde_json::Value round-trip (the path the pipeline manager takes).
+        let value = serde_json::to_value(&pc).unwrap();
+        let pc3: PipelineConfig = serde_json::from_value(value)
+            .expect("Value round-trip of PipelineConfig with f64 StorageOptions must succeed");
+        assert_eq!(
+            pc3.global.storage.unwrap().bloom_false_positive_rate,
+            Some(0.01)
         );
     }
 }

--- a/crates/feldera-types/src/config/dev_tweaks.rs
+++ b/crates/feldera-types/src/config/dev_tweaks.rs
@@ -180,20 +180,9 @@ pub struct DevTweaks {
     #[serde(default, deserialize_with = "crate::serde_via_value::deserialize")]
     pub balancer_key_distribution_refresh_threshold: Option<f64>,
 
-    /// False-positive rate for Bloom filters on batches on storage, as a
-    /// fraction f, where 0 < f < 1.
+    /// False-positive rate for Bloom filters on batches on storage.
     ///
-    /// The false-positive rate trades off between the amount of memory used by
-    /// Bloom filters and how frequently storage needs to be searched for keys
-    /// that are not actually present.  Typical false-positive rates and their
-    /// corresponding memory costs are:
-    ///
-    /// - 0.1: 4.8 bits per key
-    /// - 0.01: 9.6 bits per key
-    /// - 0.001: 14.4 bits per key
-    /// - 0.0001: 19.2 bits per key (default)
-    ///
-    /// Values outside the valid range, such as 0.0, disable Bloom filters.
+    /// Deprecated: use `storage.bloom_false_positive_rate` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default, deserialize_with = "crate::serde_via_value::deserialize")]
     pub bloom_false_positive_rate: Option<f64>,

--- a/docs.feldera.com/docs/operations/memory.md
+++ b/docs.feldera.com/docs/operations/memory.md
@@ -113,10 +113,20 @@ This section breaks down pipelines' memory usage in more detail.
   profiles.
 
   The number of bits per key can be tuned by setting
-  `bloom_false_positive_rate` in `dev_tweaks` in the pipeline [Runtime
-  configuration].  This can also be used to disable Bloom filters
-  entirely.  Reducing the number of bits per key, or disabling Bloom
-  filters, can reduce performance.
+  `bloom_false_positive_rate` in `storage` in the pipeline [Runtime
+  configuration].  Typical false-positive rates and their memory costs:
+
+  | False-positive rate | Bits per key |
+  |---------------------|--------------|
+  | 0.1                 | 4.8          |
+  | 0.01                | 9.6          |
+  | 0.001               | 14.4         |
+  | 0.0001 (default)    | 19.2         |
+
+  Setting `bloom_false_positive_rate` to 0.0 (or any value outside
+  the range (0, 1)) disables Bloom filters entirely.  Reducing the
+  number of bits per key, or disabling Bloom filters, can reduce
+  performance.
 
 - **Index batches in memory**.  The pipeline’s internal state is maintained as
   a set of indexes that are continuously updated as new data is processed. Updates
@@ -169,7 +179,7 @@ This section breaks down pipelines' memory usage in more detail.
 | Output buffering | Records produced by the circuit but not yet consumed by output connectors; can be buffered in memory or storage. | [`output_buffered_batches`], [`output_connector_buffered_records`] | Connector [`max_queued_records`] |
 | Index batches in memory | Index batches kept in memory before background merges and eventual flush to storage. |  | Runtime config `storage.min_storage_bytes`, [`max_rss_mb`](#max_rss) |
 | Storage cache | In-memory cache of index batches stored on disk; decouples working memory from total state size. | [`storage_cache_usage_bytes`], [`storage_cache_usage_limit_bytes_total`] | Runtime config `storage.cache_mib` |
-| Bloom filters | In-memory bloom filters for batches on storage; can become significant at large state sizes. | Visible in circuit profiles. | Runtime config `dev_tweaks.bloom_false_positive_rate` |
+| Bloom filters | In-memory bloom filters for batches on storage; can become significant at large state sizes. | Visible in circuit profiles. | Runtime config `storage.bloom_false_positive_rate` |
 | In-flight batches | Transient batches moving between operators during execution; usually short-lived but workload-dependent. |  | Connector [`max_batch_size`], runtime config `storage.min_step_storage_bytes` |
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -9945,7 +9945,7 @@
           "bloom_false_positive_rate": {
             "type": "number",
             "format": "double",
-            "description": "False-positive rate for Bloom filters on batches on storage, as a\nfraction f, where 0 < f < 1.\n\nThe false-positive rate trades off between the amount of memory used by\nBloom filters and how frequently storage needs to be searched for keys\nthat are not actually present.  Typical false-positive rates and their\ncorresponding memory costs are:\n\n- 0.1: 4.8 bits per key\n- 0.01: 9.6 bits per key\n- 0.001: 14.4 bits per key\n- 0.0001: 19.2 bits per key (default)\n\nValues outside the valid range, such as 0.0, disable Bloom filters.",
+            "description": "False-positive rate for Bloom filters on batches on storage.\n\nDeprecated: use `storage.bloom_false_positive_rate` instead.",
             "default": null,
             "nullable": true
           },
@@ -15117,6 +15117,13 @@
             "default": {
               "name": "default"
             }
+          },
+          "bloom_false_positive_rate": {
+            "type": "number",
+            "format": "double",
+            "description": "False-positive rate for Bloom filters on batches on storage, as a\nfraction f, where 0 < f < 1.\n\nThe false-positive rate trades off between the amount of memory used by\nBloom filters and how frequently storage needs to be searched for keys\nthat are not actually present.  Typical false-positive rates and their\ncorresponding memory costs are:\n\n- 0.1: 4.8 bits per key\n- 0.01: 9.6 bits per key\n- 0.001: 14.4 bits per key\n- 0.0001: 19.2 bits per key (default)\n\nValues outside the valid range, such as 0.0, disable Bloom filters.",
+            "default": null,
+            "nullable": true
           },
           "cache_mib": {
             "type": "integer",


### PR DESCRIPTION
Fixes #5424 

The old dev_tweaks option is still present, but it is marked as deprecated. If the storage option is present it is used first, and the dev_tweaks option is used otherwise.

The option is also documented publicly.