### PR TITLE
[dbsp] JointKeyCursor should iterate over the collection with fewer keys.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1587,10 +1587,10 @@ where
             }
 
             let delta = self.delta.borrow_mut().take().expect("no input delta provided before flush");
-            let delta_len = delta.len();
+            let delta_key_count = delta.key_count();
 
             let trace = trace.unwrap();
-            let trace_len = if self.saturate { usize::MAX } else { trace.len() };
+            let trace_key_count = if self.saturate { usize::MAX } else { trace.key_count() };
 
             self.empty_input.set(delta.is_empty());
             self.empty_output.set(true);
@@ -1621,7 +1621,7 @@ where
             let mut val = self.right_factories.val_factory().default_box();
 
             let mut joint_cursor =
-                JointKeyCursor::new(delta_cursor, trace_cursor, fetched.is_none() && (delta_len > trace_len));
+                JointKeyCursor::new(delta_cursor, trace_cursor, fetched.is_none() && (delta_key_count > trace_key_count));
 
             let batch = if size_of::<T::Time>() != 0 {
                 let time = self.clock.time();


### PR DESCRIPTION
JointKeyCursor is used in the implementation of the join operator to
allow dynamically picking a smaller input to iterate over. It used to
incorrectly pick the input based on the total number of records, but
the correct way is to pick based on the number of keys. A collection
can have a few keys, but a very large number of records due to hot
keys, in which case the old policy could be inefficient.