### PR TITLE
deploy: prefer IPv4 in glibc DNS resolution

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,6 +35,12 @@ RUN curl -sS https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
       -o /usr/local/share/ca-certificates/aws-global-rds-bundle.crt
 RUN update-ca-certificates
 
+# Prefer IPv4 over IPv6 for dual-stack DNS results. Our EKS nodes have no IPv6
+# routing, so glibc's default preference for AAAA records makes any resolver
+# (Node.js actions like setup-uv, curl, etc.) hang until the IPv6 attempt times
+# out before falling back to IPv4.
+RUN echo "precedence ::ffff:0:0/96 100" >> /etc/gai.conf
+
 # Set UTF-8 locale. Needed for the Rust compiler to handle Unicode column names.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
   locale-gen


### PR DESCRIPTION
Node.js-based GHA actions (e.g. setup-uv) hang and time out fetching raw.githubusercontent.com on our EKS runners, which have no IPv6 routing but still get an AAAA record back. glibc's getaddrinfo tries that IPv6 result first and only falls back to IPv4 after the OS-level timeout.

Fixing this in the feldera-dev image itself (via /etc/gai.conf) applies to every environment that uses it, instead of patching NODE_OPTIONS per-cluster in each ArgoCD-managed runner/job-hook config.