### PR TITLE
[adapters] Fix test_clock_advance_survives_checkpoint.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -4434,31 +4434,36 @@ impl FtState {
                 let mut changed_inputs = HashMap::new();
                 let inputs = self.controller.status.input_status();
 
-                // Stop recording if the controller is shutting down. Avoid race with
-                // `stop`, which removes input endpoints from the pipeline. Without this
-                // check we may end up recording these endpoints in `remove_inputs`.
-                if self.controller.state() == PipelineState::Terminated {
-                    return Ok(());
-                }
-                self.input_endpoints
-                    .retain(|endpoint_id, (endpoint_name, paused)| {
-                        if let Some(endpoint) = inputs.get(endpoint_id) {
-                            let now_paused = endpoint.is_paused_by_user();
-                            if *paused != now_paused {
-                                changed_inputs.insert(endpoint_name.clone(), now_paused);
-                                *paused = now_paused;
+                // Compute the endpoint lifecycle diff (added/removed/paused since
+                // the previous step) that this step's journal entry records, but
+                // skip it while the controller is shutting down: `stop`
+                // concurrently disconnects endpoints, so the diff would spuriously
+                // record still-live endpoints as removed and replay them away.
+                //
+                // We must still journal this step's already-computed input, or a
+                // clean stop would silently drop the last step and a subsequent
+                // restart would resume from before it.
+                if self.controller.state() != PipelineState::Terminated {
+                    self.input_endpoints
+                        .retain(|endpoint_id, (endpoint_name, paused)| {
+                            if let Some(endpoint) = inputs.get(endpoint_id) {
+                                let now_paused = endpoint.is_paused_by_user();
+                                if *paused != now_paused {
+                                    changed_inputs.insert(endpoint_name.clone(), now_paused);
+                                    *paused = now_paused;
+                                }
+                                true
+                            } else {
+                                remove_inputs.insert(endpoint_name.clone());
+                                false
                             }
-                            true
-                        } else {
-                            remove_inputs.insert(endpoint_name.clone());
-                            false
-                        }
-                    });
-                for (endpoint_id, status) in inputs.iter() {
-                    self.input_endpoints.entry(*endpoint_id).or_insert_with(|| {
-                        add_inputs.insert(status.endpoint_name.clone(), status.config.clone());
-                        (status.endpoint_name.clone(), status.is_paused_by_user())
-                    });
+                        });
+                    for (endpoint_id, status) in inputs.iter() {
+                        self.input_endpoints.entry(*endpoint_id).or_insert_with(|| {
+                            add_inputs.insert(status.endpoint_name.clone(), status.config.clone());
+                            (status.endpoint_name.clone(), status.is_paused_by_user())
+                        });
+                    }
                 }
                 drop(inputs);
 

--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -891,6 +891,13 @@ mod test {
     }
 
     /// After checkpoint/restart, `NOW()` resumes from the last replayed value, not the anchor.
+    ///
+    /// Regression coverage for a fault-tolerance journaling race: a step is
+    /// journaled after its circuit evaluation (so the entry can carry the
+    /// transaction id assigned there), and a `stop` landing between a step's
+    /// output being emitted and its journal write must not drop that step, or
+    /// the post-checkpoint advance is absent from the replay log and `NOW()`
+    /// regresses to the checkpoint value on restart.
     #[test]
     fn test_clock_advance_survives_checkpoint() {
         use dbsp::circuit::tokio::TOKIO;
@@ -986,6 +993,18 @@ mod test {
 
         let reader = controller.get_input_endpoint("now").unwrap();
         let clock_reader = reader.as_any().downcast::<super::ClockReader>().unwrap();
+
+        // Replay runs asynchronously on the circuit thread, feeding the journaled
+        // steps one at a time. Wait for it to finish before reading `NOW()`, or we
+        // could observe an intermediate value from before the last replayed step.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while controller.is_replaying() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "replay did not complete within 30s"
+            );
+            sleep(Duration::from_millis(10));
+        }
 
         let post_replay = TOKIO.block_on(clock_reader.advance(Some(0))).unwrap();
         assert_eq!(


### PR DESCRIPTION
This fixes two bugs that caused the test to fail:

1. A bug in the test itself, where the test did not wait for the journal to finish replay before probing pipeline's state
2. A minor bug introduced by the recent fix to exactly-once FT where the last step before the pipeline terminated did not get recorded in the journal. I don't think this violates the exactly-once FT contract, but it does make it harder to write robust tests.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
