### PR TITLE
[connectors] Tolerate transient Kafka errors in FT input tests

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -757,7 +757,12 @@ impl InputConsumer for DummyInputConsumer {
 
     fn error(&self, fatal: bool, error: AnyError, _tag: Option<&'static str>) {
         info!("error: {error}");
-        self.called(ConsumerCall::Error(fatal));
+        // Record only fatal errors. Non-fatal errors, such as a momentary
+        // broker disconnection, can arrive at any time, and recording them
+        // would break the strict call sequence that `expect()` checks.
+        if fatal {
+            self.called(ConsumerCall::Error(fatal));
+        }
     }
 
     fn request_step(&self) {}


### PR DESCRIPTION
Transient librdkafka connectivity blips ("AllBrokersDown", "N/M brokers are down") are reported to the consumer as non-fatal errors, and the connector recovers on its own. DummyInputConsumer recorded every such error in the strict call sequence that expect() checks, so a blip anywhere in a test failed it, e.g.:

  thread 'transport::kafka::ft::test::multiple_input' panicked at
  crates/adapters/src/transport/kafka/ft/test.rs:463:22:
  assertion `left == right` failed
    left: [Extended { num_records: 90, ... }]
   right: [Error(false)]

Record only fatal errors. No test expects ConsumerCall::Error, so no expectation changes.