### PR TITLE
Add preview for per-worker metrics in the profiler

### DIFF
--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { PropertyValue } from 'profiler-lib'
   import type { RenderableMetric } from '../dispatch'
   import BarChartMetric from '../parts/BarChartMetric.svelte'
 
@@ -24,9 +23,6 @@
     }
     expandedIds = next
   }
-  function values(row: RenderableMetric): PropertyValue[] {
-    return row.row.cells.map((c) => c.value)
-  }
 
   // Sticky header cells: the box-shadow paints `--header-bg` outward to cover the grid gaps
   // (gap-x 0.75rem, gap-y 0.5rem) so scrolling rows below remain hidden. Height + leading
@@ -38,7 +34,7 @@
 <div class="metrics-block rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
   <div class="scrollbar overflow-x-auto overflow-y-visible">
   <div
-    class="grid min-w-96 items-baseline gap-x-3 gap-y-2 pb-2"
+    class="grid min-w-96 items-baseline gap-x-3 gap-y-0 pb-2"
     style="grid-template-columns: minmax(8rem, 1fr) 4rem 4rem 4rem 4.5rem;"
   >
     <!-- Header row: title + Avg / Min / Max headers. The rightmost (skew) column has no header
@@ -59,7 +55,7 @@
       <BarChartMetric
         label={entry.label}
         metricId={entry.row.metric}
-        values={values(entry)}
+        cells={entry.row.cells}
         expanded={isExpanded(entry)}
         onToggle={() => toggle(entry)}
       />

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -1,33 +1,38 @@
 <script lang="ts">
   import { Popover, Tooltip } from 'common-ui'
-  import { MissingValue, type PropertyValue } from 'profiler-lib'
+  import { MissingValue, type TooltipCell } from 'profiler-lib'
   import { barColor, logScale01, skewTextColor } from '../colors'
 
   interface Props {
     label: string
     metricId: string
-    /** Per-worker values. Missing readings appear as `MissingValue` and are skipped by the
-     * statistics; their bar height is forced to zero. */
-    values: PropertyValue[]
+    /** One cell per worker. `value` is the reading (`MissingValue` when absent, skipped by the
+     * statistics). `percentile` (0-100) is normalized against the metric's range across all nodes,
+     * so bar height and color express magnitude relative to the whole circuit. */
+    cells: TooltipCell[]
     expanded: boolean
     onToggle: () => void
   }
-  const { label, metricId, values, expanded, onToggle }: Props = $props()
+  const { label, metricId, cells, expanded, onToggle }: Props = $props()
 
   /**
-   * Collapsed-view preview style:
-   *  - 'values': show avg/min/max numbers, hide bars (bars animate up from zero on expand).
-   *  - 'bars':   show short bars, hide avg/min/max (numbers fade in on expand).
+   * Collapsed-view preview style (avg/min/max numbers show in both):
+   *  - 'values': hide bars (they animate up from zero on expand).
+   *  - 'bars':   show short 6px bars that grow on expand.
    */
-  const previewMode: 'values' | 'bars' = 'values' as 'values' | 'bars'
+  const previewMode: 'values' | 'bars' = 'bars'
 
-  // Bar maths use the strictly-numeric subset. String-valued cells (enum metrics like balancer
-  // policy) skip this — they render flat bars but still contribute to the Avg column via
-  // `.average()` (returns the mode). Min/Max are suppressed for non-comparable kinds.
+  const previewBarHeight = previewMode === 'bars' ? 2 : 0
+  const minBarHeight = 6
+  const maxBarHeight = 32
+
+  // Node-local numeric subset, used only for the Skew % column. Bar height and color come from
+  // each cell's global `percentile` instead. String-valued cells (enum metrics like balancer
+  // policy) contribute nothing here but still show in the Avg column via `.average()` (the mode).
   const numbers = $derived.by(() => {
     const out: number[] = []
-    for (const v of values) {
-      const n = v.getNumericValue()
+    for (const c of cells) {
+      const n = c.value.getNumericValue()
       if (n.isSome()) {
         out.push(n.unwrap())
       }
@@ -58,7 +63,7 @@
   // StringValue) the ordering is nominal — "min false / max true" or the lexicographic ends of
   // an enum carry no information — so we suppress Min/Max and show only Avg (the mode).
   const display = $derived.by(() => {
-    const real = values.filter((v) => !(v instanceof MissingValue))
+    const real = cells.map((c) => c.value).filter((v) => !(v instanceof MissingValue))
     if (real.length === 0) {
       return { avg: MissingValue.INSTANCE, min: MissingValue.INSTANCE, max: MissingValue.INSTANCE }
     }
@@ -90,20 +95,17 @@
     return ((stats.max - stats.min) / scale) * 100
   })
 
-  function bar(v: PropertyValue) {
-    const collapsedHeight = previewMode === 'bars' ? 12 : 0
-    if (stats.n === 0 || stats.max === stats.min) {
-      return { t: 0, height: expanded ? 12 : collapsedHeight }
-    }
-    const num = v.getNumericValue()
-    const raw = num.isSome() ? (num.unwrap() - stats.min) / (stats.max - stats.min) : 0
-    const t = logScale01(raw)
-    const height = expanded ? 12 + (32 - 12) * t : collapsedHeight
+  // Height and color both scale with the global percentile (0-100, magnitude across all nodes),
+  // log-compressed so small values stay visible. Collapsed preview bars keep a fixed short height.
+  function bar(percentile: number) {
+    const t = logScale01(percentile / 100)
+    const height = expanded ? minBarHeight + (maxBarHeight - minBarHeight) * t : previewBarHeight
     return { t, height }
   }
 
-  const chartHeight = $derived(expanded ? 32 : previewMode === 'bars' ? 12 : 0)
-  const showValues = $derived(expanded || previewMode === 'values')
+  const chartHeight = $derived(expanded ? maxBarHeight : previewBarHeight)
+  // Avg/min/max stay visible in both preview modes, expanded or collapsed.
+  const showValues = true
 </script>
 
 <!-- Col 1: label -->
@@ -145,23 +147,26 @@
 <!-- Bar chart row spans full block width; container height + each bar height animate.
      Each bar gets a hover tooltip showing the worker index and the formatted reading. -->
 <div
-  class="bar-chart col-span-5 flex items-end gap-0.5"
-  style:height="{chartHeight}px"
+  class="bar-chart col-span-5 flex items-end gap-0.5 mb-2"
+  style:min-height="{chartHeight}px"
+  style:margin-top="{expanded ? "8px" : "2px"}"
 >
-  {#each values as v, i (i)}
-    {@const b = bar(v)}
+  {#each cells as c, i (i)}
+    {@const b = bar(c.percentile)}
     <div
       class="flex-1 rounded-sm transition-[height,background-color] duration-200 ease-in-out"
       style:height="{b.height}px"
       style:background-color={barColor(b.t)}
     ></div>
-    <Tooltip class="whitespace-nowrap" placement="top">Worker {i}: {v.toString()}</Tooltip>
+    <Tooltip class="whitespace-nowrap" placement="top">Worker {i}: {c.value.toString()}</Tooltip>
   {/each}
 </div>
 
 <style>
   .bar-chart {
-    transition: height 200ms ease;
+    transition:
+      min-height 200ms ease,
+      margin-top 200ms ease;
   }
   .value-cell {
     transition: opacity 150ms ease;

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -10,6 +10,7 @@ import {
     StringValue,
     TimeValue
 } from './profile.js'
+import { NumericRange } from './util.js'
 
 describe('CircuitProfile.isTop', () => {
     it('recognises the toplevel node by the parsed root id', () => {
@@ -301,5 +302,43 @@ describe('PropertyValue contract', () => {
             // Self-average: every kind should accept an empty `others` array without throwing.
             expect(() => v.average([])).not.toThrow()
         }
+    })
+})
+
+// The profiler colors per-worker bars against the metric's range across ALL nodes
+// (`CircuitProfile.dataRange`, built by unioning each node's per-worker values), not against the
+// current node's local spread. `computePropertyRanges` composes `NumericRange.union` + `percents`;
+// these tests pin that composition so a value's color depends on the whole circuit.
+describe('NumericRange cross-node normalization', () => {
+    // Two nodes: A workers [10, 20], B workers [100, 200]. The global range unions to [10, 200].
+    const nodeA = NumericRange.getRange([10, 20])
+    const nodeB = NumericRange.getRange([100, 200])
+    const global = nodeA.union(nodeB)
+
+    it('union spans the min and max across every node', () => {
+        expect(global.min).toBe(10)
+        expect(global.max).toBe(200)
+    })
+
+    it('normalizes a value against the global range, not its own node', () => {
+        // A's local max (20) is near the bottom of the circuit, so it colors cool, not hot.
+        // Local normalization would place 20 at 100% of node A's [10, 20] range — the regression.
+        expect(global.percents(20)).toBeCloseTo((100 * (20 - 10)) / (200 - 10), 5)
+        expect(global.percents(20)).toBeLessThan(10)
+        expect(nodeA.percents(20)).toBe(100)
+        expect(global.percents(200)).toBe(100)
+    })
+
+    it('a value has the same color wherever it appears, regardless of node-local spread', () => {
+        // 100 sits at the same global percentile whether reached from node A or node B.
+        expect(global.percents(100)).toBeCloseTo(nodeA.union(nodeB).percents(100), 5)
+    })
+
+    it('degenerate ranges collapse to a single point value', () => {
+        // Empty (no numeric readings) unions away; a single distinct value yields a point range.
+        const empty = NumericRange.empty()
+        expect(empty.union(nodeA)).toEqual(nodeA)
+        const point = NumericRange.getRange([42, 42])
+        expect(point.isPoint()).toBe(true)
     })
 })


### PR DESCRIPTION
~~The final design is still pending~~

Fix https://github.com/feldera/feldera/issues/6494

[Screencast From 2026-07-17 01-14-17.webm](https://github.com/user-attachments/assets/aba8ddc6-fffe-4d3b-91ee-544e79f97ef3)

- Made the preview bars thinner per design
- Reduced the distance between the preview bar and corresponding values
- Coloring and setting bar heights according to the global metric percentile, calculated by profiler-lib

[Screencast From 2026-07-17 16-30-26.webm](https://github.com/user-attachments/assets/540aca89-5865-44a4-9c2c-a2fd05977729)

<img width="858" height="514" alt="image" src="https://github.com/user-attachments/assets/ff1d4d80-938e-43a0-805f-b869e92572f0" />

