### PR TITLE
Support serving Feldera from a URL subpath

### DIFF
--- a/crates/pipeline-manager/build.rs
+++ b/crates/pipeline-manager/build.rs
@@ -83,6 +83,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // This should be safe because the build-script is single-threaded
         unsafe {
             env::set_var("BUILD_DIR", nested_build_dir.clone());
+            // Bake a sentinel base path into the bundle so the manager can
+            // rewrite it to an operator-configured subpath at serve time
+            // (`--http-base-path`). This MUST match
+            // `WEBCONSOLE_BASE_PATH_PLACEHOLDER` in `src/api/main.rs`. When
+            // pre-building the bundle out-of-band (see `WEBCONSOLE_BUILD_DIR`
+            // below), set the same `WEBCONSOLE_BASE_PATH` so the cached build
+            // carries the placeholder too.
+            env::set_var("WEBCONSOLE_BASE_PATH", "/__FELDERA_BASE_PATH__");
         }
         let asset_path: PathBuf =
             Path::new("../../js-packages/web-console/").join(nested_build_dir);

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -26,7 +26,9 @@ use actix_web_static_files::ResourceFiles;
 use anyhow::Result as AnyResult;
 use feldera_observability as observability;
 use futures_util::FutureExt;
+use std::collections::HashMap;
 use std::io::Write;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::{env, io, net::TcpListener, sync::Arc};
 use termbg::{theme, Theme};
@@ -499,6 +501,82 @@ pub struct ApiDoc;
 // `static_files` magic.
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
+/// Placeholder base path baked into the embedded web console bundle at build
+/// time (see `crates/pipeline-manager/build.rs`, which sets
+/// `WEBCONSOLE_BASE_PATH` to this value, and `js-packages/web-console`'s
+/// `svelte.config.js`, which reads it into `kit.paths.base`).
+///
+/// At serve time the manager rewrites every occurrence of this string in the
+/// bundle to the operator-configured base path (or the empty string for a root
+/// deployment), so a single prebuilt binary can be served from any subpath
+/// without a rebuild. The string is deliberately distinctive so the rewrite is
+/// an unambiguous substring replacement.
+const WEBCONSOLE_BASE_PATH_PLACEHOLDER: &str = "/__FELDERA_BASE_PATH__";
+
+/// Build the embedded web console resource map with the base-path placeholder
+/// rewritten to `base_path` (empty string for a root deployment).
+///
+/// The rewrite is computed once for the lifetime of the process — `base_path`
+/// is a process constant derived from configuration, and `HttpServer` invokes
+/// the app factory once per worker thread — so the rewritten bytes are leaked a
+/// single time and every worker rebuilds a fresh (but cheap, pointer-only)
+/// `HashMap` over the same `&'static` data.
+fn webconsole_resources(base_path: &str) -> HashMap<&'static str, static_files::Resource> {
+    static REWRITTEN: OnceLock<Vec<(&'static str, &'static [u8], u64, &'static str)>> =
+        OnceLock::new();
+
+    let entries = REWRITTEN.get_or_init(|| {
+        debug_assert!(
+            base_path.is_empty() || base_path.starts_with('/'),
+            "base path must be empty or start with '/'"
+        );
+        let mut rewrote_placeholder = false;
+        let entries = generate()
+            .into_iter()
+            .map(|(name, resource)| {
+                let data: &'static [u8] = match std::str::from_utf8(resource.data) {
+                    Ok(text) if text.contains(WEBCONSOLE_BASE_PATH_PLACEHOLDER) => {
+                        rewrote_placeholder = true;
+                        let rewritten = text.replace(WEBCONSOLE_BASE_PATH_PLACEHOLDER, base_path);
+                        Box::leak(rewritten.into_bytes().into_boxed_slice())
+                    }
+                    // Binary asset, or text without the placeholder: serve the
+                    // embedded bytes unchanged.
+                    _ => resource.data,
+                };
+                (name, data, resource.modified, resource.mime_type)
+            })
+            .collect::<Vec<_>>();
+
+        // A non-empty base path that the bundle can't carry is a
+        // misconfiguration the operator must see: the console will load its
+        // assets and call the API from the wrong paths and silently fail.
+        if !base_path.is_empty() && !rewrote_placeholder {
+            error!(
+                "--http-base-path is set to '{base_path}', but the embedded web console bundle \
+                 does not contain the expected base-path placeholder '{WEBCONSOLE_BASE_PATH_PLACEHOLDER}'. \
+                 The console was built without subpath support; the UI will not work under the subpath. \
+                 Rebuild the bundle with WEBCONSOLE_BASE_PATH={WEBCONSOLE_BASE_PATH_PLACEHOLDER}."
+            );
+        }
+        entries
+    });
+
+    entries
+        .iter()
+        .map(|&(name, data, modified, mime_type)| {
+            (
+                name,
+                static_files::Resource {
+                    data,
+                    modified,
+                    mime_type,
+                },
+            )
+        })
+        .collect()
+}
+
 /// Middleware to add aggressive caching headers for immutable static files
 /// (files with hashes in their names from web-console build)
 async fn add_cache_headers(
@@ -569,6 +647,10 @@ fn build_app(
     >,
 > {
     let cors = api_config.cors();
+    // URL prefix the API and console are served under (empty for a root
+    // deployment, e.g. `/feldera` behind a reverse proxy). Threaded into every
+    // scope below so a single binary serves any subpath.
+    let base_path = api_config.normalized_http_base_path();
     let app = App::new()
         .wrap_fn(|req, srv| {
             let log_level = if req.method() == Method::GET && req.path() == "/healthz" {
@@ -586,7 +668,7 @@ fn build_app(
         Some(auth_configuration) => {
             let auth_middleware = HttpAuthentication::with_fn(crate::auth::auth_validator);
             app.app_data(auth_configuration.clone()).service(
-                api_scope()
+                api_scope(&base_path)
                     .wrap(auth_middleware)
                     // Runs ahead of `auth_middleware` (last wrap = outermost):
                     // browsers can't set the `Authorization` header on a
@@ -599,7 +681,7 @@ fn build_app(
             )
         }
         None => app.service(
-            api_scope()
+            api_scope(&base_path)
                 .wrap_fn(|req, srv| {
                     let req = crate::auth::tag_with_default_tenant_id(req);
                     srv.call(req)
@@ -608,45 +690,53 @@ fn build_app(
         ),
     };
 
+    // Infrastructure endpoints stay at the root regardless of the base path so
+    // direct liveness probes (load balancers, k8s) and API exploration keep
+    // working when Feldera is mounted on a subpath behind a proxy that only
+    // forwards `<base-path>/*`.
+    let app = app
+        .service(healthz)
+        .service(SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-doc/openapi.json", ApiDoc::openapi()));
+
     // `public_scope` MUST be the last `.service()` registered: it contains an
     // empty-prefix sub-scope (the catch-all that serves the bundled
     // web-console static files) that would shadow any service registered
     // after it. The `public_scope_shadows_anything_registered_after_it` test
     // pins this contract.
-    app.service(public_scope(api_config))
+    app.service(public_scope(api_config, &base_path))
 }
 
-// Unauthenticated public endpoints and static UI assets. CORS is scoped to
-// `/config/*` only — it's the unauthenticated API surface that browser clients
-// may need to reach cross-origin. Every other route here is same-origin in practice
-// (swagger UI, healthz monitoring, static bundle), and keeping CORS off them
-// is what allows Firefox to honor `Cache-Control: immutable` on the bundle
-// (no `Vary: Origin`, no `Access-Control-Allow-Credentials`).
+// Unauthenticated public endpoints and static UI assets, served under the
+// configured base path (empty for a root deployment). CORS is scoped to
+// `<base>/config/*` only — it's the unauthenticated API surface that browser
+// clients may need to reach cross-origin. The static bundle is same-origin in
+// practice, and keeping CORS off it is what allows Firefox to honor
+// `Cache-Control: immutable` on the bundle (no `Vary: Origin`, no
+// `Access-Control-Allow-Credentials`).
 //
 // Must be registered LAST in the App: the inner empty-prefix scope acts as the
 // SPA fallback and would otherwise shadow other top-level scopes.
-fn public_scope(api_config: &ApiServerConfig) -> Scope {
-    let openapi = ApiDoc::openapi();
-
-    web::scope("")
+fn public_scope(api_config: &ApiServerConfig, base_path: &str) -> Scope {
+    web::scope(base_path)
         .service(
             web::scope("/config")
                 .wrap(api_config.cors())
                 .service(endpoints::config::get_config_authentication),
         )
-        .service(SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-doc/openapi.json", openapi))
-        .service(healthz)
         .service(
             web::scope("")
                 .wrap(middleware::from_fn(add_cache_headers))
-                .service(ResourceFiles::new("/", generate()).resolve_not_found_to_root()),
+                .service(
+                    ResourceFiles::new("/", webconsole_resources(base_path))
+                        .resolve_not_found_to_root(),
+                ),
         )
 }
 
 // The scope for all authenticated API endpoints
-fn api_scope() -> Scope {
-    // Make APIs available under the /v0/ prefix
-    web::scope("/v0")
+fn api_scope(base_path: &str) -> Scope {
+    // Make APIs available under the `<base-path>/v0/` prefix
+    web::scope(&format!("{base_path}/v0"))
         // Pipeline management endpoints
         .service(endpoints::pipeline_management::list_pipelines)
         .service(endpoints::pipeline_management::get_pipeline)
@@ -894,6 +984,10 @@ pub async fn run(
         common_config.api_port,
         common_config.http_workers,
     );
+    let base_path = api_config.normalized_http_base_path();
+    if !base_path.is_empty() {
+        info!("Serving the API and web console under base path '{base_path}'");
+    }
 
     let banner = if theme(Duration::from_millis(500)).unwrap_or(Theme::Light) == Theme::Dark {
         include_str!("../../light-banner.ascii")
@@ -1323,6 +1417,84 @@ mod tests {
             &body[..],
             b"LEAKED",
             "a route registered after build_app() was reached — public_scope's SPA catch-all must shadow it",
+        );
+    }
+
+    /// Base-path normalization is lenient: whitespace and trailing slashes are
+    /// trimmed and a leading slash is added when missing, so both `/feldera`
+    /// and `feldera/` resolve to the same prefix and `""`/`"/"` mean "root".
+    // `#[actix_web::test]` (not `#[test]`) because `use actix_web::test`
+    // shadows the built-in test attribute in this module; the body is pure.
+    #[actix_web::test]
+    async fn base_path_normalization() {
+        let normalized = |raw: &str| {
+            let mut cfg = ApiServerConfig::test_config();
+            cfg.http_base_path = raw.to_string();
+            cfg.normalized_http_base_path()
+        };
+        assert_eq!(normalized(""), "");
+        assert_eq!(normalized("/"), "");
+        assert_eq!(normalized("  "), "");
+        assert_eq!(normalized("/feldera"), "/feldera");
+        assert_eq!(normalized("/feldera/"), "/feldera");
+        assert_eq!(normalized("feldera"), "/feldera");
+        assert_eq!(normalized("  /feldera/  "), "/feldera");
+        assert_eq!(normalized("/a/b/"), "/a/b");
+    }
+
+    /// With a configured base path, the API and the `/config` bootstrap mount
+    /// under the prefix, the un-prefixed paths stop routing, and `/healthz`
+    /// stays at the root for infrastructure probes. Drives the production
+    /// `build_app`, so a regression in the scope wiring fails here.
+    #[actix_web::test]
+    async fn base_path_mounts_scopes_under_prefix() {
+        use actix_web::http::StatusCode;
+
+        let mut cfg = ApiServerConfig::test_config();
+        cfg.http_base_path = "/feldera".to_string();
+        let app = test::init_service(build_app(&cfg, &None)).await;
+
+        // The API moves under the prefix: a credentialed CORS preflight to
+        // `/feldera/v0/*` succeeds, exactly as `/v0/*` does at the root.
+        let req = test::TestRequest::default()
+            .method(Method::OPTIONS)
+            .uri("/feldera/v0/pipelines")
+            .insert_header((header::ORIGIN, "http://example.com"))
+            .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+            .to_request();
+        assert!(
+            test::call_service(&app, req).await.status().is_success(),
+            "/feldera/v0/* preflight failed — API not mounted under the base path",
+        );
+
+        // The `/config` auth bootstrap moves under the prefix too.
+        let req = test::TestRequest::default()
+            .method(Method::OPTIONS)
+            .uri("/feldera/config/authentication")
+            .insert_header((header::ORIGIN, "http://example.com"))
+            .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+            .to_request();
+        assert!(
+            test::call_service(&app, req).await.status().is_success(),
+            "/feldera/config/authentication preflight failed — config not mounted under the base path",
+        );
+
+        // The un-prefixed API path no longer routes to anything.
+        let req = test::TestRequest::get().uri("/v0/pipelines").to_request();
+        assert_eq!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::NOT_FOUND,
+            "/v0/* still routed despite a configured base path",
+        );
+
+        // Liveness stays at the root for direct infrastructure probes (a
+        // missing `ServerState` makes the handler error, but it must still be
+        // routed — i.e. not a 404).
+        let req = test::TestRequest::get().uri("/healthz").to_request();
+        assert_ne!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::NOT_FOUND,
+            "/healthz must remain at the root regardless of the base path",
         );
     }
 }

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -2,7 +2,7 @@ use crate::api::demo::{Demo, read_demos_from_directories};
 use crate::api::endpoints;
 use crate::api::support_data_collector::SupportDataCollector;
 use crate::auth::{IssuerJwkCache, JwkCache};
-use crate::config::{ApiServerConfig, CommonConfig};
+use crate::config::{ApiServerConfig, BasePath, CommonConfig};
 use crate::db::probe::DbProbe;
 use crate::db::storage_postgres::StoragePostgres;
 use crate::error::ManagerError;
@@ -26,7 +26,9 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 use actix_web_static_files::ResourceFiles;
 use anyhow::Result as AnyResult;
 use futures_util::FutureExt;
+use std::collections::HashMap;
 use std::io::Write;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::{env, io, net::TcpListener, sync::Arc};
 use termbg::{Theme, theme};
@@ -549,6 +551,96 @@ pub struct ApiDoc;
 // `static_files` magic.
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
+/// Placeholder base path baked into the embedded web console bundle at build
+/// time (see `crates/pipeline-manager/build.rs`, which sets
+/// `WEBCONSOLE_BASE_PATH` to this value, and `js-packages/web-console`'s
+/// `svelte.config.js`, which reads it into `kit.paths.base`).
+///
+/// At serve time the manager rewrites every occurrence of this string in the
+/// bundle to the operator-configured base path (or the empty string for a root
+/// deployment), so a single prebuilt binary can be served from any subpath
+/// without a rebuild. The string is deliberately distinctive so the rewrite is
+/// an unambiguous substring replacement.
+const WEBCONSOLE_BASE_PATH_PLACEHOLDER: &str = "/__FELDERA_BASE_PATH__";
+
+/// One file of the embedded console bundle after the base-path rewrite, holding
+/// what `static_files::Resource` needs to serve it. Kept as owned `&'static`
+/// data so every worker's resource map borrows the same bytes.
+struct RewrittenResource {
+    name: &'static str,
+    data: &'static [u8],
+    modified: u64,
+    mime_type: &'static str,
+}
+
+/// Build the embedded web console resource map with the base-path placeholder
+/// rewritten to `base_path` (empty string for a root deployment).
+///
+/// The rewrite is computed once for the lifetime of the process — `base_path`
+/// is a process constant derived from configuration, and `HttpServer` invokes
+/// the app factory once per worker thread — so the rewritten bytes are leaked a
+/// single time and every worker rebuilds a fresh (but cheap, pointer-only)
+/// `HashMap` over the same `&'static` data.
+fn webconsole_resources(base_path: &str) -> HashMap<&'static str, static_files::Resource> {
+    static REWRITTEN: OnceLock<Vec<RewrittenResource>> = OnceLock::new();
+
+    let entries = REWRITTEN.get_or_init(|| {
+        debug_assert!(
+            base_path.is_empty() || base_path.starts_with('/'),
+            "base path must be empty or start with '/'"
+        );
+        let mut rewrote_placeholder = false;
+        let entries = generate()
+            .into_iter()
+            .map(|(name, resource)| {
+                let data: &'static [u8] = match std::str::from_utf8(resource.data) {
+                    Ok(text) if text.contains(WEBCONSOLE_BASE_PATH_PLACEHOLDER) => {
+                        rewrote_placeholder = true;
+                        let rewritten = text.replace(WEBCONSOLE_BASE_PATH_PLACEHOLDER, base_path);
+                        Box::leak(rewritten.into_bytes().into_boxed_slice())
+                    }
+                    // Binary asset, or text without the placeholder: serve the
+                    // embedded bytes unchanged.
+                    _ => resource.data,
+                };
+                RewrittenResource {
+                    name,
+                    data,
+                    modified: resource.modified,
+                    mime_type: resource.mime_type,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // A non-empty base path that the bundle can't carry is a
+        // misconfiguration the operator must see: the console will load its
+        // assets and call the API from the wrong paths and silently fail.
+        if !base_path.is_empty() && !rewrote_placeholder {
+            error!(
+                "--http-base-path is set to '{base_path}', but the embedded web console bundle \
+                 does not contain the expected base-path placeholder '{WEBCONSOLE_BASE_PATH_PLACEHOLDER}'. \
+                 The console was built without subpath support; the UI will not work under the subpath. \
+                 Rebuild the bundle with WEBCONSOLE_BASE_PATH={WEBCONSOLE_BASE_PATH_PLACEHOLDER}."
+            );
+        }
+        entries
+    });
+
+    entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.name,
+                static_files::Resource {
+                    data: entry.data,
+                    modified: entry.modified,
+                    mime_type: entry.mime_type,
+                },
+            )
+        })
+        .collect()
+}
+
 /// Middleware to add aggressive caching headers for immutable static files
 /// (files with hashes in their names from web-console build)
 async fn add_cache_headers(
@@ -622,7 +714,17 @@ fn build_app(
     > + use<>,
 > {
     let cors = api_config.cors();
+    // URL prefix the API and console are served under (empty for a root
+    // deployment, e.g. `/feldera` behind a reverse proxy). Threaded into every
+    // scope below so a single binary serves any subpath.
+    let base_path = api_config.normalized_http_base_path();
     let app = App::new()
+        // Middleware inside the prefixed scopes matches root-relative paths
+        // (the RBAC route table, the session-endpoint exemption), so it needs
+        // the prefix to strip. App data rather than a captured argument
+        // because the consumers sit behind `HttpAuthentication`, which hands
+        // its validator nothing but the request.
+        .app_data(BasePath(base_path.clone()))
         .wrap_fn(|req, srv| {
             let log_level = if req.method() == Method::GET && req.path() == "/healthz" {
                 Level::TRACE
@@ -644,7 +746,7 @@ fn build_app(
             // first), then auth (installs the principal), then the RBAC check
             // (reads it), then the handler.
             app.app_data(auth_configuration.clone()).service(
-                api_scope()
+                api_scope(&base_path)
                     .wrap(middleware::from_fn(crate::api::rbac::rbac_middleware))
                     .wrap(auth_middleware)
                     .wrap(middleware::from_fn(
@@ -654,7 +756,7 @@ fn build_app(
             )
         }
         None => app.service(
-            api_scope()
+            api_scope(&base_path)
                 .wrap(middleware::from_fn(crate::api::rbac::rbac_middleware))
                 .wrap_fn(|req, srv| {
                     let req = crate::auth::tag_with_default_tenant_id(req);
@@ -664,43 +766,51 @@ fn build_app(
         ),
     };
 
+    // These stay at the root regardless of the base path: direct liveness probes
+    // (load balancers, k8s) must keep working when Feldera is mounted on a
+    // subpath behind a proxy that only forwards `<base-path>/*`, and crawlers
+    // fetch `/robots.txt` only from the origin root, never from a subpath.
+    let app = app.service(healthz).service(robots_txt);
+
     // `public_scope` MUST be the last `.service()` registered: it contains an
     // empty-prefix sub-scope (the catch-all that serves the bundled
     // web-console static files) that would shadow any service registered
     // after it. The `public_scope_shadows_anything_registered_after_it` test
     // pins this contract.
-    app.service(public_scope(api_config))
+    app.service(public_scope(api_config, &base_path))
 }
 
-// Unauthenticated public endpoints and static UI assets. CORS is scoped to
-// `/config/*` only — it's the unauthenticated API surface that browser clients
-// may need to reach cross-origin. Every other route here is same-origin in practice
-// (healthz monitoring, static bundle), and keeping CORS off them
-// is what allows Firefox to honor `Cache-Control: immutable` on the bundle
-// (no `Vary: Origin`, no `Access-Control-Allow-Credentials`).
+// Unauthenticated public endpoints and static UI assets, served under the
+// configured base path (empty for a root deployment). CORS is scoped to
+// `<base>/config/*` only — it's the unauthenticated API surface that browser
+// clients may need to reach cross-origin. The static bundle is same-origin in
+// practice, and keeping CORS off it is what allows Firefox to honor
+// `Cache-Control: immutable` on the bundle (no `Vary: Origin`, no
+// `Access-Control-Allow-Credentials`).
 //
 // Must be registered LAST in the App: the inner empty-prefix scope acts as the
 // SPA fallback and would otherwise shadow other top-level scopes.
-fn public_scope(api_config: &ApiServerConfig) -> Scope {
-    web::scope("")
+fn public_scope(api_config: &ApiServerConfig, base_path: &str) -> Scope {
+    web::scope(base_path)
         .service(
             web::scope("/config")
                 .wrap(api_config.cors())
                 .service(endpoints::config::get_config_authentication),
         )
-        .service(healthz)
-        .service(robots_txt)
         .service(
             web::scope("")
                 .wrap(middleware::from_fn(add_cache_headers))
-                .service(ResourceFiles::new("/", generate()).resolve_not_found_to_root()),
+                .service(
+                    ResourceFiles::new("/", webconsole_resources(base_path))
+                        .resolve_not_found_to_root(),
+                ),
         )
 }
 
 // The scope for all authenticated API endpoints
-fn api_scope() -> Scope {
-    // Make APIs available under the /v0/ prefix
-    web::scope("/v0")
+fn api_scope(base_path: &str) -> Scope {
+    // Make APIs available under the `<base-path>/v0/` prefix
+    web::scope(&format!("{base_path}/v0"))
         // Pipeline management endpoints
         .service(endpoints::pipeline_management::list_pipelines)
         .service(endpoints::pipeline_management::get_pipeline)
@@ -1030,6 +1140,10 @@ pub async fn run(
         common_config.api_port,
         common_config.http_workers,
     );
+    let base_path = api_config.normalized_http_base_path();
+    if !base_path.is_empty() {
+        info!("Serving the API and web console under base path '{base_path}'");
+    }
 
     let banner = if theme(Duration::from_millis(500)).unwrap_or(Theme::Light) == Theme::Dark {
         include_str!("../../light-banner.ascii")
@@ -1037,15 +1151,19 @@ pub async fn run(
         include_str!("../../dark-banner.ascii")
     };
     let addr = env::var("BANNER_ADDR").unwrap_or("127.0.0.1".to_string());
+    // The base path is part of the reachable URL: with `--http-base-path` set,
+    // the console lives at `<origin><base>/` and the API at `<origin><base>/v0`,
+    // so a bare origin printed here would send the reader to a 404.
     let url = format!(
-        "{}://{}:{}",
+        "{}://{}:{}{}",
         if common_config.enable_https {
             "https"
         } else {
             "http"
         },
         addr,
-        common_config.api_port
+        common_config.api_port,
+        base_path
     );
 
     // Lock both out streams so that the banner is printed in one go
@@ -1517,6 +1635,112 @@ mod tests {
             &body[..],
             b"LEAKED",
             "a route registered after build_app() was reached — public_scope's SPA catch-all must shadow it",
+        );
+    }
+
+    /// Base-path normalization is lenient: whitespace and trailing slashes are
+    /// trimmed and a leading slash is added when missing, so both `/feldera`
+    /// and `feldera/` resolve to the same prefix and `""`/`"/"` mean "root".
+    // `#[actix_web::test]` (not `#[test]`) because `use actix_web::test`
+    // shadows the built-in test attribute in this module; the body is pure.
+    #[actix_web::test]
+    async fn base_path_normalization() {
+        let normalized = |raw: &str| {
+            let mut cfg = ApiServerConfig::test_config();
+            cfg.http_base_path = raw.to_string();
+            cfg.normalized_http_base_path()
+        };
+        assert_eq!(normalized(""), "");
+        assert_eq!(normalized("/"), "");
+        assert_eq!(normalized("  "), "");
+        assert_eq!(normalized("/feldera"), "/feldera");
+        assert_eq!(normalized("/feldera/"), "/feldera");
+        assert_eq!(normalized("feldera"), "/feldera");
+        assert_eq!(normalized("  /feldera/  "), "/feldera");
+        assert_eq!(normalized("/a/b/"), "/a/b");
+    }
+
+    /// With a configured base path, the API and the `/config` bootstrap mount
+    /// under the prefix, the un-prefixed paths stop routing, and `/healthz`
+    /// stays at the root for infrastructure probes. Drives the production
+    /// `build_app`, so a regression in the scope wiring fails here.
+    #[actix_web::test]
+    async fn base_path_mounts_scopes_under_prefix() {
+        use actix_web::http::StatusCode;
+
+        let mut cfg = ApiServerConfig::test_config();
+        cfg.http_base_path = "/feldera".to_string();
+        let app = test::init_service(build_app(&cfg, &None)).await;
+
+        // The API moves under the prefix: a credentialed CORS preflight to
+        // `/feldera/v0/*` succeeds, exactly as `/v0/*` does at the root.
+        let req = test::TestRequest::default()
+            .method(Method::OPTIONS)
+            .uri("/feldera/v0/pipelines")
+            .insert_header((header::ORIGIN, "http://example.com"))
+            .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+            .to_request();
+        assert!(
+            test::call_service(&app, req).await.status().is_success(),
+            "/feldera/v0/* preflight failed — API not mounted under the base path",
+        );
+
+        // The `/config` auth bootstrap moves under the prefix too.
+        let req = test::TestRequest::default()
+            .method(Method::OPTIONS)
+            .uri("/feldera/config/authentication")
+            .insert_header((header::ORIGIN, "http://example.com"))
+            .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+            .to_request();
+        assert!(
+            test::call_service(&app, req).await.status().is_success(),
+            "/feldera/config/authentication preflight failed — config not mounted under the base path",
+        );
+
+        // The un-prefixed API path no longer routes to anything.
+        let req = test::TestRequest::get().uri("/v0/pipelines").to_request();
+        assert_eq!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::NOT_FOUND,
+            "/v0/* still routed despite a configured base path",
+        );
+
+        // Liveness stays at the root for direct infrastructure probes (a
+        // missing `ServerState` makes the handler error, but it must still be
+        // routed — i.e. not a 404).
+        let req = test::TestRequest::get().uri("/healthz").to_request();
+        assert_ne!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::NOT_FOUND,
+            "/healthz must remain at the root regardless of the base path",
+        );
+    }
+
+    /// A real API request under the base path must clear the RBAC guard. The
+    /// route table is authored root-relative (`/v0/pipelines`), so a guard that
+    /// classified the raw `/feldera/v0/pipelines` finds no entry and denies the
+    /// whole API — invisible to a preflight or a 404 probe, which is why this
+    /// drives a GET. Dropping the `BasePath` strip in `rbac_middleware` turns
+    /// this into a 403 and fails here.
+    #[actix_web::test]
+    async fn base_path_api_request_clears_rbac() {
+        use actix_web::http::StatusCode;
+
+        let mut cfg = ApiServerConfig::test_config();
+        cfg.http_base_path = "/feldera".to_string();
+        let app = test::init_service(build_app(&cfg, &None)).await;
+
+        // With no auth configured the request carries the default admin
+        // principal, which satisfies every route's role floor. `ServerState` is
+        // absent, so the handler itself fails — but with a server error, not the
+        // 403 an unclassified route returns.
+        let req = test::TestRequest::get()
+            .uri("/feldera/v0/pipelines")
+            .to_request();
+        assert_ne!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::FORBIDDEN,
+            "RBAC denied a base-path API request; the route table matches root-relative paths",
         );
     }
 }

--- a/crates/pipeline-manager/src/api/rbac.rs
+++ b/crates/pipeline-manager/src/api/rbac.rs
@@ -9,6 +9,7 @@
 //! cannot ship silently world-accessible.
 
 use crate::auth::AuthenticatedPrincipal;
+use crate::config::BasePath;
 use crate::db::error::DBError;
 use crate::db::types::role::Role;
 use actix_web::body::{BoxBody, MessageBody};
@@ -274,6 +275,11 @@ fn audit(method: &Method, pattern: &str, principal: Option<&AuthenticatedPrincip
 /// Refuse any `/v0` request whose principal is below the role its route
 /// requires, and record the ones that pass. Runs after `auth_validator` has
 /// installed the principal, so the role is already resolved here.
+///
+/// The route table is authored against root-relative patterns, so a deployment
+/// mounted on a subpath has its base path stripped off the request path first:
+/// `/feldera/v0/pipelines` classifies as `/v0/pipelines`. Left on, the prefix
+/// makes every path miss the table and denies the entire API.
 pub(crate) async fn rbac_middleware(
     req: ServiceRequest,
     next: Next<impl MessageBody + 'static>,
@@ -281,7 +287,7 @@ pub(crate) async fn rbac_middleware(
     let principal = req.extensions().get::<AuthenticatedPrincipal>().cloned();
     let method = req.method().clone();
     let routed = req.match_pattern().is_some();
-    let path = req.path().to_string();
+    let path = BasePath::root_relative(&req).to_string();
 
     match authorize(method.as_str(), routed, &path, principal.as_ref()) {
         Ok(pattern) => {

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -75,7 +75,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::api::main::ServerState;
-use crate::config::ApiServerConfig;
+use crate::config::{ApiServerConfig, BasePath};
 use crate::db::error::DBError;
 use crate::db::storage::Storage;
 use crate::db::storage_postgres::StoragePostgres;
@@ -141,8 +141,16 @@ pub(crate) struct LoginIdentity {
 pub(crate) struct UnresolvedActingTenant;
 
 /// Whether this request may be answered without a resolved acting tenant.
+///
+/// The path is compared root-relative, so the exemption holds for a deployment
+/// mounted on a subpath: `/feldera/v0/config/session` matches. Comparing the
+/// raw path would strand such a login, since the picker's own endpoint would be
+/// the one request it could not make.
 fn is_session_request(req: &ServiceRequest) -> bool {
-    req.method() == actix_web::http::Method::GET && req.path() == "/v0/config/session"
+    if req.method() != actix_web::http::Method::GET {
+        return false;
+    }
+    BasePath::root_relative(req) == "/v0/config/session"
 }
 
 /// Returns true if the given OIDC identity is configured as a platform owner.
@@ -1798,7 +1806,7 @@ mod test {
     use crate::{
         api::main::ServerState,
         auth::{self, AuthConfiguration, AuthProvider, OidcClaim},
-        config::ApiServerConfig,
+        config::{ApiServerConfig, BasePath},
         db::storage::Storage,
         ensure_default_crypto_provider,
     };
@@ -1806,6 +1814,39 @@ mod test {
     use rsa::pkcs1::{EncodeRsaPrivateKey, LineEnding};
     use rsa::pkcs8::EncodePublicKey;
     use rsa::{RsaPrivateKey, RsaPublicKey};
+
+    /// The session endpoint is the one route a login with no resolvable acting
+    /// tenant may reach, so the console can drive its tenant picker. The
+    /// exemption compares the path root-relative and therefore survives a
+    /// subpath deployment; comparing `req.path()` raw would strand such a login
+    /// at the very endpoint meant to unstick it. Removing the `BasePath` strip
+    /// in `is_session_request` flips the `/feldera` case to false.
+    // `#[actix_web::test]` (not `#[test]`) because `use actix_web::test`
+    // shadows the built-in test attribute in this module; the body is pure.
+    #[actix_web::test]
+    async fn session_request_is_recognized_under_a_base_path() {
+        let session_request = |base_path: &str, uri: &str| {
+            auth::is_session_request(
+                &test::TestRequest::get()
+                    .uri(uri)
+                    .app_data(BasePath(base_path.to_string()))
+                    .to_srv_request(),
+            )
+        };
+
+        assert!(session_request("", "/v0/config/session"));
+        assert!(session_request("/feldera", "/feldera/v0/config/session"));
+        // No other endpoint is exempt, prefixed or not, and neither is a write
+        // to the session path.
+        assert!(!session_request("", "/v0/pipelines"));
+        assert!(!session_request("/feldera", "/feldera/v0/pipelines"));
+        assert!(!auth::is_session_request(
+            &test::TestRequest::post()
+                .uri("/feldera/v0/config/session")
+                .app_data(BasePath("/feldera".to_string()))
+                .to_srv_request()
+        ));
+    }
 
     async fn setup(claim: OidcClaim) -> (String, DecodingKey) {
         let rsa = RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
@@ -1859,6 +1900,7 @@ mod test {
             default_role: Role::Read,
             first_user_role: Role::Admin,
             provision_on_login: true,
+            http_base_path: String::new(),
         }
     }
 

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -1081,6 +1081,7 @@ mod test {
             individual_tenant: true,
             issuer_tenant: false,
             auth_audience: "feldera-api".to_string(),
+            http_base_path: String::new(),
         };
 
         let (conn, _temp) = crate::db::test::setup_pg().await;

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -5,6 +5,7 @@ use crate::db::types::version::Version;
 use crate::db::{error::DBError, types::pipeline::PipelineId};
 use crate::has_unstable_feature;
 use crate::oidc::destination::TenantIssuerPolicy;
+use actix_web::dev::ServiceRequest;
 use actix_web::http::header;
 use anyhow::{Context, Error as AnyError, Result as AnyResult};
 use clap::Parser;
@@ -1172,6 +1173,23 @@ pub struct ApiServerConfig {
     #[serde(default = "default_provision_on_login")]
     #[arg(long, action = clap::ArgAction::Set, default_value_t = true, env = "FELDERA_AUTH_PROVISION_ON_LOGIN")]
     pub provision_on_login: bool,
+
+    /// URL path prefix that Feldera is served under.
+    ///
+    /// Set this when Feldera sits behind a reverse proxy that mounts it on a
+    /// subpath rather than at the origin root — for example, serving
+    /// `https://example.com/feldera/` instead of `https://example.com/`.
+    ///
+    /// The value must start with a `/` and must not end with one (e.g.
+    /// `/feldera`). Leave it empty (the default) to serve from the root path.
+    ///
+    /// When set, the HTTP API is mounted under `<base-path>/v0`, the web
+    /// console under `<base-path>/`, and the manager rewrites the embedded
+    /// console bundle at startup so its client-side router, links, and API
+    /// calls all use the prefix. No rebuild is required.
+    #[serde(default)]
+    #[arg(long, default_value = "", env = "FELDERA_HTTP_BASE_PATH")]
+    pub http_base_path: String,
 }
 
 /// A trust relationship granting the platform-wide `owner` role, declared at
@@ -1304,6 +1322,24 @@ impl ApiServerConfig {
         }
     }
 
+    /// The configured base path, normalized to either an empty string (a root
+    /// deployment) or a `/`-prefixed prefix without a trailing slash.
+    ///
+    /// Normalization is lenient: leading/trailing whitespace and trailing
+    /// slashes are trimmed, and a missing leading slash is added. Examples:
+    /// `""` → `""`, `"/"` → `""`, `"feldera"` → `"/feldera"`,
+    /// `"/feldera/"` → `"/feldera"`.
+    pub(crate) fn normalized_http_base_path(&self) -> String {
+        let trimmed = self.http_base_path.trim().trim_end_matches('/');
+        if trimmed.is_empty() {
+            String::new()
+        } else if trimmed.starts_with('/') {
+            trimmed.to_string()
+        } else {
+            format!("/{trimmed}")
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn test_config() -> Self {
         Self {
@@ -1327,6 +1363,50 @@ impl ApiServerConfig {
             default_role: Role::Read,
             first_user_role: Role::Admin,
             provision_on_login: true,
+            http_base_path: String::new(),
+        }
+    }
+}
+
+/// The URL prefix the API and web console are mounted under, registered as
+/// app data so middleware can recover a root-relative path from a request.
+///
+/// Actix reports the full URL path, so a manager served from `/feldera` sees
+/// `/feldera/v0/pipelines`, while every path-matching rule in the manager —
+/// the RBAC route table, the session-endpoint exemption — is authored against
+/// root-relative patterns like `/v0/pipelines`. Middleware calls
+/// [`BasePath::root_relative`] before matching.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BasePath(pub String);
+
+impl BasePath {
+    /// `req`'s path as the manager's route tables spell it: root-relative, with
+    /// the deployment's base path removed.
+    ///
+    /// The prefix comes from app data, which `build_app` registers on the App.
+    /// A request that carries none is already root-relative.
+    pub(crate) fn root_relative(req: &ServiceRequest) -> &str {
+        match req.app_data::<BasePath>() {
+            Some(base_path) => base_path.strip(req.path()),
+            None => req.path(),
+        }
+    }
+
+    /// `path` with the base prefix removed.
+    ///
+    /// Callers see only paths actix already routed into a prefixed scope, so
+    /// the prefix is always present; a path without it comes back unchanged
+    /// rather than truncated into something else.
+    fn strip<'a>(&self, path: &'a str) -> &'a str {
+        if self.0.is_empty() {
+            return path;
+        }
+        match path.strip_prefix(self.0.as_str()) {
+            // The prefix has to end on a segment boundary, as actix's own scope
+            // matching requires: `/felderax` is a different mount point, not
+            // `/feldera` with a suffix.
+            Some(rest) if rest.is_empty() || rest.starts_with('/') => rest,
+            _ => path,
         }
     }
 }
@@ -1527,6 +1607,41 @@ impl LocalRunnerConfig {
 mod tests {
     use super::*;
     use std::path::Path;
+
+    /// `root_relative` reads the prefix from app data. `build_app` always
+    /// registers it, so the fallback covers only a request built without it —
+    /// which is root-relative already.
+    #[test]
+    fn root_relative_path_falls_back_to_the_raw_path() {
+        let req = actix_web::test::TestRequest::get()
+            .uri("/v0/pipelines")
+            .to_srv_request();
+        assert_eq!(BasePath::root_relative(&req), "/v0/pipelines");
+
+        let req = actix_web::test::TestRequest::get()
+            .uri("/feldera/v0/pipelines")
+            .app_data(BasePath("/feldera".to_string()))
+            .to_srv_request();
+        assert_eq!(BasePath::root_relative(&req), "/v0/pipelines");
+    }
+
+    /// `strip` recovers the root-relative path the route tables are written
+    /// against. A root deployment is a pass-through, and a path that never
+    /// carried the prefix is left alone rather than mangled.
+    #[test]
+    fn base_path_strips_the_prefix() {
+        assert_eq!(
+            BasePath(String::new()).strip("/v0/pipelines"),
+            "/v0/pipelines"
+        );
+        let base = BasePath("/feldera".to_string());
+        assert_eq!(base.strip("/feldera/v0/pipelines"), "/v0/pipelines");
+        assert_eq!(base.strip("/feldera"), "");
+        assert_eq!(base.strip("/v0/pipelines"), "/v0/pipelines");
+        // The prefix must end on a segment boundary: `/felderax` is a different
+        // mount point, so its paths are none of this base path's business.
+        assert_eq!(base.strip("/felderax/v0"), "/felderax/v0");
+    }
 
     #[test]
     fn owner_trusts_parse_from_json() {

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -900,6 +900,23 @@ pub struct ApiServerConfig {
     #[serde(default = "default_auth_audience")]
     #[arg(long, default_value = "feldera-api", env = "FELDERA_AUTH_AUDIENCE")]
     pub auth_audience: String,
+
+    /// URL path prefix that Feldera is served under.
+    ///
+    /// Set this when Feldera sits behind a reverse proxy that mounts it on a
+    /// subpath rather than at the origin root — for example, serving
+    /// `https://example.com/feldera/` instead of `https://example.com/`.
+    ///
+    /// The value must start with a `/` and must not end with one (e.g.
+    /// `/feldera`). Leave it empty (the default) to serve from the root path.
+    ///
+    /// When set, the HTTP API is mounted under `<base-path>/v0`, the web
+    /// console under `<base-path>/`, and the manager rewrites the embedded
+    /// console bundle at startup so its client-side router, links, and API
+    /// calls all use the prefix. No rebuild is required.
+    #[serde(default)]
+    #[arg(long, default_value = "", env = "FELDERA_HTTP_BASE_PATH")]
+    pub http_base_path: String,
 }
 
 impl ApiServerConfig {
@@ -929,6 +946,24 @@ impl ApiServerConfig {
         }
     }
 
+    /// The configured base path, normalized to either an empty string (a root
+    /// deployment) or a `/`-prefixed prefix without a trailing slash.
+    ///
+    /// Normalization is lenient: leading/trailing whitespace and trailing
+    /// slashes are trimmed, and a missing leading slash is added. Examples:
+    /// `""` → `""`, `"/"` → `""`, `"feldera"` → `"/feldera"`,
+    /// `"/feldera/"` → `"/feldera"`.
+    pub(crate) fn normalized_http_base_path(&self) -> String {
+        let trimmed = self.http_base_path.trim().trim_end_matches('/');
+        if trimmed.is_empty() {
+            String::new()
+        } else if trimmed.starts_with('/') {
+            trimmed.to_string()
+        } else {
+            format!("/{trimmed}")
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn test_config() -> Self {
         Self {
@@ -944,6 +979,7 @@ impl ApiServerConfig {
             individual_tenant: true,
             authorized_groups: vec![],
             auth_audience: "feldera-api".to_string(),
+            http_base_path: String::new(),
         }
     }
 }

--- a/js-packages/web-console/src/lib/components/auth/CurrentTenant.svelte
+++ b/js-packages/web-console/src/lib/components/auth/CurrentTenant.svelte
@@ -3,6 +3,7 @@
   import { goto, invalidate } from '$app/navigation'
   import { page } from '$app/state'
   import { felderaEndpoint } from '$lib/functions/configs/felderaEndpoint'
+  import { resolve } from '$lib/functions/svelte'
   import { getSelectedTenant, setSelectedTenant } from '$lib/services/auth'
 
   let { class: className = '' }: { class?: string } = $props()
@@ -23,10 +24,10 @@
     {:else}
       <Select
         onchange={async () => {
-          if (page.url.pathname === '/') {
+          if (page.url.pathname === resolve('/')) {
             invalidate(`${felderaEndpoint}/v0/pipelines?selector=status_with_connectors`)
           } else {
-            goto('/')
+            goto(resolve('/'))
           }
         }}
         bind:value={getSelectedTenant, setSelectedTenant}

--- a/js-packages/web-console/src/lib/components/pipelines/Table.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/Table.svelte
@@ -11,6 +11,7 @@
   import { dateMax } from '$lib/functions/common/date'
   import { matchesSubstring } from '$lib/functions/common/string'
   import { type NamesInUnion, unionName } from '$lib/functions/common/union'
+  import { resolve } from '$lib/functions/svelte'
   import { formatDateTime } from '$lib/functions/format'
   import type {
     PipelineStatus as PipelineStatusType,
@@ -226,7 +227,7 @@
             <td class="{td} relative w-3/12 border-surface-100-900 group-hover:bg-surface-50-950"
               ><a
                 class=" absolute top-2 w-full overflow-hidden overflow-ellipsis whitespace-nowrap"
-                href="/pipelines/{pipeline.name}/">{pipeline.name}</a
+                href={resolve(`/pipelines/${encodeURI(pipeline.name)}/`)}>{pipeline.name}</a
               ></td
             >
             <td class="{td} relative w-12 border-surface-100-900 group-hover:bg-surface-50-950">

--- a/js-packages/web-console/src/lib/components/pipelines/Table.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/Table.svelte
@@ -9,6 +9,7 @@
   import { dateMax } from '$lib/functions/common/date'
   import { matchesSubstring } from '$lib/functions/common/string'
   import { type NamesInUnion, unionName } from '$lib/functions/common/union'
+  import { resolve } from '$lib/functions/svelte'
   import { formatDateTime } from '$lib/functions/format'
   import type {
     PipelineStatus as PipelineStatusType,
@@ -183,7 +184,7 @@
             <td class="{td} relative w-3/12 border-surface-100-900 group-hover:bg-surface-50-950"
               ><a
                 class=" absolute top-2 w-full overflow-hidden overflow-ellipsis whitespace-nowrap"
-                href="/pipelines/{pipeline.name}/">{pipeline.name}</a
+                href={resolve(`/pipelines/${encodeURI(pipeline.name)}/`)}>{pipeline.name}</a
               ></td
             >
             <td class="{td} relative w-12 border-surface-100-900 group-hover:bg-surface-50-950">

--- a/js-packages/web-console/src/lib/functions/configs/felderaEndpoint.ts
+++ b/js-packages/web-console/src/lib/functions/configs/felderaEndpoint.ts
@@ -1,7 +1,15 @@
+import { base } from '$app/paths'
+
+// `base` is the path prefix the app is served from (empty for a root
+// deployment, e.g. `/feldera` behind a reverse proxy). It must be appended to
+// the origin so REST and WebSocket calls target `<origin><base>/v0/...` rather
+// than bypassing the proxy prefix. `base` is resolved at runtime from the
+// SvelteKit payload the manager injects, so a single embedded bundle serves
+// any subpath.
 export const felderaEndpoint =
   'window' in globalThis && window.location.origin
     ? // If we're running locally with `bun run dev`, we point to the
       // backend server running on port 8080
       // Otherwise the API and UI URL will be the same
-      window.location.origin.replace(/:([45]17[34])$/, ':8080')
+      window.location.origin.replace(/:([45]17[34])$/, ':8080') + base
     : 'http://localhost:8080'

--- a/js-packages/web-console/src/lib/services/auth.ts
+++ b/js-packages/web-console/src/lib/services/auth.ts
@@ -1,4 +1,5 @@
 import * as AxaOidc from '@axa-fr/oidc-client'
+import { resolve } from '$lib/functions/svelte'
 
 const { OidcClient } = AxaOidc
 
@@ -138,10 +139,10 @@ export const triggerOidcLogin = async (): Promise<void> => {
   try {
     oidcClient = OidcClient.get()
   } catch {
-    window.location.href = '/'
+    window.location.href = resolve('/')
     return
   }
-  await oidcClient.loginAsync('/')
+  await oidcClient.loginAsync(resolve('/'))
 }
 
 /**

--- a/js-packages/web-console/src/lib/services/auth.ts
+++ b/js-packages/web-console/src/lib/services/auth.ts
@@ -1,5 +1,6 @@
 import * as AxaOidc from '@axa-fr/oidc-client'
 import { errorCodeOf, requestTenantRecheck } from '$lib/compositions/tenantAccess'
+import { resolve } from '$lib/functions/svelte'
 import { stashRedirectTarget } from '$lib/services/redirectTarget'
 
 const { OidcClient } = AxaOidc
@@ -167,10 +168,10 @@ export const triggerOidcLogin = async (): Promise<void> => {
   try {
     oidcClient = OidcClient.get()
   } catch {
-    window.location.href = '/'
+    window.location.href = resolve('/')
     return
   }
-  await oidcClient.loginAsync('/')
+  await oidcClient.loginAsync(resolve('/'))
 }
 
 /**

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/(authorized)/(pipelines)/pipelines/+page.ts
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/(authorized)/(pipelines)/pipelines/+page.ts
@@ -1,6 +1,7 @@
+import { resolve } from '$lib/functions/svelte'
 import { redirect } from '@sveltejs/kit'
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => {
-  throw redirect(308, '/')
+  throw redirect(308, resolve('/'))
 }

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/(authorized)/+layout.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/(authorized)/+layout.svelte
@@ -25,6 +25,7 @@
   import { useSystemMessages } from '$lib/compositions/useSystemMessages.svelte'
   import { useToast } from '$lib/compositions/useToastNotification'
   import { closedIntervalAction } from '$lib/functions/common/promise'
+  import { resolve } from '$lib/functions/svelte'
   import type { Snippet } from '$lib/types/svelte'
   import type { LayoutData } from './$types'
 
@@ -142,13 +143,13 @@
     ? ''
     : 'disabled pointer-events-auto select-text [&_.monaco-editor-background]:pointer-events-none [&_[role="button"]]:pointer-events-none [&_[role="separator"]]:pointer-events-none [&_a]:pointer-events-none [&_button]:pointer-events-none'}"
 >
-  {#if healthMessage && !page.url.pathname.startsWith('/health')}
+  {#if healthMessage && !page.url.pathname.startsWith(resolve('/health'))}
     <LineBanner variant="error">
       {#snippet start()}
         <span>{healthMessage}</span>
         {@render BannerButton({
           text: 'See details',
-          href: '/health/'
+          href: resolve('/health/')
         })}
       {/snippet}
     </LineBanner>

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/+page.ts
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/+page.ts
@@ -1,6 +1,7 @@
+import { resolve } from '$lib/functions/svelte'
 import { redirect } from '@sveltejs/kit'
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => {
-  throw redirect(308, '/')
+  throw redirect(308, resolve('/'))
 }

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
@@ -25,6 +25,7 @@
   import { useSystemMessages } from '$lib/compositions/useSystemMessages.svelte'
   import { useToast } from '$lib/compositions/useToastNotification'
   import { closedIntervalAction } from '$lib/functions/common/promise'
+  import { resolve } from '$lib/functions/svelte'
   import type { Snippet } from '$lib/types/svelte'
   import type { LayoutData } from './$types'
 
@@ -140,7 +141,7 @@
     ? ''
     : 'disabled pointer-events-auto select-text [&_.monaco-editor-background]:pointer-events-none [&_[role="button"]]:pointer-events-none [&_[role="separator"]]:pointer-events-none [&_a]:pointer-events-none [&_button]:pointer-events-none'}"
 >
-  {#if healthMessage && !page.url.pathname.startsWith('/health')}
+  {#if healthMessage && !page.url.pathname.startsWith(resolve('/health'))}
     <LineBanner variant="error">
       {#snippet start()}
         <span>{healthMessage}</span>

--- a/js-packages/web-console/svelte.config.js
+++ b/js-packages/web-console/svelte.config.js
@@ -11,6 +11,19 @@ const config = {
       fallback: 'index.html',
       pages: process.env.BUILD_DIR || 'build' // built webapp static files output directory
     }),
+    // Base path the app is served from. Empty for a root deployment and for
+    // local `bun run dev`. When pipeline-manager builds the embedded bundle it
+    // sets WEBCONSOLE_BASE_PATH to a sentinel, which the manager rewrites at
+    // serve time to the operator-configured prefix
+    // (WEBCONSOLE_BASE_PATH_PLACEHOLDER in crates/pipeline-manager/src/api/main.rs).
+    // The base reaches the built output in three places, all of them literal
+    // text the rewrite reaches: the `__sveltekit_*.base`/`.assets` runtime
+    // globals in index.html, the asset URLs in that same file, and the
+    // fallback base in the bundle's `$app/paths` module. Worker and font URLs
+    // are resolved relative to the bundle, so they need no prefix.
+    paths: {
+      base: process.env.WEBCONSOLE_BASE_PATH || ''
+    },
     alias: {
       $assets: 'src/assets'
     },

--- a/js-packages/web-console/svelte.config.js
+++ b/js-packages/web-console/svelte.config.js
@@ -11,6 +11,15 @@ const config = {
       fallback: 'index.html',
       pages: process.env.BUILD_DIR || 'build' // built webapp static files output directory
     }),
+    // Base path the app is served from. Empty for a root deployment and for
+    // local `bun run dev`. When pipeline-manager builds the embedded bundle it
+    // sets WEBCONSOLE_BASE_PATH to a sentinel, which the manager rewrites at
+    // serve time to the operator-configured prefix (see crates/pipeline-manager
+    // and `felderaBasePathPlaceholder`). `paths.relative` stays at its default
+    // (true), so only this base literal — not asset URLs — carries the prefix.
+    paths: {
+      base: process.env.WEBCONSOLE_BASE_PATH || ''
+    },
     alias: {
       $assets: 'src/assets'
     },


### PR DESCRIPTION
Add an `--http-base-path` (`FELDERA_HTTP_BASE_PATH`) option so Feldera can be served behind a reverse proxy that mounts it on a subpath (e.g. `https://example.com/feldera/`) rather than at the origin root.

Update:
Tested navigation around web-console and basic pipeline management (start, stop, view perf graphs) using a local nginx proxy to localhost:8080/feldera/ with and without authentication