### PR TITLE
Advanced metrics visualization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,7 @@
         "@sveltejs/vite-plugin-svelte": "7.0.0",
         "@tailwindcss/vite": "^4.1.17",
         "@vitest/browser-playwright": "^4.1.8",
+        "echarts": "6.0.0",
         "feldera-theme": "workspace:*",
         "monaco-editor": "0.55.1",
         "playwright": "1.58.2",
@@ -115,6 +116,7 @@
         "publint": "^0.3.15",
         "svelte": "5.55.7",
         "svelte-check": "^4.3.5",
+        "svelte-echarts": "1.0.0",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3",
         "vite": "^8.0.0",
@@ -122,10 +124,12 @@
       },
       "peerDependencies": {
         "@monaco-editor/loader": "1.7.0",
+        "echarts": "6.0.0",
         "monaco-editor": "0.55.1",
         "runed": "0.37.1",
         "strip-ansi": "7.1.2",
         "svelte": "5.55.7",
+        "svelte-echarts": "1.0.0",
         "tiny-invariant": "1.3.3",
         "virtua": "0.48.6",
       },
@@ -1090,7 +1094,7 @@
 
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
-    "apache-arrow": ["apache-arrow@github:Karakatiza666/arrow-js#ddba834", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^25.2.0", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-with-bigint": "^3.5.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.cjs" } }, "Karakatiza666-arrow-js-ddba834", "sha512-N2H0djCXEuIXEXsZyPKGI4NT0xBhH3DdsNNP3Z273ym1h0OKHR6qrGld4l8RnxGjDwFzXhMZDEqEfN0NMFZUTA=="],
+    "apache-arrow": ["apache-arrow@github:Karakatiza666/arrow-js#ddba834", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^25.2.0", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-with-bigint": "^3.5.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.cjs" } }, "Karakatiza666-arrow-js-ddba834"],
 
     "apexcharts": ["apexcharts@5.6.0", "", { "dependencies": { "@yr/monotone-cubic-spline": "^1.0.3" } }, "sha512-BZua59yedRsaDfnxkzNrkyLCvluq2c3ZDBIz4joxSKtgr0xDQXQ5dzceMhf/TpTbAjaF+2NYIpLP3BEEIG2s/w=="],
 

--- a/js-packages/profiler-app/package.json
+++ b/js-packages/profiler-app/package.json
@@ -16,11 +16,13 @@
     "@feldera/vite-plugin-monaco-editor": "workspace:*",
     "@monaco-editor/loader": "1.7.0",
     "common-ui": "workspace:*",
+    "echarts": "6.0.0",
     "monaco-editor": "0.55.1",
     "profiler-layout": "workspace:*",
     "profiler-lib": "workspace:*",
     "runed": "0.37.1",
     "strip-ansi": "7.1.2",
+    "svelte-echarts": "1.0.0",
     "tiny-invariant": "1.3.3",
     "triage-types": "workspace:*",
     "virtua": "0.48.6"

--- a/js-packages/profiler-layout/package.json
+++ b/js-packages/profiler-layout/package.json
@@ -29,22 +29,28 @@
   "dependencies": {
     "but-unzip": "^0.1.7",
     "common-ui": "workspace:*",
+    "d3-format": "3.1.2",
     "paneforge": "1.0.2",
     "sort-on": "^7.0.0",
     "triage-types": "workspace:*"
   },
   "peerDependencies": {
     "@monaco-editor/loader": "1.7.0",
+    "echarts": "6.0.0",
     "monaco-editor": "0.55.1",
     "runed": "0.37.1",
     "strip-ansi": "7.1.2",
     "svelte": "5.55.7",
+    "svelte-echarts": "1.0.0",
     "tiny-invariant": "1.3.3",
     "virtua": "0.48.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
+    "@types/d3-format": "3.0.4",
     "@monaco-editor/loader": "1.7.0",
+    "echarts": "6.0.0",
+    "svelte-echarts": "1.0.0",
     "@skeletonlabs/skeleton": "^4.8.0",
     "@skeletonlabs/skeleton-svelte": "^4.9.0",
     "@sveltejs/adapter-auto": "^7.0.0",

--- a/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
@@ -28,8 +28,12 @@
 
 <script lang="ts">
   import type { TooltipData } from './ProfilerTooltip.svelte'
+  import MetricKindBlock from './metrics/blocks/MetricKindBlock.svelte'
   import MetricsDistributionBlock from './metrics/blocks/MetricsDistributionBlock.svelte'
-  import { buildBlocks, type RenderableBlock } from './metrics/dispatch'
+  import { buildCacheTiles, isCacheFamilyMetric } from './metrics/cache'
+  import CacheTile from './metrics/parts/cache/CacheTile.svelte'
+  import { buildBlocks, type MetricGroup, type RenderableBlock } from './metrics/dispatch'
+  import { isCardKind } from './metrics/kind'
   import type { LookupCoordinator } from '../functions/lookup'
 
   interface Props {
@@ -67,7 +71,24 @@
   const blocks = $derived<RenderableBlock[]>(
     nodeAttributes ? buildBlocks(nodeAttributes, showAdvanced) : []
   )
+  // Within a category, bar-chart kinds go to the distribution grid; other kinds each render as
+  // their own card. Cache-family metrics are subsumed into composite CacheTiles, so they are
+  // excluded from both. Splitting here keeps MetricsDistributionBlock bar-chart-only.
+  const barGroups = (block: RenderableBlock): MetricGroup[] =>
+    block.entries.filter((g) => !isCardKind(g.kind) && !isCacheFamilyMetric(g.baseId))
+  const cardGroups = (block: RenderableBlock): MetricGroup[] =>
+    block.entries.filter((g) => isCardKind(g.kind) && !isCacheFamilyMetric(g.baseId))
+  const cacheTiles = (block: RenderableBlock) => buildCacheTiles(block.entries)
+  // A category renders a header only when it has at least one visible tile (after filtering).
+  const hasContent = (block: RenderableBlock): boolean =>
+    barGroups(block).length > 0 || cardGroups(block).length > 0 || cacheTiles(block).length > 0
   const showAttributesView = $derived(mode === 'overview' || mode === 'node')
+
+  // Per-category collapse state, keyed by block id; an absent entry means expanded.
+  let collapsed = $state<Record<string, boolean>>({})
+  const toggleCategory = (id: string) => {
+    collapsed[id] = !collapsed[id]
+  }
 
   let containerEl: HTMLDivElement | undefined = $state()
 
@@ -103,7 +124,7 @@
     }
     for (const b of blocks) {
       for (const e of b.entries) {
-        if (e.row.metric.toLowerCase().includes(q)) return b.id
+        if (e.baseId.toLowerCase().includes(q)) return b.id
       }
     }
     return null
@@ -116,6 +137,8 @@
     if (!containerEl) return
     const matchId = findMatchingBlockId(query)
     if (!matchId) return
+    // Expand the target category so the matched metric is visible after scrolling.
+    collapsed[matchId] = false
     const el = containerEl.querySelector<HTMLElement>(`[data-block-id="${matchId}"]`)
     el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
   }
@@ -156,14 +179,55 @@
         {/each}
       </div>
     {/if}
-    <!-- Two same-width columns once the container is at least TWO_COLUMN_THRESHOLD_PX wide;
-         otherwise one column. CSS multi-column flow auto-distributes blocks; the column
-         count is driven by the ResizeObserver on the scroll container. -->
-    <div class="gap-3" style="column-count: {useTwoColumns ? 2 : 1};">
+    <!-- One collapsible section per metrics category. The category name sits on the page
+         background with a chevron aligned right that collapses the whole category. Within an
+         expanded category, tiles flow across two same-width columns once the container is at
+         least TWO_COLUMN_THRESHOLD_PX wide (CSS multi-column, driven by the ResizeObserver),
+         otherwise one column. -->
+    <div class="metrics-theme">
       {#each blocks as b (b.id)}
-        <div class="mb-3 break-inside-avoid">
-          <MetricsDistributionBlock id={b.id} title={b.title} entries={b.entries} />
-        </div>
+        {#if hasContent(b)}
+          <section class="mb-4" data-block-id={b.id}>
+            <button
+              type="button"
+              class="mb-2 flex w-full items-center justify-between gap-3 text-left"
+              aria-expanded={!collapsed[b.id]}
+              onclick={() => toggleCategory(b.id)}
+            >
+              <span class="text-xl font-semibold text-surface-900-100">{b.title}</span>
+              <span
+                class="fd fd-chevron-down chevron shrink-0 text-[20px] text-surface-600-400"
+                class:rotate-180={!collapsed[b.id]}
+                aria-hidden="true"
+              ></span>
+            </button>
+            {#if !collapsed[b.id]}
+              <div style="column-count: {useTwoColumns ? 2 : 1};">
+                {#if barGroups(b).length > 0}
+                  <div class="mb-3 break-inside-avoid">
+                    <MetricsDistributionBlock id={`${b.id}-dist`} title={b.title} entries={barGroups(b)} />
+                  </div>
+                {/if}
+                {#each cardGroups(b) as g (g.baseId)}
+                  <div class="mb-3 break-inside-avoid">
+                    <MetricKindBlock id={`${b.id}-${g.baseId}`} group={g} />
+                  </div>
+                {/each}
+                {#each cacheTiles(b) as tile (tile.prefix)}
+                  <div class="mb-3 break-inside-avoid">
+                    <CacheTile
+                      id={`${b.id}-cache-${tile.prefix}`}
+                      title={tile.title}
+                      hits={tile.hits}
+                      misses={tile.misses}
+                      hitRate={tile.hitRate}
+                    />
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </section>
+        {/if}
       {/each}
     </div>
   {/if}
@@ -214,4 +278,41 @@
     {@render topNodesView()}
   {/if}
 </div>
+
+<style>
+  /* Shared theme tokens for all metric block visuals, defined once on the container so both
+     block types (bar-chart grid and per-kind cards) and their children inherit them via the
+     custom-property cascade. We use Skeleton's single-tone vars (defined under [data-theme=...]
+     and inherited reliably) and switch on `.dark` / `body.dark` ourselves, instead of relying
+     on Skeleton's dual-tone `*-200-800` vars inside color-mix() — which resolved to transparent
+     in this setup (cascade re-parsing of the dual-tone value doesn't reach the data-theme
+     scope in some browsers). Kept in a <style> block so `:global(.dark)` and `:global(body.dark)`
+     can both target the same vars; Tailwind's `dark:` variant alone doesn't cover the
+     `body.dark` form used elsewhere in this app. */
+  .chevron {
+    display: inline-block;
+    transition: transform 200ms ease;
+  }
+  .metrics-theme {
+    --bar-low: var(--color-surface-100);
+    --bar-high: var(--color-error-300);
+    --skew-low: var(--color-surface-600);
+    --skew-high: var(--color-error-500);
+    --header-bg: white;
+    /* Compaction-state chips (K6). */
+    --state-none: var(--color-surface-300);
+    --state-requested: var(--color-warning-400);
+    --state-progress: var(--color-primary-400);
+  }
+  :global(.dark) .metrics-theme,
+  :global(body.dark) .metrics-theme {
+    --bar-low: var(--color-surface-900);
+    --bar-high: var(--color-error-700);
+    --skew-low: var(--color-surface-400);
+    --header-bg: var(--color-dark);
+    --state-none: var(--color-surface-600);
+    --state-requested: var(--color-warning-600);
+    --state-progress: var(--color-primary-600);
+  }
+</style>
 

--- a/js-packages/profiler-layout/src/lib/components/icons/CircleHelp.svelte
+++ b/js-packages/profiler-layout/src/lib/components/icons/CircleHelp.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  // Inlined circle-help icon (from feldera-material-icons) so it bundles with the library rather
+  // than relying on a consumer-served static asset. Strokes with `currentColor` to inherit theme.
+  interface Props {
+    size?: number
+  }
+  const { size = 16 }: Props = $props()
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  fill="none"
+  viewBox="0 0 24 24"
+  aria-hidden="true"
+>
+  <path
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3m.08 4h.01M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z"
+  />
+</svg>

--- a/js-packages/profiler-layout/src/lib/components/metrics/README.md
+++ b/js-packages/profiler-layout/src/lib/components/metrics/README.md
@@ -1,0 +1,227 @@
+# Metrics visualization
+
+The Metrics tab renders the per-operator (and whole-circuit) readings a Feldera pipeline
+emits. This document explains **what kinds of metric exist and how each is visualized**, and
+how a raw reading travels from Rust to a rendered component.
+
+## Pipeline: from Rust to a rendered row
+
+1. **Source of truth (Rust):** `crates/dbsp/src/circuit/metadata.rs` defines
+   `CIRCUIT_METRICS` — every metric's `name` (`metric_id`), `category`
+   (`State | Inputs | Outputs | Cache | Time | Balancer | Multihost`), an `advanced`
+   flag, and a description. The value carried by a reading is a `MetaItem`
+   (`Int, Count, Percent, CacheCounts, String, Array, Map, Bytes, Duration, Bool`). Some
+   readings also carry **labels** (e.g. `compaction_state` and `completed_merges` are
+   emitted per `slot`).
+2. **Decoder (TS):** `profiler-lib` `Measurement.parseValues` dispatches on the **last
+   `_`-separated token** of `metric_id`. Scalars decode to one `PropertyValue`
+   (`CountValue`, `BytesValue`, `TimeValue`, `PercentValue`, `BooleanValue`, `StringValue`);
+   composites **expand into several sub-rows** (`x.count`, `x.avg_size`, …). Each decoded
+   `TooltipRow` is one (sub)field across all workers: `row.cells[worker].value`.
+3. **Grouping + classification (`dispatch.ts` + `kind.ts`):** `buildBlocks` groups rows by
+   category into blocks, then regroups the split sub-rows back under one `baseId` into a
+   `MetricGroup` and tags it with a `MetricKind` (`kind.ts:metricKind`).
+4. **Render:** every kind maps to a **widget** in `parts/` taking a single `MetricGroup`
+   (symmetric contract). `blocks/MetricKindBlock.svelte` is the generic single-metric card that
+   dispatches to the widget for a group's kind — including K1 (bar chart) via
+   `parts/BarChartMetric.svelte`. `blocks/MetricsDistributionBlock.svelte` is a **special case**
+   of the same system: it aggregates many bar-chart metrics into one card with a shared
+   Avg/Min/Max header, built from the same `parts/BarGrid.svelte` + `parts/BarChartRow.svelte`
+   atoms the K1 widget uses. `MetricsView` sends bar-chart kinds to the aggregated block and each
+   other kind to its own `MetricKindBlock` (`isCardKind` in `kind.ts` decides the split).
+5. **Layout (`MetricsView.svelte`):** each block (one per `category`) renders as a collapsible
+   `<section>`. The category display name sits on the page background, left-aligned at `text-xl`,
+   with a chevron aligned right that collapses the whole category; collapse state lives in a
+   `collapsed` record keyed by block id (absent = expanded). Within an expanded category the
+   tiles flow across two columns once the scroll container is `>= TWO_COLUMN_THRESHOLD_PX` wide
+   (CSS multi-column, driven by a `ResizeObserver`), otherwise one. A category with no visible
+   tiles after filtering draws no header (`hasContent`). Search (`runSearch`) expands the target
+   category before scrolling to its `data-block-id`.
+
+## Metric kinds
+
+Each kind is one distinct value shape → one visualization. `metricKind()` derives the kind
+from the base id's suffix (`kind.ts`).
+
+| Kind | Shape | Visualization | Renderer |
+|------|-------|---------------|----------|
+| K1 | per-worker magnitude scalar (count/bytes/seconds) | relative-difference bar chart + Avg/Min/Max + Skew | `parts/BarChartMetric.svelte` |
+| K2 | per-worker bounded fraction (`percent`) | full-width percentage bars, fill grows top+bottom inward | `parts/PercentRingMetric.svelte` |
+| K3 | per-worker fraction of capacity (`{used, max}` bytes) | percentage bars per worker (`used/max`), like K2 | `parts/OccupancyRingMetric.svelte` |
+| K4 | per-worker categorical / string | one chip per worker (one chip-row per sub-field) | `parts/ChipMetric.svelte` |
+| K5 | per-worker boolean | read-only checkbox per worker + `k/N true` | `parts/BooleanMetric.svelte` |
+| K6 | per-(worker × level) categorical state | grid of state chips (levels × workers) | `parts/CompactionStateMetric.svelte` |
+| K7 | batch-size summary (`{count, record_count, min/avg/max size}`) | `batches`/`records`/`avg` column + min/avg/max lines, workers on y (sorted by avg), size on x | `parts/StatsMetric.svelte` |
+| K8 | cache counts (`{avg_latency, count, bytes, elapsed}`) | grid, `avg_latency` headline, then `count`, then `bytes` | `parts/CacheCountsMetric.svelte` |
+| K9 | merge progress per (worker × level) | histogram over levels, hover L→R switches worker | `parts/MergesHistogram.svelte` |
+| K10 | worker-fanout matrix (`Array` indexed by dest worker) | N×N heatmap, vertically squished | `parts/KeyDistributionMatrix.svelte` |
+| K11 | binned size histogram (`Array` of batch sizes) | histogram, hover L→R switches worker | `parts/SizeHistogram.svelte` |
+
+### K1 — per-worker magnitude scalar
+Comparable numbers (`count`/`bytes`/`seconds`) that vary per worker; the spread across
+workers (skew) is the signal. The bar chart min-max-normalizes bar heights and shows
+Avg/Min/Max columns plus a Skew toggle. Bar geometry is shared: `colors.barMetrics` maps a
+value to a `{t, height}` pair (log curve, 6px..24px envelope) and `parts/BarRow.svelte` renders
+the row; the cache tile's `ValueBars` reuse both, so the two look identical.
+Members: `used_memory_bytes`, `allocated_memory_bytes`, `state_records_count`,
+`input_records_count`, `runtime_seconds`, `steps_count`, the filter `*_count`/`*_size_bytes`,
+the exchange `*_bytes`/`*_seconds`, and the rest of the plain count/bytes/seconds scalars.
+
+### K2 — per-worker bounded fraction
+`Percent{numerator, denominator}`, already normalized to 0–100%. A relative-difference bar
+misleads here (95% vs 99% would look like full vs empty), so each worker is a **bar whose fill
+grows from the top and bottom edges inward** — single-px lines at 0%, filling the whole bar at
+100% (`PercentBars`, plain divs like the distribution bars; no ECharts). The fill color carries
+semantics via a `surface-100-900`→`error-500` scale keyed by a `semantics` prop (`low-bad` /
+`high-bad` / `none`); a generic percent has no known good/bad end, so it stays the neutral
+surface color (`none`). Avg weights by denominator; Min/Max/Skew are suppressed.
+Members: `runtime_percent`, `output_redundancy_percent`, `merge_reduction_percent`,
+`foreground_cache_hit_rate_percent`, `background_cache_hit_rate_percent`,
+`bloom_filter_hit_rate_percent`, `roaring_filter_hit_rate_percent`,
+`range_filter_hit_rate_percent`.
+
+### K3 — per-worker fraction of capacity
+Decodes to `{used, max}` bytes — the cache's current use against its capacity. Rendered with the
+same `PercentBars` as K2, plotting `used/max` as a percentage; the tooltip shows the raw
+`used / max` byte values. A full cache is neither inherently good nor bad, so no surface→error
+semantics apply (`semantics='none'`, neutral surface color). `max` is worker-invariant (capacity
+is split evenly, or one global capacity is reported on every worker).
+Members: `foreground_cache_occupancy`, `background_cache_occupancy`.
+
+### K4 — per-worker categorical / string
+Enum / identifier strings where magnitude is meaningless. One chip per worker; metrics with
+several string sub-fields (e.g. `retainment_bounds` → `key_bounds`, `value_bounds`) get one
+chip-row per sub-field.
+Members: `balancer_policy`, `retainment_bounds`, and the `persistent_id` node attribute.
+
+### K5 — per-worker boolean
+A read-only checkbox per worker plus a "k of N workers true" summary.
+Members: `rebalancing_in_progress`.
+
+### K6 — per-(worker × level) categorical state
+A `slot`-labeled enum string → a value per (worker, spine level). A **slot is one level of
+the async spine** (an LSM-style tier grouping similarly-sized batches; up to `MAX_LEVELS = 9`).
+Rendered as a grid: rows = levels, columns = workers, each cell a state chip
+(`none` / `requested` / `in progress`). The worker columns share the row width (CSS grid,
+`1fr` tracks capped by a max width), so a large worker count **compresses the chips
+horizontally** rather than wrapping or scrolling. A header row reuses the same grid: "Worker"
+sits in the left label column and worker numbers label every 4th column.
+Members: `compaction_state`.
+
+### K7 — batch-size summary
+Decodes to `{batches_count, total_records, min_size, avg_size, max_size}` **per worker**. These
+are not five peers: `count` (# batches) and `record_count` (total records) are magnitudes, while
+`min/avg/max` form a per-batch-size **range**. Rendered as a `batches`/`records`/`avg` column
+(avg = `records / batches`) beside a horizontal line chart: **workers on the y axis, sorted by
+average batch size** (top = smallest), **batch size on the x axis**, with three lines — avg (the
+primary series) between thin min and max lines, no fill. The gap between the min and max lines at
+each worker row is that worker's batch-size spread. The x axis spans the global min..max
+(`statsMetric.ts` computes the extent and positions; `fractionIn` is unit-tested); chart height
+grows with the worker count down to a 48px floor. Hovering (or focusing) a worker row marks that
+worker's min/avg/max on the lines and shows a labeled tooltip. This metric carries only
+per-worker summaries, so the distribution is **across workers**, not across individual batches
+(per-batch sizes are K11 `size_distribution`).
+
+A help icon next to the title (any kind with an entry in `kindHelp.ts`, currently K6, K7, K9)
+shows a tooltip explaining what the card is and how to read it. `MetricKindBlock` renders it.
+Members: `input_batches_stats`, `output_batches_stats`, `left_input_batches_stats`,
+`right_input_batches_stats`, `prefix_batches_stats`.
+
+### K8 — cache counts
+Decodes to `{count, bytes, elapsed, avg_latency}` (avg_latency = elapsed/count).
+Members: `foreground_cache_hits`, `foreground_cache_misses`, `background_cache_hits`,
+`background_cache_misses`.
+
+These are **not** rendered as their own K8 widget. Together with the K2 hit-rate metric they are
+subsumed into a composite **cache tile** (`cache.ts` + `parts/cache/CacheTile.svelte`), one per
+cache (foreground / background), built with Apache ECharts. The tile is **collapsible** like a K1
+distribution row: a chevron at the top right toggles it. Always visible are a per-worker
+**hit-rate** row (`PercentBars`, `semantics='low-bad'` — a low hit rate reddens toward error) and
+per-worker **effective-latency** bars (`hit_rate·avg_hit + miss_rate·avg_miss`, reusing the K1
+bar look via `ValueBars`, hover tooltip per bar). Expanding reveals the scatter diagrams and, to
+the left of the chevron, a `SegmentedControl` toggling the count/bytes axis: a row pairing two
+scatter-with-marginals of hit/miss count-or-bytes (counts via `formatQty`, bytes via `humanSize`)
+versus average latency; and a row pairing a scatter of hit rate vs miss/hit latency ratio with
+one of hit rate vs effective latency. Scatter X axes show 3 markers, Y axes 4.
+
+Clicking a bar or a dot **selects** that worker across the whole tile: the selected scatter dot
+renders in primary while the others fall back to a base color (no size change), and the selected
+bar gets a primary outline. Clicking the same element again, or clicking empty canvas (a zrender
+click with no target, via `EChart`'s `onblank`), clears the selection.
+
+Marginal densities are `line` series (so `EChart` registers `LineChart`) anchored at the exact
+data extremes so they span the point cloud. Both are smoothed; the right marginal uses no
+`areaStyle` (ECharts would fill toward the bottom rather than toward x=0) but relies on the line
+series' default grid clipping to trim any smoothing overshoot past the count=0 axis. The
+hits/misses plots take a `tooltipFormat` that always shows **both count and bytes** (plus the
+plotted latency) regardless of the count/bytes axis toggle. The "Hit rate vs effective latency"
+caption carries an inlined `CircleHelp` icon (from `feldera-material-icons`, `currentColor`) with
+a hover `Tooltip` explaining the formula.
+
+Color scale: the heatmap and scatter dots share endpoints — error at the worst reading, a
+theme-adaptive neutral (`surface-100-900`, dark in dark mode) at the best. Scatter dots are
+colored by `cornerColors` — an inverse-distance blend of 2–4 named corners
+(`{ corner: 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right', color }`), symmetric for
+adjacent or opposite corners. ECharts renders to canvas and the theme tokens are `oklch`, so
+colors are resolved to sRGB via a 1×1 canvas pixel (`resolveRgb`) and blended in JS (`mixRgb`);
+parsing the computed string directly would misread oklch's L/C/H as R/G/B (grayscale bug).
+(`profile.propertyRange` is still plumbed onto `TooltipRow.range` → `MetricSubRow.range` as
+general per-metric range infrastructure.)
+
+### K9 — merge progress
+A `slot`-labeled tuple `{avg_step_time, batches, merges, steps}` per (worker, level). A
+**transposed** (horizontal) histogram showing the worker-averaged shape; moving the mouse
+left→right switches to an individual worker's per-level histogram. Layout (`WorkerSwitchHistogram`,
+rendered with ECharts via `EChart`): the binned category (spine level) is the **Y axis**, one bar
+per level (labels thinned to ~12 via `axisLabel.interval`); the `steps` value is the **X axis**,
+drawn in log-normalized space (`logScale01(value / sharedMax)`) so small bars stay visible. The
+axis is fixed to `[0, 1]`; ticks are round "nice" values (`niceTicks`, ≤5, integer — e.g. 500 /
+1000 / 5000) placed at their log positions via ECharts `customValues`, so labels read easily even
+though their spacing is uneven. `sharedMax` is the **global maximum across all workers** (not the
+averaged view) so switching workers never rescales it. Bars are a **flat neutral** (surface-200-800,
+resolved to RGB for the canvas since it cannot read CSS custom properties, and `.metrics-theme`
+vars are invisible to the resolver's body-level probe): length already encodes magnitude, so a
+color ramp would be redundant and the reserved error red would falsely imply "high = bad". In the
+**averaged view only**, each bar carries a right-hand **"Skew N%"** label = per-level cross-worker
+spread `(max - min) / max(|max|, |min|)`, colored neutral → error saturating at 50% (the same ramp
+K1 uses via `skewTextColor`, resolved to RGB). A `categoryTitle` ("Spine level" for K9, "Size bin"
+for K11) labels the Y axis top-left. Below the chart, next to the caption ("avg of N workers" / "Worker k"), a **worker
+strip** shows one cell per worker spanning the chart width; the hovered/focused worker's cell
+lights primary, and the cells are themselves hover/focus targets that drive the selection. The
+caller's header (e.g. "steps per level (log)") names the value quantity.
+Members: `completed_merges`.
+
+### K10 — worker-fanout matrix
+`key_distribution` is an `Array<Count>` indexed by **destination worker**; each worker reports
+its own outbound distribution, so stacked over all workers it is an N×N matrix (source →
+destination). Rendered as a vertically-squished heatmap so cross-worker skew is visible at a
+glance.
+Members: `key_distribution`.
+
+### K11 — binned size histogram
+`size_distribution` is an `Array` of the batch sizes a worker holds (index meaningless, length
+varies per worker). The sizes are binned into a histogram; like K9 it uses the transposed
+ECharts `WorkerSwitchHistogram` (size bin on the Y axis, log-scaled per-bin count on the X axis)
+and hovering left→right switches worker.
+Members: `size_distribution`.
+
+## Cross-cutting modifiers
+
+- **M1 — worker-uniform collapse:** when every worker reports an equal value, render one
+  combined value instead of N identical elements. Applies to K2/K3/K4/K5.
+- **M2 — `advanced` flag:** existing show/hide filter (`dispatch.ts`), orthogonal to kind.
+
+## Decoder support
+
+`profiler-lib`'s `parseValues` decodes every kind's suffix:
+
+| metric | suffix | decoded as |
+|--------|--------|------------|
+| `key_distribution` / `size_distribution` | `distribution` | `ArrayValue` (K10 / K11) |
+| `compaction_state` | `state` | `StringValue`, one per `slot` label (K6) |
+| `bloom_filter_bits_per_key` | `key` | `CountValue` (K1) |
+| `completed_merges` | `merges` | `merges`/`batches`/`steps`/`avg_step_seconds`/`avg_step_cpu_seconds`, per `slot` (K9) |
+
+`ArrayValue` is a non-comparable `PropertyValue` holding `number[]`; its `getNumericValue()`
+returns none so numeric-only consumers (the heatmap percentile scale, the bar chart) skip it,
+and the K10/K11 widgets read the array via `toArray()`.

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricKindBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricKindBlock.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  // Generic single-metric card: dispatches a MetricGroup to the widget for its kind. Every kind
+  // is symmetric here — including K1 (bar chart), which renders via the BarChartMetric widget.
+  // MetricsDistributionBlock is the special case that aggregates many K1 metrics into one card;
+  // this block is the single-metric case of the same system. See ../README.md.
+  import { Tooltip } from 'common-ui'
+  import CircleHelp from '../../icons/CircleHelp.svelte'
+  import type { MetricGroup } from '../dispatch'
+  import { kindHelp } from '../kindHelp'
+  import BarChartMetric from '../parts/BarChartMetric.svelte'
+  import BooleanMetric from '../parts/BooleanMetric.svelte'
+  import CacheCountsMetric from '../parts/CacheCountsMetric.svelte'
+  import ChipMetric from '../parts/ChipMetric.svelte'
+  import CompactionStateMetric from '../parts/CompactionStateMetric.svelte'
+  import KeyDistributionMatrix from '../parts/KeyDistributionMatrix.svelte'
+  import MergesHistogram from '../parts/MergesHistogram.svelte'
+  import OccupancyRingMetric from '../parts/OccupancyRingMetric.svelte'
+  import PercentRingMetric from '../parts/PercentRingMetric.svelte'
+  import SizeHistogram from '../parts/SizeHistogram.svelte'
+  import StatsMetric from '../parts/StatsMetric.svelte'
+
+  interface Props {
+    id: string
+    group: MetricGroup
+  }
+  const { id, group }: Props = $props()
+
+  const help = $derived(kindHelp(group.kind))
+</script>
+
+<div class="metrics-block rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
+  {#if group.kind === 'K1'}
+    <div class="scrollbar overflow-x-auto overflow-y-visible">
+      <BarChartMetric {group} />
+    </div>
+  {:else}
+    <h3 class="mb-2 flex items-center gap-1 text-base font-semibold text-surface-900-100">
+      {group.label}
+      {#if help}
+        <span class="inline-flex cursor-help text-surface-500"><CircleHelp /></span>
+        <Tooltip class="max-w-xs">{help}</Tooltip>
+      {/if}
+    </h3>
+    {#if group.kind === 'K2'}
+      <PercentRingMetric {group} />
+    {:else if group.kind === 'K3'}
+      <OccupancyRingMetric {group} />
+    {:else if group.kind === 'K4'}
+      <ChipMetric {group} />
+    {:else if group.kind === 'K5'}
+      <BooleanMetric {group} />
+    {:else if group.kind === 'K6'}
+      <CompactionStateMetric {group} />
+    {:else if group.kind === 'K7'}
+      <StatsMetric {group} />
+    {:else if group.kind === 'K8'}
+      <CacheCountsMetric {group} />
+    {:else if group.kind === 'K9'}
+      <MergesHistogram {group} />
+    {:else if group.kind === 'K10'}
+      <KeyDistributionMatrix {group} />
+    {:else if group.kind === 'K11'}
+      <SizeHistogram {group} />
+    {:else}
+      <div class="text-sm text-surface-600-400">No renderer for kind {group.kind} yet.</div>
+    {/if}
+  {/if}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
@@ -1,94 +1,51 @@
 <script lang="ts">
+  // Special case of the generic metric system: aggregates many bar-chart metrics into one card
+  // with a single shared Avg/Min/Max header and aligned columns. Built from the same BarGrid +
+  // BarChartRow atoms as the single-metric BarChartMetric widget. Non-bar kinds render as their
+  // own cards via MetricKindBlock and never reach here (see `isCardKind` / MetricsView).
   import type { PropertyValue } from 'profiler-lib'
-  import type { RenderableMetric } from '../dispatch'
-  import BarChartMetric from '../parts/BarChartMetric.svelte'
+  import type { MetricGroup } from '../dispatch'
+  import BarChartRow from '../parts/BarChartRow.svelte'
+  import BarGrid from '../parts/BarGrid.svelte'
 
   interface Props {
     id: string
     title?: string
-    entries: RenderableMetric[]
+    entries: MetricGroup[]
   }
   const { id, title, entries }: Props = $props()
 
-  let expandedIds = $state(new Set<string>())
-
-  function isExpanded(row: RenderableMetric): boolean {
-    return expandedIds.has(row.row.metric)
-  }
-  function toggle(row: RenderableMetric) {
-    const next = new Set(expandedIds)
-    if (next.has(row.row.metric)) {
-      next.delete(row.row.metric)
-    } else {
-      next.add(row.row.metric)
+  // A K1 scalar is one bar row; any other (not-yet-carded) kind still routed here renders one
+  // bar per decoded sub-row, its legacy look.
+  type BarRow = { key: string; label: string; metricId: string; values: PropertyValue[] }
+  function barRows(group: MetricGroup): BarRow[] {
+    if (group.kind === 'K1') {
+      return [
+        {
+          key: group.baseId,
+          label: group.label,
+          metricId: group.baseId,
+          values: group.rows[0]?.values ?? []
+        }
+      ]
     }
-    expandedIds = next
+    return group.rows.map((r) => ({
+      key: group.baseId + r.suffix,
+      label: r.label,
+      metricId: group.baseId + r.suffix,
+      values: r.values
+    }))
   }
-  function values(row: RenderableMetric): PropertyValue[] {
-    return row.row.cells.map((c) => c.value)
-  }
-
-  // Sticky header cells: the box-shadow paints `--header-bg` outward to cover the grid gaps
-  // (gap-x 0.75rem, gap-y 0.5rem) so scrolling rows below remain hidden. Height + leading
-  // force uniform header height regardless of intrinsic font size of each cell.
-  const blockHeader =
-    'sticky -top-2 z-[1] mb-2 h-5 leading-5 shadow-[0_0_0_0.5rem_var(--header-bg)]'
 </script>
 
 <div class="metrics-block rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
   <div class="scrollbar overflow-x-auto overflow-y-visible">
-  <div
-    class="grid min-w-96 items-baseline gap-x-3 gap-y-2 pb-2"
-    style="grid-template-columns: minmax(8rem, 1fr) 4rem 4rem 4rem 4.5rem;"
-  >
-    <!-- Header row: title + Avg / Min / Max headers. The rightmost (skew) column has no header
-         so the right edge is reserved for the per-row skew toggle. Sticky so it stays visible
-         while the block's rows scroll. The negative top/horizontal margins + padding extend
-         the white background out to cover the card's own padding when sticking. -->
-    {#if title}
-      <h3 class={`${blockHeader} bg-white-dark text-base font-semibold text-surface-900-100`}>{title}</h3>
-    {:else}
-      <span class={`${blockHeader} bg-white-dark`}></span>
-    {/if}
-    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Avg</div>
-    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Min</div>
-    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Max</div>
-    <div class={`${blockHeader} bg-white-dark`}></div>
-
-    {#each entries as entry, i (i)}
-      <BarChartMetric
-        label={entry.label}
-        metricId={entry.row.metric}
-        values={values(entry)}
-        expanded={isExpanded(entry)}
-        onToggle={() => toggle(entry)}
-      />
-    {/each}
-  </div>
+    <BarGrid showHeader {title}>
+      {#each entries as entry (entry.baseId)}
+        {#each barRows(entry) as br (br.key)}
+          <BarChartRow label={br.label} metricId={br.metricId} values={br.values} />
+        {/each}
+      {/each}
+    </BarGrid>
   </div>
 </div>
-
-<style>
-  /* Component-local theme tokens for bar chart visuals. We use Skeleton's single-tone vars
-     (defined under [data-theme=...] and inherited reliably) and switch on `.dark` ourselves,
-     instead of relying on Skeleton's dual-tone `*-200-800` vars inside color-mix() — which
-     resolved to transparent in this setup (cascade re-parsing of the dual-tone value doesn't
-     reach the data-theme scope in some browsers). Children consume these via the inherited
-     custom-property cascade. Kept in a <style> block so `:global(.dark)` and `:global(body.dark)`
-     can both target the same vars; Tailwind's `dark:` variant alone doesn't cover the
-     `body.dark` form used elsewhere in this app. */
-  .metrics-block {
-    --bar-low: var(--color-surface-100);
-    --bar-high: var(--color-error-300);
-    --skew-low: var(--color-surface-600);
-    --skew-high: var(--color-error-500);
-    --header-bg: white;
-  }
-  :global(.dark) .metrics-block,
-  :global(body.dark) .metrics-block {
-    --bar-low: var(--color-surface-900);
-    --bar-high: var(--color-error-700);
-    --skew-low: var(--color-surface-400);
-    --header-bg: var(--color-dark);
-  }
-</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/cache.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/cache.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildCacheTiles, isCacheFamilyMetric } from './cache.js'
+import type { MetricGroup } from './dispatch.js'
+import { metricKind } from './kind.js'
+
+function group(baseId: string): MetricGroup {
+  return { baseId, label: baseId, kind: metricKind(baseId), rows: [] }
+}
+
+describe('isCacheFamilyMetric', () => {
+  it('matches the six hit/miss/hit-rate cache metrics', () => {
+    for (const prefix of ['foreground', 'background']) {
+      for (const suffix of ['hits', 'misses', 'hit_rate_percent']) {
+        expect(isCacheFamilyMetric(`${prefix}_cache_${suffix}`)).toBe(true)
+      }
+    }
+  })
+
+  it('excludes occupancy and unrelated metrics', () => {
+    expect(isCacheFamilyMetric('foreground_cache_occupancy')).toBe(false)
+    expect(isCacheFamilyMetric('background_cache_occupancy')).toBe(false)
+    expect(isCacheFamilyMetric('used_memory_bytes')).toBe(false)
+  })
+})
+
+describe('buildCacheTiles', () => {
+  it('assembles one tile per cache, foreground first, with hits/misses/hit-rate assigned', () => {
+    const tiles = buildCacheTiles([
+      group('background_cache_misses'),
+      group('foreground_cache_hits'),
+      group('background_cache_hit_rate_percent'),
+      group('foreground_cache_hit_rate_percent'),
+      group('foreground_cache_misses'),
+      group('background_cache_hits'),
+      group('foreground_cache_occupancy') // ignored
+    ])
+    expect(tiles.map((t) => t.prefix)).toEqual(['foreground', 'background'])
+    const fg = tiles[0]!
+    expect(fg.title).toBe('Foreground cache')
+    expect(fg.hits?.baseId).toBe('foreground_cache_hits')
+    expect(fg.misses?.baseId).toBe('foreground_cache_misses')
+    expect(fg.hitRate?.baseId).toBe('foreground_cache_hit_rate_percent')
+  })
+
+  it('returns no tiles when the family is absent', () => {
+    expect(buildCacheTiles([group('used_memory_bytes')])).toEqual([])
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/cache.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/cache.ts
@@ -1,0 +1,47 @@
+// Groups the cache metric family into composite tiles. The hits/misses (K8) and hit-rate (K2)
+// metrics for each cache are subsumed into one CacheTile per cache (foreground / background)
+// rather than rendered as individual widgets. See ./README.md and parts/cache/CacheTile.svelte.
+import type { MetricGroup } from './dispatch'
+
+const CACHE_MEMBER = /^(foreground|background)_cache_(hits|misses|hit_rate_percent)$/
+
+/** True when a metric belongs to a cache tile (and so should not render as its own widget). */
+export function isCacheFamilyMetric(baseId: string): boolean {
+  return CACHE_MEMBER.test(baseId)
+}
+
+export type CacheTileData = {
+  prefix: string
+  title: string
+  hits?: MetricGroup
+  misses?: MetricGroup
+  hitRate?: MetricGroup
+}
+
+/** Assemble the cache-family groups in `groups` into one tile per cache, foreground first. */
+export function buildCacheTiles(groups: MetricGroup[]): CacheTileData[] {
+  const byPrefix = new Map<string, CacheTileData>()
+  for (const g of groups) {
+    const m = g.baseId.match(CACHE_MEMBER)
+    if (!m) {
+      continue
+    }
+    const prefix = m[1]!
+    let tile = byPrefix.get(prefix)
+    if (!tile) {
+      tile = { prefix, title: `${prefix[0]!.toUpperCase()}${prefix.slice(1)} cache` }
+      byPrefix.set(prefix, tile)
+    }
+    if (m[2] === 'hits') {
+      tile.hits = g
+    } else if (m[2] === 'misses') {
+      tile.misses = g
+    } else {
+      tile.hitRate = g
+    }
+  }
+  return ['foreground', 'background'].flatMap((p) => {
+    const t = byPrefix.get(p)
+    return t ? [t] : []
+  })
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/colors.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/colors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { barMetrics, logScale01 } from './colors.js'
+
+describe('barMetrics', () => {
+  it('maps the range endpoints to the height envelope', () => {
+    // v === min -> t 0 -> minH; v === max -> t 1 -> maxH.
+    expect(barMetrics(10, 10, 100, 6, 24)).toEqual({ t: 0, height: 6 })
+    expect(barMetrics(100, 10, 100, 6, 24)).toEqual({ t: 1, height: 24 })
+  })
+
+  it('is log-scaled between the endpoints (concave, emphasizes small values)', () => {
+    const mid = barMetrics(55, 10, 100, 6, 24) // raw 0.5
+    expect(mid.t).toBeCloseTo(logScale01(0.5), 10)
+    // Concave: the midpoint value sits above the linear halfway height.
+    expect(mid.height).toBeGreaterThan(6 + (24 - 6) * 0.5)
+  })
+
+  it('treats a degenerate range (no spread across workers) as a flat minimal bar', () => {
+    // A relative-difference chart has nothing to show when every worker is equal: t 0, not maxH.
+    expect(barMetrics(42, 42, 42)).toEqual({ t: 0, height: 6 })
+  })
+
+  it('honors custom height bounds', () => {
+    expect(barMetrics(100, 0, 100, 12, 32)).toEqual({ t: 1, height: 32 })
+    expect(barMetrics(0, 0, 100, 12, 32)).toEqual({ t: 0, height: 12 })
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
@@ -48,3 +48,22 @@ export function logScale01(t: number): number {
   // log(1 + x*(e-1)) / log(e) === log(1 + x*(e-1))
   return Math.log(1 + x * (Math.E - 1))
 }
+
+/**
+ * Bar geometry for a numeric value: log-normalize `v` within [min, max] to a fraction `t`
+ * (0..1, also the input to `barColor`) and the matching pixel `height` in [minH, maxH]. A
+ * degenerate range (min === max, i.e. no spread across workers) maps to `t = 0` — a flat
+ * minimal bar, since a relative-difference chart has nothing to show. Shared by the K1
+ * distribution bars (BarChartRow) and the cache tile's value bars (ValueBars) so both use the
+ * same curve and the same 6px..24px envelope.
+ */
+export function barMetrics(
+  v: number,
+  min: number,
+  max: number,
+  minH = 6,
+  maxH = 24
+): { t: number; height: number } {
+  const t = min === max ? 0 : logScale01((v - min) / (max - min))
+  return { t, height: minH + (maxH - minH) * t }
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { NodeAttributes, TooltipRow } from 'profiler-lib'
+import { describe, expect, it } from 'vitest'
 import { buildBlocks } from './dispatch.js'
 
 function row(metric: string): TooltipRow {
@@ -21,12 +21,7 @@ function makeAttrs(metrics: string[]): NodeAttributes {
 describe('buildBlocks', () => {
   it('orders metrics lexicographically inside each block (case-insensitive)', () => {
     // Metric IDs span categories; the order is intentionally scrambled to confirm the sort.
-    const attrs = makeAttrs([
-      'zeta_seconds',
-      'Alpha_count',
-      'gamma_size',
-      'alpha_total'
-    ])
+    const attrs = makeAttrs(['zeta_seconds', 'Alpha_count', 'gamma_size', 'alpha_total'])
     const blocks = buildBlocks(attrs, /* showAdvanced */ true)
     // All metrics fall into the same "Other" bucket (no descriptions registered),
     // so we expect a single block whose entries are alphabetised by label.

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
@@ -1,20 +1,40 @@
 // Builds the renderable block list for a NodeAttributes payload.
 //
-// Blocks are grouped by the metric's category, retrieved from the profile metadata
-// (`ProfileMetricDescription::category`). Every block renders as a distribution.
+// Blocks are grouped by the metric's category (from `ProfileMetricDescription::category`).
+// Within a block, the sub-rows a composite metric was split into by `parseValues` (e.g.
+// `output_batches_stats.count`, `.avg_size`, …) are regrouped under their shared base id into
+// a single `MetricGroup`, tagged with the visualization kind. See ./README.md.
 
-import type { NodeAttributes, TooltipRow } from 'profiler-lib'
+import type { NodeAttributes, PropertyValue } from 'profiler-lib'
 import { measurementCategory, measurementDescription } from 'profiler-lib'
+import { type MetricKind, metricKind, splitBaseId } from './kind'
 
-export type RenderableMetric = {
-  row: TooltipRow
+/** One decoded (sub)field of a metric, carrying its per-worker values (indexed by worker). */
+export type MetricSubRow = {
+  /** Suffix after the base id: '' for scalars, e.g. '.count', '.used', '.slot:0.steps'. */
+  suffix: string
+  /** Humanized label of the full metric id (base + suffix). */
   label: string
+  values: PropertyValue[]
+  /** Profile-wide value range for this metric (min/max across all nodes and workers). */
+  range?: { min: number; max: number }
+}
+
+/** A metric and all its sub-rows, grouped for rendering by a single kind renderer. */
+export type MetricGroup = {
+  /** Base metric id (before the first '.'), e.g. 'output_batches_stats'. */
+  baseId: string
+  /** Humanized label of the base id. */
+  label: string
+  kind: MetricKind
+  /** Sub-rows sharing this base id, in first-seen order. Scalars have exactly one, with ''. */
+  rows: MetricSubRow[]
 }
 
 export type RenderableBlock = {
   id: string
   title: string
-  entries: RenderableMetric[]
+  entries: MetricGroup[]
 }
 
 const UNCATEGORIZED = 'Other'
@@ -31,37 +51,41 @@ const labelFor = (id: string): string => {
 const slugify = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, '-')
 
 export function buildBlocks(attrs: NodeAttributes, showAdvanced: boolean): RenderableBlock[] {
-  // Preserve first-seen category order from the rows.
-  const byCategory = new Map<string, RenderableMetric[]>()
+  // Preserve first-seen category order; within a category, group rows by base id.
+  const byCategory = new Map<string, Map<string, MetricGroup>>()
   for (const row of attrs.rows) {
     if (!showAdvanced && measurementDescription(row.metric).advanced) {
       continue
     }
     const category = measurementCategory(row.metric) || UNCATEGORIZED
-    let bucket = byCategory.get(category)
-    if (!bucket) {
-      bucket = []
-      byCategory.set(category, bucket)
+    const { baseId, suffix } = splitBaseId(row.metric)
+    let groups = byCategory.get(category)
+    if (!groups) {
+      groups = new Map()
+      byCategory.set(category, groups)
     }
-    bucket.push({
-      row,
-      label: labelFor(row.metric)
+    let group = groups.get(baseId)
+    if (!group) {
+      group = { baseId, label: labelFor(baseId), kind: metricKind(baseId), rows: [] }
+      groups.set(baseId, group)
+    }
+    group.rows.push({
+      suffix,
+      label: labelFor(row.metric),
+      values: row.cells.map((c) => c.value),
+      ...(row.range ? { range: row.range } : {})
     })
   }
 
-  // Sort metrics inside each block by their displayed label so users can scan a long block
+  // Sort groups inside each block by their displayed label so users can scan a long block
   // without re-reading the whole thing. Locale-aware compare with `numeric: true`
   // keeps numbered labels like "slot 2 ..." / "slot 10 ..." in their natural sequence.
   const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true })
-  for (const entries of byCategory.values()) {
-    entries.sort(
-      (a, b) =>
-        collator.compare(a.label, b.label) || collator.compare(a.row.metric, b.row.metric)
-    )
-  }
-
   const out: RenderableBlock[] = []
-  for (const [category, entries] of byCategory) {
+  for (const [category, groups] of byCategory) {
+    const entries = [...groups.values()].sort(
+      (a, b) => collator.compare(a.label, b.label) || collator.compare(a.baseId, b.baseId)
+    )
     out.push({ id: `category-${slugify(category)}`, title: category, entries })
   }
   return out

--- a/js-packages/profiler-layout/src/lib/components/metrics/kind.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/kind.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { CARD_KINDS, isCardKind, type MetricKind, metricKind, splitBaseId } from './kind.js'
+
+describe('metricKind', () => {
+  // Exhaustive expected classification for every metric_id defined in CIRCUIT_METRICS
+  // (crates/dbsp/src/circuit/metadata.rs) plus the `persistent_id` node attribute. Keep in sync
+  // when metrics are added on the Rust side; a new metric that lands here as K1 by default
+  // should be moved to the kind it visualizes best. See ./README.md.
+  const EXPECTED: Record<MetricKind, string[]> = {
+    K1: [
+      'accumulator_records_to_repartition_count',
+      'allocated_memory_bytes',
+      'bloom_filter_bits_per_key',
+      'bloom_filter_hits_count',
+      'bloom_filter_misses_count',
+      'bloom_filter_size_bytes',
+      'circuit_idle_time_seconds',
+      'circuit_runtime_elapsed_seconds',
+      'circuit_runtime_seconds',
+      'circuit_wait_time_seconds',
+      'computed_output_records_count',
+      'exchange_deserialization_time_seconds',
+      'exchange_deserialized_bytes',
+      'exchange_serialization_time_seconds',
+      'exchange_serialized_bytes',
+      'exchange_wait_time_seconds',
+      'inprogress_rebalancing_time_seconds',
+      'input_integral_records_count',
+      'input_records_count',
+      'integral_records_to_repartition_count',
+      'invocations_count',
+      'left_input_records_count',
+      'local_shard_records_count',
+      'loose_batches_count',
+      'loose_memory_records_count',
+      'loose_storage_records_count',
+      'memory_allocations_count',
+      'merge_backpressure_wait_time_seconds',
+      'merging_batches_count',
+      'merging_memory_records_count',
+      'merging_size_bytes',
+      'merging_storage_records_count',
+      'negative_weight_count',
+      'range_filter_hits_count',
+      'range_filter_misses_count',
+      'range_filter_size_bytes',
+      'rebalancings_count',
+      'right_input_integral_records_count',
+      'roaring_filter_hits_count',
+      'roaring_filter_misses_count',
+      'roaring_filter_size_bytes',
+      'runtime_seconds',
+      'shared_memory_bytes',
+      'spine_batches_count',
+      'spine_count',
+      'spine_storage_size_bytes',
+      'state_records_count',
+      'steps_count',
+      'total_rebalancing_time_seconds',
+      'used_memory_bytes'
+    ],
+    K2: [
+      'background_cache_hit_rate_percent',
+      'bloom_filter_hit_rate_percent',
+      'foreground_cache_hit_rate_percent',
+      'merge_reduction_percent',
+      'nonblocking_percent',
+      'output_redundancy_percent',
+      'range_filter_hit_rate_percent',
+      'roaring_filter_hit_rate_percent',
+      'runtime_percent'
+    ],
+    K3: ['background_cache_occupancy', 'foreground_cache_occupancy'],
+    K4: ['balancer_policy', 'retainment_bounds', 'persistent_id'],
+    K5: ['rebalancing_in_progress_bool'],
+    K6: ['compaction_state'],
+    K7: [
+      'input_batches_stats',
+      'left_input_batches_stats',
+      'output_batches_stats',
+      'prefix_batches_stats',
+      'right_input_batches_stats'
+    ],
+    K8: [
+      'background_cache_hits',
+      'background_cache_misses',
+      'foreground_cache_hits',
+      'foreground_cache_misses'
+    ],
+    K9: ['completed_merges'],
+    K10: ['key_distribution'],
+    K11: ['size_distribution']
+  }
+
+  for (const [kind, ids] of Object.entries(EXPECTED) as Array<[MetricKind, string[]]>) {
+    it.each(ids)(`classifies %s as ${kind}`, (metric) => {
+      expect(metricKind(metric)).toBe(kind)
+    })
+  }
+
+  it('falls back to K1 for unknown suffixes', () => {
+    expect(metricKind('some_new_metric_widget')).toBe('K1')
+  })
+})
+
+describe('splitBaseId', () => {
+  it('returns the whole id and empty suffix when there is no dot', () => {
+    expect(splitBaseId('used_memory_bytes')).toEqual({
+      baseId: 'used_memory_bytes',
+      suffix: ''
+    })
+  })
+
+  it('splits a composite sub-row at the first dot', () => {
+    expect(splitBaseId('output_batches_stats.avg_size')).toEqual({
+      baseId: 'output_batches_stats',
+      suffix: '.avg_size'
+    })
+  })
+
+  it('keeps labels and trailing sub-fields together in the suffix', () => {
+    expect(splitBaseId('completed_merges.slot:0.steps')).toEqual({
+      baseId: 'completed_merges',
+      suffix: '.slot:0.steps'
+    })
+  })
+})
+
+describe('isCardKind', () => {
+  it('routes every non-bar kind to its own card', () => {
+    for (const k of [
+      'K2',
+      'K3',
+      'K4',
+      'K5',
+      'K6',
+      'K7',
+      'K8',
+      'K9',
+      'K10',
+      'K11'
+    ] as MetricKind[]) {
+      expect(isCardKind(k)).toBe(true)
+    }
+  })
+
+  it('keeps K1 (bar chart) in the distribution grid', () => {
+    expect(isCardKind('K1')).toBe(false)
+    expect(CARD_KINDS.has('K1')).toBe(false)
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/kind.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/kind.ts
@@ -1,0 +1,87 @@
+// Classifies a metric into a visualization kind. See ./README.md for the full catalog of
+// kinds, their value shapes, and member metrics.
+//
+// The kind is derived from the last `_`-separated token of the metric's *base id* (the part
+// before the first '.'), mirroring the suffix dispatch in profiler-lib's `parseValues`. The
+// base id is used so composite sub-rows (e.g. `output_batches_stats.count`) and labeled rows
+// (e.g. `compaction_state.slot:0`) classify by their parent metric.
+
+export type MetricKind =
+  | 'K1' //  per-worker magnitude scalar (count/bytes/seconds)  -> bar chart
+  | 'K2' //  per-worker bounded fraction (percent)              -> ring
+  | 'K3' //  per-worker fraction of capacity ({used, max})      -> ring (track = max)
+  | 'K4' //  per-worker categorical / string                    -> chips
+  | 'K5' //  per-worker boolean                                  -> checkboxes
+  | 'K6' //  per-(worker x level) categorical state             -> chip grid
+  | 'K7' //  batch-size summary tuple                            -> count/total + range bar
+  | 'K8' //  cache counts tuple                                  -> grid
+  | 'K9' //  merge progress per (worker x level)                -> histogram (switch worker)
+  | 'K10' // worker-fanout matrix                                -> heatmap
+  | 'K11' // binned size histogram                               -> histogram (switch worker)
+
+/** Split a metric id into its base id (before the first '.') and the remaining suffix. */
+export function splitBaseId(metric: string): { baseId: string; suffix: string } {
+  const dot = metric.indexOf('.')
+  if (dot < 0) {
+    return { baseId: metric, suffix: '' }
+  }
+  return { baseId: metric.slice(0, dot), suffix: metric.slice(dot) }
+}
+
+/** Classify a base metric id into its visualization kind. Unknown suffixes fall to K1. */
+export function metricKind(baseId: string): MetricKind {
+  const suffix = baseId.split('_').pop()
+  switch (suffix) {
+    case 'percent':
+      return 'K2'
+    case 'occupancy':
+      return 'K3'
+    case 'policy':
+    case 'bounds':
+    case 'id':
+      return 'K4'
+    case 'bool':
+      return 'K5'
+    case 'state':
+      return 'K6'
+    case 'stats':
+      return 'K7'
+    case 'hits':
+    case 'misses':
+      return 'K8'
+    case 'merges':
+      return 'K9'
+    case 'distribution':
+      // Both `key_distribution` and `size_distribution` share this suffix; the array axis of
+      // the former is the worker axis (a matrix), the latter is a bag of batch sizes.
+      return baseId.startsWith('key_') ? 'K10' : 'K11'
+    default:
+      return 'K1'
+  }
+}
+
+/**
+ * Kinds that render as their own self-contained card, outside the bar-chart distribution grid.
+ *
+ * The distribution grid (`MetricsDistributionBlock`) is bar-chart-only: a fixed Avg/Min/Max
+ * grid with a per-row skew toggle. Only kinds absent from this set go there; a kind is added
+ * here once its dedicated card renderer lands (see ./README.md). While empty, every metric
+ * still renders as a bar chart, exactly as before.
+ */
+export const CARD_KINDS: ReadonlySet<MetricKind> = new Set<MetricKind>([
+  'K2',
+  'K3',
+  'K4',
+  'K5',
+  'K6',
+  'K7',
+  'K8',
+  'K9',
+  'K10',
+  'K11'
+])
+
+/** True when a kind renders as its own card rather than a row in the bar-chart grid. */
+export function isCardKind(kind: MetricKind): boolean {
+  return CARD_KINDS.has(kind)
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/kindHelp.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/kindHelp.ts
@@ -1,0 +1,26 @@
+import type { MetricKind } from './kind'
+
+// Concise "what is this and how do I read it" help for kinds whose visualization is not
+// self-evident. Shown as a tooltip on a help icon next to the metric title (MetricKindBlock).
+// Kinds absent from this map get no help icon.
+const KIND_HELP: Partial<Record<MetricKind, string>> = {
+  K6:
+    'Compaction state per spine level. One row per level (slot), one cell per worker, colored by ' +
+    'state: idle, compaction requested, or compaction in progress. Read down a column to see one ' +
+    'worker across levels; read across a row to compare workers at the same level. Hover a cell ' +
+    'for its worker and state.',
+  K7:
+    'Batch-size distribution across workers. Each row is a worker, sorted by average records ' +
+    'per batch (smallest on top); the x axis is records per batch. The avg line runs between the ' +
+    'min and max lines, so the horizontal gap on a row is that worker’s batch-size spread. ' +
+    'Hover a row to mark that worker on the lines.',
+  K9:
+    'Completed merge work per spine level. Each row is a spine level; bar length is the number ' +
+    'of merge steps completed there (log-scaled, so small bars stay visible). Shows the average and skew ' +
+    'across workers by default; hover the cursor left to right to inspect a single worker.'
+}
+
+/** Help text for a kind, or undefined when the visualization needs no explanation. */
+export function kindHelp(kind: MetricKind): string | undefined {
+  return KIND_HELP[kind]
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -1,173 +1,22 @@
 <script lang="ts">
-  import { Popover, Tooltip } from 'common-ui'
-  import { MissingValue, type PropertyValue } from 'profiler-lib'
-  import { barColor, logScale01, skewTextColor } from '../colors'
+  // Widget for kind K1 (per-worker magnitude scalar). Symmetric with every other kind widget:
+  // takes a single `MetricGroup` and renders self-contained card body. The aggregated
+  // MetricsDistributionBlock is a special case that packs many BarChartRow items into one shared
+  // BarGrid; this widget is the single-metric case of the same system.
+  import type { MetricGroup } from '../dispatch'
+  import BarChartRow from './BarChartRow.svelte'
+  import BarGrid from './BarGrid.svelte'
 
   interface Props {
-    label: string
-    metricId: string
-    /** Per-worker values. Missing readings appear as `MissingValue` and are skipped by the
-     * statistics; their bar height is forced to zero. */
-    values: PropertyValue[]
-    expanded: boolean
-    onToggle: () => void
+    group: MetricGroup
   }
-  const { label, metricId, values, expanded, onToggle }: Props = $props()
-
-  /**
-   * Collapsed-view preview style:
-   *  - 'values': show avg/min/max numbers, hide bars (bars animate up from zero on expand).
-   *  - 'bars':   show short bars, hide avg/min/max (numbers fade in on expand).
-   */
-  const previewMode: 'values' | 'bars' = 'values' as 'values' | 'bars'
-
-  // Bar maths use the strictly-numeric subset. String-valued cells (enum metrics like balancer
-  // policy) skip this — they render flat bars but still contribute to the Avg column via
-  // `.average()` (returns the mode). Min/Max are suppressed for non-comparable kinds.
-  const numbers = $derived.by(() => {
-    const out: number[] = []
-    for (const v of values) {
-      const n = v.getNumericValue()
-      if (n.isSome()) {
-        out.push(n.unwrap())
-      }
-    }
-    return out
-  })
-
-  const stats = $derived.by(() => {
-    if (numbers.length === 0) {
-      return { min: 0, max: 0, n: 0 }
-    }
-    let min = numbers[0]!
-    let max = numbers[0]!
-    for (const v of numbers) {
-      if (v < min) {
-        min = v
-      }
-      if (v > max) {
-        max = v
-      }
-    }
-    return { min, max, n: numbers.length }
-  })
-
-  // Display rows operate on every non-missing cell (booleans, enum strings, numbers alike).
-  // Min/Max use `PropertyValue.compareTo`, which only carries magnitude information for
-  // comparable kinds (Count/Bytes/Time/Percent). For non-comparable kinds (BooleanValue,
-  // StringValue) the ordering is nominal — "min false / max true" or the lexicographic ends of
-  // an enum carry no information — so we suppress Min/Max and show only Avg (the mode).
-  const display = $derived.by(() => {
-    const real = values.filter((v) => !(v instanceof MissingValue))
-    if (real.length === 0) {
-      return { avg: MissingValue.INSTANCE, min: MissingValue.INSTANCE, max: MissingValue.INSTANCE }
-    }
-    const avg = real[0]!.average(real.slice(1))
-    if (!real[0]!.isComparable()) {
-      return { avg, min: MissingValue.INSTANCE, max: MissingValue.INSTANCE }
-    }
-    let min = real[0]!
-    let max = real[0]!
-    for (const v of real) {
-      if (v.compareTo(min) < 0) {
-        min = v
-      }
-      if (v.compareTo(max) > 0) {
-        max = v
-      }
-    }
-    return { avg, min, max }
-  })
-
-  // Skew = spread across workers (max - min) as a percentage of the largest-magnitude value.
-  // Using the largest absolute value as the denominator keeps the result well-defined when the
-  // values are negative (where `max` could be 0 or negative even though the spread is large).
-  const skew = $derived.by(() => {
-    const scale = Math.max(Math.abs(stats.max), Math.abs(stats.min))
-    if (stats.n === 0 || scale === 0) {
-      return 0
-    }
-    return ((stats.max - stats.min) / scale) * 100
-  })
-
-  function bar(v: PropertyValue) {
-    const collapsedHeight = previewMode === 'bars' ? 12 : 0
-    if (stats.n === 0 || stats.max === stats.min) {
-      return { t: 0, height: expanded ? 12 : collapsedHeight }
-    }
-    const num = v.getNumericValue()
-    const raw = num.isSome() ? (num.unwrap() - stats.min) / (stats.max - stats.min) : 0
-    const t = logScale01(raw)
-    const height = expanded ? 12 + (32 - 12) * t : collapsedHeight
-    return { t, height }
-  }
-
-  const chartHeight = $derived(expanded ? 32 : previewMode === 'bars' ? 12 : 0)
-  const showValues = $derived(expanded || previewMode === 'values')
+  const { group }: Props = $props()
 </script>
 
-<!-- Col 1: label -->
-<div class="col-span-1 flex min-w-0 items-baseline gap-3 pt-1">
-  <span class="truncate text-sm font-medium text-surface-900-100">{label}</span>
-  <Popover>
-    <div>{label}</div>
-    <div class="text-sm text-surface-700-300">{metricId}</div>
-  </Popover>
-</div>
-<!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
-     collapse/expand doesn't reflow the grid mid-transition. -->
-{#each [display.avg, display.min, display.max] as stat}
-<div
-  class="value-cell text-right text-sm tabular-nums text-surface-700-300 {showValues ? 'opacity-100' : 'opacity-0'}"
-  aria-hidden={!showValues}
->
-  {stat.toString()}
-</div>
-{/each}
-<!-- Col 5: skew toggle — always present, always pinned to the top-right -->
-<div class="flex items-center justify-end">
-  <button
-    type="button"
-    onclick={onToggle}
-    class="flex items-center gap-1 text-sm"
-  >
-    <span class="tabular-nums text-nowrap" style:color={skewTextColor(skew)}>
-      Skew {skew.toFixed(0)}%
-    </span>
-    <span
-      class="fd fd-chevron-down text-[16px] chevron text-surface-600-400"
-      class:rotate-180={expanded}
-      aria-hidden="true"
-    ></span>
-  </button>
-</div>
-
-<!-- Bar chart row spans full block width; container height + each bar height animate.
-     Each bar gets a hover tooltip showing the worker index and the formatted reading. -->
-<div
-  class="bar-chart col-span-5 flex items-end gap-0.5"
-  style:height="{chartHeight}px"
->
-  {#each values as v, i (i)}
-    {@const b = bar(v)}
-    <div
-      class="flex-1 rounded-sm transition-[height,background-color] duration-200 ease-in-out"
-      style:height="{b.height}px"
-      style:background-color={barColor(b.t)}
-    ></div>
-    <Tooltip class="whitespace-nowrap" placement="top">Worker {i}: {v.toString()}</Tooltip>
-  {/each}
-</div>
-
-<style>
-  .bar-chart {
-    transition: height 200ms ease;
-  }
-  .value-cell {
-    transition: opacity 150ms ease;
-  }
-  .chevron {
-    display: inline-block;
-    transition: transform 200ms ease;
-  }
-</style>
+<BarGrid showHeader>
+  <BarChartRow
+    label={group.label}
+    metricId={group.baseId}
+    values={group.rows[0]?.values ?? []}
+  />
+</BarGrid>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartRow.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartRow.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  // One bar-chart metric row: emits grid children (label, avg, min, max, skew toggle, bar row)
+  // into an enclosing BarGrid. Self-contained — owns its own expand state — so it composes both
+  // in the aggregated MetricsDistributionBlock and in a single-metric BarChartMetric widget.
+  import { Popover } from 'common-ui'
+  import { MissingValue, type PropertyValue } from 'profiler-lib'
+  import { barColor, barMetrics, skewTextColor } from '../colors'
+  import BarRow from './BarRow.svelte'
+
+  interface Props {
+    label: string
+    metricId: string
+    /** Per-worker values. Missing readings appear as `MissingValue` and are skipped by the
+     * statistics; their bar height is forced to zero. */
+    values: PropertyValue[]
+  }
+  const { label, metricId, values }: Props = $props()
+
+  let expanded = $state(false)
+
+  /**
+   * Collapsed-view preview style:
+   *  - 'values': show avg/min/max numbers, hide bars (bars animate up from zero on expand).
+   *  - 'bars':   show short bars, hide avg/min/max (numbers fade in on expand).
+   */
+  const previewMode: 'values' | 'bars' = 'values' as 'values' | 'bars'
+
+  // Bar maths use the strictly-numeric subset. String-valued cells (enum metrics like balancer
+  // policy) skip this — they render flat bars but still contribute to the Avg column via
+  // `.average()` (returns the mode). Min/Max are suppressed for non-comparable kinds.
+  const numbers = $derived.by(() => {
+    const out: number[] = []
+    for (const v of values) {
+      const n = v.getNumericValue()
+      if (n.isSome()) {
+        out.push(n.unwrap())
+      }
+    }
+    return out
+  })
+
+  const stats = $derived.by(() => {
+    if (numbers.length === 0) {
+      return { min: 0, max: 0, n: 0 }
+    }
+    let min = numbers[0]!
+    let max = numbers[0]!
+    for (const v of numbers) {
+      if (v < min) {
+        min = v
+      }
+      if (v > max) {
+        max = v
+      }
+    }
+    return { min, max, n: numbers.length }
+  })
+
+  // Display rows operate on every non-missing cell (booleans, enum strings, numbers alike).
+  // Min/Max use `PropertyValue.compareTo`, which only carries magnitude information for
+  // comparable kinds (Count/Bytes/Time/Percent). For non-comparable kinds (BooleanValue,
+  // StringValue) the ordering is nominal — "min false / max true" or the lexicographic ends of
+  // an enum carry no information — so we suppress Min/Max and show only Avg (the mode).
+  const display = $derived.by(() => {
+    const real = values.filter((v) => !(v instanceof MissingValue))
+    if (real.length === 0) {
+      return { avg: MissingValue.INSTANCE, min: MissingValue.INSTANCE, max: MissingValue.INSTANCE }
+    }
+    const avg = real[0]!.average(real.slice(1))
+    if (!real[0]!.isComparable()) {
+      return { avg, min: MissingValue.INSTANCE, max: MissingValue.INSTANCE }
+    }
+    let min = real[0]!
+    let max = real[0]!
+    for (const v of real) {
+      if (v.compareTo(min) < 0) {
+        min = v
+      }
+      if (v.compareTo(max) > 0) {
+        max = v
+      }
+    }
+    return { avg, min, max }
+  })
+
+  // Skew = spread across workers (max - min) as a percentage of the largest-magnitude value.
+  // Using the largest absolute value as the denominator keeps the result well-defined when the
+  // values are negative (where `max` could be 0 or negative even though the spread is large).
+  const skew = $derived.by(() => {
+    const scale = Math.max(Math.abs(stats.max), Math.abs(stats.min))
+    if (stats.n === 0 || scale === 0) {
+      return 0
+    }
+    return ((stats.max - stats.min) / scale) * 100
+  })
+
+  // Bars share the 6px..24px envelope and log curve with the cache tile via `barMetrics`.
+  const MIN_H = 6
+  const MAX_H = 24
+
+  // One BarRow bar per worker. Non-numeric / missing cells resolve to t=0 (a flat minimal bar).
+  // In the collapsed state the height is the preview height; on expand it animates to the full
+  // log-normalized height.
+  const bars = $derived.by(() => {
+    const collapsedHeight = previewMode === 'bars' ? MIN_H : 0
+    return values.map((v, i) => {
+      const num = v.getNumericValue()
+      const t =
+        stats.n === 0 || !num.isSome()
+          ? 0
+          : barMetrics(num.unwrap(), stats.min, stats.max, MIN_H, MAX_H).t
+      const height = expanded ? MIN_H + (MAX_H - MIN_H) * t : collapsedHeight
+      return { height, color: barColor(t), tooltip: `Worker ${i}: ${v.toString()}` }
+    })
+  })
+
+  const chartHeight = $derived(expanded ? MAX_H : previewMode === 'bars' ? MIN_H : 0)
+  const showValues = $derived(expanded || previewMode === 'values')
+</script>
+
+<!-- Col 1: label -->
+<div class="col-span-1 flex min-w-0 items-baseline gap-3 pt-1">
+  <span class="truncate text-sm font-medium text-surface-900-100">{label}</span>
+  <Popover>
+    <div>{label}</div>
+    <div class="text-sm text-surface-700-300">{metricId}</div>
+  </Popover>
+</div>
+<!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
+     collapse/expand doesn't reflow the grid mid-transition. -->
+{#each [display.avg, display.min, display.max] as stat}
+  <div
+    class="value-cell text-right text-sm tabular-nums text-surface-700-300 {showValues
+      ? 'opacity-100'
+      : 'opacity-0'}"
+    aria-hidden={!showValues}
+  >
+    {stat.toString()}
+  </div>
+{/each}
+<!-- Col 5: skew toggle — always present, always pinned to the top-right -->
+<div class="flex items-center justify-end">
+  <button
+    type="button"
+    onclick={() => (expanded = !expanded)}
+    class="flex items-center gap-1 text-sm"
+  >
+    <span class="tabular-nums text-nowrap" style:color={skewTextColor(skew)}>
+      Skew {skew.toFixed(0)}%
+    </span>
+    <span
+      class="fd fd-chevron-down chevron text-[16px] text-surface-600-400"
+      class:rotate-180={expanded}
+      aria-hidden="true"
+    ></span>
+  </button>
+</div>
+
+<!-- Bar chart row spans full block width; container height + each bar height animate.
+     Each bar gets a hover tooltip showing the worker index and the formatted reading. -->
+<BarRow class="col-span-5" {bars} height={chartHeight} />
+
+<style>
+  .value-cell {
+    transition: opacity 150ms ease;
+  }
+  .chevron {
+    display: inline-block;
+    transition: transform 200ms ease;
+  }
+</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarGrid.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarGrid.svelte
@@ -1,0 +1,48 @@
+<script lang="ts" module>
+  // The bar-chart column template, shared so a single-metric widget and the aggregated
+  // distribution block align identically (fixed columns + a flexible label column).
+  export const BAR_GRID_TEMPLATE = 'minmax(8rem, 1fr) 4rem 4rem 4rem 4.5rem'
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    /** Render the sticky Avg / Min / Max header row. */
+    showHeader?: boolean
+    /** First header cell (e.g. a category name); omitted for a single metric. */
+    title?: string
+    /** BarChartRow items filling the grid. */
+    children: Snippet
+  }
+  const { showHeader = false, title, children }: Props = $props()
+
+  // Sticky header cells: the box-shadow paints `--header-bg` outward to cover the grid gaps
+  // (gap-x 0.75rem, gap-y 0.5rem) so scrolling rows below remain hidden. Height + leading
+  // force uniform header height regardless of intrinsic font size of each cell.
+  const blockHeader =
+    'sticky -top-2 z-[1] mb-2 h-5 leading-5 shadow-[0_0_0_0.5rem_var(--header-bg)]'
+</script>
+
+<div
+  class="grid min-w-96 items-baseline gap-x-3 gap-y-2 pb-2"
+  style="grid-template-columns: {BAR_GRID_TEMPLATE};"
+>
+  {#if showHeader}
+    <!-- The rightmost (skew) column has no header so the right edge is reserved for the per-row
+         skew toggle. The negative top/horizontal margins + padding extend the background out to
+         cover the card's own padding when sticking. -->
+    {#if title}
+      <h3 class={`${blockHeader} bg-white-dark text-base font-semibold text-surface-900-100`}>
+        {title}
+      </h3>
+    {:else}
+      <span class={`${blockHeader} bg-white-dark`}></span>
+    {/if}
+    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Avg</div>
+    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Min</div>
+    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Max</div>
+    <div class={`${blockHeader} bg-white-dark`}></div>
+  {/if}
+  {@render children()}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarRow.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarRow.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  // Shared presentational bar row: a flex row of per-worker bars, each with a hover tooltip.
+  // Heights and colors are computed by the caller (via `colors.barPx` / `barColor`); this
+  // component owns only the markup, the expand/collapse height transition, and optional
+  // click-to-select. Used by both the K1 distribution bars (BarChartRow, non-interactive, grid
+  // child) and the cache tile's value bars (ValueBars, selectable).
+  import { Tooltip } from 'common-ui'
+
+  interface Bar {
+    /** Bar height in px (0 hides the bar; heights animate on change). */
+    height: number
+    /** CSS fill color. */
+    color: string
+    /** Tooltip text shown on hover. */
+    tooltip: string
+  }
+  interface Props {
+    bars: Bar[]
+    /** Container height in px; also animated, so collapsing to 0 slides the bars away. */
+    height: number
+    /** Extra classes on the container (e.g. grid `col-span-*`). */
+    class?: string
+    /** When `onselect` is given, bars become clickable buttons and the selected one is outlined. */
+    selected?: number | null
+    onselect?: (worker: number) => void
+  }
+  const { bars, height, class: klass = '', selected = null, onselect }: Props = $props()
+</script>
+
+<div class="bar-row flex items-end gap-0.5 {klass}" style:height="{height}px">
+  {#each bars as b, i (i)}
+    {#if onselect}
+      <button
+        type="button"
+        class="min-w-0 flex-1 rounded-sm transition-[height,background-color] duration-200 ease-in-out"
+        class:selected={selected === i}
+        style:height="{b.height}px"
+        style:background-color={b.color}
+        onclick={() => onselect(i)}
+        aria-label={`Worker ${i}`}
+      ></button>
+    {:else}
+      <div
+        class="min-w-0 flex-1 rounded-sm transition-[height,background-color] duration-200 ease-in-out"
+        style:height="{b.height}px"
+        style:background-color={b.color}
+      ></div>
+    {/if}
+    <Tooltip class="whitespace-nowrap" placement="top">{b.tooltip}</Tooltip>
+  {/each}
+</div>
+
+<style>
+  .bar-row {
+    transition: height 200ms ease;
+  }
+  .selected {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 1px;
+  }
+</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BooleanMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BooleanMetric.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  // K5 — per-worker boolean. A read-only checkbox per worker plus a "k of N true" summary.
+  import { Tooltip } from 'common-ui'
+  import type { MetricGroup } from '../dispatch'
+  import { isMissing, numeric } from './metricData'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const values = $derived(group.rows[0]?.values ?? [])
+  const trueCount = $derived(values.filter((v) => !isMissing(v) && numeric(v) !== 0).length)
+  const total = $derived(values.filter((v) => !isMissing(v)).length)
+</script>
+
+<div class="flex flex-col gap-2">
+  <div class="flex flex-wrap gap-1.5">
+    {#each values as v, i (i)}
+      <div>
+        <input
+          type="checkbox"
+          class="pointer-events-none"
+          checked={!isMissing(v) && numeric(v) !== 0}
+          disabled
+          aria-label={`Worker ${i}`}
+        />
+        <Tooltip class="whitespace-nowrap" placement="top">Worker {i}: {v.toString()}</Tooltip>
+      </div>
+    {/each}
+  </div>
+  <div class="text-xs tabular-nums text-surface-600-400">{trueCount} of {total} true</div>
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/CacheCountsMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/CacheCountsMetric.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  // K8 — cache counts. A per-worker grid with avg_latency as the headline column, then count,
+  // then bytes. (avg_latency = elapsed/count already summarizes the elapsed total.)
+  import type { PropertyValue } from 'profiler-lib'
+  import type { MetricGroup } from '../dispatch'
+  import { rowEndingWith, workerCount } from './metricData'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const latency = $derived(rowEndingWith(group, '.avg_latency'))
+  const count = $derived(rowEndingWith(group, '.count'))
+  const bytes = $derived(rowEndingWith(group, '.bytes'))
+  const n = $derived(workerCount(group))
+  const workers = $derived(Array.from({ length: n }, (_, i) => i))
+
+  const cell = (v: PropertyValue | undefined) => v?.toString() ?? '–'
+</script>
+
+<div
+  class="grid gap-x-3 gap-y-0.5 text-sm tabular-nums"
+  style="grid-template-columns: 3rem 1fr 1fr 1fr;"
+>
+  <div></div>
+  <div class="text-right text-xs font-medium text-surface-600-400">avg latency</div>
+  <div class="text-right text-xs font-medium text-surface-600-400">count</div>
+  <div class="text-right text-xs font-medium text-surface-600-400">bytes</div>
+  {#each workers as i (i)}
+    <div class="text-xs text-surface-600-400">W{i}</div>
+    <div class="text-right font-medium text-surface-900-100">{cell(latency?.values[i])}</div>
+    <div class="text-right text-surface-700-300">{cell(count?.values[i])}</div>
+    <div class="text-right text-surface-700-300">{cell(bytes?.values[i])}</div>
+  {/each}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/ChipMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/ChipMetric.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  // K4 — per-worker categorical / string. One chip per worker; one chip-row per string sub-field
+  // (e.g. retainment_bounds → key_bounds, value_bounds).
+  import { Tooltip } from 'common-ui'
+  import type { MetricGroup } from '../dispatch'
+  import { isMissing } from './metricData'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+</script>
+
+<div class="flex flex-col gap-2">
+  {#each group.rows as row (row.suffix)}
+    <div>
+      {#if group.rows.length > 1}
+        <div class="mb-1 text-xs font-medium text-surface-700-300">{row.label}</div>
+      {/if}
+      <div class="flex flex-wrap gap-1">
+        {#each row.values as v, i (i)}
+          <span
+            class="rounded-base bg-surface-200-800 px-2 py-0.5 text-xs text-surface-800-200"
+            class:opacity-50={isMissing(v)}
+          >
+            {isMissing(v) ? '–' : v.toString()}
+          </span>
+          <Tooltip class="whitespace-nowrap" placement="top">Worker {i}</Tooltip>
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/CompactionStateMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/CompactionStateMetric.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  // K6 — per-(worker × level) categorical state. Grid of state chips: one row per spine level
+  // (slot), one cell per worker, colored by status (none / requested / in progress).
+  import { Tooltip } from 'common-ui'
+  import type { MetricGroup, MetricSubRow } from '../dispatch'
+  import { isMissing, workerCount } from './metricData'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  // Sub-rows are labeled per slot, e.g. suffix '.slot:0'. Parse the level and sort ascending.
+  const levels = $derived.by(() => {
+    const out: Array<{ slot: number; row: MetricSubRow }> = []
+    for (const row of group.rows) {
+      const m = row.suffix.match(/slot:(\d+)/)
+      if (m) {
+        out.push({ slot: Number(m[1]), row })
+      }
+    }
+    out.sort((a, b) => a.slot - b.slot)
+    return out
+  })
+
+  const n = $derived(workerCount(group))
+  const workers = $derived(Array.from({ length: n }, (_, i) => i))
+
+  function stateColor(s: string): string {
+    const t = s.toLowerCase()
+    if (t.includes('progress')) {
+      return 'var(--state-progress)'
+    }
+    if (t.includes('request')) {
+      return 'var(--state-requested)'
+    }
+    return 'var(--state-none)'
+  }
+</script>
+
+{#if levels.length === 0}
+  <div class="text-sm text-surface-600-400">No compaction state reported.</div>
+{:else}
+  <div class="flex flex-col gap-1">
+    <!-- Header: "Worker" outside the grid on the left; worker numbers over every 4th column,
+         using the same grid template as the chip rows so they stay aligned. -->
+    <div class="flex items-center gap-2">
+      <span class="w-14 shrink-0 text-xs text-surface-600-400">Worker</span>
+      <div
+        class="grid flex-1 gap-0.5"
+        style:grid-template-columns="repeat({n}, minmax(0, 1fr))"
+        style:max-width="{n * 14}px"
+      >
+        {#each workers as i (i)}
+          <span class="text-center text-[10px] tabular-nums text-surface-500">
+            {i % 4 === 0 ? i : ''}
+          </span>
+        {/each}
+      </div>
+    </div>
+    {#each levels as { slot, row } (slot)}
+      <div class="flex items-center gap-2">
+        <span class="w-14 shrink-0 text-sm tabular-nums text-surface-700-300">Slot {slot}</span>
+        <!-- One column per worker: columns share the row width, so a large worker count
+             compresses the chips horizontally instead of wrapping or scrolling. A max width
+             keeps chips square-ish when workers are few. -->
+        <div
+          class="grid flex-1 gap-0.5"
+          style:grid-template-columns="repeat({n}, minmax(0, 1fr))"
+          style:max-width="{n * 14}px"
+        >
+          {#each workers as i (i)}
+            {@const v = row.values[i]}
+            <div
+              class="h-3 w-full rounded-[2px]"
+              style:background-color={isMissing(v) ? 'transparent' : stateColor(v.toString())}
+            ></div>
+            <Tooltip class="whitespace-nowrap" placement="top">
+              Worker {i}: {isMissing(v) ? '–' : v.toString()}
+            </Tooltip>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/EChart.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/EChart.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" module>
+  // Thin wrapper around svelte-echarts. Registers (tree-shaken) the chart types and components
+  // the cache tile uses, once for the whole app, then renders any EChartsOption in a sized box.
+  import { BarChart, HeatmapChart, LineChart, ScatterChart } from 'echarts/charts'
+  import {
+    GraphicComponent,
+    GridComponent,
+    MarkLineComponent,
+    TooltipComponent,
+    VisualMapComponent
+  } from 'echarts/components'
+  import { use } from 'echarts/core'
+  import { CanvasRenderer } from 'echarts/renderers'
+
+  use([
+    ScatterChart,
+    HeatmapChart,
+    BarChart,
+    LineChart, // marginal density curves in ScatterWithMarginals
+    GridComponent,
+    TooltipComponent,
+    VisualMapComponent,
+    MarkLineComponent,
+    GraphicComponent,
+    CanvasRenderer
+  ])
+</script>
+
+<script lang="ts">
+  import type { EChartsOption } from 'echarts'
+  import { init } from 'echarts/core'
+  import { Chart } from 'svelte-echarts'
+
+  interface Props {
+    options: EChartsOption
+    height?: number
+    /** Forwarded ECharts click; `e` carries `seriesIndex` / `dataIndex`. */
+    onclick?: (e: any) => void
+    /** Fired when the click lands on empty canvas (no data element). */
+    onblank?: () => void
+  }
+  const { options, height = 160, onclick, onblank }: Props = $props()
+
+  let instance = $state<any>()
+
+  // Capture the ECharts instance as it is created so we can reach its zrender layer.
+  const initChart: typeof init = (dom, theme, opts) => {
+    instance = init(dom, theme, opts)
+    return instance
+  }
+
+  // ECharts' series `click` only fires on elements; a click on empty canvas has no zrender
+  // target, which is how we detect "clicked nothing" to clear a selection.
+  $effect(() => {
+    if (!instance || !onblank) {
+      return
+    }
+    const zr = instance.getZr()
+    const handler = (e: any) => {
+      if (!e.target) {
+        onblank()
+      }
+    }
+    zr.on('click', handler)
+    return () => zr.off('click', handler)
+  })
+</script>
+
+<div class="w-full" style:height="{height}px">
+  <Chart init={initChart} {options} {onclick} />
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/KeyDistributionMatrix.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/KeyDistributionMatrix.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  // K10 — worker-fanout matrix. Each worker (row = source) reports an array indexed by
+  // destination worker; together an N×N matrix. Rendered as a vertically-squished heatmap so
+  // cross-worker skew is visible at a glance.
+  import { Tooltip } from 'common-ui'
+  import { lerpThemeColor } from '../colors'
+  import type { MetricGroup } from '../dispatch'
+  import { asArray } from './metricData'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const matrix = $derived.by(() => {
+    const rows = (group.rows[0]?.values ?? []).map((v) => asArray(v))
+    if (rows.length === 0 || rows.some((r) => r === undefined)) {
+      return null
+    }
+    const grid = rows as number[][]
+    const peak = grid.reduce((m, r) => r.reduce((mm, v) => Math.max(mm, v), m), 0)
+    return { grid, peak }
+  })
+</script>
+
+{#if !matrix}
+  <div class="text-sm text-surface-600-400">No key distribution reported.</div>
+{:else}
+  <div class="flex flex-col gap-0.5">
+    {#each matrix.grid as row, src (src)}
+      <div class="flex items-center gap-1">
+        <span class="w-8 shrink-0 text-xs tabular-nums text-surface-600-400">W{src}</span>
+        <div class="flex flex-1 gap-px">
+          {#each row as v, dst (dst)}
+            <div
+              class="h-3 flex-1 rounded-[1px]"
+              style:background-color={lerpThemeColor(
+                matrix.peak > 0 ? v / matrix.peak : 0,
+                '--bar-low',
+                '--bar-high'
+              )}
+            ></div>
+            <Tooltip class="whitespace-nowrap" placement="top">
+              W{src} → W{dst}: {v.toLocaleString('en-US')}
+            </Tooltip>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/MergesHistogram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/MergesHistogram.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  // K9 — merge progress per (worker × level). Histogram over spine levels (x = slot, y = steps);
+  // the worker-averaged shape shows by default, hovering left→right switches to one worker.
+  import type { MetricGroup } from '../dispatch'
+  import { numeric, workerCount } from './metricData'
+  import WorkerSwitchHistogram from './WorkerSwitchHistogram.svelte'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  // perWorker[worker][slot] = steps at that level. Built from '.slot:<n>.steps' sub-rows.
+  const perWorker = $derived.by(() => {
+    const n = workerCount(group)
+    let maxSlot = -1
+    const stepRows: Array<{ slot: number; values: (number | undefined)[] }> = []
+    for (const row of group.rows) {
+      const m = row.suffix.match(/slot:(\d+)\.steps$/)
+      if (m) {
+        const slot = Number(m[1])
+        maxSlot = Math.max(maxSlot, slot)
+        stepRows.push({ slot, values: row.values.map((v) => numeric(v)) })
+      }
+    }
+    if (maxSlot < 0) {
+      return []
+    }
+    const out: number[][] = Array.from({ length: n }, () => new Array<number>(maxSlot + 1).fill(0))
+    for (const { slot, values } of stepRows) {
+      for (let w = 0; w < n; w++) {
+        out[w]![slot] = values[w] ?? 0
+      }
+    }
+    return out
+  })
+</script>
+
+{#if perWorker.length === 0}
+  <div class="text-sm text-surface-600-400">No completed merges reported.</div>
+{:else}
+  <div class="text-sm text-surface-600-400">steps per level (log)</div>
+  <WorkerSwitchHistogram {perWorker} categoryTitle="Spine level" unit="steps" />
+{/if}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/OccupancyRingMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/OccupancyRingMetric.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // K3 — per-worker fraction of capacity ({used, max} bytes). Rendered with the same percentage
+  // bars as K2 (used/max as a percentage). A full cache is not inherently good or bad, so no
+  // surface->error semantics apply (semantics='none', neutral surface color). The tooltip shows
+  // the raw used / max byte values.
+  import type { MetricGroup } from '../dispatch'
+  import { numeric, rowEndingWith, workerCount } from './metricData'
+  import PercentBars from './PercentBars.svelte'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const used = $derived(rowEndingWith(group, '.used'))
+  const max = $derived(rowEndingWith(group, '.max'))
+  const n = $derived(workerCount(group))
+
+  const values = $derived(
+    Array.from({ length: n }, (_, i) => {
+      const u = numeric(used?.values[i])
+      const m = numeric(max?.values[i])
+      return u !== undefined && m && m > 0 ? (u / m) * 100 : undefined
+    })
+  )
+
+  const detail = (i: number) =>
+    `${used?.values[i]?.toString() ?? '–'} / ${max?.values[i]?.toString() ?? '–'}`
+</script>
+
+<PercentBars {values} label={detail} />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/PercentBars.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/PercentBars.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  // Per-worker percentage bars, drawn with plain divs (like the distribution bars), spanning the
+  // full width. Each bar has a fixed total height; the fill grows from the top and bottom edges
+  // inward — two stripes that are single-px lines at 0% and meet in the middle at 100%. A bar can
+  // be clicked to select its worker (when `onselect` is provided); the selected bar is outlined.
+  //
+  // Color carries semantics: the fill interpolates between a theme-adaptive neutral
+  // (surface-100-900) and error-500 by a "badness" fraction. `semantics` says which end is bad:
+  //   - 'low-bad':  low % is bad (e.g. cache hit rate) — redder as the value drops.
+  //   - 'high-bad': high % is bad — redder as the value rises.
+  //   - 'none':     no known semantics — always the neutral surface color.
+  import { Tooltip } from 'common-ui'
+  import { mixRgb, neutralErrorScale } from '../../../functions/format'
+
+  interface Props {
+    /** Percentage 0..100 per worker; undefined renders an empty bar. */
+    values: (number | undefined)[]
+    height?: number
+    /** Which end of the range is "bad" (drives the surface->error interpolation). */
+    semantics?: 'low-bad' | 'high-bad' | 'none'
+    selected?: number | null
+    onselect?: (worker: number) => void
+    format?: (n: number) => string
+    /** Optional per-worker tooltip text; defaults to the formatted percentage. */
+    label?: (worker: number) => string
+  }
+  const {
+    values,
+    height = 24,
+    semantics = 'none',
+    selected = null,
+    onselect,
+    format = (n) => `${Math.round(n)}%`,
+    label
+  }: Props = $props()
+
+  const scale = $derived(neutralErrorScale())
+
+  // Height of each stripe (top and bottom): a 2px line at 0%, growing to half the bar at 100%.
+  function stripe(v: number | undefined): number {
+    if (v === undefined) {
+      return 0
+    }
+    const frac = Math.max(0, Math.min(1, v / 100))
+    return Math.max(2, frac * (height / 2))
+  }
+
+  // Fill color: neutral surface with no semantics, otherwise blended toward error by badness.
+  function color(v: number | undefined): string {
+    if (v === undefined || semantics === 'none') {
+      return mixRgb(scale.neutral, scale.error, 0)
+    }
+    const frac = Math.max(0, Math.min(1, v / 100))
+    const badness = semantics === 'low-bad' ? 1 - frac : frac
+    return mixRgb(scale.neutral, scale.error, badness)
+  }
+</script>
+
+<div class="flex items-stretch gap-0.5" style:height="{height}px">
+  {#each values as v, i (i)}
+    {@const s = stripe(v)}
+    {@const c = color(v)}
+    <button
+      type="button"
+      class="relative min-w-0 flex-1 rounded-sm"
+      class:selected={selected === i}
+      onclick={() => onselect?.(i)}
+      aria-label={`Worker ${i}`}
+    >
+      <div
+        class="absolute inset-x-0 top-0 rounded-t-sm"
+        style:height="{s}px"
+        style:background-color={c}
+      ></div>
+      <div
+        class="absolute inset-x-0 bottom-0 rounded-b-sm"
+        style:height="{s}px"
+        style:background-color={c}
+      ></div>
+    </button>
+    <Tooltip class="whitespace-nowrap" placement="top">
+      Worker {i}: {label ? label(i) : v === undefined ? '–' : format(v)}
+    </Tooltip>
+  {/each}
+</div>
+
+<style>
+  .selected {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 1px;
+  }
+</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/PercentRingMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/PercentRingMetric.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  // K2 — per-worker bounded fraction (percent). A full-width row of per-worker bars whose fill
+  // grows from the top and bottom edges inward (PercentBars); no ECharts.
+  import type { MetricGroup } from '../dispatch'
+  import { numeric } from './metricData'
+  import PercentBars from './PercentBars.svelte'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const values = $derived((group.rows[0]?.values ?? []).map((v) => numeric(v)))
+</script>
+
+<PercentBars {values} />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/SizeHistogram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/SizeHistogram.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  // K11 — binned size histogram. Each worker holds an array of batch sizes; the sizes are binned
+  // into a shared histogram. Worker-averaged by default; hover left→right switches worker.
+  import type { MetricGroup } from '../dispatch'
+  import { asArray } from './metricData'
+  import WorkerSwitchHistogram from './WorkerSwitchHistogram.svelte'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const BIN_COUNT = 12
+
+  // Bin every worker's batch sizes over a shared [min, max] range so the per-worker histograms
+  // are comparable when switching between them.
+  const perWorker = $derived.by(() => {
+    const arrays = (group.rows[0]?.values ?? []).map((v) => asArray(v))
+    if (arrays.length === 0 || arrays.some((a) => a === undefined)) {
+      return []
+    }
+    const all = arrays as number[][]
+    let min = Infinity
+    let max = -Infinity
+    for (const a of all) {
+      for (const x of a) {
+        min = Math.min(min, x)
+        max = Math.max(max, x)
+      }
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return all.map(() => [])
+    }
+    const span = max - min || 1
+    return all.map((sizes) => {
+      const bins = new Array<number>(BIN_COUNT).fill(0)
+      for (const x of sizes) {
+        const idx = Math.min(BIN_COUNT - 1, Math.floor(((x - min) / span) * BIN_COUNT))
+        bins[idx]!++
+      }
+      return bins
+    })
+  })
+</script>
+
+{#if perWorker.length === 0}
+  <div class="text-sm text-surface-600-400">No size distribution reported.</div>
+{:else}
+  <div class="text-xs text-surface-600-400">count per size bin (log)</div>
+  <WorkerSwitchHistogram {perWorker} categoryTitle="Size bin" unit="batches" />
+{/if}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/StatsMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/StatsMetric.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  // K7 — batch-size summary. Two magnitudes (batches, records) and the pooled average in a column
+  // beside a per-worker distribution of batch sizes, drawn as a horizontal line chart: workers on
+  // the y axis (sorted by average batch size), batch size on the x axis, with min / avg / max
+  // lines (no fill between them). This metric carries only per-worker {min, avg, max} summaries
+  // (no per-batch array — that is K11 `size_distribution`), so the distribution shown is across
+  // workers, not across individual batches.
+  import { Tooltip } from 'common-ui'
+  import type { MetricGroup } from '../dispatch'
+  import { numeric, rowEndingWith, sumRow, workerCount } from './metricData'
+  import { batchRange, fractionIn } from './statsMetric'
+
+  interface Props {
+    group: MetricGroup
+  }
+  const { group }: Props = $props()
+
+  const batches = $derived(sumRow(rowEndingWith(group, '.count')))
+  const records = $derived(sumRow(rowEndingWith(group, '.record_count')))
+
+  const n = $derived(workerCount(group))
+
+  // Per-worker {min, avg, max} batch size (undefined where a worker did not report), kept with
+  // the original worker index and sorted by average so the avg line reads as a distribution curve
+  // (workers with no avg sort last). Sorting by avg orders workers by their typical batch size;
+  // switch the key to `max` to order by worst-case batch size instead.
+  const sorted = $derived.by(() => {
+    const minRow = rowEndingWith(group, '.min_size')
+    const avgRow = rowEndingWith(group, '.avg_size')
+    const maxRow = rowEndingWith(group, '.max_size')
+    const rows = Array.from({ length: n }, (_, i) => ({
+      worker: i,
+      min: numeric(minRow?.values[i]),
+      avg: numeric(avgRow?.values[i]),
+      max: numeric(maxRow?.values[i])
+    }))
+    return rows.sort((a, b) => (a.avg ?? Infinity) - (b.avg ?? Infinity))
+  })
+
+  const range = $derived(batchRange(sorted, batches, records))
+
+  // Chart view box (stroke widths are non-scaling, so W/H are just a coordinate space). Height
+  // grows with the worker count so rows stay separable, down to a compact floor.
+  const W = 100
+  const H = $derived(Math.max(48, n * 10))
+
+  // x = batch size; a degenerate axis (every batch the same size) draws down the middle.
+  const xOf = (v: number): number =>
+    range.max > range.min ? fractionIn(v, range.min, range.max) * W : W / 2
+  const yOf = (i: number): number => (n > 1 ? ((i + 0.5) / n) * H : H / 2)
+
+  const pts = (pick: (s: (typeof sorted)[number]) => number | undefined): string =>
+    sorted
+      .map((s, i) => {
+        const v = pick(s)
+        return v === undefined ? null : `${xOf(v).toFixed(2)},${yOf(i).toFixed(2)}`
+      })
+      .filter((p): p is string => p !== null)
+      .join(' ')
+
+  const avgLine = $derived(pts((s) => s.avg))
+  const maxLine = $derived(pts((s) => s.max))
+  const minLine = $derived(pts((s) => s.min))
+
+  const fmt = (v: number) => Math.round(v).toLocaleString('en-US')
+  const s = (v: number | undefined) => (v === undefined ? '–' : fmt(v))
+  const pct = (v: number) => `${((xOf(v) / W) * 100).toFixed(2)}%`
+
+  // Worker (index within `sorted`) currently hovered/focused, marked on the lines.
+  let hovered = $state<number | null>(null)
+</script>
+
+<div class="flex items-start gap-4">
+  <div class="shrink-0 text-sm tabular-nums">
+    <div><span class="text-surface-600-400">batches</span> {fmt(batches)}</div>
+    <div><span class="text-surface-600-400">records</span> {fmt(records)}</div>
+    <div><span class="text-surface-600-400">avg recs per batch</span> {fmt(range.avg)}</div>
+  </div>
+  <div class="min-w-0 flex-1">
+    <div class="relative w-full" style:height="{H}px">
+      {#if n > 1}
+        <svg
+          class="absolute inset-0 h-full w-full"
+          viewBox="0 0 {W} {H}"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          {#if maxLine}
+            <polyline class="edge" points={maxLine} vector-effect="non-scaling-stroke" />
+          {/if}
+          {#if minLine}
+            <polyline class="edge" points={minLine} vector-effect="non-scaling-stroke" />
+          {/if}
+          {#if avgLine}
+            <polyline class="avg-line" points={avgLine} vector-effect="non-scaling-stroke" />
+          {/if}
+        </svg>
+      {:else if sorted[0]}
+        <!-- One worker: a centered horizontal range with an avg dot (HTML avoids the SVG
+             non-uniform-scale distortion). -->
+        {@const w = sorted[0]}
+        {#if w.min !== undefined && w.max !== undefined}
+          <div
+            class="absolute top-1/2 h-0.5 -translate-y-1/2 rounded-full bg-surface-400-600"
+            style:left={pct(w.min)}
+            style:width="{((xOf(w.max) - xOf(w.min)) / W) * 100}%"
+          ></div>
+        {/if}
+        {#if w.avg !== undefined}
+          <div
+            class="absolute top-1/2 h-[5px] w-[5px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-500"
+            style:left={pct(w.avg)}
+          ></div>
+        {/if}
+      {/if}
+      <!-- Highlight the hovered/focused worker: a row guide with markers on each line. -->
+      {#if hovered !== null && sorted[hovered]}
+        {@const w = sorted[hovered]}
+        {@const y = (yOf(hovered) / H) * 100}
+        <div
+          class="pointer-events-none absolute inset-x-0 h-px -translate-y-1/2 bg-surface-400-600 opacity-60"
+          style:top="{y}%"
+        ></div>
+        {#if w.min !== undefined}
+          <div
+            class="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-surface-500"
+            style:left={pct(w.min)}
+            style:top="{y}%"
+          ></div>
+        {/if}
+        {#if w.max !== undefined}
+          <div
+            class="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-surface-500"
+            style:left={pct(w.max)}
+            style:top="{y}%"
+          ></div>
+        {/if}
+        {#if w.avg !== undefined}
+          <div
+            class="pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-500"
+            style:left={pct(w.avg)}
+            style:top="{y}%"
+          ></div>
+        {/if}
+      {/if}
+      <!-- Per-worker hover targets (rows, aligned to the plotted points). Buttons so keyboard
+           focus also marks the worker. -->
+      <div class="absolute inset-0 flex flex-col">
+        {#each sorted as w, i (w.worker)}
+          <button
+            type="button"
+            class="w-full flex-1"
+            aria-label={`Worker ${w.worker}`}
+            onpointerenter={() => (hovered = i)}
+            onpointerleave={() => (hovered = null)}
+            onfocus={() => (hovered = i)}
+            onblur={() => (hovered = null)}
+          ></button>
+          <Tooltip placement="top">
+            <div class="font-medium">Worker {w.worker}</div>
+            <div class="whitespace-nowrap">
+              min {s(w.min)} · avg {s(w.avg)} · max {s(w.max)} recs/batch
+            </div>
+          </Tooltip>
+        {/each}
+      </div>
+    </div>
+    <!-- Batch-size axis extent. -->
+    <div class="relative mt-1 h-4 text-xs tabular-nums text-surface-500">
+      <span class="absolute left-0">{fmt(range.min)}</span>
+      <span class="absolute right-0">{fmt(range.max)}</span>
+    </div>
+    <!-- Legend + sort direction; text in muted ink, color only on the swatches. -->
+    <div class="mt-0.5 flex items-center gap-3 text-xs text-surface-600-400">
+      <span class="flex items-center gap-1">
+        <span class="inline-block h-0.5 w-3 bg-primary-500"></span>avg per batch
+      </span>
+      <span class="flex items-center gap-1">
+        <span class="inline-block h-px w-3 bg-surface-400-600"></span>min / max
+      </span>
+      <span class="ml-auto">sorted by avg ↓</span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .edge {
+    fill: none;
+    stroke: var(--color-surface-400-600);
+    stroke-width: 1;
+    opacity: 0.8;
+  }
+  .avg-line {
+    fill: none;
+    stroke: var(--color-primary-500);
+    stroke-width: 2;
+    stroke-linejoin: round;
+  }
+</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/WorkerSwitchHistogram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/WorkerSwitchHistogram.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  // Shows a worker-averaged histogram by default; moving the mouse left→right over it switches to
+  // an individual worker's histogram (x-position maps to worker index). Backs K9 and K11.
+  //
+  // Transposed horizontal bar chart (ECharts): the binned category (spine level / size bin) runs
+  // down the Y axis, one bar per bin; the value runs along the X axis on a log scale so small
+  // bars stay visible next to large ones. The worker-switch hover and the worker strip legend
+  // below are unchanged.
+  import type { EChartsOption } from 'echarts'
+  import { isDarkTheme, mixRgb, resolveCssColor, resolveRgb } from '../../../functions/format'
+  import { formatQty } from '../../../functions/formatQty'
+  import { logScale01 } from '../colors'
+  import EChart from './EChart.svelte'
+  import { niceTicks } from './histogramTicks'
+
+  interface Props {
+    /** One bin array per worker (ragged arrays are aligned by index, padded with 0). */
+    perWorker: number[][]
+    /** Y-axis (row) label for bin i (0..width-1). Defaults to the bin index. */
+    binLabel?: (i: number, width: number) => string
+    /** Y-axis (category) title, shown top-left so the row numbers have meaning. */
+    categoryTitle?: string
+    /** Unit noun for the value, appended in the tooltip (e.g. "steps", "batches"). */
+    unit?: string
+  }
+  const { perWorker, binLabel = (i) => String(i), categoryTitle, unit }: Props = $props()
+
+  const width = $derived(perWorker.reduce((m, a) => Math.max(m, a.length), 0))
+
+  // Thin out row labels so they never collide: at most ~12 are drawn.
+  const labelStride = $derived(Math.max(1, Math.ceil(width / 12)))
+
+  const averaged = $derived.by(() => {
+    const out = new Array<number>(width).fill(0)
+    if (perWorker.length === 0) {
+      return out
+    }
+    for (const a of perWorker) {
+      for (let i = 0; i < a.length; i++) {
+        out[i]! += a[i]!
+      }
+    }
+    for (let i = 0; i < width; i++) {
+      out[i]! /= perWorker.length
+    }
+    return out
+  })
+
+  // Normalization ceiling = the largest single value across ALL workers (not the averaged view),
+  // shared by the averaged and every per-worker view so switching workers never rescales the axis.
+  const sharedMax = $derived(
+    perWorker.reduce((m, a) => a.reduce((mm, v) => (v > mm ? v : mm), m), 0)
+  )
+
+  // The X axis is drawn in log-normalized space [0, 1] (`logScale01`), so a bar's length is
+  // `logScale01(value / sharedMax)`. Ticks are round "nice" values (…, 500, 1000, 5000, …) placed
+  // at their log positions, so the labels read easily even though their spacing is uneven.
+  const norm = (v: number): number => (sharedMax > 0 ? logScale01(v / sharedMax) : 0)
+
+  let hovered = $state<number | null>(null)
+  const shown = $derived(hovered === null ? averaged : (perWorker[hovered] ?? averaged))
+  const caption = $derived(
+    hovered === null ? `avg of ${perWorker.length} workers` : `Worker ${hovered}`
+  )
+
+  function onMove(e: MouseEvent) {
+    if (perWorker.length === 0) {
+      return
+    }
+    // The worker strip owns its highlight via per-cell pointer handlers; skip moves that land on
+    // a cell so its exact per-worker mapping isn't overridden by the chart's x→worker mapping.
+    if ((e.target as HTMLElement).closest('[data-worker-cell]')) {
+      return
+    }
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const t = (e.clientX - rect.left) / rect.width
+    hovered = Math.max(0, Math.min(perWorker.length - 1, Math.floor(t * perWorker.length)))
+  }
+
+  // Canvas colors must be resolved to RGB (ECharts cannot read CSS custom properties or
+  // color-mix()); scoped `.metrics-theme` vars are invisible to the resolver's body-level probe,
+  // so resolve the underlying global tokens for the current theme. Bars are a flat neutral
+  // (surface-200-800): length already encodes magnitude, so a color ramp would be redundant.
+  const barFill = $derived(
+    resolveCssColor(
+      isDarkTheme() ? 'var(--color-surface-800)' : 'var(--color-surface-200)',
+      [226, 232, 240]
+    )
+  )
+  const axisColor = $derived.by(() => {
+    isDarkTheme()
+    return resolveCssColor('var(--color-surface-500)', [156, 163, 175])
+  })
+
+  // Per-level cross-worker skew = spread across workers (max - min) as a % of the largest-magnitude
+  // value, matching K1's BarChartRow. Shown only in the averaged view (a single worker has no
+  // cross-worker spread). Missing/ragged cells count as 0 (that worker holds nothing at the level).
+  const skews = $derived.by(() =>
+    Array.from({ length: width }, (_, i) => {
+      let mn = Number.POSITIVE_INFINITY
+      let mx = Number.NEGATIVE_INFINITY
+      for (const a of perWorker) {
+        const v = a[i] ?? 0
+        if (v < mn) {
+          mn = v
+        }
+        if (v > mx) {
+          mx = v
+        }
+      }
+      const scale = Math.max(Math.abs(mx), Math.abs(mn))
+      return Number.isFinite(scale) && scale !== 0 ? ((mx - mn) / scale) * 100 : 0
+    })
+  )
+
+  // Skew label color, resolved to RGB: neutral (--skew-low) → error (--skew-high), saturating at
+  // 50%, the same ramp K1 uses via `skewTextColor`.
+  const skewRamp = $derived.by(() => {
+    const dark = isDarkTheme()
+    return {
+      low: resolveRgb(dark ? 'var(--color-surface-400)' : 'var(--color-surface-600)', [82, 82, 91]),
+      high: resolveRgb('var(--color-error-500)', [239, 68, 68])
+    }
+  })
+  const skewColor = (pct: number): string =>
+    mixRgb(skewRamp.low, skewRamp.high, Math.max(0, Math.min(1, pct / 50)))
+
+  // Bars stay ~14px apart; grow with the bin count, down to a compact floor.
+  const chartHeight = $derived(Math.max(64, width * 16 + 28))
+
+  const options = $derived.by((): EChartsOption => {
+    const cats = Array.from({ length: width }, (_, i) => binLabel(i, width))
+    // Per-item label carries the (colored) skew text; the series toggles it off outside the
+    // averaged view.
+    const showSkew = hovered === null
+    const data = Array.from({ length: width }, (_, i) => ({
+      value: norm(shown[i] ?? 0),
+      label: { color: skewColor(skews[i]!) }
+    }))
+    // Round tick values (integer, so step/bin counts never show fractions), placed at their log
+    // positions on the [0, 1] axis. The label maps a position back to its own nice value.
+    const tickVals = niceTicks(sharedMax, 5, true)
+    const tickPos = tickVals.map((v) => logScale01(v / sharedMax))
+    return {
+      animation: false,
+      // Right gutter holds the per-level "Skew N%" labels drawn at each bar's end.
+      grid: { left: 34, right: 56, top: 6, bottom: 24 },
+      xAxis: {
+        type: 'value',
+        min: 0,
+        max: 1,
+        axisLabel: {
+          color: axisColor,
+          fontSize: 10,
+          customValues: tickPos,
+          formatter: (v: number) => {
+            const i = tickPos.findIndex((p) => Math.abs(p - v) < 1e-6)
+            return i >= 0 ? formatQty(tickVals[i]!) : ''
+          }
+        },
+        axisTick: { show: true, customValues: tickPos, lineStyle: { color: axisColor } },
+        axisLine: { lineStyle: { color: axisColor } },
+        splitLine: { show: false }
+      },
+      yAxis: {
+        type: 'category',
+        inverse: true, // bin 0 at the top
+        data: cats,
+        axisTick: { show: false },
+        axisLine: { lineStyle: { color: axisColor } },
+        axisLabel: {
+          color: axisColor,
+          fontSize: 10,
+          interval: (index: number) => index % labelStride === 0
+        }
+      },
+      tooltip: {
+        trigger: 'item',
+        formatter: (p: any) => {
+          const i = p.dataIndex as number
+          const label = binLabel(i, width)
+          const head = categoryTitle ? `${categoryTitle} ${label}` : label
+          const suffix = unit ? ` ${unit}` : ''
+          return `${head}: ${formatQty(Math.round(shown[i] ?? 0))}${suffix}`
+        }
+      },
+      series: [
+        {
+          type: 'bar',
+          data,
+          barCategoryGap: '30%',
+          itemStyle: { color: barFill },
+          label: {
+            show: showSkew,
+            position: 'right',
+            fontSize: 12,
+            formatter: (p: any) =>
+              (averaged[p.dataIndex] ?? 0) > 0 ? `Skew ${Math.round(skews[p.dataIndex]!)}%` : ''
+          }
+        }
+      ]
+    }
+  })
+</script>
+
+<div role="img" aria-label="{caption} histogram">
+  {#if categoryTitle}
+    <div class="mb-0.5 text-[10px] text-surface-500">{categoryTitle}</div>
+  {/if}
+  <!-- One continuous hover surface over the chart AND the worker strip: mouse left→right switches
+       worker (the canvas' mousemove bubbles here). The strip carries top padding rather than a
+       margin so the visual gap stays inside the hover surface, leaving no dead zone between the
+       chart and the strip that would interrupt the hover. -->
+  <div onmousemove={onMove} onmouseleave={() => (hovered = null)} role="presentation">
+    <EChart {options} height={chartHeight} />
+    <!-- Legend: caption plus a worker strip, one cell per worker spanning the chart width; the
+         hovered/focused worker's cell lights up. The cells are themselves hover/focus targets. -->
+    <div class="flex items-center gap-2 pt-1 text-sm tabular-nums text-surface-700-300">
+      <span class="shrink-0">{caption}</span>
+      {#if perWorker.length > 0}
+        <div class="flex flex-1 gap-px">
+          {#each perWorker as _, i (i)}
+            <button
+              type="button"
+              data-worker-cell
+              class="h-2 flex-1 rounded-[1px] {hovered === i
+                ? 'bg-primary-500'
+                : 'bg-surface-100-900'}"
+              aria-label={`Worker ${i}`}
+              onpointerenter={() => (hovered = i)}
+              onpointerleave={() => (hovered = null)}
+              onfocus={() => (hovered = i)}
+              onblur={() => (hovered = null)}
+            ></button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/CacheTile.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/CacheTile.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+  // Composite tile for one cache (foreground / background). Combines three metrics —
+  // {prefix}_cache_hits, {prefix}_cache_misses, {prefix}_cache_hit_rate_percent — into five
+  // diagrams. See ../../README.md (K8 note) for the rationale.
+  import { SegmentedControl, Tooltip } from 'common-ui'
+  import { humanSeconds, humanSize, isDarkTheme } from '../../../../functions/format'
+  import { formatQty } from '../../../../functions/formatQty'
+  import CircleHelp from '../../../icons/CircleHelp.svelte'
+  import type { MetricGroup } from '../../dispatch'
+  import { numeric, rowEndingWith, workerCount } from '../metricData'
+  import PercentBars from '../PercentBars.svelte'
+  import type { Corner } from './cornerColors'
+  import Scatter from './Scatter.svelte'
+  import ScatterWithMarginals from './ScatterWithMarginals.svelte'
+  import ValueBars from './ValueBars.svelte'
+
+  interface Props {
+    id: string
+    title: string
+    hits?: MetricGroup
+    misses?: MetricGroup
+    hitRate?: MetricGroup
+  }
+  const { id, title, hits, misses, hitRate }: Props = $props()
+
+  // Collapsed by default, like a K1 distribution row: only the hit-rate and effective-latency
+  // rows show. The scatter diagrams (and the count/bytes control) appear on expand.
+  let expanded = $state(false)
+
+  // false = counts, true = bytes; toggled by the segmented control, drives the scatter X axis.
+  let bytesMode = $state(false)
+
+  // Worker selected by clicking a bar/dot; highlighted across every diagram in the tile.
+  let selected = $state<number | null>(null)
+  const selectWorker = (worker: number) => {
+    selected = selected === worker ? null : worker
+  }
+
+  const n = $derived(
+    Math.max(
+      hits ? workerCount(hits) : 0,
+      misses ? workerCount(misses) : 0,
+      hitRate ? workerCount(hitRate) : 0
+    )
+  )
+
+  function col(group: MetricGroup | undefined, end: string): (number | undefined)[] {
+    const row = group ? rowEndingWith(group, end) : undefined
+    return Array.from({ length: n }, (_, i) => numeric(row?.values[i]))
+  }
+
+  const hitCount = $derived(col(hits, '.count'))
+  const hitBytes = $derived(col(hits, '.bytes'))
+  const hitLat = $derived(col(hits, '.avg_latency'))
+  const missCount = $derived(col(misses, '.count'))
+  const missBytes = $derived(col(misses, '.bytes'))
+  const missLat = $derived(col(misses, '.avg_latency'))
+
+  const rates = $derived(Array.from({ length: n }, (_, i) => numeric(hitRate?.rows[0]?.values[i])))
+
+  // Effective latency per worker: hit_rate·avg_hit + miss_rate·avg_miss (same value the diagram-5
+  // scatter plots on Y). Shown per worker in the diagram-1 heatmap.
+  const effLatency = $derived(
+    Array.from({ length: n }, (_, i) => {
+      const r = rates[i]
+      const h = hitLat[i]
+      const m = missLat[i]
+      if (r === undefined || h === undefined || m === undefined) {
+        return undefined
+      }
+      const f = r / 100
+      return f * h + (1 - f) * m
+    })
+  )
+
+  // Diagram 2/3: X = count or bytes (segmented control), Y = average latency (s). One pt/worker.
+  function latencyPoints(
+    counts: (number | undefined)[],
+    bytes: (number | undefined)[],
+    lat: (number | undefined)[]
+  ) {
+    const xs = bytesMode ? bytes : counts
+    const out: { x: number; y: number; worker: number }[] = []
+    for (let i = 0; i < n; i++) {
+      const x = xs[i]
+      const y = lat[i]
+      if (x !== undefined && y !== undefined) {
+        out.push({ x, y, worker: i })
+      }
+    }
+    return out
+  }
+  const hitPoints = $derived(latencyPoints(hitCount, hitBytes, hitLat))
+  const missPoints = $derived(latencyPoints(missCount, missBytes, missLat))
+
+  // Diagram 4: X = hit rate %, Y = avg miss latency / avg hit latency.
+  const ratioPoints = $derived.by(() => {
+    const out: { x: number; y: number; worker: number }[] = []
+    for (let i = 0; i < n; i++) {
+      const r = rates[i]
+      const h = hitLat[i]
+      const m = missLat[i]
+      if (r !== undefined && h !== undefined && h > 0 && m !== undefined) {
+        out.push({ x: r, y: m / h, worker: i })
+      }
+    }
+    return out
+  })
+
+  // Diagram 5: X = hit rate %, Y = effective latency = hit_rate*avg_hit + miss_rate*avg_miss.
+  const effectivePoints = $derived.by(() => {
+    const out: { x: number; y: number; worker: number }[] = []
+    for (let i = 0; i < n; i++) {
+      const r = rates[i]
+      const h = hitLat[i]
+      const m = missLat[i]
+      if (r !== undefined && h !== undefined && m !== undefined) {
+        const f = r / 100
+        out.push({ x: r, y: f * h + (1 - f) * m, worker: i })
+      }
+    }
+    return out
+  })
+
+  const xName = $derived(bytesMode ? 'bytes' : 'count')
+  // Count axis labels are integers formatted with `formatQty` (ported from web-console).
+  const xFormat = $derived(bytesMode ? humanSize : (v: number) => formatQty(Math.round(v)))
+
+  // Tooltip for the hits/misses plots: both count and bytes are shown regardless of the
+  // count/bytes axis toggle, plus the plotted average latency. Missing values render as an em dash.
+  const q = (v?: number) => formatQty(v === undefined ? Number.NaN : Math.round(v))
+  const sz = (v?: number) => (v === undefined ? '—' : humanSize(v))
+  const sec = (v?: number) => (v === undefined ? '—' : humanSeconds(v))
+  const latencyTooltip =
+    (counts: (number | undefined)[], bytes: (number | undefined)[], lat: (number | undefined)[]) =>
+    (p: { worker: number }) =>
+      `W${p.worker}<br/>count: ${q(counts[p.worker])}<br/>bytes: ${sz(bytes[p.worker])}<br/>latency: ${sec(lat[p.worker])}`
+
+  // Color for non-selected dots once a worker is selected (the selected one is primary). A
+  // theme-adaptive surface-100-900 so the faded dots stay subtle rather than reading as dark.
+  const BASE_DOT = $derived(isDarkTheme() ? 'var(--color-surface-900)' : 'var(--color-surface-100)')
+
+  // Diagram color corners: error at the worst corner, a theme-adaptive neutral at the best
+  // (opposite) corner. Any 2–4 corners are supported; here each diagram uses two.
+  const ERROR = 'var(--color-error-500)'
+  const neutral = $derived(isDarkTheme() ? 'var(--color-surface-900)' : 'var(--color-surface-100)')
+  // Hits: worst = few hits + high latency (top-left). Misses: worst = many misses + high
+  // latency (top-right). The opposite corner is the theme-adaptive neutral.
+  const hitCorners = $derived<{ corner: Corner; color: string }[]>([
+    { corner: 'top_left', color: ERROR },
+    { corner: 'bottom_right', color: neutral }
+  ])
+  const missCorners = $derived<{ corner: Corner; color: string }[]>([
+    { corner: 'top_right', color: ERROR },
+    { corner: 'bottom_left', color: neutral }
+  ])
+  // Ratio / effective latency: worst = low hit rate + high value (top-left).
+  const rateCorners = $derived<{ corner: Corner; color: string }[]>([
+    { corner: 'top_left', color: ERROR },
+    { corner: 'bottom_right', color: neutral }
+  ])
+</script>
+
+<div class="metrics-block rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
+  <div class="mb-2 flex items-center justify-between gap-2">
+    <h3 class="text-base font-semibold text-surface-900-100">{title}</h3>
+    <!-- The count/bytes control only drives the (expand-only) scatter axes, so it appears to the
+         left of the chevron once the tile is expanded. -->
+    <div class="flex items-center gap-2">
+      {#if expanded}
+        <SegmentedControl
+          value={bytesMode ? 'bytes' : 'count'}
+          onValueChange={(v) => (bytesMode = v === 'bytes')}
+          items={[
+            { value: 'count', label: 'count' },
+            { value: 'bytes', label: 'bytes' }
+          ]}
+        />
+      {/if}
+      <button
+        type="button"
+        class="flex items-center"
+        onclick={() => (expanded = !expanded)}
+        aria-label={expanded ? 'Collapse' : 'Expand'}
+      >
+        <span
+          class="fd fd-chevron-down chevron text-[16px] text-surface-600-400"
+          class:rotate-180={expanded}
+          aria-hidden="true"
+        ></span>
+      </button>
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-3">
+    <div>
+      <div class="mb-1 text-base text-surface-600-400">Hit rate per worker</div>
+      <!-- A low hit rate is the bad end, so the bars redden as the rate drops. -->
+      <PercentBars
+        values={rates}
+        semantics="low-bad"
+        {selected}
+        onselect={selectWorker}
+        format={(n) => `${n.toFixed(1)}%`}
+      />
+    </div>
+    <div>
+      <div class="mb-1 text-base text-surface-600-400">Effective latency per worker</div>
+      <ValueBars values={effLatency} format={humanSeconds} {selected} onselect={selectWorker} />
+    </div>
+    {#if expanded}
+      <!-- Diagrams 2 + 3: hits / misses, paired in one row. Worst corner: high latency, with
+           low hits (fewer served) resp. high misses. -->
+      <div class="grid grid-cols-2 gap-3">
+      <div>
+        <div class="mb-1 text-base text-surface-600-400">Hits: {xName} vs avg latency</div>
+        <ScatterWithMarginals
+          points={hitPoints}
+          {xName}
+          yName="latency"
+          {xFormat}
+          yFormat={humanSeconds}
+          corners={hitCorners}
+          {selected}
+          onselect={selectWorker}
+          onclear={() => (selected = null)}
+          baseColor={BASE_DOT}
+          height={160}
+          tooltipFormat={latencyTooltip(hitCount, hitBytes, hitLat)}
+        />
+      </div>
+      <div>
+        <div class="mb-1 text-base text-surface-600-400">Misses: {xName} vs avg latency</div>
+        <ScatterWithMarginals
+          points={missPoints}
+          {xName}
+          yName="latency"
+          {xFormat}
+          yFormat={humanSeconds}
+          corners={missCorners}
+          {selected}
+          onselect={selectWorker}
+          onclear={() => (selected = null)}
+          baseColor={BASE_DOT}
+          height={160}
+          tooltipFormat={latencyTooltip(missCount, missBytes, missLat)}
+        />
+      </div>
+    </div>
+    <!-- Diagrams 4 + 5: paired in one row. Worst corner: low hit rate with a high ratio /
+         high effective latency. -->
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <div class="mb-1 text-base text-surface-600-400">Hit rate vs miss/hit latency ratio</div>
+        <Scatter
+          points={ratioPoints}
+          xName="hit rate %"
+          yName="miss / hit"
+          xFormat={(v) => `${Math.round(v)}%`}
+          yFormat={(v) => v.toFixed(2)}
+          corners={rateCorners}
+          {selected}
+          onselect={selectWorker}
+          onclear={() => (selected = null)}
+          baseColor={BASE_DOT}
+          height={160}
+        />
+      </div>
+      <div>
+        <div class="mb-1 flex items-center gap-1 text-base text-surface-600-400">
+          Hit rate vs effective latency
+          <span class="inline-flex cursor-help text-surface-500"><CircleHelp /></span>
+          <Tooltip class="max-w-xs">
+            Effective latency = hit rate × avg hit latency + miss rate × avg miss latency (miss
+            rate = 1 − hit rate). The average latency of a cache access at this worker's hit rate.
+          </Tooltip>
+        </div>
+        <Scatter
+          points={effectivePoints}
+          xName="hit rate %"
+          yName="eff. latency"
+          xFormat={(v) => `${Math.round(v)}%`}
+          yFormat={humanSeconds}
+          corners={rateCorners}
+          {selected}
+          onselect={selectWorker}
+          onclear={() => (selected = null)}
+          baseColor={BASE_DOT}
+          height={160}
+        />
+      </div>
+    </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .chevron {
+    display: inline-block;
+    transition: transform 200ms ease;
+  }
+</style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/Scatter.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/Scatter.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  // A plain scatter plot, one point per worker. Used for the cache tile's ratio and
+  // effective-latency diagrams (no marginal distributions). A point can be clicked to select its
+  // worker across the tile; the selected point is drawn in primary.
+  import type { EChartsOption } from 'echarts'
+  import { resolveCssColor, resolveRgb } from '../../../../functions/format'
+  import EChart from '../EChart.svelte'
+  import { type Corner, type CornerColor, cornerColors } from './cornerColors'
+
+  /** A named corner and the CSS color at it (any expr; resolved to RGB). */
+  export type CornerSpec = { corner: Corner; color: string }
+
+  interface Props {
+    points: { x: number; y: number; worker: number }[]
+    xName: string
+    yName: string
+    xFormat?: (n: number) => string
+    yFormat?: (n: number) => string
+    /** 2–4 corners with colors; each point is the inverse-distance blend of them. Omit for a
+     *  uniform accent color. */
+    corners?: CornerSpec[]
+    selected?: number | null
+    onselect?: (worker: number) => void
+    onclear?: () => void
+    /** CSS color for non-selected dots while a worker is selected. */
+    baseColor?: string
+    height?: number
+  }
+  const {
+    points,
+    xName,
+    yName,
+    xFormat = (n) => `${n}`,
+    yFormat = (n) => `${n}`,
+    corners,
+    selected = null,
+    onselect,
+    onclear,
+    baseColor = 'var(--color-surface-500)',
+    height = 200
+  }: Props = $props()
+
+  const axis = resolveCssColor('var(--color-surface-500)', [156, 163, 175])
+  const accent = resolveCssColor('var(--color-primary-500)', [99, 102, 241])
+  const primary = resolveCssColor('var(--color-primary-500)', [99, 102, 241])
+  const baseDot = $derived(resolveCssColor(baseColor, [156, 163, 175]))
+
+  function domain(vals: number[]): [number, number] {
+    if (vals.length === 0) {
+      return [0, 1]
+    }
+    let min = Math.min(...vals)
+    let max = Math.max(...vals)
+    if (min === max) {
+      const pad = Math.abs(min) || 1
+      return [min - pad, max + pad]
+    }
+    const pad = (max - min) * 0.08
+    return [min - pad, max + pad]
+  }
+
+  const data = $derived.by(() => {
+    let base: string[] | null = null
+    if (corners && corners.length > 0) {
+      const resolved: CornerColor[] = corners.map((c) => ({
+        corner: c.corner,
+        rgb: resolveRgb(c.color, [128, 128, 128])
+      }))
+      base = cornerColors(points, resolved)
+    }
+    const anySelected = selected !== null
+    return points.map((p, i) => ({
+      value: [p.x, p.y],
+      itemStyle: {
+        // No selection: corner-blend (or accent). With a selection: the picked worker is
+        // primary, the rest fall back to the base color.
+        color: anySelected ? (p.worker === selected ? primary : baseDot) : base ? base[i]! : accent,
+        opacity: 0.9
+      }
+    }))
+  })
+
+  function onclick(e: any) {
+    const p = points[e?.dataIndex]
+    if (p) {
+      onselect?.(p.worker)
+    }
+  }
+
+  const options = $derived.by((): EChartsOption => {
+    const xd = domain(points.map((p) => p.x))
+    const yd = domain(points.map((p) => p.y))
+    return {
+      animation: false,
+      grid: { left: 56, right: 16, top: 16, bottom: 40 },
+      xAxis: {
+        type: 'value',
+        name: xName,
+        nameLocation: 'middle',
+        nameGap: 26,
+        min: xd[0],
+        max: xd[1],
+        interval: (xd[1] - xd[0]) / 2, // 3 markers: min, mid, max
+        axisLabel: { color: axis, formatter: (v: number) => xFormat(v) },
+        axisLine: { lineStyle: { color: axis } },
+        splitLine: { show: false }
+      },
+      yAxis: {
+        type: 'value',
+        name: yName,
+        nameLocation: 'middle',
+        nameGap: 44,
+        min: yd[0],
+        max: yd[1],
+        interval: (yd[1] - yd[0]) / 3, // 4 markers
+        axisLabel: { color: axis, formatter: (v: number) => yFormat(v) },
+        axisLine: { lineStyle: { color: axis } },
+        splitLine: { show: false }
+      },
+      tooltip: {
+        trigger: 'item',
+        formatter: (p: any) => {
+          const [x, y] = p.value as [number, number]
+          const who = `W${points[p.dataIndex]?.worker ?? p.dataIndex}`
+          return `${who}<br/>${xName}: ${xFormat(x)}<br/>${yName}: ${yFormat(y)}`
+        }
+      },
+      series: [
+        {
+          type: 'scatter',
+          symbolSize: 9,
+          data
+        }
+      ]
+    }
+  })
+</script>
+
+<EChart {options} {height} {onclick} onblank={onclear} />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/ScatterWithMarginals.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/ScatterWithMarginals.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  // A scatter plot (one point per worker) with marginal distribution curves along the top (X)
+  // and right (Y) edges. ECharts has no native marginal scatter, so this composes three grids:
+  // the main scatter plus two small density areas that share the main axes' ranges.
+  import type { EChartsOption } from 'echarts'
+  import { resolveCssColor, resolveRgb } from '../../../../functions/format'
+  import EChart from '../EChart.svelte'
+  import { type Corner, type CornerColor, cornerColors } from './cornerColors'
+
+  /** A named corner and the CSS color at it (any expr; resolved to RGB). */
+  export type CornerSpec = { corner: Corner; color: string }
+
+  interface Props {
+    points: { x: number; y: number; worker: number }[]
+    xName: string
+    yName: string
+    xFormat?: (n: number) => string
+    yFormat?: (n: number) => string
+    /** 2–4 corners with colors; each point is the inverse-distance blend of them. Omit for a
+     *  uniform accent color. */
+    corners?: CornerSpec[]
+    selected?: number | null
+    onselect?: (worker: number) => void
+    onclear?: () => void
+    /** CSS color for non-selected dots while a worker is selected. */
+    baseColor?: string
+    height?: number
+    /** Custom tooltip HTML for a point; overrides the default `xName/yName` two-line body. */
+    tooltipFormat?: (p: { x: number; y: number; worker: number }) => string
+  }
+  const {
+    points,
+    xName,
+    yName,
+    xFormat = (n) => `${n}`,
+    yFormat = (n) => `${n}`,
+    corners,
+    selected = null,
+    onselect,
+    onclear,
+    baseColor = 'var(--color-surface-500)',
+    height = 200,
+    tooltipFormat
+  }: Props = $props()
+
+  const axis = resolveCssColor('var(--color-surface-500)', [156, 163, 175])
+  const accent = resolveCssColor('var(--color-primary-500)', [99, 102, 241])
+  const primary = resolveCssColor('var(--color-primary-500)', [99, 102, 241])
+  const baseDot = $derived(resolveCssColor(baseColor, [156, 163, 175]))
+
+  const scatterData = $derived.by(() => {
+    let base: string[] | null = null
+    if (corners && corners.length > 0) {
+      const resolved: CornerColor[] = corners.map((c) => ({
+        corner: c.corner,
+        rgb: resolveRgb(c.color, [128, 128, 128])
+      }))
+      base = cornerColors(points, resolved)
+    }
+    const anySelected = selected !== null
+    return points.map((p, i) => ({
+      value: [p.x, p.y],
+      itemStyle: {
+        // No selection: corner-blend (or accent). With a selection: the picked worker is
+        // primary, the rest fall back to the base color.
+        color: anySelected ? (p.worker === selected ? primary : baseDot) : base ? base[i]! : accent,
+        opacity: 0.9
+      }
+    }))
+  })
+
+  // Clicks on the scatter series (index 0) select a worker; marginal series are ignored.
+  function onclick(e: any) {
+    if (e?.seriesIndex !== 0) {
+      return
+    }
+    const p = points[e.dataIndex]
+    if (p) {
+      onselect?.(p.worker)
+    }
+  }
+
+  function domain(vals: number[]): [number, number] {
+    if (vals.length === 0) {
+      return [0, 1]
+    }
+    let min = Math.min(...vals)
+    let max = Math.max(...vals)
+    if (min === max) {
+      const pad = Math.abs(min) || 1
+      return [min - pad, max + pad]
+    }
+    const pad = (max - min) * 0.08
+    return [min - pad, max + pad]
+  }
+
+  // Density curve (bin centers + counts) over a fixed domain, for a marginal edge.
+  function density(vals: number[], [lo, hi]: [number, number], bins = 16): [number, number][] {
+    if (vals.length === 0 || hi <= lo) {
+      return []
+    }
+    const w = (hi - lo) / bins
+    const counts = new Array<number>(bins).fill(0)
+    for (const v of vals) {
+      const i = Math.max(0, Math.min(bins - 1, Math.floor((v - lo) / w)))
+      counts[i]!++
+    }
+    const pts: [number, number][] = counts.map((c, i) => [lo + (i + 0.5) * w, c])
+    // Anchor the curve at the exact data extremes so it spans the full point range, with no
+    // half-bin inset at either end.
+    return [[lo, counts[0]!], ...pts, [hi, counts[bins - 1]!]]
+  }
+
+  const options = $derived.by((): EChartsOption => {
+    const xs = points.map((p) => p.x)
+    const ys = points.map((p) => p.y)
+    const xd = domain(xs)
+    const yd = domain(ys)
+    // Bin over the actual data extent (not the padded axis domain) so the marginal curve lines
+    // up horizontally with the scatter's point cloud rather than spanning the padding.
+    const range = (v: number[]): [number, number] =>
+      v.length ? [Math.min(...v), Math.max(...v)] : [0, 1]
+    const topDensity = density(xs, range(xs))
+    const rightDensity = density(ys, range(ys)).map(([c, n]) => [n, c]) // [count, yCenter]
+
+    return {
+      animation: false,
+      grid: [
+        { left: 56, right: 58, top: 44, bottom: 40 }, // main scatter
+        { left: 56, right: 58, top: 8, height: 30 }, // top marginal (X)
+        { right: 8, width: 44, top: 44, bottom: 40 } // right marginal (Y)
+      ],
+      xAxis: [
+        {
+          gridIndex: 0,
+          type: 'value',
+          name: xName,
+          nameLocation: 'middle',
+          nameGap: 26,
+          min: xd[0],
+          max: xd[1],
+          interval: (xd[1] - xd[0]) / 2, // only 3 markers: min, mid, max
+          axisLabel: { color: axis, formatter: (v: number) => xFormat(v) },
+          axisLine: { lineStyle: { color: axis } },
+          splitLine: { show: false }
+        },
+        { gridIndex: 1, type: 'value', min: xd[0], max: xd[1], show: false },
+        { gridIndex: 2, type: 'value', min: 0, show: false }
+      ],
+      yAxis: [
+        {
+          gridIndex: 0,
+          type: 'value',
+          name: yName,
+          nameLocation: 'middle',
+          nameGap: 44,
+          min: yd[0],
+          max: yd[1],
+          interval: (yd[1] - yd[0]) / 3, // 4 markers
+          axisLabel: { color: axis, formatter: (v: number) => yFormat(v) },
+          axisLine: { lineStyle: { color: axis } },
+          splitLine: { show: false }
+        },
+        { gridIndex: 1, type: 'value', min: 0, show: false },
+        { gridIndex: 2, type: 'value', min: yd[0], max: yd[1], show: false }
+      ],
+      tooltip: {
+        trigger: 'item',
+        formatter: (p: any) => {
+          if (p.seriesIndex !== 0) {
+            return ''
+          }
+          const [x, y] = p.value as [number, number]
+          const pt = points[p.dataIndex]
+          if (tooltipFormat && pt) {
+            return tooltipFormat(pt)
+          }
+          const who = `W${pt?.worker ?? p.dataIndex}`
+          return `${who}<br/>${xName}: ${xFormat(x)}<br/>${yName}: ${yFormat(y)}`
+        }
+      },
+      series: [
+        {
+          type: 'scatter',
+          xAxisIndex: 0,
+          yAxisIndex: 0,
+          symbolSize: 9,
+          data: scatterData
+        },
+        {
+          type: 'line',
+          xAxisIndex: 1,
+          yAxisIndex: 1,
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: accent, width: 1 },
+          data: topDensity
+        },
+        {
+          // Right marginal: count runs along X (≥0), y is the shared vertical axis. Smoothed to
+          // match the top marginal's curve (no areaStyle: ECharts would fill toward the bottom,
+          // not toward x=0). The line series clips to the grid, so any smoothing overshoot past
+          // x=0 is trimmed at the axis rather than drawing on both sides.
+          type: 'line',
+          xAxisIndex: 2,
+          yAxisIndex: 2,
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: accent, width: 1 },
+          data: rightDensity
+        }
+      ]
+    }
+  })
+</script>
+
+<EChart {options} {height} {onclick} onblank={onclear} />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/ValueBars.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/ValueBars.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  // Per-worker value bars reusing the K1 bar look (log-scaled heights via `barMetrics`, shared
+  // 6px..24px envelope, `barColor`), rendered through the shared BarRow. A bar can be clicked to
+  // select its worker across the whole tile; the selected bar gets a primary outline.
+  import { barColor, barMetrics } from '../../colors'
+  import BarRow from '../BarRow.svelte'
+
+  interface Props {
+    /** One value per worker; undefined entries render as a zero-height gap. */
+    values: (number | undefined)[]
+    format?: (n: number) => string
+    selected?: number | null
+    onselect?: (worker: number) => void
+  }
+  const { values, format = (n) => `${n}`, selected = null, onselect }: Props = $props()
+
+  // Simple value bars use a fixed 6px..24px envelope throughout (see colors.barMetrics).
+  const MIN_H = 6
+  const MAX_H = 24
+
+  const stats = $derived.by(() => {
+    const nums = values.filter((v): v is number => v !== undefined)
+    if (nums.length === 0) {
+      return { min: 0, max: 0 }
+    }
+    return { min: Math.min(...nums), max: Math.max(...nums) }
+  })
+
+  const bars = $derived(
+    values.map((v, i) => {
+      if (v === undefined) {
+        return { height: 0, color: barColor(0), tooltip: `Worker ${i}: –` }
+      }
+      const { t, height } = barMetrics(v, stats.min, stats.max, MIN_H, MAX_H)
+      return { height, color: barColor(t), tooltip: `Worker ${i}: ${format(v)}` }
+    })
+  )
+</script>
+
+<BarRow {bars} height={MAX_H} {selected} {onselect} />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/cornerColors.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/cornerColors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { Rgb } from '../../../../functions/format'
+import { cornerColors } from './cornerColors.js'
+
+const RED: Rgb = [255, 0, 0]
+const BLUE: Rgb = [0, 0, 255]
+
+describe('cornerColors', () => {
+  it('gives each corner its exact color, and a 50/50 blend at the midpoint', () => {
+    // Normalized positions (Y up): (0,0)=bottom_left, (1,1)=top_right, (0.5,0.5)=center.
+    const points = [
+      { x: 0, y: 0 },
+      { x: 10, y: 100 },
+      { x: 5, y: 50 }
+    ]
+    const out = cornerColors(points, [
+      { corner: 'bottom_left', rgb: RED },
+      { corner: 'top_right', rgb: BLUE }
+    ])
+    expect(out[0]).toBe('rgb(255, 0, 0)')
+    expect(out[1]).toBe('rgb(0, 0, 255)')
+    expect(out[2]).toBe('rgb(128, 0, 128)')
+  })
+
+  it('blends symmetrically for adjacent corners too', () => {
+    // Normalized: (0,0), (1,0), (0.5,1). The top-middle point is equidistant from both bottom
+    // corners, so it blends 50/50 regardless of the corners being adjacent (not opposite).
+    const points = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 5, y: 10 }
+    ]
+    const out = cornerColors(points, [
+      { corner: 'bottom_left', rgb: RED },
+      { corner: 'bottom_right', rgb: BLUE }
+    ])
+    expect(out[2]).toBe('rgb(128, 0, 128)')
+  })
+
+  it('supports up to four corners', () => {
+    const points = [{ x: 5, y: 5 }] // single point → normalized (0.5, 0.5)
+    const out = cornerColors(points, [
+      { corner: 'bottom_left', rgb: [255, 0, 0] },
+      { corner: 'bottom_right', rgb: [0, 255, 0] },
+      { corner: 'top_left', rgb: [0, 0, 255] },
+      { corner: 'top_right', rgb: [255, 255, 255] }
+    ])
+    // Equidistant from all four corners → equal blend → average of the four colors.
+    expect(out[0]).toBe('rgb(128, 128, 128)')
+  })
+
+  it('returns the single color when one corner is given', () => {
+    expect(cornerColors([{ x: 1, y: 2 }], [{ corner: 'top_left', rgb: RED }])).toEqual([
+      'rgb(255, 0, 0)'
+    ])
+  })
+
+  it('returns empty for no points', () => {
+    expect(cornerColors([], [{ corner: 'top_left', rgb: RED }])).toEqual([])
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/cornerColors.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/cache/cornerColors.ts
@@ -1,0 +1,71 @@
+// Colors scatter points by their position relative to a set of labeled corners. Points are
+// normalized to [0, 1] across the data; each point's color is the inverse-distance-weighted
+// blend of the corner colors. This is symmetric, so any 2–4 corners work regardless of whether
+// they are adjacent or opposite (2 opposite corners reduce to a diagonal gradient; 2 adjacent
+// corners give a gradient along that edge).
+import type { Rgb } from '../../../../functions/format'
+
+type Point = { x: number; y: number }
+
+/** A named corner of the plot area. Y is up: `top_*` is high Y, `right_*` is high X. */
+export type Corner = 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right'
+
+/** Normalized [x, y] position (Y up) of each named corner. */
+const CORNER_XY: Record<Corner, [number, number]> = {
+  bottom_left: [0, 0],
+  bottom_right: [1, 0],
+  top_left: [0, 1],
+  top_right: [1, 1]
+}
+
+/** A named corner of the plot area and the color at that corner. */
+export type CornerColor = { corner: Corner; rgb: Rgb }
+
+function rgbStr(rgb: Rgb): string {
+  return `rgb(${Math.round(rgb[0])}, ${Math.round(rgb[1])}, ${Math.round(rgb[2])})`
+}
+
+export function cornerColors(points: Point[], corners: CornerColor[]): string[] {
+  if (points.length === 0 || corners.length === 0) {
+    return points.map(() => rgbStr(corners[0]?.rgb ?? [128, 128, 128]))
+  }
+  let xmin = Infinity
+  let xmax = -Infinity
+  let ymin = Infinity
+  let ymax = -Infinity
+  for (const p of points) {
+    xmin = Math.min(xmin, p.x)
+    xmax = Math.max(xmax, p.x)
+    ymin = Math.min(ymin, p.y)
+    ymax = Math.max(ymax, p.y)
+  }
+  const nx = (v: number) => (xmax > xmin ? (v - xmin) / (xmax - xmin) : 0.5)
+  const ny = (v: number) => (ymax > ymin ? (v - ymin) / (ymax - ymin) : 0.5)
+
+  return points.map((p) => {
+    const px = nx(p.x)
+    const py = ny(p.y)
+    // Inverse-distance-squared weights; a point sitting on a corner takes that color exactly.
+    let exact = -1
+    const weights = corners.map((c, i) => {
+      const [cx, cy] = CORNER_XY[c.corner]
+      const d2 = (px - cx) ** 2 + (py - cy) ** 2
+      if (d2 < 1e-12) {
+        exact = i
+      }
+      return 1 / (d2 + 1e-9)
+    })
+    if (exact >= 0) {
+      return rgbStr(corners[exact]!.rgb)
+    }
+    const sum = weights.reduce((a, b) => a + b, 0)
+    const out: Rgb = [0, 0, 0]
+    corners.forEach((c, i) => {
+      const w = weights[i]! / sum
+      out[0] += c.rgb[0] * w
+      out[1] += c.rgb[1] * w
+      out[2] += c.rgb[2] * w
+    })
+    return rgbStr(out)
+  })
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/histogramTicks.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/histogramTicks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { niceTicks } from './histogramTicks'
+
+describe('niceTicks', () => {
+  it('returns empty for a non-positive max', () => {
+    expect(niceTicks(0)).toEqual([])
+    expect(niceTicks(-5)).toEqual([])
+    expect(niceTicks(Number.NaN)).toEqual([])
+  })
+
+  it('produces round multiples of 5 / 10 at a larger scale', () => {
+    expect(niceTicks(1500)).toEqual([0, 500, 1000, 1500])
+    expect(niceTicks(1800)).toEqual([0, 500, 1000, 1500]) // top nice tick may be below max
+  })
+
+  it('never exceeds maxCount, thinning the step when needed', () => {
+    for (const max of [5, 8, 23, 47, 99, 250, 1234, 9999, 55000]) {
+      expect(niceTicks(max).length).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('always starts at 0 and stays within [0, max]', () => {
+    const t = niceTicks(1234)
+    expect(t[0]).toBe(0)
+    expect(Math.max(...t)).toBeLessThanOrEqual(1234)
+  })
+
+  it('keeps ticks integral when integer=true (no fractional counts)', () => {
+    const t = niceTicks(2, 5, true)
+    expect(t).toEqual([0, 1, 2])
+    for (const v of niceTicks(8, 5, true)) {
+      expect(Number.isInteger(v)).toBe(true)
+    }
+  })
+
+  it('allows fractional steps when integer=false', () => {
+    expect(niceTicks(2, 5, false)).toContain(0.5)
+  })
+
+  it('honors a custom maxCount', () => {
+    expect(niceTicks(100, 3).length).toBeLessThanOrEqual(3)
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/histogramTicks.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/histogramTicks.ts
@@ -1,0 +1,39 @@
+/**
+ * "Nice" tick values in [0, max] using a 1-2-5-10 step, at most `maxCount` of them (0 included).
+ * Values are round multiples (…, 500, 1000, 2000, 5000, …) for easy reading; the caller positions
+ * them on whatever scale it draws (e.g. a log axis). With `integer` the step is forced to a whole
+ * number, so bin/step counts never get fractional ticks. Returns [] for a non-positive max.
+ */
+export function niceTicks(max: number, maxCount = 5, integer = false): number[] {
+  if (!(max > 0) || maxCount < 2) {
+    return []
+  }
+  const niceStep = (raw: number): number => {
+    const mag = 10 ** Math.floor(Math.log10(raw))
+    const n = raw / mag
+    return (n < 1.5 ? 1 : n < 3 ? 2 : n < 7 ? 5 : 10) * mag
+  }
+  // Next nice step up (1 → 2 → 5 → 10 …), used to thin the ticks when there are too many.
+  const nextStep = (s: number): number => {
+    const mag = 10 ** Math.floor(Math.log10(s))
+    const n = Math.round(s / mag)
+    return (n < 2 ? 2 : n < 5 ? 5 : 10) * mag
+  }
+  const build = (step: number): number[] => {
+    const out: number[] = []
+    for (let v = 0; v <= max + step * 1e-9; v += step) {
+      out.push(Number(v.toFixed(10)))
+    }
+    return out
+  }
+  let step = niceStep(max / (maxCount - 1))
+  if (integer) {
+    step = Math.max(1, step)
+  }
+  let ticks = build(step)
+  while (ticks.length > maxCount) {
+    step = nextStep(step)
+    ticks = build(step)
+  }
+  return ticks
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/metricData.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/metricData.ts
@@ -1,0 +1,46 @@
+// Small helpers shared by the kind widgets for reading per-worker values out of a MetricGroup.
+import { ArrayValue, MissingValue, type PropertyValue } from 'profiler-lib'
+import type { MetricGroup, MetricSubRow } from '../dispatch'
+
+/** Numeric value of a cell, or undefined when missing/non-numeric. */
+export function numeric(v: PropertyValue | undefined): number | undefined {
+  if (!v) {
+    return undefined
+  }
+  const n = v.getNumericValue()
+  return n.isSome() ? n.unwrap() : undefined
+}
+
+export function isMissing(v: PropertyValue | undefined): boolean {
+  return !v || v instanceof MissingValue
+}
+
+/** The array payload of a distribution cell, or undefined when the cell is not array-valued. */
+export function asArray(v: PropertyValue | undefined): number[] | undefined {
+  return v instanceof ArrayValue ? v.toArray() : undefined
+}
+
+/** Number of workers in a group (max cell count across its sub-rows). */
+export function workerCount(group: MetricGroup): number {
+  return group.rows.reduce((m, r) => Math.max(m, r.values.length), 0)
+}
+
+/** First sub-row whose suffix ends with `end` (e.g. '.used', '.avg_latency'). */
+export function rowEndingWith(group: MetricGroup, end: string): MetricSubRow | undefined {
+  return group.rows.find((r) => r.suffix.endsWith(end))
+}
+
+/** Sum of a sub-row's numeric values across workers (missing cells skipped). */
+export function sumRow(row: MetricSubRow | undefined): number {
+  if (!row) {
+    return 0
+  }
+  let sum = 0
+  for (const v of row.values) {
+    const n = numeric(v)
+    if (n !== undefined) {
+      sum += n
+    }
+  }
+  return sum
+}

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/statsMetric.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/statsMetric.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { batchRange, fractionIn } from './statsMetric.js'
+
+describe('fractionIn', () => {
+  it('maps a value to its clamped fraction within the range', () => {
+    expect(fractionIn(10, 10, 100)).toBe(0)
+    expect(fractionIn(100, 10, 100)).toBe(1)
+    expect(fractionIn(55, 10, 100)).toBeCloseTo(0.5, 10)
+  })
+
+  it('clamps out-of-range values to [0, 1]', () => {
+    expect(fractionIn(-5, 0, 10)).toBe(0)
+    expect(fractionIn(20, 0, 10)).toBe(1)
+  })
+
+  it('returns 0 for a degenerate range', () => {
+    expect(fractionIn(42, 42, 42)).toBe(0)
+    expect(fractionIn(5, 10, 10)).toBe(0)
+  })
+})
+
+describe('batchRange', () => {
+  it('takes the smallest min and largest max across workers', () => {
+    const r = batchRange(
+      [
+        { min: 30, avg: 50, max: 90 },
+        { min: 10, avg: 40, max: 200 }
+      ],
+      10,
+      450
+    )
+    expect(r.min).toBe(10)
+    expect(r.max).toBe(200)
+    expect(r.avg).toBe(45) // 450 records / 10 batches
+  })
+
+  it('skips missing per-worker fields', () => {
+    const r = batchRange([{ avg: 5 }, { min: 3, max: 7 }, {}], 4, 20)
+    expect(r.min).toBe(3)
+    expect(r.max).toBe(7)
+    expect(r.avg).toBe(5)
+  })
+
+  it('is well-defined with no batches or no workers', () => {
+    expect(batchRange([], 0, 0)).toEqual({ min: 0, max: 0, avg: 0 })
+    // No records but nonzero batches -> average 0, not NaN.
+    expect(batchRange([{ min: 1, max: 2 }], 3, 0)).toEqual({ min: 1, max: 2, avg: 0 })
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/statsMetric.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/statsMetric.ts
@@ -1,0 +1,47 @@
+// Pure helpers for the K7 batch-size widget (StatsMetric.svelte). Kept out of the component so
+// the range/positioning math can be unit-tested without a DOM.
+
+/** Fraction of `v` within [min, max], clamped to [0, 1]. Returns 0 for a degenerate range
+ *  (max <= min); callers that want to center a degenerate range handle that themselves. */
+export function fractionIn(v: number, min: number, max: number): number {
+  if (max <= min) {
+    return 0
+  }
+  return Math.max(0, Math.min(1, (v - min) / (max - min)))
+}
+
+/** One worker's per-batch size summary; any field may be missing. */
+export interface BatchSummary {
+  min?: number
+  avg?: number
+  max?: number
+}
+
+/**
+ * Overall batch-size range and pooled average across workers:
+ *  - `min` = smallest per-worker min, `max` = largest per-worker max (the axis extent).
+ *  - `avg` = pooled mean = total records / total batches (0 when there are no batches).
+ * The pooled average is a record-weighted mean, not the mean of per-worker averages, so it
+ * matches the "records / batches" identity shown in the widget.
+ */
+export function batchRange(
+  workers: BatchSummary[],
+  batches: number,
+  records: number
+): { min: number; max: number; avg: number } {
+  let min = Number.POSITIVE_INFINITY
+  let max = 0
+  for (const w of workers) {
+    if (w.min !== undefined) {
+      min = Math.min(min, w.min)
+    }
+    if (w.max !== undefined) {
+      max = Math.max(max, w.max)
+    }
+  }
+  if (!Number.isFinite(min)) {
+    min = 0
+  }
+  const avg = batches > 0 ? records / batches : 0
+  return { min, max, avg }
+}

--- a/js-packages/profiler-layout/src/lib/functions/format.ts
+++ b/js-packages/profiler-layout/src/lib/functions/format.ts
@@ -1,0 +1,137 @@
+/**
+ * Convert a byte count to a human-readable string, e.g. humanSize(1024) === "1.0 KiB".
+ * Ported from web-console's string utils so the profiler view can format byte axes/labels.
+ */
+export function humanSize(bytes: number): string {
+  const thresh = 1024
+  if (Math.abs(bytes) < thresh) {
+    return bytes + ' B'
+  }
+  const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+  let u = -1
+  do {
+    bytes /= thresh
+    ++u
+  } while (Math.abs(bytes) >= thresh && u < units.length - 1)
+  return bytes.toFixed(1) + ' ' + units[u]
+}
+
+/** Format a duration in seconds as a compact human-readable string (ns/µs/ms/s). */
+export function humanSeconds(s: number): string {
+  if (!Number.isFinite(s)) {
+    return 'n/a'
+  }
+  if (s === 0) {
+    return '0'
+  }
+  const abs = Math.abs(s)
+  if (abs < 1e-6) {
+    return (s * 1e9).toFixed(0) + 'ns'
+  }
+  if (abs < 1e-3) {
+    return (s * 1e6).toFixed(1) + 'µs'
+  }
+  if (abs < 1) {
+    return (s * 1e3).toFixed(1) + 'ms'
+  }
+  return s.toFixed(2) + 's'
+}
+
+/**
+ * Resolve a CSS custom property (e.g. '--color-primary-500') to its computed value. ECharts
+ * renders to canvas and cannot consume CSS variables, so charts read theme colors this way.
+ * Returns `fallback` when unavailable (e.g. SSR, or the variable is unset).
+ */
+export function cssVar(name: string, fallback: string): string {
+  if (typeof document === 'undefined') {
+    return fallback
+  }
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return v || fallback
+}
+
+export type Rgb = [number, number, number]
+
+let colorProbe: HTMLSpanElement | undefined
+let normCtx: CanvasRenderingContext2D | null | undefined
+
+/**
+ * Resolve any CSS color expression (hex, `oklch(…)`, `var(--…)`) to concrete sRGB `[r, g, b]`.
+ * `getComputedStyle` resolves the `var()`, then a 1×1 canvas pixel converts the (possibly
+ * `oklch`) computed color to sRGB — parsing the computed string directly would misread oklch's
+ * L/C/H as R/G/B. ECharts renders to canvas and cannot interpolate CSS colors, so charts resolve
+ * endpoints to RGB and interpolate in JS. Returns `fallback` outside the browser.
+ */
+export function resolveRgb(expr: string, fallback: Rgb): Rgb {
+  if (typeof document === 'undefined') {
+    return fallback
+  }
+  if (!colorProbe) {
+    colorProbe = document.createElement('span')
+    colorProbe.style.display = 'none'
+    document.body.appendChild(colorProbe)
+  }
+  colorProbe.style.color = ''
+  colorProbe.style.color = expr
+  const computed = getComputedStyle(colorProbe).color
+  if (!computed) {
+    return fallback
+  }
+  if (normCtx === undefined) {
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+    normCtx = canvas.getContext('2d', { willReadFrequently: true })
+  }
+  if (!normCtx) {
+    return fallback
+  }
+  normCtx.clearRect(0, 0, 1, 1)
+  try {
+    normCtx.fillStyle = computed
+  } catch {
+    return fallback
+  }
+  normCtx.fillRect(0, 0, 1, 1)
+  const d = normCtx.getImageData(0, 0, 1, 1).data
+  return [d[0]!, d[1]!, d[2]!]
+}
+
+/** Resolve a CSS color expression to an `rgb(...)` string (for ECharts axis/series colors). */
+export function resolveCssColor(expr: string, fallback: Rgb): string {
+  const [r, g, b] = resolveRgb(expr, fallback)
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+/** True when the app is in dark mode (the metrics theme keys off `.dark` / `body.dark`). */
+export function isDarkTheme(): boolean {
+  if (typeof document === 'undefined') {
+    return false
+  }
+  return (
+    document.documentElement.classList.contains('dark') || document.body.classList.contains('dark')
+  )
+}
+
+/** Linearly interpolate between two RGB colors, `t` clamped to [0, 1]; returns `rgb(...)`. */
+export function mixRgb(a: Rgb, b: Rgb, t: number): string {
+  const k = Math.max(0, Math.min(1, Number.isFinite(t) ? t : 0))
+  const r = Math.round(a[0] + (b[0] - a[0]) * k)
+  const g = Math.round(a[1] + (b[1] - a[1]) * k)
+  const bl = Math.round(a[2] + (b[2] - a[2]) * k)
+  return `rgb(${r}, ${g}, ${bl})`
+}
+
+/**
+ * The shared cache-diagram color scale endpoints: a theme-adaptive neutral (surface-100 in
+ * light mode, surface-900 in dark — subtle against the card) and error. Used for the value
+ * heatmap and for corner-based dot coloring so both read on the same scale.
+ */
+export function neutralErrorScale(): { neutral: Rgb; error: Rgb } {
+  const neutral = resolveRgb(
+    isDarkTheme() ? 'var(--color-surface-900)' : 'var(--color-surface-100)',
+    isDarkTheme() ? [30, 33, 40] : [241, 243, 246]
+  )
+  const error = resolveRgb('var(--color-error-500)', [239, 68, 68])
+  return { neutral, error }
+}

--- a/js-packages/profiler-layout/src/lib/functions/formatQty.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/formatQty.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatQty } from './formatQty.js'
+
+describe('formatQty', () => {
+  it('formats integers with comma grouping by default', () => {
+    expect(formatQty(999)).toBe('999')
+    expect(formatQty(12345)).toBe('12,345')
+    expect(formatQty(1234567)).toBe('1,234,567')
+    expect(formatQty(0)).toBe('0')
+  })
+
+  it('rounds fractional inputs to whole numbers', () => {
+    expect(formatQty(12.7)).toBe('13')
+  })
+
+  it("uses 3 significant digits with an SI suffix in 'rounded' mode once >= 1000", () => {
+    expect(formatQty(12345, 'rounded')).toBe('12.3k')
+    expect(formatQty(1500, 'rounded')).toBe('1.50k')
+    // Below 1000 the rounded flag keeps the plain grouped integer.
+    expect(formatQty(999, 'rounded')).toBe('999')
+  })
+
+  it('renders an em dash for non-finite / missing values', () => {
+    expect(formatQty(null)).toBe('—')
+    expect(formatQty(undefined)).toBe('—')
+    expect(formatQty(Number.NaN)).toBe('—')
+    expect(formatQty(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/formatQty.ts
+++ b/js-packages/profiler-layout/src/lib/functions/formatQty.ts
@@ -1,0 +1,15 @@
+import { format } from 'd3-format'
+
+/**
+ * Format a quantity (record/row count) for display.
+ * Copied verbatim from web-console's `$lib/functions/format` so the profiler view can format
+ * count axes/labels identically. Kept as a standalone copy on purpose: the web-console impl is
+ * not shared, so the two stay in lockstep by duplication rather than a cross-package import.
+ *
+ *  - default: comma-grouped integer (`,.0f`), e.g. 12345 -> "12,345".
+ *  - `'rounded'`: 3 significant digits with an SI suffix (`.3s`) once >= 1000, e.g. "12.3k".
+ */
+export const formatQty = (v: number | null | undefined, rounded?: 'rounded') =>
+  typeof v === 'number' && Number.isFinite(v)
+    ? format(v >= 1000 && rounded ? '.3s' : ',.0f')(v)
+    : '—'

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -32,7 +32,9 @@ class MeasurementMatrix {
         // Order that the metrics should be displayed in
         readonly metricOrder: Array<string>,
         // Keys are measurement names, arrays contain one element per column name.
-        readonly attributes: Map<string, Array<SerializedMeasurement>>) {
+        readonly attributes: Map<string, Array<SerializedMeasurement>>,
+        // Profile-wide value range per metric (min/max across all nodes and workers).
+        readonly ranges: Map<string, { min: number; max: number }> = new Map()) {
         for (const a of attributes.entries()) {
             assert(columnNames.length == a[1].length,
                 "Measurement count mismatch for '" + a[0] + "':" + columnNames.length + " vs " + a.length);
@@ -683,10 +685,14 @@ export class CytographRendering {
         for (const node of this.currentGraph!.nodes) {
             let profileNode = profile.getNode(node.getId()).unwrap();
             let data = new Map<string, Array<SerializedMeasurement>>();
+            let ranges = new Map<string, { min: number; max: number }>();
             // Select just the visible metrics
             // Compute per-worker attributes
             for (let metric of profileNode.measurements.getMetrics()) {
                 let range = profile.propertyRange(metric);
+                if (!range.isEmpty()) {
+                    ranges.set(metric, { min: range.min, max: range.max });
+                }
                 let metrics = profileNode.getMeasurements(metric);
                 let selected = selection.workersVisible.getSelectedElements(metrics);
                 let measurements: Array<SerializedMeasurement> = [];
@@ -708,7 +714,7 @@ export class CytographRendering {
                 const p = parent.unwrap();
                 kv.set("parent", p);
             }
-            let matrix = new MeasurementMatrix(columnNames, [...profileNode.measurements.getMetrics()], data);
+            let matrix = new MeasurementMatrix(columnNames, [...profileNode.measurements.getMetrics()], data, ranges);
             let attributes = new Attributes(matrix, kv);
             let rendered = this.getRenderedNode(node.getId());
             rendered.data("expanded", node.expanded);
@@ -1049,10 +1055,12 @@ export class CytographRendering {
                     }
                 }
 
+                let range = attributes.matrix.ranges.get(key);
                 tooltipData.rows.push({
                     metric: key,
                     isCurrentMetric: key === this.getCurrentMetric(),
-                    cells
+                    cells,
+                    ...(range ? { range } : {})
                 });
             }
         }

--- a/js-packages/profiler-lib/src/index.ts
+++ b/js-packages/profiler-lib/src/index.ts
@@ -19,6 +19,7 @@ export {
     CircuitProfile,
     PropertyValue,
     MissingValue,
+    ArrayValue,
     type JsonProfiles
 } from './profile.js';
 export { type Dataflow, type SourcePositionRange } from './dataflow.js';

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+    ArrayValue,
     BooleanValue,
     BytesValue,
     CircuitProfile,
     CountValue,
+    Measurement,
     MissingValue,
     PercentValue,
     PropertyValue,
@@ -301,5 +303,73 @@ describe('PropertyValue contract', () => {
             // Self-average: every kind should accept an empty `others` array without throwing.
             expect(() => v.average([])).not.toThrow()
         }
+    })
+})
+
+describe('ArrayValue', () => {
+    it('reports its array and is non-comparable with no scalar value', () => {
+        const a = new ArrayValue([1, 2, 3])
+        expect(a.toArray()).toEqual([1, 2, 3])
+        expect(a.isComparable()).toBe(false)
+        expect(a.getNumericValue().isNone()).toBe(true)
+    })
+
+    it('combines element-wise, padding the shorter array', () => {
+        const combined = new ArrayValue([1, 2]).combine(new ArrayValue([10, 20, 30]))
+        expect((combined as ArrayValue).toArray()).toEqual([11, 22, 30])
+    })
+})
+
+describe('Measurement.parseValues', () => {
+    it('decodes key/size distributions into an ArrayValue', () => {
+        const ms = Measurement.parseValues({
+            metric_id: 'key_distribution',
+            value: [
+                { type: 'count', value: 3 },
+                { type: 'count', value: 5 }
+            ]
+        } as never)
+        expect(ms).toHaveLength(1)
+        const v = ms[0]!.value.unwrap()
+        expect(v).toBeInstanceOf(ArrayValue)
+        expect((v as ArrayValue).toArray()).toEqual([3, 5])
+    })
+
+    it('decodes a slot-labeled compaction state into a StringValue', () => {
+        const ms = Measurement.parseValues({
+            metric_id: 'compaction_state',
+            labels: [['slot', '0']],
+            value: { type: 'string', value: 'requested' }
+        } as never)
+        expect(ms).toHaveLength(1)
+        expect(ms[0]!.property).toBe('compaction_state.slot:0')
+        expect(ms[0]!.value.unwrap().toString()).toBe('requested')
+    })
+
+    it('decodes bloom_filter_bits_per_key (suffix "key") as a count', () => {
+        const ms = Measurement.parseValues({
+            metric_id: 'bloom_filter_bits_per_key',
+            value: { type: 'int', value: 7 }
+        } as never)
+        expect(ms).toHaveLength(1)
+        expect(ms[0]!.value.unwrap().getNumericValue().unwrap()).toBe(7)
+    })
+
+    it('decodes completed_merges into merges/batches/steps/avg sub-rows', () => {
+        const ms = Measurement.parseValues({
+            metric_id: 'completed_merges',
+            labels: [['slot', '1']],
+            value: {
+                merges: { value: 2 },
+                batches: { value: 10 },
+                steps: { value: 4 },
+                avg_step_seconds: { value: { secs: 0, nanos: 500_000_000 } },
+                avg_step_cpu_seconds: { value: { secs: 0, nanos: 250_000_000 } }
+            }
+        } as never)
+        const byProp = new Map(ms.map((m) => [m.property, m.value.unwrap()]))
+        expect(byProp.get('completed_merges.slot:1.steps')?.getNumericValue().unwrap()).toBe(4)
+        expect(byProp.get('completed_merges.slot:1.merges')?.getNumericValue().unwrap()).toBe(2)
+        expect(byProp.has('completed_merges.slot:1.avg_step_seconds')).toBe(true)
     })
 })

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -77,10 +77,11 @@ interface StatsMetricValue extends MetricValue {
 }
 
 interface MergesMetricValue extends MetricValue {
-    avg_step_time: DurationMetricValue;
-    batches: CountMetricValue;
     merges: CountMetricValue;
+    batches: CountMetricValue;
     steps: CountMetricValue;
+    avg_step_seconds: DurationMetricValue;
+    avg_step_cpu_seconds: DurationMetricValue;
 }
 
 interface SerializedStringValue {
@@ -622,6 +623,71 @@ export class MissingValue extends PropertyValue {
     }
 }
 
+/** A property value that is an array of numbers, e.g. a distribution (`key_distribution`,
+ * `size_distribution`). Non-comparable and without a scalar numeric value — consumers that
+ * visualize distributions read the array via `toArray()`. */
+export class ArrayValue extends PropertyValue {
+    constructor(readonly array: number[]) {
+        super();
+    }
+
+    toArray(): number[] {
+        return this.array;
+    }
+
+    override isComparable(): boolean {
+        return false;
+    }
+
+    // No single scalar summarizes a distribution; return none so numeric-only consumers (the
+    // heatmap percentile scale, the bar chart) skip it rather than misrepresent it.
+    getNumericValue(): Option<number> {
+        return Option.none();
+    }
+
+    // Element-wise sum, padding the shorter array with zeros. Used when a complex node folds in
+    // its children's readings (e.g. per-shard key distributions).
+    override combine(other: PropertyValue): PropertyValue {
+        if (other instanceof MissingValue) {
+            return this;
+        }
+        if (other instanceof ArrayValue) {
+            const n = Math.max(this.array.length, other.array.length);
+            const out = new Array<number>(n);
+            for (let i = 0; i < n; i++) {
+                out[i] = (this.array[i] ?? 0) + (other.array[i] ?? 0);
+            }
+            return new ArrayValue(out);
+        }
+        throw new Error("Cannot add ArrayValue to " + other);
+    }
+
+    override average(others: PropertyValue[]): PropertyValue {
+        const arrays = [this, ...others].filter((v): v is ArrayValue => v instanceof ArrayValue);
+        if (arrays.length === 0) {
+            return MissingValue.INSTANCE;
+        }
+        const n = arrays.reduce((m, a) => Math.max(m, a.array.length), 0);
+        const out = new Array<number>(n).fill(0);
+        for (const a of arrays) {
+            for (let i = 0; i < a.array.length; i++) {
+                out[i]! += a.array[i]!;
+            }
+        }
+        for (let i = 0; i < n; i++) {
+            out[i]! /= arrays.length;
+        }
+        return new ArrayValue(out);
+    }
+
+    override toString(): string {
+        if (this.array.length <= 8) {
+            return "[" + this.array.join(", ") + "]";
+        }
+        return `${this.array.length} values`;
+    }
+}
+
 /** A property value that represents a time with seconds and nanoseconds. */
 export class TimeValue extends PropertyValue {
     constructor(readonly seconds: number) {
@@ -998,21 +1064,37 @@ export class Measurement {
             }
             case "merges": {
                 let s = metric.value as MergesMetricValue;
-                let avg_step_time = undefined;
-                let result = [];
-                if (s.avg_step_time !== undefined) {
-                    avg_step_time = TimeValue.fromDurationMetric(s.avg_step_time);
-                    result.push(new Measurement(metric_id + ".avg_step_time", Option.some(avg_step_time)));
+                let result = [
+                    new Measurement(metric_id + ".merges", Option.some(CountValue.fromCountMetric(s.merges))),
+                    new Measurement(metric_id + ".batches", Option.some(CountValue.fromCountMetric(s.batches))),
+                    new Measurement(metric_id + ".steps", Option.some(CountValue.fromCountMetric(s.steps))),
+                ];
+                if (s.avg_step_seconds !== undefined) {
+                    result.push(new Measurement(metric_id + ".avg_step_seconds",
+                        Option.some(TimeValue.fromDurationMetric(s.avg_step_seconds))));
                 }
-                let batches = CountValue.fromCountMetric(s.batches);
-                let merges = CountValue.fromCountMetric(s.merges);
-                let steps = CountValue.fromCountMetric(s.steps);
-                result.push(
-                    new Measurement(metric_id + ".batches", Option.some(batches)),
-                    new Measurement(metric_id + ".merges", Option.some(merges)),
-                    new Measurement(metric_id + ".steps", Option.some(steps)),
-                );
+                if (s.avg_step_cpu_seconds !== undefined) {
+                    result.push(new Measurement(metric_id + ".avg_step_cpu_seconds",
+                        Option.some(TimeValue.fromDurationMetric(s.avg_step_cpu_seconds))));
+                }
                 return result;
+            }
+            case "distribution": {
+                // Serialized as a JSON array of typed MetaItems (e.g. {type:"count",value:n});
+                // extract the numeric payloads into a single array-valued measurement.
+                let items = metric.value as unknown as Array<{ value: number }>;
+                let arr = Array.isArray(items) ? items.map((e) => enforceNumber(e.value)) : [];
+                return [new Measurement(metric_id, Option.some(new ArrayValue(arr)))];
+            }
+            case "state": {
+                // e.g. compaction_state (a per-slot status string).
+                let s = metric.value as StringMetricValue;
+                return [new Measurement(metric_id, Option.some(StringValue.fromString(s.value)))];
+            }
+            case "key": {
+                // e.g. bloom_filter_bits_per_key (an integer density).
+                let s = metric.value as IntMetricValue;
+                return [new Measurement(metric_id, Option.some(new CountValue(s.value)))];
             }
             case "policy": {
                 let s = metric.value as StringMetricValue;

--- a/js-packages/profiler-lib/src/profiler.ts
+++ b/js-packages/profiler-lib/src/profiler.ts
@@ -36,6 +36,9 @@ export interface TooltipRow {
     metric: string;
     isCurrentMetric: boolean;
     cells: TooltipCell[];
+    /** Profile-wide value range for this metric (min/max across all nodes and workers), when
+     * numeric. Lets consumers color a value relative to the whole profile, not just this node. */
+    range?: { min: number; max: number };
 }
 
 /** Tooltip data structure */


### PR DESCRIPTION
This PR introduces multiple new widgets for visualizing the profile metrics. The goal is to to try to effectively summarize the relationships between the metrics to convert a wall of numbers into distinct charts that allow to see relationships and trends without reading through every number, while still allowing to inspect individual values when necessary.

Every widget is designed to accommodate a large number of workers without complicating or visually cluttering the visualization.

The charts may seem involved, but I feel they are very information dense and yet easy to read after getting used to them.

Once I confirm the direction I will ask Anna for feedback on the design. I needed to come up with ways to summarize necessary relationships in a compact footprint.

The widgets in this PR:
- Percentage widget - clearly visualizes percentage for many workers in a compact widget
<img width="1205" height="210" alt="image" src="https://github.com/user-attachments/assets/e651894f-0b6a-449e-bd10-6659d9f40545" />
=========================================

- Composite cache widget - see how workers cluster in terms of cache latency, cache miss performance hit, etc.:
<img width="1809" height="1108" alt="image" src="https://github.com/user-attachments/assets/039429ff-d811-45e4-8133-358d7c92a5f7" />
=========================================

- Input/output batches stats - see average records per batch and compare values workers
<img width="1778" height="339" alt="image" src="https://github.com/user-attachments/assets/12ef0d65-17f0-4797-9849-20571b819b48" />
=========================================

- Compaction state matrix
<img width="728" height="837" alt="image" src="https://github.com/user-attachments/assets/12db14bd-4525-4dd6-a174-ad84231c5490" />
=========================================

- Completed merges
<img width="1838" height="367" alt="image" src="https://github.com/user-attachments/assets/22afb309-0c7f-4bac-acba-e544b497d2a8" />
=========================================

Demo (ignore the mouse pointer - it glitched, frozen in place):
[Screencast from 2026-07-08 18-59-19.webm](https://github.com/user-attachments/assets/3d7a2fac-a5e9-46dc-9b6e-2a5354b89d21)



Please let me know if you would like to see a specific chart or relationship  - we are using a powerful diagram library which enables most chart designs you can think of: https://echarts.apache.org/examples/en/index.html
