### PR TITLE
[adapters] Tolerate transient Kafka errors in FT input tests

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -757,7 +757,12 @@ impl InputConsumer for DummyInputConsumer {
 
     fn error(&self, fatal: bool, error: AnyError, _tag: Option<&'static str>) {
         info!("error: {error}");
-        self.called(ConsumerCall::Error(fatal));
+        // Record only fatal errors. Non-fatal errors, such as a momentary
+        // broker disconnection, can arrive at any time, and recording them
+        // would break the strict call sequence that `expect()` checks.
+        if fatal {
+            self.called(ConsumerCall::Error(fatal));
+        }
     }
 
     fn request_step(&self) {}


### PR DESCRIPTION
## Problem

`transport::kafka::ft::test::multiple_input` failed in the merge queue ([run 28634798524](https://github.com/feldera/feldera/actions/runs/28634798524/job/84920558598)) and kicked out an unrelated PR (#6584):

```
assertion `left == right` failed
  left: [Extended { num_records: 90, metadata: Object {"offsets": [{"start": 60, "end": 150}]} }]
 right: [Error(false)]
```

The job log shows the cause: librdkafka reported a momentary connectivity blip ("1/2 brokers are down", "AllBrokersDown"). `refine_kafka_error` classifies such errors as non-fatal, and the connector recovered on its own: the expected `Extended { num_records: 90 }` call arrived 100 ms after the panic.

The bug is in the test harness: `DummyInputConsumer::error` records every error, fatal or not, in the strict call sequence that `expect()` checks, so a transient blip anywhere in `test_input` or `test_input_partition` fails the test.

## Fix

Record only fatal errors; log non-fatal ones. No test expects `ConsumerCall::Error`, so no expectation changes. This matches the `MockInputConsumer`-based Kafka tests, which install `on_error(|_, _| {})`. Same flake class as #1830.

## Validation

Reproduced the blip locally by bouncing a dedicated Redpanda broker mid-test (`docker restart -t 1`), which produces the exact CI error signature (`Message consumption error: AllBrokersDown ...`, `N/M brokers are down`):

| Run | Code | Broker bounce | Result |
|-----|------|---------------|--------|
| baseline | fixed | no | ok |
| blip tolerance | fixed | yes | ok, 2 non-fatal errors received and ignored |
| repro | fix reverted | yes | FAILED: `right: [Error(false)]`, same as CI |
| regression | fixed | no | full `kafka::ft::test` module: 39 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
