### PR TITLE
Add fda copy/clone command to duplicate a pipeline

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -342,6 +342,22 @@ pub enum PipelineAction {
         )]
         stdin: bool,
     },
+    /// Copy an existing pipeline into a new pipeline.
+    ///
+    /// Clones the source pipeline's program code, UDFs, runtime configuration,
+    /// and compilation (program) configuration into a newly created pipeline
+    /// with the given name. The new pipeline is created in the stopped state;
+    /// it is not started. This is convenient for launching several copies of a
+    /// pipeline for testing.
+    #[command(visible_alias = "clone")]
+    Copy {
+        /// The name of the existing pipeline to copy from.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        source: String,
+        /// The name of the new pipeline to create.
+        #[arg(value_hint = ValueHint::Other)]
+        name: String,
+    },
     /// Start a pipeline.
     ///
     /// If the pipeline is compiling it will wait for the compilation to finish.
@@ -1069,6 +1085,30 @@ mod tests {
             Commands::Pipeline(crate::cli::PipelineAction::Program {
                 action: ProgramAction::Errors { name }
             }) if name == "pipeline"
+        ));
+    }
+
+    #[test]
+    fn parse_copy_command() {
+        let cli = Cli::try_parse_from(["fda", "copy", "source-pipeline", "new-pipeline"])
+            .expect("copy command should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Pipeline(crate::cli::PipelineAction::Copy { source, name })
+                if source == "source-pipeline" && name == "new-pipeline"
+        ));
+    }
+
+    #[test]
+    fn parse_copy_clone_alias() {
+        let cli = Cli::try_parse_from(["fda", "clone", "source-pipeline", "new-pipeline"])
+            .expect("clone alias should parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Pipeline(crate::cli::PipelineAction::Copy { source, name })
+                if source == "source-pipeline" && name == "new-pipeline"
         ));
     }
 }

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -844,6 +844,58 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 std::process::exit(1);
             }
         }
+        PipelineAction::Copy { source, name } => {
+            // Clone the source pipeline's program, UDFs, runtime configuration,
+            // and compilation configuration into a new pipeline.
+            let src = client
+                .get_pipeline()
+                .pipeline_name(source.clone())
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to fetch the source pipeline",
+                    1,
+                ))
+                .unwrap();
+            let response = client
+                .post_pipeline()
+                .body(PostPutPipeline {
+                    description: src.description.clone(),
+                    tags: src.tags.clone(),
+                    name: name.to_string(),
+                    program_code: src.program_code.clone().unwrap_or_default(),
+                    udf_rust: src.udf_rust.clone(),
+                    udf_toml: src.udf_toml.clone(),
+                    program_config: src.program_config.clone(),
+                    runtime_config: src.runtime_config.clone(),
+                })
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to create the copied pipeline",
+                    1,
+                ))
+                .unwrap();
+            match format {
+                OutputFormat::Text => {
+                    println!("Pipeline `{source}` copied to `{name}` successfully.");
+                    debug!("{:#?}", response);
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&response.into_inner())
+                            .expect("Failed to serialize pipeline response")
+                    );
+                }
+                _ => {
+                    eprintln!("Unsupported output format: {format}");
+                    std::process::exit(1);
+                }
+            }
+        }
         PipelineAction::Start {
             name,
             recompile,

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,12 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        - The `fda` CLI can now copy a pipeline with `fda copy <source> <name>`
+          (alias `fda clone`), cloning the source pipeline's program, UDFs,
+          runtime configuration, and compilation configuration into a new,
+          stopped pipeline. Convenient for launching several copies of a
+          pipeline for testing.
+
         - New DynamoDB output connector. It writes a SQL view to an Amazon
           DynamoDB table, mapping inserts and updates to upserts and deletes to
           deletes keyed by the table's primary key. See the

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -255,6 +255,13 @@ Retrieve the program for `p1` and create a new pipeline `p2` from it:
 fda program get p1 | fda create p2 -s
 ```
 
+Copy the pipeline `p1` to a new pipeline `p2`, cloning its program, UDFs,
+runtime configuration, and compilation configuration (`fda clone` works too):
+
+```bash
+fda copy p1 p2
+```
+
 Enable storage for `p1`:
 
 ```bash


### PR DESCRIPTION
Adds an `fda copy <source> <name>` command (alias `fda clone`) that duplicates a pipeline. It fetches the source pipeline and creates a new one with the same program code, UDFs, runtime configuration, and compilation (program) configuration under a new name. The new pipeline is created stopped. Convenient for launching several copies of a pipeline for testing.

Closes #6399.

### Describe Manual Test Plan

- `cargo test -p fda` — 23 pass, including two new clap parse tests covering `fda copy` and the `fda clone` alias.
- `cargo clippy -p fda` and `cargo fmt -p fda -- --check` — clean.
- Built and ran the binary: `fda copy --help` and `fda clone --help` render the expected usage and arguments.

Note: the command was not exercised end-to-end against a running Feldera instance. The handler mirrors the existing `create` / `get_pipeline` flow, and every field of the `PostPutPipeline` body is type-checked against the generated REST API types. Happy to add an integration test or adjust which fields are cloned (e.g. tags/description) if you'd prefer a different shape.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (the copy round-trip needs a running Feldera instance)
- [x] Documentation updated (CLI examples)
- [x] Changelog updated

## Breaking Changes?

- [ ] OpenAPI / REST HTTP API / feldera-types / manager
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib
- [ ] Python SDK
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

This adds a new `fda copy` / `fda clone` command; it does not change any existing CLI arguments.
