### PR TITLE
[dbsp] Don't issue warning for pidlock file.

### DIFF
--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -1,6 +1,7 @@
 //! Logic to manage persistent checkpoints for a circuit.
 
 use crate::dynamic::{self, data::DataTyped};
+use crate::storage::dirlock::LockedDirectory;
 use crate::storage::file::SerializerInner;
 use crate::{Error, NumEntries, TypedBox};
 use enum_map::{Enum, EnumMap};
@@ -120,6 +121,7 @@ impl Checkpointer {
         in_use_paths.insert(format!("{}.mut", STATUS_FILE).into(), SmallVec::new());
         in_use_paths.insert(DATAFUSION_TEMP_DIR.into(), SmallVec::new());
         in_use_paths.insert(ACTIVATION_MARKER_FILE.into(), SmallVec::new());
+        in_use_paths.insert(LockedDirectory::LOCKFILE_NAME.into(), SmallVec::new());
         for (checkpoint_index, cpm) in self.checkpoint_list.iter().enumerate() {
             in_use_paths
                 .entry(cpm.uuid.to_string().into())

--- a/crates/dbsp/src/storage/dirlock.rs
+++ b/crates/dbsp/src/storage/dirlock.rs
@@ -92,7 +92,7 @@ fn get_lock(file: &File) -> Result<Option<u32>, IoError> {
 }
 
 impl LockedDirectory {
-    const LOCKFILE_NAME: &'static str = "feldera.pidlock";
+    pub const LOCKFILE_NAME: &'static str = "feldera.pidlock";
 
     /// Attempts to create a new pidfile in the `base_path` directory, returning
     /// an error if the file was already created by a different process (and


### PR DESCRIPTION
This suppresses a warning of the form

```
INFO dbsp::circuit::checkpointer:  Keeping unexpected File { size: 0 } feldera.pidlock
```

when a pipeline restarts.

Tested manually by starting a pipeline with nonempty storage with and without this commit.

Fixes: https://github.com/feldera/cloud/issues/1726
