### PR TITLE
types: add PipelineIdentity struct to enable S3 bucket locking

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -36,7 +36,7 @@ use crate::server::{InitializationState, ServerState};
 use crate::transport::Step;
 use crate::transport::clock::now_endpoint_config;
 use crate::transport::{input_transport_config_to_endpoint, output_transport_config_to_endpoint};
-use crate::util::{LongOperationWarning, run_on_thread_pool};
+use crate::util::{LongOperationWarning, missing_pipeline_identity_message, run_on_thread_pool};
 use crate::{
     CircuitCatalog, Encoder, InputConsumer, OutputConsumer, OutputEndpoint, ParseError,
     PipelineError, PipelineState, TransportInputEndpoint,
@@ -172,7 +172,7 @@ pub use feldera_types::config::{
 };
 use feldera_types::config::{
     DEFAULT_MAX_WORKER_BATCH_SIZE, DevTweaks, FileBackendConfig, FtConfig, FtModel,
-    OutputBufferConfig, StorageBackendConfig, SyncConfig,
+    OutputBufferConfig, PipelineIdentity, StorageBackendConfig, SyncConfig,
 };
 use feldera_types::constants::{STATE_FILE, STEPS_FILE};
 use feldera_types::format::json::{JsonFlavor, JsonParserConfig, JsonUpdateFormat};
@@ -299,7 +299,12 @@ impl ControllerBuilder {
     pub(crate) fn pull_once(&self, _sync: &SyncConfig) -> Result<(), ControllerError> {
         #[cfg(feature = "feldera-enterprise")]
         if let Some(storage) = &self.storage {
-            return sync::pull_once(storage, _sync, None);
+            let pipeline = self.config.pipeline_identity().ok_or_else(|| {
+                ControllerError::checkpoint_fetch_error(missing_pipeline_identity_message(
+                    "cannot pull checkpoint from object store",
+                ))
+            })?;
+            return sync::pull_once(storage, _sync, None, &pipeline);
         };
 
         Ok(())
@@ -312,7 +317,12 @@ impl ControllerBuilder {
     {
         #[cfg(feature = "feldera-enterprise")]
         if let Some(storage) = &self.storage {
-            sync::continuous_pull(storage, _is_activated, None)
+            let pipeline = self.config.pipeline_identity().ok_or_else(|| {
+                ControllerError::checkpoint_fetch_error(missing_pipeline_identity_message(
+                    "cannot pull checkpoint from object store",
+                ))
+            })?;
+            sync::continuous_pull(storage, _is_activated, None, &pipeline)
         } else {
             Err(ControllerError::InvalidStandby(
                 "standby mode requires storage configuration",
@@ -2383,11 +2393,19 @@ struct CheckpointSyncThread {
     storage: Arc<dyn StorageBackend>,
     config: SyncConfig,
     host_info: Option<HostInfo>,
+    /// Identity of this pipeline, used to enforce S3 bucket ownership on push.
+    pipeline: PipelineIdentity,
 }
 
 impl CheckpointSyncThread {
     fn run(self) -> Result<(), Arc<ControllerError>> {
-        match SYNCHRONIZER.push(self.uuid, self.storage, self.config, self.host_info) {
+        match SYNCHRONIZER.push(
+            self.uuid,
+            self.storage,
+            self.config,
+            self.host_info,
+            self.pipeline,
+        ) {
             Err(err) => {
                 CHECKPOINT_SYNC_PUSH_FAILURES.fetch_add(1, Ordering::Relaxed);
                 Err(Arc::new(ControllerError::checkpoint_push_error(
@@ -2434,6 +2452,17 @@ impl RunningCheckpointSync {
     }
 
     fn start(circuit: &mut CircuitThread, uuid: uuid::Uuid) -> Result<Self, Arc<ControllerError>> {
+        let pipeline = circuit
+            .controller
+            .status
+            .pipeline_config
+            .pipeline_identity()
+            .ok_or_else(|| {
+                Arc::new(ControllerError::checkpoint_push_error(
+                    missing_pipeline_identity_message("cannot push checkpoints to object store"),
+                ))
+            })?;
+
         let Some((_, options)) = circuit.controller.status.pipeline_config.storage() else {
             return Err(Arc::new(ControllerError::storage_error(
                 "cannot sync checkpoints when storage is disabled",
@@ -2474,6 +2503,7 @@ impl RunningCheckpointSync {
             ))?,
             config: sync.to_owned(),
             host_info: circuit.controller.layout.host_info(),
+            pipeline,
         };
         let unparker = circuit.parker.unparker().clone();
         let join_handle = std::thread::Builder::new()

--- a/crates/adapters/src/controller/sync.rs
+++ b/crates/adapters/src/controller/sync.rs
@@ -19,7 +19,10 @@ use feldera_types::{
     config::{FileBackendConfig, StorageBackendConfig},
     constants::ACTIVATION_MARKER_FILE,
 };
-use feldera_types::{checkpoint::HostInfo, config::SyncConfig};
+use feldera_types::{
+    checkpoint::HostInfo,
+    config::{PipelineIdentity, SyncConfig},
+};
 
 // Pull metrics
 /// Bytes transferred when pulling a checkpoint.
@@ -82,9 +85,16 @@ fn pull_and_gc(
     prev: &mut uuid::Uuid,
     host_info: Option<HostInfo>,
     standby: bool,
+    pipeline: &PipelineIdentity,
 ) -> Result<CheckpointMetadata, ControllerError> {
     match SYNCHRONIZER
-        .pull(storage.clone(), sync.to_owned(), host_info, standby)
+        .pull(
+            storage.clone(),
+            sync.to_owned(),
+            host_info,
+            standby,
+            pipeline.clone(),
+        )
         .map_err(|e| ControllerError::checkpoint_fetch_error(format!("{e:?}")))
     {
         Err(err) => {
@@ -135,6 +145,7 @@ pub fn pull_once(
     storage: &CircuitStorageConfig,
     sync: &SyncConfig,
     host_info: Option<HostInfo>,
+    pipeline: &PipelineIdentity,
 ) -> Result<(), ControllerError> {
     pull_and_gc(
         storage.backend.clone(),
@@ -142,6 +153,7 @@ pub fn pull_once(
         &mut uuid::Uuid::nil(),
         host_info,
         false,
+        pipeline,
     )?;
 
     Ok(())
@@ -158,8 +170,16 @@ pub fn pull_once_with_backend(
     sync: &SyncConfig,
     host_info: Option<HostInfo>,
     standby: bool,
+    pipeline: &PipelineIdentity,
 ) -> Result<(), ControllerError> {
-    pull_and_gc(storage, sync, &mut uuid::Uuid::nil(), host_info, standby)?;
+    pull_and_gc(
+        storage,
+        sync,
+        &mut uuid::Uuid::nil(),
+        host_info,
+        standby,
+        pipeline,
+    )?;
     Ok(())
 }
 
@@ -169,6 +189,7 @@ pub fn pull_once_with_backend(
     _sync: &SyncConfig,
     _host_info: Option<HostInfo>,
     _standby: bool,
+    _pipeline: &PipelineIdentity,
 ) -> Result<(), ControllerError> {
     Err(ControllerError::EnterpriseFeature("checkpoint pull"))
 }
@@ -194,6 +215,7 @@ pub fn continuous_pull<F>(
     storage: &CircuitStorageConfig,
     is_activated: F,
     host_info: Option<HostInfo>,
+    pipeline: &PipelineIdentity,
 ) -> Result<(), ControllerError>
 where
     F: Fn() -> bool,
@@ -251,7 +273,14 @@ where
     // Also, if we receive an activation signal, we run one more iteration to
     // ensure that we have the latest checkpoint before activating.
     loop {
-        match pull_and_gc(storage.backend.clone(), sync, &mut prev, host_info, true) {
+        match pull_and_gc(
+            storage.backend.clone(),
+            sync,
+            &mut prev,
+            host_info,
+            true,
+            pipeline,
+        ) {
             Err(err) => {
                 // On our final attempt to pull the checkpoint after activation, if we fail, we should error out and not activate with a potentially stale or missing checkpoint.
                 if pull_once_again_after_activation {

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -9,7 +9,10 @@ use crate::server::metrics::{
 };
 use crate::static_compile::catalog::OUTPUT_MAPPING;
 use crate::transport::http::HttpOutputFormat;
-use crate::util::{LongOperationWarning, RateLimitCheckResult, TokenBucketRateLimiter};
+use crate::util::{
+    LongOperationWarning, RateLimitCheckResult, TokenBucketRateLimiter,
+    missing_pipeline_identity_message,
+};
 use crate::{Catalog, ControllerStatus, dyn_event};
 use crate::{
     CircuitCatalog, Controller, ControllerError, FormatConfig, InputEndpointConfig, OutputEndpoint,
@@ -62,7 +65,7 @@ use feldera_types::checkpoint::{
 use feldera_types::completion_token::{
     CompletionStatusArgs, CompletionStatusResponse, CompletionTokenResponse,
 };
-use feldera_types::config::SyncConfig;
+use feldera_types::config::{PipelineIdentity, SyncConfig};
 use feldera_types::constants::STATUS_FILE;
 use feldera_types::coordination::{
     AdHocScan, CoordinationActivate, CoordinationStatus, Labels, RestartArgs, Step, StepRequest,
@@ -287,6 +290,13 @@ pub(crate) struct ServerState {
     /// restarts.
     deployment_id: Uuid,
 
+    /// Identity of this pipeline (system name + given name).
+    ///
+    /// Used by the `/coordination/checkpoint/pull` endpoint to identify the
+    /// pipeline when checking S3 bucket ownership.  `None` when the pipeline has
+    /// no system-assigned name.
+    pipeline_identity: Option<PipelineIdentity>,
+
     /// Incarnation UUID.
     ///
     /// This is randomly generated each time the process starts.
@@ -341,6 +351,7 @@ impl ServerState {
         desired_status: RuntimeDesiredStatus,
         bootstrap_config: BootstrapConfig,
         deployment_id: Uuid,
+        pipeline_identity: Option<PipelineIdentity>,
         storage: Option<Arc<dyn StorageBackend>>,
         sync_config: Option<SyncConfig>,
         host_info: Option<HostInfo>,
@@ -357,6 +368,7 @@ impl ServerState {
             desired_status: Mutex::new(desired_status),
             bootstrap_config: Mutex::new(bootstrap_config),
             deployment_id,
+            pipeline_identity,
             storage,
             sync_config,
             host_info,
@@ -376,6 +388,7 @@ impl ServerState {
             RuntimeDesiredStatus::Paused,
             BootstrapConfig::default(),
             deployment_id,
+            None,
             None,
             None,
             None,
@@ -804,6 +817,7 @@ pub fn run_server(
             initial_status,
             bootstrap_config,
             args.deployment_id,
+            config.pipeline_identity(),
             builder.storage().clone(),
             builder.sync_config(),
             host_info,
@@ -2893,6 +2907,16 @@ async fn coordination_checkpoint_pull(
     let host_info = state.host_info;
     let standby = body.into_inner().standby;
 
+    let pipeline =
+        state
+            .pipeline_identity
+            .clone()
+            .ok_or_else(|| PipelineError::ControllerError {
+                error: Arc::new(ControllerError::checkpoint_fetch_error(
+                    missing_pipeline_identity_message("checkpoint pull requires pipeline identity"),
+                )),
+            })?;
+
     {
         let mut pull_state = state.pull_state.lock().unwrap();
         if matches!(*pull_state, CheckpointPullStatus::InProgress) {
@@ -2904,7 +2928,9 @@ async fn coordination_checkpoint_pull(
 
     spawn(async move {
         let result = spawn_blocking(move || {
-            crate::controller::sync::pull_once_with_backend(storage, &sync, host_info, standby)
+            crate::controller::sync::pull_once_with_backend(
+                storage, &sync, host_info, standby, &pipeline,
+            )
         })
         .await
         .unwrap();

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -3443,6 +3443,7 @@ mod test_http_helpers {
             None,
             None,
             None,
+            None,
         ));
         let state_clone = state.clone();
 

--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -177,7 +177,9 @@ pub(crate) fn truncate_ellipse<'a>(s: &'a str, len: usize, ellipse: &str) -> Cow
 }
 
 pub(crate) fn missing_pipeline_identity_message(operation: &str) -> String {
-    format!("{operation}: pipeline has no system-assigned name (config.name)")
+    format!(
+        "{operation}: pipeline has no system-assigned name (config.name), which is necessary to verify ownership"
+    )
 }
 
 /// For logging with a non-constant level.  From

--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -176,6 +176,10 @@ pub(crate) fn truncate_ellipse<'a>(s: &'a str, len: usize, ellipse: &str) -> Cow
     Cow::Owned(result)
 }
 
+pub(crate) fn missing_pipeline_identity_message(operation: &str) -> String {
+    format!("{operation}: pipeline has no system-assigned name (config.name)")
+}
+
 /// For logging with a non-constant level.  From
 /// <https://github.com/tokio-rs/tracing/issues/2730>
 #[macro_export]

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -66,6 +66,25 @@ pub struct ProgramIr {
     pub program_schema: serde_json::Value,
 }
 
+/// Identity of a pipeline, used to record and check ownership of an S3
+/// checkpoint bucket.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineIdentity {
+    /// System-generated name of the pipeline (format `pipeline-<uuid>`).
+    pub name: String,
+    /// Name given to the pipeline by the tenant.
+    pub given_name: Option<String>,
+}
+
+impl Display for PipelineIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.given_name {
+            Some(given_name) => write!(f, "{given_name} (id: {})", self.name),
+            None => write!(f, "{}", self.name),
+        }
+    }
+}
+
 /// Pipeline deployment configuration.
 /// It represents configuration entries directly provided by the user
 /// (e.g., runtime configuration) and entries derived from the schema
@@ -162,6 +181,17 @@ impl PipelineConfig {
         let storage_options = self.global.storage.as_ref();
         let storage_config = self.storage_config.as_ref();
         storage_config.zip(storage_options)
+    }
+
+    /// Returns this pipeline's [`PipelineIdentity`], used to identify the
+    /// pipeline that owns an S3 checkpoint bucket.
+    ///
+    /// Returns `None` when the pipeline has no system-generated [`name`](Self::name).
+    pub fn pipeline_identity(&self) -> Option<PipelineIdentity> {
+        self.name.as_ref().map(|name| PipelineIdentity {
+            name: name.clone(),
+            given_name: self.given_name.clone(),
+        })
     }
 
     /// Returns `self.secrets_dir`, or the default secrets directory if it isn't
@@ -1219,9 +1249,42 @@ impl Default for FtConfig {
 mod test {
     use super::deserialize_fault_tolerance;
     use crate::config::{
-        DEFAULT_DATAFUSION_MEMORY_MB_CEILING, FtConfig, FtModel, ResourceConfig, RuntimeConfig,
+        DEFAULT_DATAFUSION_MEMORY_MB_CEILING, FtConfig, FtModel, PipelineConfig, ResourceConfig,
+        RuntimeConfig,
     };
     use serde::{Deserialize, Serialize};
+
+    fn config_with_name(name: Option<&str>) -> PipelineConfig {
+        PipelineConfig {
+            global: RuntimeConfig::default(),
+            multihost: None,
+            name: name.map(str::to_string),
+            given_name: None,
+            storage_config: None,
+            secrets_dir: None,
+            inputs: Default::default(),
+            outputs: Default::default(),
+            program_ir: None,
+        }
+    }
+
+    #[test]
+    fn pipeline_identity_uses_system_and_given_names() {
+        let mut config = config_with_name(Some("pipeline-018f6f57-4e15-7438-91af-3fd21ff2a8d3"));
+        config.given_name = Some("my-pipeline".to_string());
+
+        let metadata = config.pipeline_identity().unwrap();
+        assert_eq!(
+            metadata.name,
+            "pipeline-018f6f57-4e15-7438-91af-3fd21ff2a8d3"
+        );
+        assert_eq!(metadata.given_name.as_deref(), Some("my-pipeline"));
+    }
+
+    #[test]
+    fn pipeline_identity_is_none_without_system_name() {
+        assert_eq!(config_with_name(None).pipeline_identity(), None);
+    }
 
     #[test]
     fn resolved_datafusion_memory_explicit_passes_through() {

--- a/crates/storage/src/checkpoint_synchronizer.rs
+++ b/crates/storage/src/checkpoint_synchronizer.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, LazyLock};
 
 use feldera_types::{
     checkpoint::{CheckpointMetadata, CheckpointSyncMetrics, HostInfo, RemoteCheckpoint},
-    config::SyncConfig,
+    config::{PipelineIdentity, SyncConfig},
 };
 
 use crate::StorageBackend;
@@ -14,12 +14,17 @@ pub trait CheckpointSynchronizer: Sync {
     /// When `Some`, the checkpoint zip and catalog are written under
     /// `host{N}/` in the remote bucket; when `None` (solo pipeline), the
     /// existing flat layout is used for backward compatibility.
+    ///
+    /// `pipeline` identifies the pipeline performing the push and is used to
+    /// enforce bucket ownership: the push fails before writing any data if the
+    /// bucket is already owned by a different pipeline.
     fn push(
         &self,
         checkpoint: uuid::Uuid,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
         host_info: Option<HostInfo>,
+        pipeline: PipelineIdentity,
     ) -> anyhow::Result<Option<CheckpointSyncMetrics>>;
 
     /// Pull a checkpoint from remote object storage.
@@ -30,12 +35,17 @@ pub trait CheckpointSynchronizer: Sync {
     /// `standby` indicates that the pipeline is in standby mode: the
     /// local-storage cache is bypassed (always pull from remote) and a missing
     /// remote checkpoint is treated as an error rather than a fresh start.
+    ///
+    /// `pipeline` identifies the pipeline performing the pull. It is used only
+    /// to warn (never fail) when pulling from a bucket owned by a different
+    /// pipeline.
     fn pull(
         &self,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
         host_info: Option<HostInfo>,
         standby: bool,
+        pipeline: PipelineIdentity,
     ) -> anyhow::Result<(CheckpointMetadata, Option<CheckpointSyncMetrics>)>;
 
     /// List checkpoints available in remote object storage.

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -43,6 +43,25 @@ This configuration restores from the latest checkpoint on startup (downloading
 from S3 if not available locally) and pushes new checkpoints to S3 every 120
 seconds.
 
+## Bucket ownership
+
+The configured `bucket` is a read/write checkpoint location owned by one
+pipeline. This location can be either an entire S3 bucket or a prefix inside a
+bucket, for example `mybucket/checkpoints/pipeline-a`. Do not configure two
+different pipelines with the same `bucket` location.
+
+On the first checkpoint sync to a location without an ownership file, Feldera
+writes an `owner.json` file at the root of the configured `bucket` location.
+The file records the system-generated pipeline name that owns the checkpoint
+location. Before every push, Feldera reads `owner.json` again and refuses
+to write checkpoint data if the file names a different pipeline.
+
+If the ownership file is changed manually, the current owner can lose write
+access to the location and future checkpoint syncs will fail until the
+configuration or ownership file is corrected. Pulling checkpoints is less
+strict: if a pipeline pulls from a location owned by another pipeline, Feldera
+logs a warning but does not fail the pull.
+
 ## Standby mode
 
 Pipelines can start in **standby** mode by passing `initial=standby` to the
@@ -85,6 +104,10 @@ primary fails. The following table illustrates a typical failover scenario:
 `read_bucket` lets you seed a new pipeline from a read-only checkpoint source
 without giving it write access to the source.
 
+This is the supported way to share checkpoint data between pipelines. Each
+pipeline still writes to its own `bucket`; `read_bucket` points at another
+pipeline's checkpoint location and is never modified by the reader.
+
 For example, suppose pipeline **A** pushes checkpoints to `bucket-a/pipeline-a`
 and you want a new pipeline **B** to start from **A**'s latest state without
 writing back to **A**'s bucket:
@@ -114,7 +137,7 @@ On its first start **B** pulls from `bucket-a/pipeline-a` (because
 | Field                   | Type            | Default     | Description                                                                                                                                                                                                                                                                                                                                                                         |
 | ----------------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `endpoint`              | `string`        |             | The S3-compatible object store endpoint (e.g., `http://localhost:9000` for MinIO).                                                                                                                                                                                                                                                                                                  |
-| `bucket` \*             | `string`        |             | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`).                                                                                                                                                                                                                                                                                            |
+| `bucket` \*             | `string`        |             | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`). This is the pipeline's read/write checkpoint location and must be unique to this pipeline. See [Bucket ownership](#bucket-ownership).                                                                                                                                                      |
 | `read_bucket`           | `string`        |             | A read-only fallback bucket used to seed the pipeline when `bucket` has no checkpoint. Uses the same connection settings as `bucket` (`provider`, `access_key`, `secret_key`, `endpoint`, `region`). The pipeline **never writes** to `read_bucket`. Must point to a different location than `bucket`. See [Seeding from an existing pipeline](#seeding-from-an-existing-pipeline). |
 | `region`                | `string`        | `us-east-1` | The region of the bucket. Leave empty for MinIO. If `provider` is AWS, and no region is specified, `us-east-1` is used.                                                                                                                                                                                                                                                             |
 | `provider` \*           | `string`        |             | The S3 provider identifier. Must match [rclone's list](https://rclone.org/s3/#providers). Case-sensitive. Use `"Other"` if unsure.                                                                                                                                                                                                                                                  |
@@ -196,6 +219,9 @@ Example policy:
 ```
 
 For more details, refer to [rclone S3 permissions](https://rclone.org/s3/#s3-permissions).
+
+These permissions also cover the `owner.json` ownership file stored at the
+root of the configured `bucket` location.
 
 ## IRSA
 
@@ -332,6 +358,7 @@ may reference the same files.
 
 ```
 storage-bucket/
+├── owner.json                    # Pipeline that owns this checkpoint location
 ├── w0-[UUID].feldera            # LSM tree reference file (shared across hosts)
 ├── w1-[UUID].feldera            # LSM tree reference file (shared across hosts)
 ├── dependencies/                # Per-checkpoint dependency manifests

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -359,9 +359,9 @@ may reference the same files.
 ```
 storage-bucket/
 ├── owner.json                    # Pipeline that owns this checkpoint location
-├── w0-[UUID].feldera            # LSM tree reference file (shared across hosts)
-├── w1-[UUID].feldera            # LSM tree reference file (shared across hosts)
-├── dependencies/                # Per-checkpoint dependency manifests
+├── w0-[UUID].feldera             # LSM tree reference file (shared across hosts)
+├── w1-[UUID].feldera             # LSM tree reference file (shared across hosts)
+├── dependencies/                 # Per-checkpoint dependency manifests
 │   ├── [UUID-host0-ckpt1].json
 │   ├── [UUID-host1-ckpt1].json
 │   └── ...

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -459,6 +459,65 @@ class TestCheckpointSync(SharedTestPipeline):
             self._restart_from_checkpoint("latest", auth_err=True, strict=False)
 
     @enterprise_only
+    def test_bucket_owner_lock_rejects_other_pipeline(self):
+        # Two different pipelines intentionally point at the same remote bucket.
+        # The first one claims ownership when it syncs a checkpoint; the second
+        # must fail before writing anything to that bucket.
+        ft = FaultToleranceModel.AtLeastOnce
+
+        owner = self.new_pipeline_with_suffix("owner")
+        intruder = self.new_pipeline_with_suffix("intruder")
+        shared_storage = Storage(config=storage_cfg(owner.name))
+
+        owner.set_runtime_config(
+            RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=ft,
+                storage=shared_storage,
+            )
+        )
+        owner.start()
+        owner.input_json("t0", [{"c0": i, "c1": f"owner_{i}"} for i in range(1, 6)])
+        owner.wait_for_completion()
+        owner.checkpoint(wait=True)
+        owner.sync_checkpoint(wait=True)
+
+        intruder.set_runtime_config(
+            RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=ft,
+                storage=shared_storage,
+            )
+        )
+        intruder.start()
+        intruder.input_json(
+            "t0", [{"c0": i, "c1": f"intruder_{i}"} for i in range(6, 11)]
+        )
+        intruder.wait_for_completion()
+        intruder.checkpoint(wait=True)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Refusing to write checkpoint data|owned by pipeline|Current pipeline is",
+        ):
+            intruder.sync_checkpoint(wait=True)
+
+        # The failed intruder write must not disturb the legitimate owner.
+        owner.input_json(
+            "t0", [{"c0": i, "c1": f"owner_again_{i}"} for i in range(11, 16)]
+        )
+        owner.wait_for_completion()
+        owner.checkpoint(wait=True)
+        owner.sync_checkpoint(wait=True)
+
+        intruder.stop(force=True)
+        owner.stop(force=True)
+        intruder.clear_storage()
+        owner.clear_storage()
+
+    @enterprise_only
     @single_host_only
     def test_nonexistent_checkpoint_fail(self):
         self._configure_and_start()

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -1,3 +1,4 @@
+import platform
 import random
 import sys
 import time
@@ -22,6 +23,13 @@ from tests.utils import (
 )
 
 from .helper import wait_for_condition
+
+
+_CHECKPOINT_SYNC_BUCKET_ARCH = platform.machine().lower()
+
+
+def checkpoint_sync_bucket(pipeline_name: str) -> str:
+    return f"{MINIO_BUCKET}/{_CHECKPOINT_SYNC_BUCKET_ARCH}/{pipeline_name}"
 
 
 def storage_cfg(
@@ -51,7 +59,7 @@ def storage_cfg(
     secret_key = required_env("CI_K8S_MINIO_SECRET_ACCESS_KEY")
 
     sync: dict = {
-        "bucket": f"{MINIO_BUCKET}/{pipeline_name}",
+        "bucket": checkpoint_sync_bucket(pipeline_name),
         "access_key": access_key,
         "secret_key": secret_key if not auth_err else secret_key + "extra",
         "provider": "Minio",
@@ -850,7 +858,7 @@ class TestCheckpointSync(SharedTestPipeline):
         uuid = source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: start the main pipeline with an empty bucket and read_bucket
         # pointing at the source.
@@ -938,7 +946,7 @@ class TestCheckpointSync(SharedTestPipeline):
         source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: push a checkpoint to the main pipeline's own bucket.
         storage_config = storage_cfg(self.pipeline.name)
@@ -1014,7 +1022,7 @@ class TestCheckpointSync(SharedTestPipeline):
         source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: start the main pipeline; it will push newer checkpoints to
         # its own bucket during the test.
@@ -1198,7 +1206,7 @@ class TestCheckpointSync(SharedTestPipeline):
         source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: main pipeline takes a LOCAL-ONLY checkpoint (never synced).
         # Its own S3 bucket stays empty, ensuring the only remote source of data
@@ -1283,7 +1291,7 @@ class TestCheckpointSync(SharedTestPipeline):
         source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: main pipeline takes a LOCAL-ONLY checkpoint (never synced).
         # Main bucket stays empty; source_bucket (read_bucket) has a checkpoint
@@ -1397,7 +1405,9 @@ class TestCheckpointSync(SharedTestPipeline):
         ft = FaultToleranceModel.AtLeastOnce
 
         # A bucket path with no checkpoints.
-        empty_read_bucket = f"{MINIO_BUCKET}/{self.pipeline.name}_read_bucket_empty"
+        empty_read_bucket = checkpoint_sync_bucket(
+            f"{self.pipeline.name}_read_bucket_empty"
+        )
 
         storage_config = storage_cfg(
             self.pipeline.name,
@@ -1441,7 +1451,7 @@ class TestCheckpointSync(SharedTestPipeline):
         source.sync_checkpoint(wait=True)
         source.stop(force=True)
 
-        source_bucket = f"{MINIO_BUCKET}/{source.name}"
+        source_bucket = checkpoint_sync_bucket(source.name)
 
         # Step 2: main pipeline creates and syncs its own checkpoint.
         storage_config = storage_cfg(self.pipeline.name)

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -1,11 +1,15 @@
+import json
+import logging
 import platform
 import random
 import sys
 import time
 import warnings
 from typing import Optional
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
+from feldera import Pipeline
 from feldera.enums import FaultToleranceModel, PipelineStatus
 from feldera.runtime_config import RuntimeConfig, Storage
 from feldera.testutils import (
@@ -25,11 +29,50 @@ from tests.utils import (
 from .helper import wait_for_condition
 
 
+LOGGER = logging.getLogger(__name__)
 _CHECKPOINT_SYNC_BUCKET_ARCH = platform.machine().lower()
 
 
 def checkpoint_sync_bucket(pipeline_name: str) -> str:
     return f"{MINIO_BUCKET}/{_CHECKPOINT_SYNC_BUCKET_ARCH}/{pipeline_name}"
+
+
+def checkpoint_sync_owner(bucket_name: str) -> Optional[dict]:
+    """Read the checkpoint-sync owner file from S3 if Python can access S3."""
+    try:
+        import pyarrow.fs as pafs
+
+        endpoint = MINIO_ENDPOINT.rstrip("/")
+        parsed = urlparse(endpoint)
+        s3 = pafs.S3FileSystem(  # type: ignore[attr-defined]
+            access_key=required_env("CI_K8S_MINIO_ACCESS_KEY_ID"),
+            secret_key=required_env("CI_K8S_MINIO_SECRET_ACCESS_KEY"),
+            endpoint_override=parsed.netloc,
+            scheme=parsed.scheme,
+            region=MINIO_REGION,
+        )
+        owner_path = f"{checkpoint_sync_bucket(bucket_name)}/owner.json"
+        info = s3.get_file_info(owner_path)
+    except Exception as e:
+        print(
+            f"S3 is not accessible from the Python SDK; skipping owner.json check: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+    if not info.is_file:
+        raise AssertionError(f"checkpoint ownership file not found: {owner_path}")
+
+    with s3.open_input_file(owner_path) as f:
+        owner = json.loads(f.read().decode("utf-8"))
+
+    LOGGER.debug(
+        "read checkpoint ownership file from S3: bucket=%s path=%s pipeline_name=%s",
+        checkpoint_sync_bucket(bucket_name),
+        owner_path,
+        owner.get("pipeline_name"),
+    )
+    return owner
 
 
 def storage_cfg(
@@ -508,7 +551,9 @@ class TestCheckpointSync(SharedTestPipeline):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "Refusing to write checkpoint data|owned by pipeline|Current pipeline is",
+            "S3 bucket is owned by pipeline 'pipeline-[^']+'[\\s\\S]*"
+            "Current pipeline is 'pipeline-[^']+'[\\s\\S]*"
+            "Refusing to write checkpoint data",
         ):
             intruder.sync_checkpoint(wait=True)
 
@@ -524,6 +569,57 @@ class TestCheckpointSync(SharedTestPipeline):
         owner.stop(force=True)
         intruder.clear_storage()
         owner.clear_storage()
+
+    @enterprise_only
+    def test_bucket_owner_lock_allows_renamed_pipeline(self):
+        # Renaming a pipeline changes the user-visible name, but keeps the
+        # system-generated pipeline name used for bucket ownership.
+        old_name = self.pipeline.name
+        pipeline_id = self.pipeline.id()
+        system_name = f"pipeline-{pipeline_id}"
+        bucket_name = f"{old_name}-{pipeline_id}"
+        self.pipeline.set_runtime_config(
+            RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=FaultToleranceModel.AtLeastOnce,
+                storage=Storage(
+                    config=storage_cfg(bucket_name, start_from_checkpoint="latest")
+                ),
+            )
+        )
+        self.pipeline.start()
+        _, got_before = self._insert_data_and_wait()
+        self.pipeline.checkpoint(wait=True)
+        self.pipeline.sync_checkpoint(wait=True)
+        owner_before = checkpoint_sync_owner(bucket_name)
+        if owner_before is not None:
+            self.assertEqual(owner_before["pipeline_name"], system_name)
+
+        self.pipeline.stop(force=True)
+        self.pipeline.clear_storage()
+        new_name = f"{old_name[:50]}-{uuid4().hex[:8]}"
+        self.client.http.patch(f"/pipelines/{old_name}", {"name": new_name})
+        self.p = Pipeline.get(new_name, self.client)
+
+        self.pipeline.start()
+        got_after = list(self.pipeline.query("SELECT * FROM v0"))
+        print(
+            f"{self.pipeline.name}: after rename: {len(got_after)}, {got_after}",
+            file=sys.stderr,
+        )
+        self.assertCountEqual(got_before, got_after)
+
+        self.pipeline.input_json("t0", [{"c0": 42, "c1": "after_rename"}])
+        self.pipeline.wait_for_completion()
+        self.pipeline.checkpoint(wait=True)
+        self.pipeline.sync_checkpoint(wait=True)
+        owner_after = checkpoint_sync_owner(bucket_name)
+        if owner_after is not None:
+            self.assertEqual(owner_after["pipeline_name"], system_name)
+
+        self.pipeline.stop(force=True)
+        self.pipeline.clear_storage()
 
     @enterprise_only
     @single_host_only

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -551,8 +551,8 @@ class TestCheckpointSync(SharedTestPipeline):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "S3 bucket is owned by pipeline 'pipeline-[^']+'[\\s\\S]*"
-            "Current pipeline is 'pipeline-[^']+'[\\s\\S]*"
+            "S3 checkpoint bucket is already owned by [\\s\\S]*id: pipeline-[^,)]+[\\s\\S]*"
+            "Current pipeline is [\\s\\S]*id: pipeline-[^,)]+[\\s\\S]*"
             "Refusing to write checkpoint data",
         ):
             intruder.sync_checkpoint(wait=True)


### PR DESCRIPTION
Adds a `PipelineIdentity` struct that carries both the pipeline's auto generated name, and its given name.

This is then passed to the trait `CheckpointSynchronizer` for S3 sync.

Adds a couple tests to ensure S3 bucket locking works correctly.

Not forward compatible, requires updating the ci machines.

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

