### PR TITLE
[docs] add required domains

### DIFF
--- a/docs.feldera.com/docs/operations/required-domains.md
+++ b/docs.feldera.com/docs/operations/required-domains.md
@@ -1,0 +1,13 @@
+# Add Feldera domains to your network
+
+To use Feldera in a network that requires you to allowlist new domains, ask your network administrator to allowlist the following hostnames (all over `https`, port `443`).
+
+## Standard Usage
+- `https://cloud1.feldera.com`: License key validation and usage-telemetry server. (**Enterprise Only**)
+- `https://public.ecr.aws/feldera/*`: The Feldera Enterprise Helm Chart pulls images from this repository. (**Enterprise Only**)
+
+## Custom Runtime Usage (Optional)
+In some cases, advanced users deploy a custom Feldera runtime to test features before they are officially released. To use a custom runtime, enable the `runtime_version` flag via the [`unstableFeatures` Helm value](/get-started/enterprise/helm-chart-reference#miscellaneous).
+- `static.crates.io` and `index.crates.io`: If the runtime version has a new dependency, the crate and its index are downloaded from here.
+- `https://github.com/feldera/feldera`: Feldera source code.
+- `https://feldera-sql2dbsp.s3.us-west-1.amazonaws.com/*`: Build artifacts for the custom runtime, published by Feldera CI/CD.

--- a/docs.feldera.com/docs/sidebars.js
+++ b/docs.feldera.com/docs/sidebars.js
@@ -501,6 +501,7 @@ const operations = {
         'operations/metrics',
         'operations/json-logging',
         'operations/visualizing-profiles',
+        'operations/required-domains',
     ]
 };
 


### PR DESCRIPTION
Updated documentation with domains required to run Feldera enterprise and Feldera enterprise with a custom runtime version

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
