### PR TITLE
test: wait for the data checkpoint to sync in test_automated_checkpoint_sync1

### DIFF
--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -382,10 +382,16 @@ class TestCheckpointSync(SharedTestPipeline):
     def test_automated_checkpoint_sync1(self):
         # Manual checkpoint, automated sync.
         self._configure_and_start(ft_interval=5, push_interval=10)
-        _, got_before = self._insert_data_and_wait()
+        processed, got_before = self._insert_data_and_wait()
         self.pipeline.checkpoint(wait=True)
+        # Wait for the automated sync to upload a checkpoint that covers the data
+        # we just inserted, before restarting. Waiting for *any* sync is not
+        # enough: "latest" can otherwise resolve to an earlier, pre-data synced
+        # checkpoint (especially in multihost, where per-pod sync timing varies),
+        # and the restored pipeline would come up empty.
+        chk_uuid, chk_steps = self._wait_for_automated_checkpoint(processed)
         time.sleep(1)
-        self._wait_for_automated_sync()
+        self._wait_for_automated_sync(chk_uuid, chk_steps)
 
         self._restart_from_checkpoint("latest")
 


### PR DESCRIPTION
## Problem

`test_automated_checkpoint_sync1` intermittently failed in multihost CI: after
`_restart_from_checkpoint("latest")`, `SELECT * FROM v0` returned 0 rows and
`assertCountEqual` failed. (It is currently quarantined via the
`PYTEST_EXTRA_MULTIHOST` repo variable in feldera/cloud.)

## Root cause

The test restarted from `"latest"` after only `_wait_for_automated_sync()` with
no arguments, which returns as soon as *any* checkpoint has been synced — not
necessarily the manual checkpoint that contains the inserted data. When an
earlier (pre-data) checkpoint was synced first, `"latest"` resolved to it and
the restored pipeline came up empty.

This is a test under-synchronization issue, not a product bug: every sibling
test waits for the specific checkpoint and passes un-quarantined in multihost.
Multihost just widens the race, since per-pod sync timing varies.

## Fix

Wait for the automated sync to cover the checkpoint that includes the inserted
data before restarting, mirroring `test_automated_checkpoint_sync`.

## Validation

Ran the fixed test 15× against a fresh multihost install (`FELDERA_TEST_NUM_HOSTS=2`):
**15 passed / 0 failed** (previously failed ~30% of multihost runs).

After this merges, `test_automated_checkpoint_sync1` can be removed from the
`PYTEST_EXTRA_MULTIHOST` exclusion in feldera/cloud.
