### PR TITLE
[SQL] Optimization to pull aggregate filters into temporal filters where possible

### DIFF
--- a/docs.feldera.com/docs/sql/datetime.md
+++ b/docs.feldera.com/docs/sql/datetime.md
@@ -426,6 +426,16 @@ result.  A conjunction of such terms is also accepted if all terms
 involve the same expression (e.g.: `T.ts >= NOW() - INTERVAL 1 DAYS
 AND T.ts <= NOW() + INTERVAL 1 DAYS`).
 
+Such conditions are also recognized when they guard the argument of an
+aggregate, either in a `CASE` expression or in a `FILTER` clause.  Both
+of the following views count the rows from the last day, and both are
+implemented with a temporal filter:
+
+```sql
+SELECT COUNT(CASE WHEN T.ts >= NOW() - INTERVAL 1 DAYS THEN 1 END) FROM T;
+SELECT COUNT(*) FILTER (WHERE T.ts >= NOW() - INTERVAL 1 DAYS) FROM T;
+```
+
 ## Date parsing and formatting
 
 We support the following functions for formatting and parsing date-like values:

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -107,7 +107,10 @@
                                     <groupId>org.apache.calcite</groupId>
                                     <artifactId>calcite-core</artifactId>
                                     <type>jar</type>
-                                    <overWrite>true</overWrite>
+                                    <!-- overWrite=false: re-unpack only when the jar is newer,
+                                         so the template keeps a stable mtime and incremental
+                                         builds can skip parser regeneration. -->
+                                    <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <includes>**/Parser.jj</includes>
                                 </artifactItem>
@@ -160,8 +163,40 @@
                         </goals>
                         <configuration>
                             <cfgFile>${project.build.directory}/codegen/config.fmpp</cfgFile>
-                            <outputDirectory>target/generated-sources</outputDirectory>
+                            <!-- FMPP rewrites its outputs unconditionally, so it renders
+                                 into a staging directory; the antrun step below copies to
+                                 generated-sources only files whose content changed. -->
+                            <outputDirectory>target/fmpp-generated</outputDirectory>
                             <templateDirectory>${project.build.directory}/codegen/templates</templateDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Publish FMPP outputs, preserving the mtime of unchanged files.
+                 The JavaCC plugin skips grammars that are older than the parser
+                 generated from them, and the Java compiler skips compilation when
+                 no source changed; both checks work only if an unchanged Parser.jj
+                 keeps its mtime across builds. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sync-fmpp-output</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.directory}/generated-sources" overwrite="true">
+                                    <fileset dir="${project.build.directory}/fmpp-generated">
+                                        <different targetdir="${project.build.directory}/generated-sources"
+                                                   ignoreFileTimes="true"/>
+                                    </fileset>
+                                </copy>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/AggregateNowFilterRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/AggregateNowFilterRule.java
@@ -1,0 +1,228 @@
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.optimizer;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Util;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Rule that extracts an aggregate FILTER condition that calls NOW()
+ * into a Filter child of the aggregate.
+ *
+ * <p>Rewrite (one FILTER condition per application; calls with structurally
+ * equal conditions move together, even from different filter columns;
+ * repeated application by the HEP planner handles the remaining conditions).
+ * Here $f3 and $f4 hold equal conditions, so SUM and the filtered COUNT
+ * move together, behind a single join:
+ * <pre>
+ * LogicalAggregate(group=[{0}], s=[SUM($2) FILTER $3], c=[COUNT() FILTER $4], t=[COUNT()])
+ *   LogicalProject([$0, ..., $f3=[>=($1, -(NOW(), 86400000:INTERVAL))],
+ *                            $f4=[>=($1, -(NOW(), 86400000:INTERVAL))]])
+ * </pre>
+ * becomes
+ * <pre>
+ * LogicalProject([$0, s=[$3], c=[COALESCE($4, 0)], t=[$1]])
+ *   LogicalJoin(left, IS NOT DISTINCT FROM($0, $2))
+ *     LogicalAggregate(group=[{0}], t=[COUNT()])                 "anchor"
+ *       LogicalProject(...)
+ *     LogicalAggregate(group=[{0}], s=[SUM($2)], c=[COUNT()])    "filtered"
+ *       LogicalProject(...)
+ *         LogicalFilter([>=($1, -(NOW(), 86400000:INTERVAL))])
+ * </pre>
+ * COUNT over a group with no qualifying rows must be 0, not NULL, hence
+ * the COALESCE on the column coming from the left join's filtered side.
+ *
+ * <p>The join is needed because grouping keys come from the unfiltered
+ * input: a group whose rows all fail the condition must still be output.
+ * The left join produces NULL for the filtered aggregates of groups absent
+ * from the filtered side.  Only calls whose value over an empty set is
+ * NULL (see {@link #emptyGroupValueKnown}) or COUNT may be moved; any
+ * other filtered call prevents the rewrite.
+ *
+ * <p>Without GROUP BY both sides always produce exactly one row, so the
+ * left join degenerates to a cross join.  When there are no unfiltered
+ * calls at all no join is needed.
+ */
+public class AggregateNowFilterRule
+        extends RelRule<DefaultOptRuleConfig<AggregateNowFilterRule>>
+        implements TransformationRule {
+    public AggregateNowFilterRule() {
+        super(CONFIG);
+    }
+
+    /** True if the expression contains a call of the niladic NOW() function. */
+    static boolean containsNow(RexNode node) {
+        try {
+            node.accept(new RexVisitorImpl<Void>(true) {
+                @Override
+                public Void visitCall(RexCall call) {
+                    if (call.getOperands().isEmpty()
+                            && call.getOperator().getName().equalsIgnoreCase("NOW"))
+                        throw Util.FoundOne.NULL;
+                    return super.visitCall(call);
+                }
+            });
+            return false;
+        } catch (Util.FoundOne e) {
+            return true;
+        }
+    }
+
+    /** True if the rewrite can produce this call's value for a group with
+     * no qualifying rows, where the left join manufactures NULL.  The
+     * listed kinds return NULL over an empty set (AggregateCompiler defines
+     * each empty-set result), and COUNT, which returns 0, is repaired in
+     * the final projection.  Any other call, e.g. ARRAY_AGG, whose
+     * empty-set value is an empty array, must prevent the rewrite. */
+    static boolean emptyGroupValueKnown(AggregateCall call) {
+        SqlKind kind = call.getAggregation().getKind();
+        if (kind == SqlKind.COUNT)
+            return true;
+        if (!call.getType().isNullable())
+            // NULL from the join would violate the declared type
+            return false;
+        return switch (kind) {
+            case SUM, AVG, MIN, MAX,
+                 STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP,
+                 BIT_AND, BIT_OR, BIT_XOR -> true;
+            default -> false;
+        };
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final Aggregate aggregate = call.rel(0);
+        final Project project = call.rel(1);
+        if (aggregate.getGroupType() != Aggregate.Group.SIMPLE)
+            return;
+
+        final List<RexNode> projects = project.getProjects();
+        // The column containing the filter with NOW()
+        int filterColumn = -1;
+        for (AggregateCall aggCall : aggregate.getAggCallList()) {
+            if (aggCall.filterArg >= 0 && containsNow(projects.get(aggCall.filterArg))) {
+                filterColumn = aggCall.filterArg;
+                break;
+            }
+        }
+        if (filterColumn < 0)
+            return;
+
+        final int groupCount = aggregate.getGroupCount();
+        // Calls move together when their filter columns hold structurally
+        // equal expressions.
+        final RexNode condition = projects.get(filterColumn);
+        final List<AggregateCall> aggCalls = aggregate.getAggCallList();
+        final boolean[] isMoved = new boolean[aggCalls.size()];
+        final List<AggregateCall> moved = new ArrayList<>();
+        final List<AggregateCall> kept = new ArrayList<>();
+        for (int i = 0; i < aggCalls.size(); i++) {
+            AggregateCall aggCall = aggCalls.get(i);
+            if (aggCall.filterArg >= 0 && projects.get(aggCall.filterArg).equals(condition)) {
+                if (groupCount > 0 && !emptyGroupValueKnown(aggCall))
+                    return;
+                isMoved[i] = true;
+                moved.add(aggCall.withFilter(-1));
+            } else {
+                kept.add(aggCall);
+            }
+        }
+
+        final RelBuilder builder = call.builder();
+        final RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
+
+        // The NOW() condition becomes a Filter child of the projection
+        builder.push(project.getInput())
+                .filter(condition)
+                .project(projects);
+        RelBuilder.GroupKey groupKey =
+                builder.groupKey(aggregate.getGroupSet(), aggregate.getGroupSets());
+        builder.aggregate(groupKey, moved);
+        final RelNode filtered = builder.build();
+
+        if (kept.isEmpty() && groupCount == 0) {
+            // Single row, all calls moved: the filtered aggregate is the result.
+            call.transformTo(filtered);
+            // No-op in the HEP planner, needed if this ever runs under Volcano
+            call.getPlanner().prune(aggregate);
+            return;
+        }
+
+        // Kept aggregates
+        builder.push(project.getInput()).project(projects);
+        groupKey = builder.groupKey(aggregate.getGroupSet(), aggregate.getGroupSets());
+        builder.aggregate(groupKey, kept);
+        final RelNode anchor = builder.build();
+
+        builder.push(anchor).push(filtered);
+        if (groupCount == 0) {
+            // Both sides produce exactly one row
+            builder.join(JoinRelType.INNER, builder.literal(true));
+        } else {
+            List<RexNode> conditions = new ArrayList<>();
+            for (int i = 0; i < groupCount; i++) {
+                // Use IS_NOT_DISTINCT_FROM for the JOIN condition to treat NULL keys as equal
+                conditions.add(rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM,
+                        builder.field(2, 0, i), builder.field(2, 1, i)));
+            }
+            builder.join(JoinRelType.LEFT, builder.and(conditions));
+        }
+
+        // Restore the original column order:
+        // join row = anchor [keys, kept...] ++ filtered [keys, moved...]
+        final int anchorFieldCount = groupCount + kept.size();
+        final List<RexNode> resultFields = new ArrayList<>();
+        for (int i = 0; i < groupCount; i++)
+            resultFields.add(builder.field(i));
+        int keptIndex = 0;
+        int movedIndex = 0;
+        for (int i = 0; i < aggCalls.size(); i++) {
+            AggregateCall aggCall = aggCalls.get(i);
+            if (isMoved[i]) {
+                RexNode field = builder.field(anchorFieldCount + groupCount + movedIndex);
+                if (groupCount > 0 && aggCall.getAggregation().getKind() == SqlKind.COUNT) {
+                    // COUNT over a group with no qualifying rows is 0, but
+                    // such groups are absent from the filtered side, so the
+                    // left join produced NULL; correct it to a 0 using COALESCE.
+                    RexNode zero = rexBuilder.makeExactLiteral(
+                            BigDecimal.ZERO, aggCall.getType());
+                    field = rexBuilder.makeCall(SqlStdOperatorTable.COALESCE, field, zero);
+                }
+                resultFields.add(field);
+                movedIndex++;
+            } else {
+                resultFields.add(builder.field(groupCount + keptIndex));
+                keptIndex++;
+            }
+        }
+        builder.project(resultFields)
+                .convert(aggregate.getRowType(), false);
+
+        call.transformTo(builder.build());
+        // No-op in the HEP planner, needed if this ever runs under Volcano
+        call.getPlanner().prune(aggregate);
+    }
+
+    public static final DefaultOptRuleConfig<AggregateNowFilterRule> CONFIG =
+            DefaultOptRuleConfig.<AggregateNowFilterRule>create()
+                    .withOperandSupplier(
+                            b0 -> b0.operand(Aggregate.class)
+                                    .oneInput(b1 -> b1.operand(Project.class)
+                                            .anyInputs()));
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
@@ -256,7 +256,13 @@ public class CalciteOptimizer implements IWritesLogs {
                 PruneEmptyRules.SORT_FETCH_ZERO_INSTANCE
         ));
         this.addStep(new SimpleOptimizerStep("Convert complex aggregates", 0,
-                new MaxCaseToCountRule()
+                // MaxCaseToCountRule must run before AGGREGATE_CASE_TO_FILTER:
+                // both match MAX(CASE WHEN c THEN 1 END), but a COUNT-based
+                // rewrite is linear.
+                new MaxCaseToCountRule(),
+                // Prepares inputs for next rule
+                CoreRules.AGGREGATE_CASE_TO_FILTER,
+                new AggregateNowFilterRule()
         ));
         this.addStep(new SimpleOptimizerStep("Simplify set operations", 0,
                 CoreRules.UNION_MERGE,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
@@ -204,17 +204,21 @@ public class RewriteNow extends CircuitCloneVisitor {
         return result;
     }
 
+    void warnExpensive(@Nullable DBSPExpression expression) {
+        this.compiler.reportWarning(
+                Objects.requireNonNull(expression).getSourcePosition(), "Inefficient pattern",
+                "NOW() expression is used in a pattern that could require expensive computations\n"
+                        + "See https://docs.feldera.com/sql/datetime/#now");
+    }
+
     @Override
     public void postorder(DBSPMapOperator operator) {
         ContainsNow cn = new ContainsNow(this.compiler(), true);
         DBSPExpression function = operator.getFunction();
         cn.apply(function);
         if (cn.found()) {
-            this.compiler.reportWarning(
-                    Objects.requireNonNull(cn.nowExpression).getSourcePosition(), "Inefficient pattern",
-                    "NOW() expression is used in a pattern that could require expensive computations\n"
-                    + "See https://docs.feldera.com/sql/datetime/#now");
             OutputPort input = this.mapped(operator.input());
+            this.warnExpensive(cn.nowExpression);
             DBSPSimpleOperator join = this.createJoin(input.simpleNode(), operator);
             RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
             function = rn.apply(function).to(DBSPExpression.class);
@@ -441,6 +445,7 @@ public class RewriteNow extends CircuitCloneVisitor {
             DBSPSimpleOperator join = this.createJoin(result, operator);
             RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
             DBSPExpression filterBody = leftOver.to(NonTemporalFilter.class).expression().wrapBoolIfNeeded();
+            this.warnExpensive(filterBody);
             function = filterBody.closure(function.parameters);
             function = rn.apply(function).to(DBSPClosureExpression.class);
             DBSPSimpleOperator filter = new DBSPFilterOperator(operator.getRelNode(), function, join.outputPort());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -439,6 +439,32 @@ public class Regression2Tests extends SqlIoTest {
     }
 
     @Test
+    public void issue6658a() {
+        // now() used in SELECT
+        String sql = """
+                CREATE TABLE transactions (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW window_computation AS
+                SELECT id, ts
+                FROM transactions
+                WHERE LEAST(ts, NOW()) < ts - INTERVAL 1 DAY;""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.options.ioOptions.quiet = false;
+        PrintStream saved = System.err;
+        System.setErr(NullPrintStream.INSTANCE);
+        compiler.submitStatementsForCompilation(sql);
+        System.setErr(saved);
+        TestUtil.assertMessagesContain(compiler, """
+                warning: Inefficient pattern: NOW() expression is used in a pattern that could require expensive computations
+                See https://docs.feldera.com/sql/datetime/#now
+                    7|FROM transactions
+                    8|WHERE LEAST(ts, NOW()) < ts - INTERVAL 1 DAY;
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^""");
+    }
+
+    @Test
     public void issue5541c() {
         DBSPCompiler compiler = this.testCompiler();
         compiler.options.ioOptions.quiet = false;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -2512,6 +2512,234 @@ public class StreamingTests extends StreamingTestBase {
                  z| -1""");
     }
 
+    @Test
+    public void issue6655() {
+        // Test AggregateNowFilterRule: result is NULL for SUM and 0 for COUNT.
+        String sql = """
+                CREATE TABLE T(k VARCHAR, tt TIMESTAMP);
+                CREATE VIEW V AS
+                SELECT k,
+                       SUM(CASE WHEN tt >= NOW() - INTERVAL 1 DAY THEN 1 END) AS s,
+                       COUNT(CASE WHEN tt >= NOW() - INTERVAL 1 DAY THEN 1 END) AS c,
+                       COUNT(*) AS total
+                FROM T GROUP BY k;""";
+        var ccs = this.getCCS(sql);
+        CircuitVisitor visitor = new CircuitVisitor(ccs.compiler) {
+            int window = 0;
+            int aggregate = 0;
+
+            @Override
+            public void postorder(DBSPWindowOperator operator) {
+                this.window++;
+            }
+
+            @Override
+            public void postorder(DBSPAggregateLinearPostprocessOperator operator) {
+                this.aggregate++;
+            }
+
+            @Override
+            public void endVisit() {
+                // SUM and COUNT share one condition, so one window suffices
+                Assert.assertEquals(1, this.window);
+                // ... and both live in one filtered aggregate; the anchor
+                // aggregate computing COUNT(*) is the second one
+                Assert.assertEquals(2, this.aggregate);
+            }
+        };
+        ccs.visit(visitor);
+        ccs.step("""
+                INSERT INTO NOW VALUES('2020-01-01 00:00:00');
+                INSERT INTO T VALUES('a', '2020-01-01 00:00:00');
+                INSERT INTO T VALUES('b', '2019-12-30 00:00:00');""", """
+                 k | s    | c | total | weight
+                --------------------------------
+                 a| 1    | 1 | 1     | 1
+                 b|NULL  | 0 | 1     | 1""");
+        // Two days later a's row leaves the window; b is unchanged
+        ccs.step("INSERT INTO NOW VALUES('2020-01-03 00:00:00')", """
+                 k | s    | c | total | weight
+                --------------------------------
+                 a| 1    | 1 | 1     | -1
+                 a|NULL  | 0 | 1     | 1""");
+    }
+
+    @Test
+    public void issue6655a() {
+        // Aggregates with two different temporal conditions:
+        // AggregateNowFilterRule peels one condition per application,
+        // so each condition gets its own window operator.
+        String sql = """
+                CREATE TABLE T(k VARCHAR, tt TIMESTAMP);
+                CREATE VIEW V AS
+                SELECT k,
+                       SUM(CASE WHEN tt >= NOW() - INTERVAL 1 DAY THEN 1 END) AS d,
+                       SUM(CASE WHEN tt >= NOW() - INTERVAL 7 DAYS THEN 1 END) AS w,
+                       COUNT(*) AS total
+                FROM T GROUP BY k;""";
+        var ccs = this.getCCS(sql);
+        CircuitVisitor visitor = new CircuitVisitor(ccs.compiler) {
+            int window = 0;
+
+            @Override
+            public void postorder(DBSPWindowOperator operator) {
+                this.window++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(2, this.window);
+            }
+        };
+        ccs.visit(visitor);
+        ccs.step("""
+                INSERT INTO NOW VALUES('2020-01-10 00:00:00');
+                INSERT INTO T VALUES('a', '2020-01-10 00:00:00');
+                INSERT INTO T VALUES('a', '2020-01-05 00:00:00');""", """
+                 k | d    | w    | total | weight
+                ----------------------------------
+                 a| 1    | 2    | 2     | 1""");
+        // Two days later the newest row leaves the 1-day window;
+        // both rows are still inside the 7-day window
+        ccs.step("INSERT INTO NOW VALUES('2020-01-12 00:00:00')", """
+                 k | d    | w    | total | weight
+                ----------------------------------
+                 a| 1    | 2    | 2     | -1
+                 a|NULL  | 2    | 2     | 1""");
+        // Ten days after the first step both rows have left both windows
+        ccs.step("INSERT INTO NOW VALUES('2020-01-20 00:00:00')", """
+                 k | d    | w    | total | weight
+                ----------------------------------
+                 a|NULL  | 2    | 2     | -1
+                 a|NULL  |NULL  | 2     | 1""");
+    }
+
+    @Test
+    public void issue6655b() {
+        // AggregateNowFilterRule without GROUP BY: no join is needed,
+        // the aggregate runs directly over the temporal filter.
+        String sql = """
+                CREATE TABLE T(tt TIMESTAMP);
+                CREATE VIEW V AS
+                SELECT SUM(CASE WHEN tt >= NOW() - INTERVAL 1 DAY THEN 1 END) AS s
+                FROM T;""";
+        var ccs = this.getCCS(sql);
+        ccs.step("""
+                INSERT INTO NOW VALUES('2020-01-01 00:00:00');
+                INSERT INTO T VALUES('2020-01-01 00:00:00');""", """
+                 s | weight
+                -----------
+                 1 | 1""");
+        ccs.step("INSERT INTO NOW VALUES('2020-01-03 00:00:00')", """
+                 s | weight
+                -----------
+                 1 | -1
+                NULL | 1""");
+        CircuitVisitor visitor = new CircuitVisitor(ccs.compiler) {
+            int window = 0;
+
+            @Override
+            public void postorder(DBSPJoinBaseOperator operator) {
+                Assert.fail();
+            }
+
+            @Override
+            public void postorder(DBSPWindowOperator operator) {
+                this.window++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(1, this.window);
+            }
+        };
+        ccs.visit(visitor);
+    }
+
+    @Test
+    public void issue6655c() {
+        String sql = """
+                CREATE TABLE T(
+                   id INT,
+                   tt TIMESTAMP
+                );
+
+                CREATE VIEW V AS
+                SELECT
+                    id,
+                    SUM(CASE WHEN tt >= (NOW() - INTERVAL '24' HOUR) THEN 1 END) AS tc_24h,
+                    SUM(CASE WHEN tt >= (NOW() - INTERVAL '1' HOUR) THEN 1 END) AS tc_1h,
+                    MAX(tt) AS max_tt
+                FROM T
+                WHERE tt BETWEEN (NOW() - INTERVAL '25' HOUR) AND NOW()
+                  AND id IS NOT NULL
+                GROUP BY id;""";
+        var ccs = this.getCCS(sql);
+        CircuitVisitor visitor = new CircuitVisitor(ccs.compiler) {
+            int window = 0;
+
+            @Override
+            public void postorder(DBSPWindowOperator operator) {
+                this.window++;
+            }
+
+            @Override
+            public void endVisit() {
+                // one window for the WHERE, one per aggregate condition.
+                Assert.assertEquals(3, this.window);
+            }
+        };
+        ccs.visit(visitor);
+        // id 1: one row in all windows, one row only in the 24h window;
+        // id 2: row between 25h and 24h ago, in WHERE but in no window;
+        // the NULL id is removed by the WHERE clause
+        ccs.step("""
+                INSERT INTO NOW VALUES('2020-01-01 12:00:00');
+                INSERT INTO T VALUES(1, '2020-01-01 11:30:00');
+                INSERT INTO T VALUES(1, '2020-01-01 00:00:00');
+                INSERT INTO T VALUES(2, '2019-12-31 11:30:00');
+                INSERT INTO T VALUES(NULL, '2020-01-01 11:45:00');""", """
+                 id | tc_24h | tc_1h | max_tt              | weight
+                -----------------------------------------------------
+                 1  | 2      | 1     | 2020-01-01 11:30:00 | 1
+                 2  |NULL    |NULL   | 2019-12-31 11:30:00 | 1""");
+        // One hour later id 1 has no rows in the 1h window,
+        // and id 2's row leaves the WHERE band
+        ccs.step("INSERT INTO NOW VALUES('2020-01-01 13:00:00')", """
+                 id | tc_24h | tc_1h | max_tt              | weight
+                -----------------------------------------------------
+                 1  | 2      | 1     | 2020-01-01 11:30:00 | -1
+                 1  | 2      |NULL   | 2020-01-01 11:30:00 | 1
+                 2  |NULL    |NULL   | 2019-12-31 11:30:00 | -1""");
+        // A day later id 1's rows leave the WHERE band as well
+        ccs.step("INSERT INTO NOW VALUES('2020-01-02 13:00:00')", """
+                 id | tc_24h | tc_1h | max_tt              | weight
+                -----------------------------------------------------
+                 1  | 2      |NULL   | 2020-01-01 11:30:00 | -1""");
+    }
+
+    @Test
+    public void issue6655d() {
+        // ARRAY_AGG must not be moved by AggregateNowFilterRule (results would be wrong if it was).
+        String sql = """
+                CREATE TABLE T(k VARCHAR, tt TIMESTAMP, x INT);
+                CREATE VIEW V AS
+                SELECT k, ARRAY_AGG(x) FILTER (WHERE tt >= NOW() - INTERVAL 1 DAY) AS agg
+                FROM T GROUP BY k;""";
+        var ccs = this.getCCS(sql);
+        ccs.step("""
+                INSERT INTO NOW VALUES('2020-01-01 00:00:00');
+                INSERT INTO T VALUES('a', '2020-01-01 00:00:00', 10);""", """
+                 k | agg  | weight
+                -------------------
+                 a|{ 10 } | 1""");
+        ccs.step("INSERT INTO NOW VALUES('2020-01-03 00:00:00')", """
+                 k | agg  | weight
+                -------------------
+                 a|{ 10 } | -1
+                 a|{}     | 1""");
+    }
+
     static final String issue4909data = """
             INSERT INTO T VALUES ('alpha', TRUE, '2025-10-20 14:23:00', '2025-10-19 09:15:00', '2025-10-18 17:45:00', 'lp1', '2025-10-20 20:00:00');
                 INSERT INTO T VALUES ('bravo', FALSE, '2025-10-15 11:00:00', '2025-10-14 08:30:00', '2025-10-13 19:10:00', 'lp2', '2025-10-15 22:00:00');


### PR DESCRIPTION
Fixes #6655

### Describe Manual Test Plan

I have manually checked the generated plans.

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated

Example program:
```sql
CREATE VIEW V AS SELECT
   id,
  SUM(CASE WHEN tt >= (NOW() - INTERVAL '24' HOUR) THEN 1 END) AS tc_24h,
  SUM(CASE WHEN tt >= (NOW() - INTERVAL '1' HOUR) THEN 1 END) AS tc_1h,
  MAX(tt) AS max_tt
FROM T
  WHERE tt BETWEEN (NOW() - INTERVAL '25' HOUR) AND NOW() AND id IS NOT NULL
  GROUP BY id;
```

This is implemented in a Calcite-level optimization which pulls the conditions gating the aggregates into filters, which are subsequently implemented as temporal filters where possible.

Plan before:

<img width="702" height="1211" alt="before" src="https://github.com/user-attachments/assets/3771690d-395f-4cbb-8865-46f9837b30d2" />

Plan after:

<img width="826" height="1499" alt="final" src="https://github.com/user-attachments/assets/c5af1a0a-c0ff-4fd6-9604-434fc58322a9" />

The plan has more joins, but the inputs to the joins come from Window operators, which produce much smaller deltas (only rows that changed since last clock tick).