### PR TITLE
Quote curl URLs in docs to prevent shell globbing

### DIFF
--- a/docs.feldera.com/docs/connectors/completion-tokens.md
+++ b/docs.feldera.com/docs/connectors/completion-tokens.md
@@ -96,7 +96,7 @@ CREATE TABLE price (
 ### Step 1. Push data via HTTP
 
   ```shell
-  curl -s -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json -d '
+  curl -s -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json' -d '
   {"insert": {"part": 1, "vendor": 2, "price": 10000}}
   {"insert": {"part": 2, "vendor": 1, "price": 15000}}
   {"insert": {"part": 3, "vendor": 3, "price": 9000}}'| jq
@@ -115,7 +115,7 @@ CREATE TABLE price (
   Let us generate another completion token for the URL input connector attached to the table.
 
   ```shell
-  curl -s -X 'GET' http://127.0.0.1:8080/v0/pipelines/supply-chain/tables/PRICE/connectors/tutorial-price-s3/completion_token | jq
+  curl -s -X 'GET' 'http://127.0.0.1:8080/v0/pipelines/supply-chain/tables/PRICE/connectors/tutorial-price-s3/completion_token' | jq
   ```
 
   > Note that this endpoint requires the user to explicitly assign a name to the connector (`"name": "tutorial-price-s3"`)
@@ -132,7 +132,7 @@ CREATE TABLE price (
 ### Step 3. Check the status of both tokens
 
   ```shell
-  curl -s -X 'GET' http://127.0.0.1:8080/v0/pipelines/supply-chain/completion_status?token=eyJ1IjoiMDE5NmIxMjAtNjIwMy03YjkwLWI2YmQtMTY4OTBkZjE1ZTI4IiwiZSI6MywiYyI6M30= | jq
+  curl -s -X 'GET' 'http://127.0.0.1:8080/v0/pipelines/supply-chain/completion_status?token=eyJ1IjoiMDE5NmIxMjAtNjIwMy03YjkwLWI2YmQtMTY4OTBkZjE1ZTI4IiwiZSI6MywiYyI6M30=' | jq
   ```
 
   ```json
@@ -142,7 +142,7 @@ CREATE TABLE price (
   ```
 
   ```shell
-  curl -s -X 'GET' http://127.0.0.1:8080/v0/pipelines/supply-chain/completion_status?token=eyJ1IjoiMDE5NmIxMjAtNjIwMy03YjkwLWI2YmQtMTY4OTBkZjE1ZTI4IiwiZSI6MSwiYyI6M30= | jq
+  curl -s -X 'GET' 'http://127.0.0.1:8080/v0/pipelines/supply-chain/completion_status?token=eyJ1IjoiMDE5NmIxMjAtNjIwMy03YjkwLWI2YmQtMTY4OTBkZjE1ZTI4IiwiZSI6MSwiYyI6M30=' | jq
   ```
 
   ```json
@@ -150,3 +150,4 @@ CREATE TABLE price (
     "status": "complete"
   }
   ```
+

--- a/docs.feldera.com/docs/connectors/completion-tokens.md
+++ b/docs.feldera.com/docs/connectors/completion-tokens.md
@@ -150,4 +150,3 @@ CREATE TABLE price (
     "status": "complete"
   }
   ```
-

--- a/docs.feldera.com/docs/connectors/sinks/http.md
+++ b/docs.feldera.com/docs/connectors/sinks/http.md
@@ -41,14 +41,14 @@ Stream incremental updates (default):
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json'
 ```
 
 Receive a full snapshot followed by incremental updates:
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json\&send_snapshot=true
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json\&send_snapshot=true'
 ```
 
 ### Python (direct API calls)
@@ -75,3 +75,4 @@ For more information, see:
 
 * [REST API documentation](/api/subscribe-to-view)
   for the `/egress` endpoint.
+

--- a/docs.feldera.com/docs/connectors/sinks/http.md
+++ b/docs.feldera.com/docs/connectors/sinks/http.md
@@ -75,4 +75,3 @@ For more information, see:
 
 * [REST API documentation](/api/subscribe-to-view)
   for the `/egress` endpoint.
-

--- a/docs.feldera.com/docs/connectors/sinks/http.md
+++ b/docs.feldera.com/docs/connectors/sinks/http.md
@@ -48,7 +48,7 @@ Receive a full snapshot followed by incremental updates:
 
 ```bash
 curl -i -X 'POST' \
-  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json\&send_snapshot=true'
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?format=json&send_snapshot=true'
 ```
 
 ### Python (direct API calls)

--- a/docs.feldera.com/docs/connectors/sources/http-get.md
+++ b/docs.feldera.com/docs/connectors/sources/http-get.md
@@ -95,4 +95,3 @@ For more information, see:
 
 * Data formats such as [JSON](/formats/json),
   [CSV](/formats/csv), and [Parquet](/formats/parquet)
-

--- a/docs.feldera.com/docs/connectors/sources/http-get.md
+++ b/docs.feldera.com/docs/connectors/sources/http-get.md
@@ -49,7 +49,7 @@ WITH ('connectors' = '[{
 ### curl
 
 ```bash
-curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/workshop \
+curl -i -X PUT 'http://127.0.0.1:8080/v0/pipelines/workshop' \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile code program.sql \
@@ -95,3 +95,4 @@ For more information, see:
 
 * Data formats such as [JSON](/formats/json),
   [CSV](/formats/csv), and [Parquet](/formats/parquet)
+

--- a/docs.feldera.com/docs/connectors/sources/http.md
+++ b/docs.feldera.com/docs/connectors/sources/http.md
@@ -49,7 +49,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json\&array=true' \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json&array=true' \
   -d '[{"insert": {"pid": 0, "name": "hammer", "price": 5}}, {"insert": {"pid": 1, "name": "nail", "price": 0.02}}]'
 ```
 

--- a/docs.feldera.com/docs/connectors/sources/http.md
+++ b/docs.feldera.com/docs/connectors/sources/http.md
@@ -24,7 +24,7 @@ We will insert rows into table `product` for pipeline `supply-chain-pipeline`.
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json' \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5.0}}'
 ```
 
@@ -32,7 +32,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -H "Authorization: Bearer <API-KEY>" -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json' \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5.0}}'
 ```
 
@@ -40,7 +40,7 @@ curl -i -H "Authorization: Bearer <API-KEY>" -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json' \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5}}
 {"insert": {"pid": 1, "name": "nail", "price": 0.02}}'
 ```
@@ -49,7 +49,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json\&array=true \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json\&array=true' \
   -d '[{"insert": {"pid": 0, "name": "hammer", "price": 5}}, {"insert": {"pid": 1, "name": "nail", "price": 0.02}}]'
 ```
 
@@ -57,7 +57,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  'http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json' \
   -d '{"delete": {"pid": 1}}'
 ```
 
@@ -130,3 +130,4 @@ For more information, see:
   [CSV](/formats/csv)
 
 * [Python API documentation](pathname:///python/)
+

--- a/docs.feldera.com/docs/connectors/sources/http.md
+++ b/docs.feldera.com/docs/connectors/sources/http.md
@@ -130,4 +130,3 @@ For more information, see:
   [CSV](/formats/csv)
 
 * [Python API documentation](pathname:///python/)
-

--- a/docs.feldera.com/docs/connectors/sources/nats.md
+++ b/docs.feldera.com/docs/connectors/sources/nats.md
@@ -347,4 +347,3 @@ For more information, see:
 * Data formats such as [JSON](/formats/json) and [CSV](/formats/csv)
 * [NATS JetStream documentation](https://docs.nats.io/nats-concepts/jetstream)
 * [NATS Ordered Consumer documentation](https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#orderedconsumer)
-

--- a/docs.feldera.com/docs/connectors/sources/nats.md
+++ b/docs.feldera.com/docs/connectors/sources/nats.md
@@ -143,7 +143,7 @@ Before using the NATS input connector, you need a NATS server with JetStream ena
 The quickest way to start experimenting with Feldera and NATS is to use Docker Compose:
 
 ```bash
-curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml -o docker-compose.yml
+curl -L 'https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml' -o docker-compose.yml
 docker compose --profile nats up
 ```
 
@@ -347,3 +347,4 @@ For more information, see:
 * Data formats such as [JSON](/formats/json) and [CSV](/formats/csv)
 * [NATS JetStream documentation](https://docs.nats.io/nats-concepts/jetstream)
 * [NATS Ordered Consumer documentation](https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#orderedconsumer)
+

--- a/docs.feldera.com/docs/formats/raw.md
+++ b/docs.feldera.com/docs/formats/raw.md
@@ -139,4 +139,3 @@ curl -i -X 'POST' \
   -d 'hello
   world'
 ```
-

--- a/docs.feldera.com/docs/formats/raw.md
+++ b/docs.feldera.com/docs/formats/raw.md
@@ -135,7 +135,8 @@ Insert two records with values `hello` and `world`:
 
 ```bash
 curl -i -X 'POST' \
-  http://127.0.0.1:8080/v0/pipelines/my_pipeline/ingress/raw_table?format=raw&mode=lines \
+  'http://127.0.0.1:8080/v0/pipelines/my_pipeline/ingress/raw_table?format=raw&mode=lines' \
   -d 'hello
   world'
 ```
+

--- a/docs.feldera.com/docs/get-started/docker.md
+++ b/docs.feldera.com/docs/get-started/docker.md
@@ -73,4 +73,3 @@ You also need `curl` and a web browser such as Chrome or Firefox.
 [3]: https://docs.docker.com/compose/install/linux
 [4]: https://docs.docker.com/engine/install/linux-postinstall/
 
-

--- a/docs.feldera.com/docs/get-started/docker.md
+++ b/docs.feldera.com/docs/get-started/docker.md
@@ -20,14 +20,14 @@ Feldera with auxiliary services included in the Docker Compose file
 like Redpanda, Prometheus and Grafana.
 
 ```
-curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
+curl -L 'https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml' | \
 docker compose -f - up
 ```
 
 You can enable specific services from the Docker Compose file as follows:
 
 ```
-curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
+curl -L 'https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml' | \
 docker compose -f - up pipeline-manager redpanda
 ```
 
@@ -72,4 +72,5 @@ You also need `curl` and a web browser such as Chrome or Firefox.
 [2]: https://docs.docker.com/engine/install/
 [3]: https://docs.docker.com/compose/install/linux
 [4]: https://docs.docker.com/engine/install/linux-postinstall/
+
 

--- a/docs.feldera.com/docs/get-started/enterprise/https.md
+++ b/docs.feldera.com/docs/get-started/enterprise/https.md
@@ -223,7 +223,7 @@ section below describes one way to generate these files.
    errors about an insecure connection (or self-signed certificates).
    For example, when using curl:
    ```
-   curl --cacert tls.crt https://localhost:8080/v0/pipelines
+   curl --cacert tls.crt 'https://localhost:8080/v0/pipelines'
    ```
 
    It is no longer possible to reach the endpoints via HTTP.
@@ -232,3 +232,4 @@ section below describes one way to generate these files.
    "localhost sent an invalid response" (Chrome) or
    "Received HTTP/0.9 when not allowed" (curl).
    Use `https://` as the protocol.
+

--- a/docs.feldera.com/docs/get-started/enterprise/https.md
+++ b/docs.feldera.com/docs/get-started/enterprise/https.md
@@ -232,4 +232,3 @@ section below describes one way to generate these files.
    "localhost sent an invalid response" (Chrome) or
    "Received HTTP/0.9 when not allowed" (curl).
    Use `https://` as the protocol.
-

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -338,4 +338,3 @@ Within the shell, you can interact with the pipeline `p1` by sending [ad-hoc SQL
 
 The shell also lets you execute certain CLI commands like `start`, `restart`, `shutdown` without having to provide the
 pipeline name every time. Type `help` for more information.
-

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -15,7 +15,7 @@ It allows you to create, manage, and monitor pipelines. It also features an inte
   <TabItem value="linux" label="Linux">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | bash
 ```
 
 | Supported platforms |
@@ -29,7 +29,7 @@ Requires glibc >= 2.39 (Ubuntu 24.04+, Debian 13+, Fedora 40+, RHEL 10+).
   <TabItem value="macos" label="macOS">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | bash
 ```
 
 | Supported platforms |
@@ -70,14 +70,14 @@ To install a specific version, pass the release git tag to the install script:
   <TabItem value="linux" label="Linux">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | FDA_VERSION=v0.290.0 bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | FDA_VERSION=v0.290.0 bash
 ```
 
   </TabItem>
   <TabItem value="macos" label="macOS">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | FDA_VERSION=v0.290.0 bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | FDA_VERSION=v0.290.0 bash
 ```
 
   </TabItem>
@@ -96,14 +96,14 @@ To install to a custom directory:
   <TabItem value="linux" label="Linux">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | FDA_VERSION=v0.290.0 FELDERA_INSTALL=/opt/feldera bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | FDA_VERSION=v0.290.0 FELDERA_INSTALL=/opt/feldera bash
 ```
 
   </TabItem>
   <TabItem value="macos" label="macOS">
 
 ```bash
-curl -fsSL https://docs.feldera.com/install-fda | FDA_VERSION=v0.290.0 FELDERA_INSTALL=/opt/feldera bash
+curl -fsSL 'https://docs.feldera.com/install-fda' | FDA_VERSION=v0.290.0 FELDERA_INSTALL=/opt/feldera bash
 ```
 
   </TabItem>
@@ -338,3 +338,4 @@ Within the shell, you can interact with the pipeline `p1` by sending [ad-hoc SQL
 
 The shell also lets you execute certain CLI commands like `start`, `restart`, `shutdown` without having to provide the
 pipeline name every time. Type `help` for more information.
+

--- a/docs.feldera.com/docs/operations/visualizing-profiles.md
+++ b/docs.feldera.com/docs/operations/visualizing-profiles.md
@@ -292,7 +292,7 @@ This flag adds the `PERFMON` capability to the pipeline pod to enable profiling.
 
 ```bash
 # Start a 60 second profiling session
-curl -X POST "http://localhost:8080/v0/pipelines/my-pipeline/samply_profile?duration_secs=60"
+curl -X POST 'http://localhost:8080/v0/pipelines/my-pipeline/samply_profile?duration_secs=60'
 ```
 
 #### Retrieve the profile
@@ -302,7 +302,7 @@ Wait for `duration_secs` for the profiling to complete. Then make a `GET` reques
 ```bash
 
 # Retrieve the profile (after the session completes)
-curl "http://localhost:8080/v0/pipelines/my-pipeline/samply_profile" -o prof.json.gz
+curl 'http://localhost:8080/v0/pipelines/my-pipeline/samply_profile' -o prof.json.gz
 ```
 
 ##### Failures

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -54,7 +54,7 @@ staying ready for immediate activation.
 To activate a standby pipeline:
 
 ```sh
-curl -X POST https://{FELDERA_HOST}/v0/pipelines/{PIPELINE_NAME}/activate
+curl -X POST 'https://{FELDERA_HOST}/v0/pipelines/{PIPELINE_NAME}/activate'
 ```
 
 :::important
@@ -217,7 +217,7 @@ Automatic sync is **disabled by default**.
 The status of the most recent automatic sync operation can be queried with:
 
 ```bash
-curl http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status | jq '.periodic'
+curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status' | jq '.periodic'
 ```
 
 It is recommended to set `push_interval` greater than
@@ -240,7 +240,7 @@ following conditions are met:
 A sync operation can be triggered by making a `POST` request to:
 
 ```bash
-curl -X POST http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync
+curl -X POST 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync'
 ```
 
 This initiates the sync and returns the UUID of the checkpoint being synced:
@@ -254,7 +254,7 @@ This initiates the sync and returns the UUID of the checkpoint being synced:
 The status of the sync operation can be checked with:
 
 ```bash
-curl http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status
+curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
 ```
 
 ### Response fields
@@ -401,3 +401,4 @@ average speeds were observed in testing:
 - Both GP2 and GP3 can briefly hit maximum download speeds of around 1 GiB/s, but performance drops off quickly.
 - NVMe speeds were tested on an i4i.4xlarge instance type.
 - Performance may improve by tuning sync parameters such as `transfers`, `checkers`, `upload_concurrency`, etc.
+

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -401,4 +401,3 @@ average speeds were observed in testing:
 - Both GP2 and GP3 can briefly hit maximum download speeds of around 1 GiB/s, but performance drops off quickly.
 - NVMe speeds were tested on an i4i.4xlarge instance type.
 - Performance may improve by tuning sync parameters such as `transfers`, `checkers`, `upload_concurrency`, etc.
-

--- a/docs.feldera.com/docs/pipelines/transactions.md
+++ b/docs.feldera.com/docs/pipelines/transactions.md
@@ -56,7 +56,7 @@ Use the [`start_transaction`](/api/begin-transaction) API to start a transaction
 <Tabs>
     <TabItem value="rest" label="REST API">
     ```shell
-    $ curl -X POST http://localhost:8080/v0/pipelines/my_pipeline/start_transaction
+    $ curl -X POST 'http://localhost:8080/v0/pipelines/my_pipeline/start_transaction'
 
     {"transaction_id":1}
     ```
@@ -93,7 +93,7 @@ commit the transaction using the [`commit_transaction`](/api/commit-transaction)
 <Tabs>
     <TabItem value="rest" label="REST API">
     ```shell
-    $ curl -X POST http://localhost:8080/v0/pipelines/my_pipeline/commit_transaction
+    $ curl -X POST 'http://localhost:8080/v0/pipelines/my_pipeline/commit_transaction'
     "Transaction commit initiated"
     ```
     </TabItem>
@@ -152,10 +152,10 @@ Transaction status is also available through [metrics](/operations/metrics.md#tr
 <Tabs>
     <TabItem value="rest" label="REST API">
     ```shell
-    $ curl -s http://localhost:8080/v0/pipelines/my_pipeline/stats | jq -r '.global_metrics.transaction_status'
+    $ curl -s 'http://localhost:8080/v0/pipelines/my_pipeline/stats' | jq -r '.global_metrics.transaction_status'
     TransactionInProgress
 
-    $ curl -s http://localhost:8080/v0/pipelines/my_pipeline/stats | jq -r '.global_metrics.transaction_id'
+    $ curl -s 'http://localhost:8080/v0/pipelines/my_pipeline/stats' | jq -r '.global_metrics.transaction_id'
     1
     ```
     </TabItem>
@@ -286,3 +286,4 @@ $ fda query transaction_test "select * from v"
 | 1 |
 +---+
 ```
+

--- a/docs.feldera.com/docs/pipelines/transactions.md
+++ b/docs.feldera.com/docs/pipelines/transactions.md
@@ -286,4 +286,3 @@ $ fda query transaction_test "select * from v"
 | 1 |
 +---+
 ```
-

--- a/docs.feldera.com/docs/sql/udf.md
+++ b/docs.feldera.com/docs/sql/udf.md
@@ -226,7 +226,7 @@ base64 = \"0.22.1\"
 " > udf.toml
 
 
-curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/udf_api_test \
+curl -i -X PUT 'http://127.0.0.1:8080/v0/pipelines/udf_api_test' \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile sql program.sql \
@@ -1173,4 +1173,5 @@ CREATE VIEW v WITH (
 Currently exactly one postprocessor may be specified per connector.
 
 :::
+
 

--- a/docs.feldera.com/docs/sql/udf.md
+++ b/docs.feldera.com/docs/sql/udf.md
@@ -1174,4 +1174,3 @@ Currently exactly one postprocessor may be specified per connector.
 
 :::
 
-

--- a/docs.feldera.com/docs/tutorials/basics/part2.md
+++ b/docs.feldera.com/docs/tutorials/basics/part2.md
@@ -25,7 +25,7 @@ Start the pipeline you created in Part 1 of the tutorial from a clean state:
 Subscribe to changes to the `PREFERRED_VENDOR` view:
 
 ```bash
-curl -s -N -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/egress/PREFERRED_VENDOR?format=json | jq
+curl -s -N -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply_chain/egress/PREFERRED_VENDOR?format=json' | jq
 ```
 
 You should see periodic heartbeat messages:
@@ -52,7 +52,7 @@ In another terminal, use the following command to populate the `PART` table
 with the same data we entered manually in part 1 of the tutorial:
 
 ```bash
-curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PART?format=json -d '
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PART?format=json' -d '
 {"insert": {"id": 1, "name": "Flux Capacitor"}}
 {"insert": {"id": 2, "name": "Warp Core"}}
 {"insert": {"id": 3, "name": "Kyber Crystal"}}'
@@ -66,12 +66,12 @@ Records are encoded as JSON objects with one key per table column.
 Next, we populate the other two tables:
 
 ```bash
-curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/VENDOR?format=json -d '
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/VENDOR?format=json' -d '
 {"insert": {"id": 1, "name": "Gravitech Dynamics", "address": "222 Graviton Lane"}}
 {"insert": {"id": 2, "name": "HyperDrive Innovations", "address": "456 Warp Way"}}
 {"insert": {"id": 3, "name": "DarkMatter Devices", "address": "333 Singularity Street"}}'
 
-curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json' -d '
 {"insert": {"part": 1, "vendor": 2, "price": 10000}}
 {"insert": {"part": 2, "vendor": 1, "price": 15000}}
 {"insert": {"part": 3, "vendor": 3, "price": 9000}}'
@@ -137,7 +137,7 @@ that there is no `update` command.  Modifying a record amounts to deleting the
 old version and inserting the new one.
 
 ```bash
-curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json' -d '
 {"delete": {"part": 1, "vendor": 2, "price": 10000}}
 {"insert": {"part": 1, "vendor": 2, "price": 30000}}
 {"delete": {"part": 2, "vendor": 1, "price": 15000}}
@@ -225,3 +225,4 @@ Let us review:
 - Internally, Feldera also works with changes: the Feldera query engine employs
   incremental algorithms to compute only what has changed in each view without
   requiring a full re-computation.
+

--- a/docs.feldera.com/docs/tutorials/basics/part2.md
+++ b/docs.feldera.com/docs/tutorials/basics/part2.md
@@ -225,4 +225,3 @@ Let us review:
 - Internally, Feldera also works with changes: the Feldera query engine employs
   incremental algorithms to compute only what has changed in each view without
   requiring a full re-computation.
-

--- a/docs.feldera.com/docs/tutorials/basics/part3.md
+++ b/docs.feldera.com/docs/tutorials/basics/part3.md
@@ -335,4 +335,3 @@ To summarize Part 3 of the tutorial,
 - Combined with the incremental query evaluation mechanism, this enables Feldera
   to analyze data on the fly as it moves from sources to destinations, so that
   the destination receives up-to-date query results in real time.
-

--- a/docs.feldera.com/docs/tutorials/basics/part3.md
+++ b/docs.feldera.com/docs/tutorials/basics/part3.md
@@ -97,7 +97,7 @@ the Redpanda container should already be running.  Otherwise, you can start it
 using the following command:
 
 ```bash
-curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | docker compose -f - up redpanda
+curl -L 'https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml' | docker compose -f - up redpanda
 ```
 
 Next, you will need to install `rpk`, the Redpanda CLI, by following the instructions on
@@ -335,3 +335,4 @@ To summarize Part 3 of the tutorial,
 - Combined with the incremental query evaluation mechanism, this enables Feldera
   to analyze data on the fly as it moves from sources to destinations, so that
   the destination receives up-to-date query results in real time.
+

--- a/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
@@ -32,7 +32,7 @@ The cluster monitor events can be retrieved via two endpoints:
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/cluster/events | jq
+curl -X GET 'http://127.0.0.1:8080/v0/cluster/events' | jq
 ```
 
 **Response**
@@ -62,7 +62,7 @@ curl -X GET http://127.0.0.1:8080/v0/cluster/events | jq
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/cluster/events/latest | jq
+curl -X GET 'http://127.0.0.1:8080/v0/cluster/events/latest' | jq
 ```
 
 **Response**
@@ -81,7 +81,7 @@ curl -X GET http://127.0.0.1:8080/v0/cluster/events/latest | jq
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/cluster/events/019afe45-ec1f-7de0-9cd1-3a6a4350b5e9?selector=all | jq
+curl -X GET 'http://127.0.0.1:8080/v0/cluster/events/019afe45-ec1f-7de0-9cd1-3a6a4350b5e9?selector=all' | jq
 ```
 
 **Response**
@@ -103,3 +103,4 @@ curl -X GET http://127.0.0.1:8080/v0/cluster/events/019afe45-ec1f-7de0-9cd1-3a6a
 ```
 
 ... with `"(...)"` representing human-readable status explanations (omitted for brevity).
+

--- a/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
@@ -103,4 +103,3 @@ curl -X GET 'http://127.0.0.1:8080/v0/cluster/events/019afe45-ec1f-7de0-9cd1-3a6
 ```
 
 ... with `"(...)"` representing human-readable status explanations (omitted for brevity).
-

--- a/docs.feldera.com/docs/tutorials/rest_api/index.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/index.md
@@ -26,7 +26,7 @@ language (e.g., in Python using the `requests` module).
 3. **Feldera instance:**  If you haven't done so already, you can start Feldera locally using
    [**docker**](https://docs.docker.com/engine/install/):
    ```
-   curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
+   curl -L 'https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml' | \
    docker compose -f - up
    ```
    (leave it running in a separate terminal while going through this tutorial)
@@ -41,7 +41,7 @@ language (e.g., in Python using the `requests` module).
    You can add it to a `curl` call by replacing `<API-KEY>`
    with the generated string starting with `apikey:...`:
    ```
-   curl -s -H "Authorization: Bearer <API-KEY>" -X GET http://127.0.0.1:8080/v0/pipelines | jq
+   curl -s -H "Authorization: Bearer <API-KEY>" -X GET 'http://127.0.0.1:8080/v0/pipelines' | jq
    ```
 
    > For the remainder of this tutorial, you will need to add
@@ -49,7 +49,7 @@ language (e.g., in Python using the `requests` module).
 
 5. **Check whether your setup works:** You can verify your setup by running:
    ```
-   curl -s -X GET http://127.0.0.1:8080/v0/programs | jq
+   curl -s -X GET 'http://127.0.0.1:8080/v0/programs' | jq
    ```
 
    ... this will output a JSON array of program objects, which when there are
@@ -162,7 +162,7 @@ specifies the pipeline's name, description, the different configuration paramter
 contents of `program.sql` into the `program_code` field.
 
 ```
-curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/supply-chain \
+curl -i -X PUT 'http://127.0.0.1:8080/v0/pipelines/supply-chain' \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile code program.sql \
@@ -184,7 +184,7 @@ updated, its version is incremented and compilation is automatically triggered.
 Now let's check the program's compilation status a few times:
 
 ```
-curl -s http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.program_status'
+curl -s 'http://127.0.0.1:8080/v0/pipelines/supply-chain' | jq '.program_status'
 ```
 ...which will show "CompilingRust" at first, but in about 30 seconds or so say "Success".
 
@@ -195,7 +195,7 @@ The pipeline is now ready to be started.
 We start the pipeline using:
 
 ```
-curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/start
+curl -i -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/start'
 ```
 
 ... which will return `HTTP/1.1 202 Accepted` when successful.
@@ -205,7 +205,7 @@ As such, it will take some time before the final target state has been reached.
 Regularly poll the status until the start has completed:
 
 ```
-curl -s GET http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_status'
+curl -s GET 'http://127.0.0.1:8080/v0/pipelines/supply-chain' | jq '.deployment_status'
 ```
 
 ... which eventually will say `Running` when the pipeline has started.
@@ -218,11 +218,11 @@ curl -s GET http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_st
 > take effect):
 > ```
 > # Shut it down:
-> curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown
+> curl -i -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown'
 > # ... wait for the current_status to become Shutdown by checking:
-> curl -X GET http://127.0.0.1:8080/v0/pipelines/supply-chain
+> curl -X GET 'http://127.0.0.1:8080/v0/pipelines/supply-chain'
 > # ... and then start:
-> curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/start
+> curl -i -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/start'
 > ```
 
 ### Step 3: Pipeline progress
@@ -230,7 +230,7 @@ curl -s GET http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_st
 A running pipeline provides several useful stats:
 
 ```
-curl -sX GET http://127.0.0.1:8080/v0/pipelines/supply-chain/stats | jq
+curl -sX GET 'http://127.0.0.1:8080/v0/pipelines/supply-chain/stats' | jq
 ```
 
 ... such as the number of input and processed records.
@@ -318,7 +318,7 @@ It is possible to INSERT, UPSERT or even DELETE a single row within a table. In 
 we have HyperDrive Innovations supply the Warp Core at a lower price of 12000:
 
 ```
-curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json \
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json' \
 -d '{"insert": {"part": 2, "vendor": 2, "price": 12000}}'
 ```
 
@@ -361,19 +361,19 @@ down the pipeline (which will automatically terminate monitoring the
 view if it is still running):
 
 ```
-curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown
+curl -i -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown'
 ```
 
 Check that it has been shut down using:
 
 ```
-curl -s http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_status'
+curl -s 'http://127.0.0.1:8080/v0/pipelines/supply-chain' | jq '.deployment_status'
 ```
 ... and you  should see `deployment_status` set to `Shutdown`.
 
 Next, let's DELETE the pipeline:
 ```
-curl -i -X DELETE http://127.0.0.1:8080/v0/pipelines/supply-chain
+curl -i -X DELETE 'http://127.0.0.1:8080/v0/pipelines/supply-chain'
 ```
 
 You can also delete the `program.sql` file we used to create the program.
@@ -387,3 +387,4 @@ Interested in building applications using the API? Consider reading our API and 
 
 - [Browse the API documentation](/api/)
 - [Read the SQL reference](/sql/intro/)
+

--- a/docs.feldera.com/docs/tutorials/rest_api/index.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/index.md
@@ -387,4 +387,3 @@ Interested in building applications using the API? Consider reading our API and 
 
 - [Browse the API documentation](/api/)
 - [Read the SQL reference](/sql/intro/)
-

--- a/docs.feldera.com/docs/tutorials/rest_api/pipeline-monitoring.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/pipeline-monitoring.md
@@ -120,4 +120,3 @@ curl -X GET 'http://127.0.0.1:8080/v0/pipelines/example/events/019dd514-9fbd-7a4
 
 ... with `(JSON value)` representing JSON status details (omitted for brevity)
 which can be any JSON value (e.g., string, object, etc.).
-

--- a/docs.feldera.com/docs/tutorials/rest_api/pipeline-monitoring.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/pipeline-monitoring.md
@@ -27,7 +27,7 @@ get further details using the individual endpoint as needed.
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events | jq
+curl -X GET 'http://127.0.0.1:8080/v0/pipelines/example/events' | jq
 ```
 
 **Response**
@@ -74,7 +74,7 @@ curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events | jq
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events/latest | jq
+curl -X GET 'http://127.0.0.1:8080/v0/pipelines/example/events/latest' | jq
 ```
 
 **Response**
@@ -96,7 +96,7 @@ curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events/latest | jq
 
 **Request**
 ```
-curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events/019dd514-9fbd-7a40-804c-9f9165007fc3?selector=all | jq
+curl -X GET 'http://127.0.0.1:8080/v0/pipelines/example/events/019dd514-9fbd-7a40-804c-9f9165007fc3?selector=all' | jq
 ```
 
 **Response**
@@ -120,3 +120,4 @@ curl -X GET http://127.0.0.1:8080/v0/pipelines/example/events/019dd514-9fbd-7a40
 
 ... with `(JSON value)` representing JSON status details (omitted for brevity)
 which can be any JSON value (e.g., string, object, etc.).
+

--- a/docs.feldera.com/docs/use_cases/batch/part4.md
+++ b/docs.feldera.com/docs/use_cases/batch/part4.md
@@ -170,7 +170,7 @@ Live stream of updates to the view can be observed using the following `curl`
 command:
 
 ```sh
-curl -i -X 'POST' http://127.0.0.1:8080/v0/pipelines/batch/egress/q2?format=json
+curl -i -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/batch/egress/q2?format=json'
 ```
 
 As the contents of the view change, the changes will be
@@ -213,3 +213,4 @@ This is useful for:
 - Feldera allows streaming data directly to popular data sinks like
   **PostgreSQL**, **Kafka**, **Delta Lake** and **Redis**.
 - By connecting Feldera's incremental SQL engine to different sources and destinations, you can query data from multiple independent sources and materialize the results in multiple independent destinations in real-time.
+

--- a/docs.feldera.com/docs/use_cases/batch/part4.md
+++ b/docs.feldera.com/docs/use_cases/batch/part4.md
@@ -213,4 +213,3 @@ This is useful for:
 - Feldera allows streaming data directly to popular data sinks like
   **PostgreSQL**, **Kafka**, **Delta Lake** and **Redis**.
 - By connecting Feldera's incremental SQL engine to different sources and destinations, you can query data from multiple independent sources and materialize the results in multiple independent destinations in real-time.
-

--- a/docs.feldera.com/docs/use_cases/medallion_architecture/part1.md
+++ b/docs.feldera.com/docs/use_cases/medallion_architecture/part1.md
@@ -31,7 +31,7 @@ Each GitHub page above has a **Download raw file** button. To fetch a file from 
 terminal, use its raw URL, e.g.:
 
 ```bash
-curl -O https://raw.githubusercontent.com/feldera/feldera/main/docs.feldera.com/docs/use_cases/medallion_architecture/push_changes.py
+curl -O 'https://raw.githubusercontent.com/feldera/feldera/main/docs.feldera.com/docs/use_cases/medallion_architecture/push_changes.py'
 ```
 :::
 
@@ -104,3 +104,4 @@ SELECT * FROM gold_supplier_performance ORDER BY total_net_revenue DESC LIMIT 10
 ```
 
 After the pipeline has loaded the snapshot, continue to [Part 2](./part2.md) to push CDC changes and watch the Gold views update in real time.
+

--- a/docs.feldera.com/docs/use_cases/medallion_architecture/part1.md
+++ b/docs.feldera.com/docs/use_cases/medallion_architecture/part1.md
@@ -104,4 +104,3 @@ SELECT * FROM gold_supplier_performance ORDER BY total_net_revenue DESC LIMIT 10
 ```
 
 After the pipeline has loaded the snapshot, continue to [Part 2](./part2.md) to push CDC changes and watch the Gold views update in real time.
-

--- a/docs.feldera.com/docs/use_cases/medallion_architecture/part3.md
+++ b/docs.feldera.com/docs/use_cases/medallion_architecture/part3.md
@@ -51,4 +51,3 @@ Some of the silver views could be made incremental by hand by a data engineer â€
 More complex views, such as `gold_weekly_revenue_trend`, would require merge logic that is difficult to validate and entails significant engineering effort.
 
 With Feldera, you use the same SQL your batch engine runs now, get the same results, and pay a cost that tracks change size instead of data size. In addition, you get millisecond update latency across your full medallion architecture.
-

--- a/docs.feldera.com/docs/use_cases/medallion_architecture/part3.md
+++ b/docs.feldera.com/docs/use_cases/medallion_architecture/part3.md
@@ -7,7 +7,7 @@ The batch job is provided as a Databricks notebook:
 - [`spark_notebook.py`](https://github.com/feldera/feldera/blob/main/docs.feldera.com/docs/use_cases/medallion_architecture/spark_notebook.py) — *Compute Silver & Gold Delta Tables — Spark Batch*
 
 ```bash
-curl -O https://raw.githubusercontent.com/feldera/feldera/main/docs.feldera.com/docs/use_cases/medallion_architecture/spark_notebook.py
+curl -O 'https://raw.githubusercontent.com/feldera/feldera/main/docs.feldera.com/docs/use_cases/medallion_architecture/spark_notebook.py'
 ```
 
 Import it into Databricks (or any Spark 3.x environment with Delta Lake), or run it as a plain PySpark script — outside Databricks you'll need the `delta-spark` and `hadoop-aws` packages configured, and the `# COMMAND` / `# MAGIC` lines are just comments. It reads the same Bronze snapshot from `s3://feldera-demos/ecommerce-cdc-0-01/snapshot` and produces the **same 8 Silver and 7 Gold tables** as the SQL pipeline.
@@ -51,3 +51,4 @@ Some of the silver views could be made incremental by hand by a data engineer �
 More complex views, such as `gold_weekly_revenue_trend`, would require merge logic that is difficult to validate and entails significant engineering effort.
 
 With Feldera, you use the same SQL your batch engine runs now, get the same results, and pay a cost that tracks change size instead of data size. In addition, you get millisecond update latency across your full medallion architecture.
+


### PR DESCRIPTION
Unquoted URLs with query strings (e.g. `?format=json`) fail in zsh because `?` triggers glob expansion before curl runs. Wrap every curl URL in single quotes across documentation examples so commands work when copied verbatim.

Fixes #6560

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

