### PR TITLE
[connectors] Do not ignore fractional seconds in Debezium timestamps

### DIFF
--- a/crates/feldera-types/src/serde_with_context/serde_config.rs
+++ b/crates/feldera-types/src/serde_with_context/serde_config.rs
@@ -201,9 +201,9 @@ impl From<JsonFlavor> for SqlSerdeConfig {
             JsonFlavor::DebeziumMySql => Self {
                 time_format: TimeFormat::Micros,
                 date_format: DateFormat::DaysSinceEpoch,
-                // Why is this missing fractions of second?
-                timestamp_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%Z"),
-                timestamp_tz_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%Z"),
+                // `2018-06-20T13:37:03Z` and `2018-06-20T13:37:03.123456Z`.
+                timestamp_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%.f%Z"),
+                timestamp_tz_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%.f%Z"),
                 decimal_format: DecimalFormat::String,
                 variant_format: VariantFormat::JsonString,
                 binary_format: BinaryFormat::Array,

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -4054,6 +4054,25 @@ mod test {
         );
     }
 
+    /// Debezium MySQL emits `io.debezium.time.ZonedTimestamp` values with
+    /// fractional seconds when the column has sub-second precision.
+    /// The fraction must be preserved, not silently dropped.
+    #[test]
+    fn debezium_fractional_seconds() {
+        assert_eq!(
+            deserialize_with_debezium_config::<TestStruct>(
+                r#"{"date": 16816, "time": 10800000000, "timestamp": "2018-06-20T13:37:03.123456Z", "timestampTz": "2018-06-20T13:37:03.123456Z" }"#
+            )
+            .unwrap(),
+            TestStruct {
+                date: Date::from_days(16816),
+                time: Time::from_nanoseconds(10800000000000),
+                timestamp: Timestamp::from_microseconds(1529501823123456),
+                timestampTz: TimestampTz::from_microseconds(1529501823123456),
+            }
+        );
+    }
+
     #[test]
     fn snowflake_json() {
         assert_eq!(


### PR DESCRIPTION
Fixes #6115

## Checklist

- [x] Unit tests added/updated
