### PR TITLE
Journal replay fix

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -102,7 +102,7 @@ use governor::DefaultDirectRateLimiter;
 use governor::Quota;
 use governor::RateLimiter;
 use itertools::Itertools;
-use journal::StepMetadata;
+use journal::{InputChecksums, StepMetadata};
 use nonzero_ext::nonzero;
 use rmpv::Value as RmpValue;
 use serde_json::Value as JsonValue;
@@ -2586,6 +2586,20 @@ struct CircuitThread {
     /// Set to true on startup if the circuit requires bootstrapping.
     /// Cleared when the circuit completes bootstrapping.
     bootstrapping: bool,
+
+    /// Input metadata collected by [Self::input_step] for the step in progress,
+    /// to be journaled by [FtState::write_step] *after* [Self::step_circuit] has
+    /// run, so that the journal entry can be stamped with the transaction id
+    /// that the step's circuit evaluation belongs to. `None` when the current
+    /// step produced nothing to journal (e.g. while bootstrapping or committing
+    /// a transaction).
+    pending_step_metadata: Option<HashMap<EndpointId, (String, StepResults)>>,
+
+    /// Whether [Self::input_step] fed a replay step to the circuit this step.
+    /// Used by [FtState::next_step] to decide whether to advance the replay
+    /// cursor (it must not advance on steps that only commit the open replay
+    /// transaction).
+    replay_consumed: bool,
 }
 
 struct CommitUpdates {
@@ -2709,6 +2723,7 @@ impl CircuitThread {
             pipeline_config,
             circuit_config,
             processed_records,
+            transaction_number,
             initial_start_time,
             step,
             input_metadata,
@@ -2846,6 +2861,7 @@ impl CircuitThread {
             lir,
             error_cb,
             processed_records,
+            transaction_number,
             initial_start_time,
             &resume_info,
             &output_statistics,
@@ -2929,6 +2945,8 @@ impl CircuitThread {
             input_metadata: input_metadata.unwrap_or_default(),
             commit_updates: None,
             bootstrapping,
+            pending_step_metadata: None,
+            replay_consumed: false,
         })
     }
 
@@ -3088,6 +3106,8 @@ impl CircuitThread {
     }
 
     fn step(&mut self) -> Result<bool, ControllerError> {
+        // Step number under which this step's input is journaled.
+        let journal_step = self.step;
         self.controller
             .status
             .global_metrics
@@ -3116,6 +3136,16 @@ impl CircuitThread {
         // backpressure.
         self.controller.unpark_backpressure();
         self.step_circuit();
+
+        // Journal the step we just executed, stamped with the
+        // transaction id it belonged to.  Needs to be done after
+        // `step_circuit`, because the transaction id is only assigned there.
+        if let Some(step_metadata) = self.pending_step_metadata.take() {
+            let transaction_id = self.controller.get_transaction_number() as TransactionId;
+            if let Some(ft) = self.ft.as_mut() {
+                ft.write_step(step_metadata, journal_step, transaction_id)?;
+            }
+        }
 
         let transaction_state = self.controller.get_transaction_state();
 
@@ -3175,8 +3205,9 @@ impl CircuitThread {
         }
         // Push output batches to output pipelines.
         self.push_output(processed_records);
+        let replay_consumed = self.replay_consumed;
         if let Some(ft) = self.ft.as_mut() {
-            ft.next_step(self.step)?;
+            ft.next_step(replay_consumed)?;
             self.finish_replaying();
         }
         self.controller.unpark_backpressure();
@@ -3291,11 +3322,13 @@ impl CircuitThread {
                         .record();
                     TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
 
-                    self.controller
-                        .transaction_info
-                        .lock()
-                        .unwrap()
-                        .transaction_state = TransactionState::None;
+                    {
+                        let mut transaction_info = self.controller.transaction_info.lock().unwrap();
+                        transaction_info.transaction_state = TransactionState::None;
+                        // A replay transaction just committed; clear the open id
+                        // so the next replayed transaction can start.
+                        transaction_info.replay_open_transaction_id = None;
+                    }
 
                     self.commit_updates = None;
                     self.controller
@@ -3637,9 +3670,16 @@ impl CircuitThread {
     ///   recovered, so the pipeline process should exit as soon as it can.
     /// - `Err(error)` if there was an error.
     fn input_step(&mut self) -> Result<Option<BufferSize>, ControllerError> {
-        // No ingestion during bootstrap.
+        // Reset; set again at the end only if this step fed input. Early returns
+        // below leave them as is, so those steps neither journal nor
+        // advance the replay cursor.
+        self.pending_step_metadata = None;
+        self.replay_consumed = false;
+        // No ingestion during bootstrap, while committing a transaction, or at a
+        // replay transaction boundary.
         if self.controller.status.bootstrap_in_progress()
             || self.controller.transaction_commit_in_progress()
+            || self.replay_at_boundary()
         {
             return Ok(Some(BufferSize::empty()));
         }
@@ -3895,8 +3935,15 @@ impl CircuitThread {
             }
         };
 
-        if let Some(ft) = &mut self.ft {
-            ft.write_step(step_metadata, self.step)?;
+        // Defer journaling to `step()`, after `step_circuit` assigns the
+        // transaction id that this step's circuit evaluation belongs to.
+        if self.ft.is_some() {
+            self.pending_step_metadata = Some(step_metadata);
+        }
+        // We fed the current replay step (if any), so the replay cursor may
+        // advance after this step.
+        if self.replaying() {
+            self.replay_consumed = true;
         }
 
         Ok(Some(total_consumed))
@@ -3943,12 +3990,14 @@ impl CircuitThread {
 
             for (i, endpoint_id) in endpoints.iter().enumerate() {
                 let endpoint = outputs.lookup_by_id(endpoint_id).unwrap();
+                let transaction = self.controller.get_transaction_number();
 
                 // Silent bootstrap: send empty batch for progress tracking only.
                 if silent_bootstrap {
                     self.controller.status.enqueue_batch(*endpoint_id, 0);
                     endpoint.queue.push(BatchQueueEntry {
                         step: self.step,
+                        transaction,
                         batch_type: OutputBatchType::Delta,
                         data: None,
                         processed_records,
@@ -3969,6 +4018,7 @@ impl CircuitThread {
                     // We need to propagate processed_records to the connector for progress tracking.
                     endpoint.queue.push(BatchQueueEntry {
                         step: self.step,
+                        transaction,
                         batch_type: OutputBatchType::Delta,
                         data: None,
                         processed_records,
@@ -4006,6 +4056,7 @@ impl CircuitThread {
 
                 endpoint.queue.push(BatchQueueEntry {
                     step: self.step,
+                    transaction,
                     batch_type: OutputBatchType::Delta,
                     data: Some(batch),
                     processed_records,
@@ -4022,6 +4073,26 @@ impl CircuitThread {
 
     fn replaying(&self) -> bool {
         self.ft.as_ref().is_some_and(|ft| ft.is_replaying())
+    }
+
+    /// True while replaying when the next journaled step belongs to a
+    /// different transaction than the one currently open — meaning the open
+    /// transaction must commit (with no new input) before that step is fed.
+    /// `input_step` suppresses input on such steps and
+    /// `advance_transaction_state` commits the open transaction.
+    fn replay_at_boundary(&self) -> bool {
+        let Some(next) = self
+            .ft
+            .as_ref()
+            .and_then(|ft| ft.replay_step.as_ref())
+            .map(|r| r.transaction_id)
+        else {
+            return false;
+        };
+        matches!(
+            self.controller.get_transaction_state(),
+            TransactionState::Started { .. }
+        ) && self.controller.replay_open_transaction_id() != Some(next)
     }
 
     fn sync_checkpoint_requested(&self) -> bool {
@@ -4101,6 +4172,58 @@ impl CheckpointRequest {
     }
 }
 
+/// Per-endpoint aggregate of a replayed transaction's input checksums.
+///
+/// During fault-tolerance replay we verify that re-ingesting the journaled
+/// input reproduces what was recorded. The check is done per transaction, not
+/// per step: a transaction's commit can take a different number of physical
+/// steps on replay than during recording (e.g. under a streaming exchange with
+/// several workers), so the individual per-step record counts and hashes are
+/// not reproducible, but their per-transaction aggregate is.
+///
+/// `num_records` is summed and `hash` is XORed across the transaction's steps,
+/// which makes the aggregate independent of how the input was split across
+/// steps. A divergence is overwhelmingly likely to be detected: replay would
+/// have to reproduce both the exact total record count and the XOR of every
+/// per-step 64-bit hash while still ingesting different data.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+struct ReplayChecksumAggregate {
+    num_records: u64,
+    hash: u64,
+}
+
+impl ReplayChecksumAggregate {
+    fn add(&mut self, checksums: &InputChecksums) {
+        self.num_records = self.num_records.wrapping_add(checksums.num_records);
+        self.hash ^= checksums.hash;
+    }
+}
+
+/// Accumulates the recorded and replayed input checksums of the transaction
+/// currently being replayed, so the two can be compared when the transaction
+/// boundary is reached (see [FtState::verify_replay_transaction]).
+struct ReplayTransactionCheck {
+    /// Journaled id of the transaction being accumulated.
+    transaction_id: TransactionId,
+
+    /// Checksums read from the journal, aggregated per input endpoint.
+    recorded: HashMap<String, ReplayChecksumAggregate>,
+
+    /// Checksums actually re-ingested during replay, aggregated per input
+    /// endpoint.
+    replayed: HashMap<String, ReplayChecksumAggregate>,
+}
+
+impl ReplayTransactionCheck {
+    fn new(transaction_id: TransactionId) -> Self {
+        Self {
+            transaction_id,
+            recorded: HashMap::new(),
+            replayed: HashMap::new(),
+        }
+    }
+}
+
 /// Tracks fault-tolerant state in a controller [CircuitThread].
 struct FtState {
     /// Used to temporarily disable journaling.
@@ -4112,8 +4235,21 @@ struct FtState {
     /// The journal.
     journal: Journal,
 
-    /// The journal record that we're replaying, if we're replaying.
+    /// The journal record currently being replayed (fed to the circuit), if
+    /// we're replaying.
     replay_step: Option<StepMetadata>,
+
+    /// Journaled step numbers to replay, in recorded order. Replay iterates
+    /// these (decoupled from the physical step counter, which can diverge when
+    /// a transaction's commit takes a different number of steps on replay).
+    /// `replay_cursor` indexes the current `replay_step`.
+    replay_steps: Vec<Step>,
+    replay_cursor: usize,
+
+    /// Accumulates the current replay transaction's recorded and replayed input
+    /// checksums, verified at each transaction boundary. `None` while not
+    /// replaying or before the first replayed step of a transaction.
+    replay_check: Option<ReplayTransactionCheck>,
 
     /// Input endpoint ids, names, and whether the endpoints are paused, at the
     /// time we wrote the last step, so that we can log changes for the replay
@@ -4128,18 +4264,29 @@ impl FtState {
         step: Step,
         controller: Arc<ControllerInner>,
     ) -> Result<Self, ControllerError> {
-        info!("{STEPS_FILE}: opening to start from step {step}");
+        info!("{STEPS_FILE}: opening to start replay from step {step}");
         let journal = Journal::open(backend, &StoragePath::from(STEPS_FILE));
-        let replay_step = journal.read(step)?;
-        if let Some(record) = &replay_step {
-            // Start replaying the step.
-            Self::replay_step(step, record, &controller)?;
-        }
+        let replay_steps = journal.list_steps(step)?;
+        let replay_step = match replay_steps.first() {
+            Some(&first) => {
+                let record = journal.read(first)?;
+                if let Some(record) = &record {
+                    // Start replaying the first step.
+                    Self::replay_step(first, record, &controller)?;
+                }
+                record
+            }
+            None => None,
+        };
+        controller.set_replay_transaction_id(replay_step.as_ref().map(|r| r.transaction_id));
         Ok(Self {
             enabled: true,
             input_endpoints: Self::initial_input_endpoints(&controller),
             controller,
             replay_step,
+            replay_steps,
+            replay_cursor: 0,
+            replay_check: None,
             journal,
         })
     }
@@ -4158,6 +4305,9 @@ impl FtState {
             input_endpoints: Self::initial_input_endpoints(&controller),
             controller,
             replay_step: None,
+            replay_steps: Vec::new(),
+            replay_cursor: 0,
+            replay_check: None,
             journal,
         })
     }
@@ -4185,6 +4335,7 @@ impl FtState {
             step: 0,
             config,
             processed_records: 0,
+            transaction_number: 0,
             initial_start_time: controller.status.global_metrics.initial_start_time,
             input_metadata: CheckpointOffsets::default(),
             input_statistics: HashMap::new(),
@@ -4197,6 +4348,9 @@ impl FtState {
             input_endpoints: Self::initial_input_endpoints(&controller),
             controller,
             replay_step: None,
+            replay_steps: Vec::new(),
+            replay_cursor: 0,
+            replay_check: None,
             journal,
         })
     }
@@ -4268,6 +4422,7 @@ impl FtState {
         &mut self,
         step_metadata: HashMap<u64, (String, StepResults)>,
         step: Step,
+        transaction_id: TransactionId,
     ) -> Result<(), ControllerError> {
         if !self.enabled {
             return Ok(());
@@ -4313,6 +4468,7 @@ impl FtState {
                     .collect();
                 let step_metadata = StepMetadata {
                     step,
+                    transaction_id,
                     remove_inputs,
                     add_inputs,
                     changed_inputs,
@@ -4320,27 +4476,105 @@ impl FtState {
                 };
                 self.journal.write(&step_metadata)?;
             }
-            Some(record) => {
-                let mut logged = HashMap::new();
-                for (name, log) in &record.input_logs {
-                    logged.insert(name, log.checksums);
-                }
-
-                let mut replayed = HashMap::new();
-                for (name, results) in step_metadata.values() {
-                    replayed.insert(name, results.checksums().unwrap());
-                }
-
-                if replayed != logged {
-                    let error = format!(
-                        "Logged and replayed step {step} contained different numbers of records or hashes:\nLogged: {logged:?}\nReplayed: {replayed:?}"
-                    );
-                    error!("{error}");
-                    return Err(ControllerError::ReplayFailure { error });
-                }
+            Some(_) => {
+                // We're replaying, so there's nothing to record in the journal.
+                // Instead, accumulate this step's input checksums so we can
+                // verify that the transaction re-ingested the recorded input
+                // once it reaches its boundary. We check per transaction, not
+                // per step, because a transaction's commit can take a different
+                // number of physical steps on replay than during recording (see
+                // `ReplayChecksumAggregate`).
+                self.accumulate_replay_check(&step_metadata)?;
             }
         };
         Ok(())
+    }
+
+    /// Accumulates one replayed step's recorded and re-ingested input checksums
+    /// into the current transaction's [ReplayTransactionCheck]. When the step
+    /// begins a new transaction, the previous one is first verified (see
+    /// [Self::verify_replay_transaction]).
+    fn accumulate_replay_check(
+        &mut self,
+        step_metadata: &HashMap<u64, (String, StepResults)>,
+    ) -> Result<(), ControllerError> {
+        // Recorded checksums for this step, copied out so the borrow of
+        // `self.replay_step` ends before we touch `self.replay_check`.
+        let (transaction_id, recorded) = match &self.replay_step {
+            Some(record) => (
+                record.transaction_id,
+                record
+                    .input_logs
+                    .iter()
+                    .map(|(name, log)| (name.clone(), log.checksums))
+                    .collect::<Vec<_>>(),
+            ),
+            None => return Ok(()),
+        };
+
+        // A change of transaction id marks a boundary: the transaction we were
+        // accumulating is complete, so verify it before starting the next one.
+        if self
+            .replay_check
+            .as_ref()
+            .is_some_and(|check| check.transaction_id != transaction_id)
+        {
+            self.verify_replay_transaction()?;
+        }
+
+        let check = self
+            .replay_check
+            .get_or_insert_with(|| ReplayTransactionCheck::new(transaction_id));
+        for (name, checksums) in &recorded {
+            check
+                .recorded
+                .entry(name.clone())
+                .or_default()
+                .add(checksums);
+        }
+        for (name, results) in step_metadata.values() {
+            if let Some(checksums) = Self::replayed_checksums(results) {
+                check
+                    .replayed
+                    .entry(name.clone())
+                    .or_default()
+                    .add(&checksums);
+            }
+        }
+        Ok(())
+    }
+
+    /// Verifies that the transaction just replayed re-ingested the same input
+    /// that was recorded for it, comparing the per-endpoint aggregates
+    /// collected by [Self::accumulate_replay_check]. Returns
+    /// [ControllerError::ReplayFailure] on any divergence. A no-op when no
+    /// transaction is currently accumulated.
+    fn verify_replay_transaction(&mut self) -> Result<(), ControllerError> {
+        let Some(check) = self.replay_check.take() else {
+            return Ok(());
+        };
+        if check.replayed != check.recorded {
+            let error = format!(
+                "replayed transaction {} ingested different input than was recorded:\n\
+                 recorded: {:?}\nreplayed: {:?}",
+                check.transaction_id, check.recorded, check.replayed
+            );
+            error!("{error}");
+            return Err(ControllerError::ReplayFailure { error });
+        }
+        Ok(())
+    }
+
+    /// Extracts the input record count and hash from a replayed step's results,
+    /// or `None` if the results carry no replay checksums.
+    fn replayed_checksums(results: &StepResults) -> Option<InputChecksums> {
+        match &results.resume {
+            Some(Resume::Replay { hash, .. }) => Some(InputChecksums {
+                num_records: results.amt.records as u64,
+                hash: *hash,
+            }),
+            _ => None,
+        }
     }
 
     /// Waits for the step writer to commit the step (written by
@@ -4350,27 +4584,40 @@ impl FtState {
         Ok(())
     }
 
-    /// If we just replayed a step, try to replay the next one too.
-    fn next_step(&mut self, step: Step) -> Result<(), ControllerError> {
+    /// Advance to the next journaled step to replay, but only if the current
+    /// one was actually fed to the circuit this step (`consumed`). When the
+    /// current step was instead suppressed — e.g. to commit the open
+    /// transaction at a recorded boundary — we keep it so it is fed once the
+    /// commit completes.
+    fn next_step(&mut self, consumed: bool) -> Result<(), ControllerError> {
         if !self.enabled {
             return Ok(());
         }
 
-        if self.is_replaying() {
-            // Read a step.
-            self.replay_step = self.journal.read(step)?;
-            match &self.replay_step {
-                None => {
-                    // No more steps to replay.
-                    info!("replay complete, starting pipeline");
-                    self.replay_step = None;
-                    self.input_endpoints = Self::initial_input_endpoints(&self.controller);
+        if self.is_replaying() && consumed {
+            self.replay_cursor += 1;
+            // `.copied()` ends the borrow of `self.replay_steps` so the `None`
+            // arm can take `&mut self` to verify the final transaction.
+            match self.replay_steps.get(self.replay_cursor).copied() {
+                Some(step) => {
+                    let record = self.journal.read(step)?;
+                    if let Some(record) = &record {
+                        Self::replay_step(step, record, &self.controller)?;
+                    }
+                    self.replay_step = record;
                 }
-                Some(record) => {
-                    // There's a step to replay.
-                    Self::replay_step(step, record, &self.controller)?;
+                None => {
+                    // No more steps to replay. The boundary check in
+                    // `accumulate_replay_check` only fires when a later
+                    // transaction begins, so verify the last one here.
+                    self.verify_replay_transaction()?;
+                    info!("replay complete, starting pipeline");
+                    self.input_endpoints = Self::initial_input_endpoints(&self.controller);
+                    self.replay_step = None;
                 }
             };
+            self.controller
+                .set_replay_transaction_id(self.replay_step.as_ref().map(|r| r.transaction_id));
         }
         Ok(())
     }
@@ -4605,6 +4852,11 @@ pub struct ControllerInit {
     /// Initial counter for `total_processed_records`.
     processed_records: u64,
 
+    /// Initial value for the engine's per-transaction counter, restored from the
+    /// checkpoint so transaction ids (and thus fault-tolerant output dedup) are
+    /// reproduced across replay.
+    transaction_number: u64,
+
     /// Value for `initial_start_time`.
     initial_start_time: Option<DateTime<Utc>>,
 
@@ -4653,6 +4905,7 @@ impl ControllerInit {
             circuit_config: Self::circuit_config(layout, &config, storage)?,
             pipeline_config: config,
             processed_records: 0,
+            transaction_number: 0,
             initial_start_time: None,
             step: 0,
             input_metadata: None,
@@ -4713,6 +4966,7 @@ impl ControllerInit {
             step,
             config: checkpoint_config,
             processed_records,
+            transaction_number,
             initial_start_time,
             input_metadata,
             input_statistics,
@@ -4887,6 +5141,7 @@ impl ControllerInit {
             output_statistics,
             modified_output_endpoints,
             processed_records,
+            transaction_number,
             initial_start_time: Some(initial_start_time),
             pipeline_diff: Some(pipeline_diff),
             incarnation_uuid: Uuid::nil(),
@@ -5204,6 +5459,11 @@ struct BatchQueueEntry {
     /// The step in which the output was produced.
     step: Step,
 
+    /// The transaction whose output this batch carries. Fault-tolerant output
+    /// connectors key their exactly-once dedup on this (it is reproduced
+    /// deterministically across replay, unlike the physical step).
+    transaction: u64,
+
     /// Whether this batch contains a delta or a full snapshot.
     batch_type: OutputBatchType,
 
@@ -5366,6 +5626,10 @@ struct OutputBuffer {
     /// out.
     buffered_step: Step,
 
+    /// Transaction of the last update in the buffer, used to key fault-tolerant
+    /// output dedup when the buffer is flushed.
+    buffered_transaction: u64,
+
     /// Time when the first batch was pushed to the buffer.
     buffer_since: Instant,
 
@@ -5385,6 +5649,7 @@ impl OutputBuffer {
             endpoint_name: endpoint_name.to_string(),
             buffer: None,
             buffered_step: 0,
+            buffered_transaction: 0,
             buffer_since: Instant::now(),
             buffered_processed_records: ProcessedRecords::default(),
         }
@@ -5406,6 +5671,7 @@ impl OutputBuffer {
         &mut self,
         batch: Option<Arc<dyn SerBatchReader>>,
         step: Step,
+        transaction: u64,
         processed_records: Option<ProcessedRecords>,
     ) {
         if let Some(batch) = batch {
@@ -5431,6 +5697,7 @@ impl OutputBuffer {
             }
         }
         self.buffered_step = step;
+        self.buffered_transaction = transaction;
         if let Some(records) = processed_records {
             self.buffered_processed_records = records;
         }
@@ -5741,6 +6008,19 @@ pub struct TransactionInfo {
     /// Actual pipeline state, set by the circuit thread.
     transaction_state: TransactionState,
 
+    /// Journaled transaction id of the replay step the circuit thread is about
+    /// to feed during fault-tolerance replay, or `None` once the journal is
+    /// exhausted (or when not replaying). Set by the circuit thread before each
+    /// step; read by [ControllerInner::advance_transaction_state] to drive
+    /// transaction-aligned replay.
+    replay_transaction_id: Option<TransactionId>,
+
+    /// Journaled transaction id of the transaction currently open during
+    /// replay: set when it is started, cleared when it commits. Replay commits
+    /// the open transaction (and starts the next) when `replay_transaction_id`
+    /// differs from this — reproducing the recorded transaction boundaries.
+    replay_open_transaction_id: Option<TransactionId>,
+
     /// For sending updates to the coordination status to the coordinator.
     sender: tokio::sync::watch::Sender<TransactionCoordination>,
 }
@@ -5755,6 +6035,8 @@ impl TransactionInfo {
             last_transaction_id: 0,
             initiators: TransactionInitiators::default(),
             transaction_state: TransactionState::None,
+            replay_transaction_id: None,
+            replay_open_transaction_id: None,
             sender,
         }
     }
@@ -6041,6 +6323,7 @@ impl ControllerInner {
         lir: LirCircuit,
         error_cb: Box<dyn Fn(Arc<ControllerError>, Option<String>) + Send + Sync>,
         processed_records: u64,
+        transaction_number: u64,
         initial_start_time: Option<DateTime<Utc>>,
         resume_info: &HashMap<String, (JsonValue, CheckpointInputEndpointMetrics)>,
         output_statistics: &HashMap<String, CheckpointOutputEndpointMetrics>,
@@ -6092,7 +6375,7 @@ impl ControllerInner {
                     transaction_sender,
                 )),
                 restoring: AtomicBool::new(config.global.fault_tolerance.is_enabled()),
-                transaction_number: AtomicU64::new(0),
+                transaction_number: AtomicU64::new(transaction_number),
                 step_receiver,
                 checkpoint_receiver,
                 transaction_receiver,
@@ -6223,6 +6506,21 @@ impl ControllerInner {
 
     fn increment_transaction_number(&self) {
         self.transaction_number.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Sets the journaled transaction id of the replay step the circuit thread
+    /// is about to feed (`None` once the journal is exhausted). Drives
+    /// transaction-aligned replay in [Self::advance_transaction_state].
+    fn set_replay_transaction_id(&self, tid: Option<TransactionId>) {
+        self.transaction_info.lock().unwrap().replay_transaction_id = tid;
+    }
+
+    /// Journaled transaction id of the transaction currently open during replay.
+    fn replay_open_transaction_id(&self) -> Option<TransactionId> {
+        self.transaction_info
+            .lock()
+            .unwrap()
+            .replay_open_transaction_id
     }
 
     fn input_endpoint_id_by_name(
@@ -6975,6 +7273,7 @@ impl ControllerInner {
                 .map(|processed| processed.total_processed_steps)
                 .unwrap_or_default()
         });
+        let transaction = self.get_transaction_number();
         // Flip the "snapshot delivered" flag for this endpoint before
         // pushing so subsequent `push_output` calls take the regular delta
         // path.
@@ -6993,6 +7292,7 @@ impl ControllerInner {
             self.status.enqueue_batch(endpoint_id, 0);
             queue.push(BatchQueueEntry {
                 step,
+                transaction,
                 batch_type: OutputBatchType::Snapshot,
                 data: None,
                 processed_records,
@@ -7003,6 +7303,7 @@ impl ControllerInner {
             self.status.enqueue_batch(endpoint_id, merged.len());
             queue.push(BatchQueueEntry {
                 step,
+                transaction,
                 batch_type: OutputBatchType::Snapshot,
                 data: Some(merged),
                 processed_records,
@@ -7025,10 +7326,10 @@ impl ControllerInner {
         endpoint_id: EndpointId,
         endpoint_name: &str,
         encoder: &mut dyn Encoder,
-        step: Step,
+        transaction: u64,
         controller: &ControllerInner,
     ) {
-        encoder.consumer().batch_start(step, batch_type);
+        encoder.consumer().batch_start(transaction, batch_type);
         encoder.encode(batch).unwrap_or_else(|e| {
             controller.encode_error(endpoint_id, endpoint_name, e, Some("encoder_error"))
         });
@@ -7076,7 +7377,7 @@ impl ControllerInner {
                     endpoint_id,
                     &endpoint_name,
                     encoder.as_mut(),
-                    output_buffer.buffered_step,
+                    output_buffer.buffered_transaction,
                     &controller,
                 );
 
@@ -7086,6 +7387,7 @@ impl ControllerInner {
                 controller.circuit_thread_unparker.unpark()
             } else if let Some(BatchQueueEntry {
                 step,
+                transaction,
                 batch_type,
                 data,
                 processed_records,
@@ -7102,7 +7404,7 @@ impl ControllerInner {
                 // Buffer the new output if buffering is enabled.
                 if output_buffer_config.enable_output_buffer && batch_type == OutputBatchType::Delta
                 {
-                    output_buffer.insert(data, step, processed_records);
+                    output_buffer.insert(data, step, transaction, processed_records);
                     controller.status.buffer_batch(
                         endpoint_id,
                         num_records,
@@ -7118,14 +7420,20 @@ impl ControllerInner {
                         );
                     }
                 } else {
-                    if let Some(data) = data {
+                    // Skip empty batches: each transaction must open exactly one
+                    // output batch, because fault-tolerant output dedup keys on
+                    // the transaction and requires strictly increasing ids. Empty
+                    // in-progress steps of a transaction produce no output.
+                    if let Some(data) = data
+                        && num_records > 0
+                    {
                         Self::push_batch_to_encoder(
                             data,
                             batch_type,
                             endpoint_id,
                             &endpoint_name,
                             encoder.as_mut(),
-                            step,
+                            transaction,
                             &controller,
                         );
                     }
@@ -7636,7 +7944,77 @@ impl ControllerInner {
         let transaction_info = &mut *self.transaction_info.lock().unwrap();
 
         let is_multihost = transaction_info.is_multihost;
-        let result = if transaction_info.initiators.is_ongoing(is_multihost) {
+        // Gated on `!is_multihost`: in a multihost pipeline the coordinator
+        // centrally starts and commits transactions on every host via the API
+        // and requires all hosts to report the same transaction state each
+        // step, so a host must not open a transaction on its own. Fixing
+        // multihost FT replay the same way needs the coordinator to drive one
+        // replay transaction across all hosts -- a separate change (multihost +
+        // fault tolerance is currently untested).
+        let result = if self.restoring.load(Ordering::Acquire) && !is_multihost {
+            // Transaction-aligned fault-tolerance replay (single-host).
+            //
+            // We reproduce the *recorded* transaction boundaries:
+            // `replay_transaction_id` is the journaled transaction id of the
+            // step the circuit thread is about to feed (`None` once the journal
+            // is exhausted), and `replay_open_transaction_id` is the journaled
+            // id of the transaction currently open. We keep feeding the open
+            // transaction while the two match, and commit it (then start the
+            // next) when they differ or the journal ends.
+            //
+            // The journal cursor is iterated in recorded order, decoupled from
+            // the physical step counter (see `FtState` / `Journal::list_steps`),
+            // so a commit taking a different number of steps on replay than
+            // during recording cannot shift logged input onto the wrong step.
+            // Reproducing the boundaries also reproduces the per-transaction
+            // output structure that fault-tolerant output connectors (e.g. Kafka
+            // exactly-once) rely on for dedup.
+            let next = transaction_info.replay_transaction_id;
+            let open = transaction_info.replay_open_transaction_id;
+            match transaction_info.transaction_state {
+                TransactionState::None => {
+                    if let Some(tid) = next {
+                        // Start the next recorded transaction. There is no
+                        // API/connector initiator to take an engine transaction
+                        // id from, so allocate one like the auto-transaction
+                        // path does.
+                        transaction_info.replay_open_transaction_id = Some(tid);
+                        transaction_info.last_transaction_id += 1;
+                        let engine_tid = transaction_info.last_transaction_id;
+                        info!("Transaction {engine_tid}: replaying journaled transaction {tid}");
+                        transaction_info.transaction_state = TransactionState::Started {
+                            tid: engine_tid,
+                            start: Instant::now(),
+                            processed_records: self
+                                .status
+                                .global_metrics
+                                .num_total_processed_records(),
+                        };
+                        Some(AdvanceTransaction::Start)
+                    } else {
+                        // Journal exhausted and nothing open: replay is done.
+                        None
+                    }
+                }
+                TransactionState::Started {
+                    tid,
+                    start,
+                    processed_records,
+                } if next.is_none() || next != open => {
+                    // The next step belongs to a different transaction, or the
+                    // journal is exhausted: commit the open replay transaction.
+                    info!("Transaction {tid}: committing replayed transaction");
+                    transaction_info.transaction_state = TransactionState::Committing {
+                        tid,
+                        start: Instant::now(),
+                        processed_records,
+                    };
+                    Some(AdvanceTransaction::Commit)
+                }
+                // Same transaction: keep feeding it; or a commit is in progress.
+                TransactionState::Started { .. } | TransactionState::Committing { .. } => None,
+            }
+        } else if transaction_info.initiators.is_ongoing(is_multihost) {
             // The API and connectors want us to be in a transaction, so start a
             // new one if there's not one already.
             match transaction_info.transaction_state {
@@ -8199,6 +8577,7 @@ impl RunningCheckpoint {
             step: circuit.step,
             config,
             processed_records,
+            transaction_number: circuit.controller.get_transaction_number(),
             initial_start_time,
             input_metadata: CheckpointOffsets(input_metadata),
             input_statistics,

--- a/crates/adapters/src/controller/checkpoint.rs
+++ b/crates/adapters/src/controller/checkpoint.rs
@@ -44,6 +44,13 @@ pub struct Checkpoint {
     /// Number of records processed.
     pub processed_records: u64,
 
+    /// The engine's per-transaction counter at checkpoint time.
+    ///
+    /// Restored on startup so transaction ids are reproduced across replay
+    /// and continue monotonically afterward, rather than restarting at 0.
+    #[serde(default)]
+    pub transaction_number: u64,
+
     /// Time at which the ultimate ancestor pipeline process of this
     /// checkpoint started.
     #[serde(with = "chrono::serde::ts_seconds", default = "unix_epoch")]

--- a/crates/adapters/src/controller/journal.rs
+++ b/crates/adapters/src/controller/journal.rs
@@ -10,7 +10,7 @@ use dbsp::storage::{
     buffer_cache::FBuf,
 };
 use feldera_adapterlib::{errors::journal::StepError, transport::Step};
-use feldera_types::config::InputEndpointConfig;
+use feldera_types::{config::InputEndpointConfig, transaction::TransactionId};
 use rmpv::Value as RmpValue;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -111,6 +111,36 @@ impl Journal {
         }
     }
 
+    /// Returns the step numbers present in the journal that are `>= start`, in
+    /// increasing order.
+    ///
+    /// Replay iterates these in order (decoupled from the physical step
+    /// counter), so a transaction's commit taking a different number of steps
+    /// on replay than during recording cannot shift logged input onto the wrong
+    /// entry. Tolerates gaps in the step numbering (e.g. steps that were not
+    /// journaled because they only continued a transaction commit).
+    pub fn list_steps(&self, start: Step) -> Result<Vec<Step>, StepError> {
+        let mut steps = Vec::new();
+        self.backend
+            .list(&self.path, &mut |entry| {
+                let Some(file_name) = entry.name.filename() else {
+                    return;
+                };
+                let Some(number) = file_name.strip_suffix(".bin") else {
+                    return;
+                };
+                let Ok(step) = number.parse::<Step>() else {
+                    return;
+                };
+                if step >= start {
+                    steps.push(step);
+                }
+            })
+            .map_err(|error| self.storage_error(error))?;
+        steps.sort_unstable();
+        Ok(steps)
+    }
+
     fn storage_error(&self, error: StorageError) -> StepError {
         StepError::storage_error(&self.path, error)
     }
@@ -121,6 +151,17 @@ impl Journal {
 pub struct StepMetadata {
     /// Step number.
     pub step: Step,
+
+    /// Id of the transaction whose circuit evaluation consumed this step's
+    /// input.
+    ///
+    /// Replay groups journaled steps into transactions by this id and commits
+    /// at each boundary (where the id changes from one journaled step to the
+    /// next), reproducing the original transaction structure regardless of how
+    /// many physical steps each commit took during recording. Fault-tolerant
+    /// output connectors key their exactly-once dedup on this id, which (unlike
+    /// the physical step number) is deterministic across replay.
+    pub transaction_id: TransactionId,
 
     /// Names of input endpoints removed in the step.
     pub remove_inputs: HashSet<String>,
@@ -238,6 +279,7 @@ mod tests {
         let records = (0..10)
             .map(|step| StepMetadata {
                 step,
+                transaction_id: step as i64,
                 remove_inputs: HashSet::new(),
                 add_inputs: HashMap::new(),
                 changed_inputs: HashMap::new(),

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -1552,18 +1552,6 @@ impl TryFrom<StepResults> for InputLog {
     }
 }
 
-impl StepResults {
-    pub(super) fn checksums(&self) -> Option<InputChecksums> {
-        match self.resume {
-            Some(Resume::Replay { hash, .. }) => Some(InputChecksums {
-                hash,
-                num_records: self.amt.records as u64,
-            }),
-            _ => None,
-        }
-    }
-}
-
 const MAX_TOKENLIST_LEN: usize = 1_000_000;
 
 /// Tracks the set of tokens issued by the connector and the state needed to report

--- a/crates/adapters/src/transport/kafka/ft/output.rs
+++ b/crates/adapters/src/transport/kafka/ft/output.rs
@@ -2,10 +2,7 @@ use crate::transport::kafka::{
     MemoryUseReporter, build_headers, generate_oauthbearer_token, kafka_send,
     validate_aws_msk_region,
 };
-use crate::{
-    AsyncErrorCallback, OutputEndpoint,
-    transport::{Step, kafka::DeferredLogging},
-};
+use crate::{AsyncErrorCallback, OutputEndpoint, transport::kafka::DeferredLogging};
 use anyhow::{Context, Error as AnyError, Result as AnyResult, anyhow, bail};
 use feldera_adapterlib::transport::OutputBatchType;
 use feldera_types::transport::kafka::KafkaOutputConfig;
@@ -51,8 +48,8 @@ enum State {
     /// will write at position `.0`.
     BatchOpen(OutputPosition),
 
-    /// `batch_end` has been called for step `.0`.
-    BatchClosed(Step),
+    /// `batch_end` has been called for transaction `.0`.
+    BatchClosed(u64),
 }
 
 /// A position in the output partition.
@@ -60,10 +57,16 @@ enum State {
 /// This is stored as the Kafka message key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct OutputPosition {
-    /// The step number.
-    step: Step,
+    /// The transaction number.
+    ///
+    /// Exactly-once dedup keys on the transaction (not the physical step):
+    /// a transaction produces output once per output stream, and the
+    /// transaction number is reproduced deterministically across replay,
+    /// whereas the step at which a commit lands is not (streaming exchange
+    /// makes the commit-step count vary between the original run and replay).
+    transaction: u64,
 
-    /// An index within the step.  The first message output in a step has
+    /// An index within the transaction's output.  The first message has
     /// substep 0, the second has substep 1, and so on.
     ///
     /// We don't have an a priori need to store the substep number in the Kafka
@@ -90,7 +93,7 @@ pub struct KafkaOutputEndpoint {
     next_partition: usize,
     n_partitions: usize,
     max_message_size: usize,
-    next_step: Step,
+    next_transaction: u64,
     state: State,
 }
 
@@ -152,8 +155,8 @@ impl KafkaOutputEndpoint {
 
         // Read the number of partitions and the next step number.  We do this
         // after initializing transactions to avoid a race.
-        let (n_partitions, next_step) =
-            Self::read_next_step(&common.seekable_consumer_config, &config)?;
+        let (n_partitions, next_transaction) =
+            Self::read_next_transaction(&common.seekable_consumer_config, &config)?;
 
         Ok(Self {
             kafka_producer,
@@ -162,23 +165,23 @@ impl KafkaOutputEndpoint {
             n_partitions,
             next_partition: 0,
             max_message_size,
-            next_step,
+            next_transaction,
             state: State::New,
         })
     }
 
     /// Reads the tail of `topic` using `seekable_consumer_config`. Returns the
-    /// number of partitions in `topic` and the step number for the next step to
-    /// be written.
-    fn read_next_step(
+    /// number of partitions in `topic` and the transaction number for the next
+    /// transaction to be written.
+    fn read_next_transaction(
         seekable_consumer_config: &ClientConfig,
         kafka_config: &KafkaOutputConfig,
-    ) -> AnyResult<(usize, Step)> {
+    ) -> AnyResult<(usize, u64)> {
         let topic = &kafka_config.topic;
         let context = DataConsumerContext::new(|error| warn!("{error}"), kafka_config)?;
         let consumer = BaseConsumer::from_config_and_context(seekable_consumer_config, context)?;
         let n_partitions = count_partitions_in_topic(&consumer, topic)?;
-        let mut next_step = 0;
+        let mut next_transaction = 0;
         for partition in 0..n_partitions {
             let ctp = Ctp::new(&consumer, topic, partition as i32);
             let watermarks = ctp.fetch_watermarks(None)?;
@@ -186,11 +189,11 @@ impl KafkaOutputEndpoint {
                 if let Some(msg) = ctp.read_last_message(&watermarks)? {
                     let key = OutputPosition::from_message(&msg).with_context(|| {
                         format!(
-                            "message at offset {} in {ctp} should have step and substep as key",
+                            "message at offset {} in {ctp} should have transaction and substep as key",
                             msg.offset()
                         )
                     })?;
-                    next_step = max(next_step, key.step + 1);
+                    next_transaction = max(next_transaction, key.transaction + 1);
                 }
             } else if watermarks != (0..0) {
                 // The partition is empty, but it has nonzero watermarks:
@@ -210,7 +213,7 @@ impl KafkaOutputEndpoint {
                 );
             };
         }
-        Ok((n_partitions, next_step))
+        Ok((n_partitions, next_transaction))
     }
 }
 
@@ -235,19 +238,26 @@ impl OutputEndpoint for KafkaOutputEndpoint {
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
         let _guard = span(&self.topic);
-        let State::BatchOpen(OutputPosition { step, substep }) = self.state else {
+        let State::BatchOpen(OutputPosition {
+            transaction,
+            substep,
+        }) = self.state
+        else {
             unreachable!(
                 "state should be BatchOpen (not {:?}) in `push_buffer()`",
                 self.state
             )
         };
         self.state = State::BatchOpen(OutputPosition {
-            step,
+            transaction,
             substep: substep + 1,
         });
 
-        if step >= self.next_step {
-            let key = OutputPosition { step, substep };
+        if transaction >= self.next_transaction {
+            let key = OutputPosition {
+                transaction,
+                substep,
+            };
             let key = serde_json::to_string(&key).unwrap();
             let record = BaseRecord::to(&self.topic)
                 .key(&key)
@@ -281,45 +291,56 @@ impl OutputEndpoint for KafkaOutputEndpoint {
                 self.state
             )
         };
-        self.state = State::BatchClosed(position.step);
+        self.state = State::BatchClosed(position.transaction);
 
-        if position.step >= self.next_step {
+        if position.transaction >= self.next_transaction {
             self.kafka_producer.commit_transaction(None)?;
-            self.next_step = position.step + 1;
+            self.next_transaction = position.transaction + 1;
         }
         Ok(())
     }
 
-    fn batch_start(&mut self, step: Step, _batch_type: OutputBatchType) -> AnyResult<()> {
+    fn batch_start(&mut self, transaction: u64, _batch_type: OutputBatchType) -> AnyResult<()> {
         let _guard = span(&self.topic);
-        let first_step = match self.state {
+        // The caller invokes `batch_start` exactly once per transaction, with
+        // strictly increasing transaction numbers (the controller skips empty
+        // output batches, so an in-progress step that produced no output does
+        // not open a batch). That keeps each `(transaction, substep)` key
+        // unique.
+        let first_transaction = match self.state {
             State::New => unreachable!("connect() should be called first"),
             State::Connected => true,
-            State::BatchClosed(closed_step) => {
-                if step <= closed_step {
+            State::BatchClosed(closed_transaction) => {
+                if transaction <= closed_transaction {
                     unreachable!(
-                        "step numbers should increase, not go from {closed_step} to {step}"
+                        "transaction numbers should increase, not go from {closed_transaction} to {transaction}"
                     );
                 };
                 false
             }
             State::BatchOpen(_) => {
-                unreachable!("batch_end() should be called before next batch_start_step()")
+                unreachable!("batch_end() should be called before the next batch_start()")
             }
         };
 
-        if step >= self.next_step {
-            if step > self.next_step {
-                warn!("skipping from step {} to {step}", self.next_step);
+        if transaction >= self.next_transaction {
+            if transaction > self.next_transaction {
+                warn!(
+                    "skipping from transaction {} to {transaction}",
+                    self.next_transaction
+                );
             }
             self.kafka_producer.begin_transaction()?;
-        } else if first_step {
+        } else if first_transaction {
             info!(
-                "dropping steps {step}..{} that were already output in a previous run",
-                self.next_step
+                "dropping transactions {transaction}..{} that were already output in a previous run",
+                self.next_transaction
             );
         }
-        self.state = State::BatchOpen(OutputPosition { step, substep: 0 });
+        self.state = State::BatchOpen(OutputPosition {
+            transaction,
+            substep: 0,
+        });
         Ok(())
     }
 

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -12,7 +12,15 @@ import TabItem from '@theme/TabItem';
     <TabItem className="changelogItem" value="enterprise"
         label="Enterprise">
 
-        ## Unreleased
+	## Unreleased
+
+	- A bug fix introduced a backward incompatible change to the replay journal format.
+          This only affects pipelines configured with exactly-once fault tolerance. Such
+          pipelines should not be upgraded to the new Feldera runtime if they are in a failed
+          state with non-empty replay journal.  Upgrade is possible once the pipeline has been
+          cleanly stopped without a failure.
+
+        ## v0.313.0
 
         - New DynamoDB output connector. It writes a SQL view to an Amazon
           DynamoDB table, mapping inserts and updates to upserts and deletes to

--- a/python/tests/platform/test_fault_tolerance.py
+++ b/python/tests/platform/test_fault_tolerance.py
@@ -1,0 +1,151 @@
+"""Fault-tolerant restart-recovery tests (enterprise only).
+
+A fault-tolerant pipeline (`fault_tolerance: latest_checkpoint`) must replay its
+logged input *deterministically* across restarts: on resume the engine restores
+the latest checkpoint and replays the input log, and every replayed step must
+contain the same records (count + hash) as were originally logged.
+
+``test_ft_input_replay_determinism`` exercises this by repeatedly force-stopping
+(crashing) and restarting a single-host FT pipeline while a datagen connector is
+actively producing, so each restart replays a partially-logged step. On a buggy
+build the input is re-sharded across workers non-deterministically on replay; the
+engine detects
+
+    Logged and replayed step N contained different numbers of records or hashes
+
+and self-terminates the pipeline (``PipelineTerminated`` -> ``Stopped``), which
+this test reports as a recovery failure. The bug requires >= 2 workers (the input
+is sharded across workers); with a single worker replay is deterministic.
+
+Regression test for the intermittent ``fault_tolerance_tests`` CI failures.
+"""
+
+import json
+import os
+import time
+from http import HTTPStatus
+
+from tests import enterprise_only
+from .helper import (
+    api_url,
+    get,
+    post_json,
+    wait_for_program_success,
+    start_pipeline,
+    stop_pipeline,
+    wait_for_condition,
+    gen_pipeline_name,
+)
+
+# A large datagen limit keeps input flowing across many restart cycles, so each
+# force-stop interrupts an in-progress step whose input is in the log but not yet
+# checkpointed -- the precondition for exercising input replay.
+_DATAGEN_CONNECTOR = json.dumps(
+    [
+        {
+            "transport": {
+                "name": "datagen",
+                "config": {
+                    "seed": 12345,
+                    "plan": [
+                        {
+                            "limit": 200000,
+                            "rate": 500,
+                            "fields": {
+                                "id": {"strategy": "increment", "range": [0, 2000000]},
+                                "name": {"strategy": "word"},
+                                "grp": {"strategy": "uniform", "range": [0, 50]},
+                            },
+                        }
+                    ],
+                },
+            }
+        }
+    ]
+)
+
+_SQL = f"""
+CREATE TABLE example1 (
+    id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR NOT NULL,
+    grp INT NOT NULL
+) WITH (
+    'materialized' = 'true',
+    'connectors' = '{_DATAGEN_CONNECTOR}'
+);
+
+CREATE MATERIALIZED VIEW view1 AS (SELECT * FROM example1);
+"""
+
+# Number of crash -> resume cycles. The bug reproduces within the first few
+# cycles; the extra cycles give margin against its intermittency.
+_CYCLES = 15
+
+# The bug needs the input sharded across >= 2 workers (a single worker replays
+# deterministically). 2 workers is the most reliable trigger -- it reproduces
+# within a few cycles, whereas higher worker counts need more cycles -- so the
+# test pins 2 rather than using FELDERA_TEST_NUM_WORKERS.
+_WORKERS = 2
+
+
+def _create_ft_pipeline(name: str, workers: int):
+    """Create a single-host fault-tolerant pipeline (mirrors helper.create_pipeline
+    but with a fault-tolerant runtime config)."""
+    payload = {
+        "name": name,
+        "program_code": _SQL,
+        "runtime_config": {
+            "fault_tolerance": "latest_checkpoint",
+            "storage": True,
+            "workers": workers,
+            "logging": "debug",
+        },
+    }
+    runtime_version = os.environ.get("FELDERA_RUNTIME_VERSION")
+    if runtime_version:
+        payload["program_config"] = {"runtime_version": runtime_version}
+    r = post_json(api_url("/pipelines"), payload)
+    assert r.status_code == HTTPStatus.CREATED, r.text
+    wait_for_program_success(name, 1)
+
+
+def _deployment(name: str):
+    d = get(api_url(f"/pipelines/{name}")).json()
+    return d.get("deployment_status"), d.get("deployment_error")
+
+
+@enterprise_only
+@gen_pipeline_name
+def test_ft_input_replay_determinism(pipeline_name):
+    _create_ft_pipeline(pipeline_name, _WORKERS)
+    start_pipeline(pipeline_name)
+
+    for cycle in range(1, _CYCLES + 1):
+        wait_for_condition(
+            f"running before crash (cycle {cycle})",
+            lambda: _deployment(pipeline_name)[0] == "Running",
+            timeout_s=90.0,
+            poll_interval_s=0.5,
+        )
+        # Let datagen feed a partial, not-yet-checkpointed step into the log.
+        time.sleep(1.0)
+
+        stop_pipeline(pipeline_name, force=True)  # crash: no final checkpoint
+        start_pipeline(pipeline_name, wait=False)  # resume: restore + replay log
+
+        def recovered():
+            status, error = _deployment(pipeline_name)
+            assert not (status == "Stopped" and error), (
+                f"fault-tolerant recovery failed on cycle {cycle}: the pipeline "
+                f"self-terminated on resume -- most likely non-deterministic input "
+                f"replay ('Logged and replayed step N contained different numbers "
+                f"of records or hashes'). deployment_error={error}"
+            )
+            return status == "Running"
+
+        wait_for_condition(
+            f"recovered to Running after crash (cycle {cycle})",
+            recovered,
+            timeout_s=90.0,
+            poll_interval_s=0.5,
+        )

--- a/python/tests/platform/test_fault_tolerance.py
+++ b/python/tests/platform/test_fault_tolerance.py
@@ -2,22 +2,14 @@
 
 A fault-tolerant pipeline (`fault_tolerance: latest_checkpoint`) must replay its
 logged input *deterministically* across restarts: on resume the engine restores
-the latest checkpoint and replays the input log, and every replayed step must
+the latest checkpoint and replays the input log, and every replayed transaction must
 contain the same records (count + hash) as were originally logged.
 
 ``test_ft_input_replay_determinism`` exercises this by repeatedly force-stopping
 (crashing) and restarting a single-host FT pipeline while a datagen connector is
 actively producing, so each restart replays a partially-logged step. On a buggy
-build the input is re-sharded across workers non-deterministically on replay; the
-engine detects
-
-    Logged and replayed step N contained different numbers of records or hashes
-
-and self-terminates the pipeline (``PipelineTerminated`` -> ``Stopped``), which
-this test reports as a recovery failure. The bug requires >= 2 workers (the input
-is sharded across workers); with a single worker replay is deterministic.
-
-Regression test for the intermittent ``fault_tolerance_tests`` CI failures.
+build the pipeline crashes because validation code in controller.rs detects the
+mismatch in the recorded vs replay input digest.
 """
 
 import json


### PR DESCRIPTION
### Describe Manual Test Plan

With the introduction of transactions, the model of computation changed so that
the circuit now produces one output per transaction rather than per step. As a
result the existing journal replay mechanism that runs each input step in a
separate transaction is only correct assuming that the original inputs were
also ingested with a step per transaction. But even that is no longer true
after the introduction of streaming exchange, which can cause a transaction
processing the exact same input take more or fewer steps than the original run
of the program. This broke the validation mechanism that assumed that step
numbers during recording and replay should match precisely.

The solution that this commit implements has repa

- The journal records transaction boundaries in addition to individual steps.
- The replay mechanisms breaks up the sequence of replayed input steps into
  transactions and commits each transaction at exactly the recorded boundary.

This restores the invariant the the outputs of the circuit during replay are
identical to the outputs produced while processing the same inputs before the
failure.

As a side effect of this fix, we also save the last transaction number as part
of the checkpoint, so after restart the circuit will resume contigous
transaction count.

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [x] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

This PR introduces an incompatible change to the replay journal format; however it only affects existing pipelines in the following rare situatiions:

- The pipeline is configured with exactly-once FT
- The pipeline crashed with a non-empty journal and for some reason did not restart automatically
- The user upgraded the pipeline's runtime before restarting the failed pipeline.


@blp , we will likely merge this before you come back from vacation. This could still use your review when you're back