### PR TITLE
Fix vertical resize bar behaves inverted sometimes, add regression test

### DIFF
--- a/.github/workflows/test-web-console-unit.yml
+++ b/.github/workflows/test-web-console-unit.yml
@@ -29,6 +29,11 @@ jobs:
         run: bun run test-unit
         working-directory: js-packages/web-console
 
+      - name: Run profiler-layout vitest unit & component tests
+        if: ${{ vars.CI_DRY_RUN != 'true' }}
+        run: bun run test-unit
+        working-directory: js-packages/profiler-layout
+
       - name: Show Kubernetes node
         if: always()
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.0",
         "vitest": "^4.1.8",
+        "vitest-browser-svelte": "^2.1.1",
       },
       "peerDependencies": {
         "@monaco-editor/loader": "1.7.0",
@@ -1090,7 +1091,7 @@
 
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
-    "apache-arrow": ["apache-arrow@github:Karakatiza666/arrow-js#ddba834", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^25.2.0", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-with-bigint": "^3.5.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.cjs" } }, "Karakatiza666-arrow-js-ddba834", "sha512-N2H0djCXEuIXEXsZyPKGI4NT0xBhH3DdsNNP3Z273ym1h0OKHR6qrGld4l8RnxGjDwFzXhMZDEqEfN0NMFZUTA=="],
+    "apache-arrow": ["apache-arrow@github:Karakatiza666/arrow-js#ddba834", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^25.2.0", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-with-bigint": "^3.5.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.cjs" } }, "Karakatiza666-arrow-js-ddba834"],
 
     "apexcharts": ["apexcharts@5.6.0", "", { "dependencies": { "@yr/monotone-cubic-spline": "^1.0.3" } }, "sha512-BZua59yedRsaDfnxkzNrkyLCvluq2c3ZDBIz4joxSKtgr0xDQXQ5dzceMhf/TpTbAjaF+2NYIpLP3BEEIG2s/w=="],
 

--- a/js-packages/profiler-layout/package.json
+++ b/js-packages/profiler-layout/package.json
@@ -13,9 +13,12 @@
     "check": "svelte-kit sync && svelte-check --threshold error",
     "check:watch": "svelte-kit sync && svelte-check --threshold error --watch",
     "test": "vitest --run",
+    "test-watch": "vitest",
+    "test-unit": "vitest --run --project component --project unit",
+    "test-component": "vitest --run --project component",
     "format": "biome check --write ."
   },
-  "files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
+  "files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*", "!dist/test-support/**"],
   "sideEffects": ["**/*.css"],
   "svelte": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -63,7 +66,8 @@
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "vitest-browser-svelte": "^2.1.1"
   },
   "overrides": {
     "devalue": "^5.6.2"

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -342,7 +342,7 @@
           />
         </div>
       {:else}
-        <p class="text-sm text-surface-600-400">
+        <p class="text-surface-800-200">
           This bundle has no circuit profile, so the dataflow graph is unavailable.
         </p>
       {/if}
@@ -509,7 +509,12 @@
 {#if !sqlPanelFullHeight}
   <PaneGroup direction="vertical" class="!overflow-visible h-full">
     {#if hasProfile}
-      <Pane defaultSize={graphPaneDefaultSize} minSize={graphPaneMinSize} class="!overflow-visible">
+      <Pane
+        order={1}
+        defaultSize={graphPaneDefaultSize}
+        minSize={graphPaneMinSize}
+        class="!overflow-visible"
+      >
         {@render graphPanel()}
       </Pane>
       <PaneResizer class="pane-divider-horizontal my-2" />
@@ -518,7 +523,7 @@
         {@render graphPanel()}
       </div>
     {/if}
-    <Pane defaultSize={belowGraphPaneDefaultSize} minSize={15} class="!overflow-visible">
+    <Pane order={2} defaultSize={belowGraphPaneDefaultSize} minSize={15} class="!overflow-visible">
       <PaneGroup direction="horizontal" class="!overflow-visible h-full">
         <Pane defaultSize={50} minSize={0} class="!overflow-visible">
           <div use:sqlPanelRect.placeholder class="h-full"></div>
@@ -541,6 +546,7 @@
       <PaneGroup direction="vertical" class="!overflow-visible h-full">
         {#if hasProfile}
           <Pane
+            order={1}
             defaultSize={graphPaneDefaultSize}
             minSize={graphPaneMinSize}
             class="!overflow-visible"
@@ -553,7 +559,7 @@
             {@render graphPanel()}
           </div>
         {/if}
-        <Pane defaultSize={belowGraphPaneDefaultSize} minSize={15} class="!overflow-visible">
+        <Pane order={2} defaultSize={belowGraphPaneDefaultSize} minSize={15} class="!overflow-visible">
           {@render analysisPanel()}
         </Pane>
       </PaneGroup>

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test for the vertical resizer in the support bundle viewer layout.
+ *
+ * The graph pane is rendered inside `{#if hasProfile}`; the analysis pane below it is
+ * unconditional. PaneForge orders panes by registration time unless each pane declares an
+ * explicit `order`. When a profile loads *after* the layout has mounted (profileData
+ * undefined -> defined), the graph pane registers second and, without `order`, PaneForge
+ * treats it as the *lower* pane. The resizer then drives the panes backwards, so moving the
+ * divider down shrinks the top pane instead of growing it - the reversal the user reported.
+ *
+ * The test drives the actual resize behavior rather than an internal-order proxy: it presses
+ * ArrowDown on the handle (equivalent to dragging the divider down) and asserts the top pane
+ * grows. PaneForge writes each pane's layout size straight to its `flex-grow` (see
+ * computePaneFlexBoxStyle), so the rendered size is read directly - no pixel layout needed.
+ * An inverted order shrinks the top pane and fails the assertion.
+ *
+ * ProfilerDiagram and the tab panels are stubbed so the test exercises only the pane layout,
+ * not cytoscape or Monaco. To see the assertion fail, drop the `order` props from the two
+ * vertical panes in SupportBundleViewerLayout.svelte.
+ */
+
+import { TriageResults } from 'triage-types'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+
+// vi.mock is hoisted above module-scope bindings, so each factory imports the stub inline
+// (no top-level references allowed). Stubbing ProfilerDiagram and the tab panels keeps the
+// test on the pane layout, off cytoscape and Monaco.
+vi.mock('./ProfilerDiagram.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+vi.mock('./tabs/MetricsTab.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+vi.mock('./tabs/LogsTab.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+vi.mock('./tabs/ConfigTab.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+vi.mock('./tabs/IssuesTab.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+vi.mock('./tabs/SqlTab.svelte', async () => ({
+  default: (await import('../test-support/ComponentStub.svelte')).default
+}))
+
+// Imported after vi.mock so the stubs take effect.
+import SupportBundleViewerLayout from './SupportBundleViewerLayout.svelte'
+
+const baseProps = () => ({
+  profileData: undefined,
+  dataflowData: undefined,
+  programCode: undefined,
+  triageResults: new TriageResults(),
+  profileFiles: [],
+  selectedTimestamp: null,
+  onSelectTimestamp: () => {},
+  sqlPanelFullHeight: false
+})
+
+// Any non-undefined value flips `hasProfile`; the parsed profile is only ever handed to the
+// stubbed ProfilerDiagram, so its shape is irrelevant here.
+const someProfile = {} as never
+
+/**
+ * Move the vertical divider down and assert the pane above it grows.
+ *
+ * The graph/analysis split is the only PaneGroup using `pane-divider-horizontal`. The top
+ * pane is that group's first `[data-pane]` in DOM order (the graph pane). Pressing ArrowDown
+ * on the handle nudges the divider down, which must enlarge the top pane; PaneForge mirrors
+ * each pane's size onto its `flex-grow`, so we compare that before and after. When the panes
+ * are inverted the top pane shrinks instead, exactly as a mouse drag would appear.
+ */
+const expectDividerDownGrowsTopPane = async (container: HTMLElement) => {
+  const resizer = container.querySelector<HTMLElement>(
+    '.pane-divider-horizontal[data-pane-resizer]'
+  )
+  if (!resizer) {
+    throw new Error('vertical resize handle not found')
+  }
+  const groupId = resizer.getAttribute('data-pane-group-id')
+  const topPane = container.querySelector<HTMLElement>(
+    `[data-pane][data-pane-group-id="${groupId}"]`
+  )
+  if (!topPane) {
+    throw new Error('top pane not found')
+  }
+
+  const topPaneSize = () => Number.parseFloat(topPane.style.flexGrow)
+  // PaneForge assigns flex-grow from an effect after the pane registers; wait for it.
+  await expect.poll(() => Number.isFinite(topPaneSize())).toBe(true)
+  const sizeBefore = topPaneSize()
+
+  resizer.focus()
+  resizer.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+  )
+
+  await expect.poll(topPaneSize).toBeGreaterThan(sizeBefore)
+}
+
+describe('SupportBundleViewerLayout vertical pane order', () => {
+  it('grows the graph pane when the divider moves down after a profile loads late', async () => {
+    const { container, rerender } = render(SupportBundleViewerLayout, baseProps())
+
+    // Bundle without a circuit profile: no graph pane, no vertical resizer yet.
+    expect(container.querySelector('.pane-divider-horizontal')).toBeNull()
+
+    // Profile arrives -> graph pane mounts and registers after the analysis pane.
+    await rerender({ profileData: someProfile })
+
+    await expectDividerDownGrowsTopPane(container)
+  })
+
+  it('keeps the correct direction in the SQL full-height layout too', async () => {
+    const { container, rerender } = render(SupportBundleViewerLayout, {
+      ...baseProps(),
+      sqlPanelFullHeight: true
+    })
+
+    await rerender({ profileData: someProfile })
+
+    await expectDividerDownGrowsTopPane(container)
+  })
+})

--- a/js-packages/profiler-layout/src/lib/test-support/ComponentStub.svelte
+++ b/js-packages/profiler-layout/src/lib/test-support/ComponentStub.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  // Stand-in for the heavy leaf components (ProfilerDiagram, tab panels) in layout tests.
+  // It swallows every prop and exposes the ProfilerDiagram imperative API the layout invokes
+  // on its `bind:this` instance, so those calls stay harmless no-ops. Rendering the real
+  // children would pull in cytoscape and Monaco, which the pane-ordering test does not need.
+  // Accept and ignore whatever props the parent passes. Never read, so Svelte emits no
+  // reactive-capture warning; underscore marks it intentionally unused for the linter.
+  const _props = $props()
+
+  export function getProfile() {
+    return null
+  }
+  export function selectMetric(_metricId: string) {}
+  export function search(_query: string) {}
+  export function showGlobalMetrics(_isSticky?: boolean) {}
+  export function showTopNodes(_isSticky?: boolean) {}
+</script>

--- a/js-packages/profiler-layout/vitest.config.ts
+++ b/js-packages/profiler-layout/vitest.config.ts
@@ -1,19 +1,45 @@
 import { playwright } from '@vitest/browser-playwright'
 import { defineConfig } from 'vitest/config'
 
-// Tests import from `profiler-lib` and `monaco-editor`, both of which touch real browser
-// APIs at import time (cytoscape; Monaco's clipboard / DOM probes). Run them in a real
-// Chromium via @vitest/browser + playwright so we exercise actual browser semantics — that
-// also lets the SQL view's theme test read live computed styles when needed.
-export default defineConfig({
+// Real-Chromium browser project, shaped like web-console's `browserTestProject`. Tests import
+// from `profiler-lib` and `monaco-editor`, both of which touch real browser APIs at import
+// time (cytoscape; Monaco's clipboard / DOM probes), so they run in a real browser via
+// @vitest/browser + playwright.
+const browserTestProject = (name: string, include: string[]) => ({
+  // extends the app Vite config so the Svelte + Tailwind plugins compile component imports.
+  extends: './vite.config.ts',
   test: {
-    include: ['src/**/*.test.ts'],
+    name,
+    include,
     setupFiles: ['./test/setup.ts'],
     browser: {
       enabled: true,
-      provider: playwright(),
+      provider: playwright({ contextOptions: {} }),
       headless: true,
-      instances: [{ browser: 'chromium' }]
+      instances: [{ browser: 'chromium' as const }]
     }
+  }
+})
+
+// Naming split mirrors web-console:
+//   *.test.ts        existing function / theme suites (browser)
+//   *.svelte.spec.ts Svelte component unit tests (browser)
+//   *.spec.ts        pure unit tests that need no browser (node)
+export default defineConfig({
+  test: {
+    // The `unit` project has no files yet; don't fail the run until one lands.
+    passWithNoTests: true,
+    projects: [
+      browserTestProject('browser', ['src/**/*.test.ts']),
+      browserTestProject('component', ['src/**/*.svelte.spec.ts']),
+      {
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.spec.ts'],
+          exclude: ['src/**/*.svelte.spec.ts']
+        }
+      }
+    ]
   }
 })


### PR DESCRIPTION
The issue was the resizeable pane management library needed an explicit pane index when the panes are conditionally rendered (recent change / regression), so they get mounted in DOM in an unexpected order, and the library's automatically assigned index based on pane initialization order is incorrect.

The fix is only in SupportBundleViewerLayout.svelte, the rest of the changes introduce testing setup to profiler-layout project similar to the one in web-console

Side change: made the "no circuit profile" warning text more visible

Fix https://github.com/feldera/feldera/issues/6654

Testing: manual, added component test