### PR TITLE
[SQL] Give a warning for inefficient use of NOW()

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ContainsNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ContainsNow.java
@@ -5,15 +5,20 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.util.Logger;
+
+import javax.annotation.Nullable;
 
 /** Discovers whether an expression contains a call to the now() function. */
 class ContainsNow extends InnerVisitor {
     public boolean found;
     /** If true the 'found' is reset for each invocation. */
     public final boolean perExpression;
+    @Nullable
+    DBSPExpression nowExpression = null;
 
     public ContainsNow(DBSPCompiler compiler, boolean perExpression) {
         super(compiler);
@@ -23,7 +28,7 @@ class ContainsNow extends InnerVisitor {
 
     static boolean isNow(DBSPApplyExpression node) {
         String name = node.getFunctionName();
-        return name != null && name.equalsIgnoreCase("now");
+        return name != null && name.equalsIgnoreCase("now") && node.arguments.length == 0;
     }
 
     @Override
@@ -41,7 +46,8 @@ class ContainsNow extends InnerVisitor {
             Logger.INSTANCE.belowLevel(this, 1)
                     .append("Found 'now' call")
                     .newline();
-            found = true;
+            this.found = true;
+            this.nowExpression = node;
             return VisitDecision.STOP;
         }
         return super.preorder(node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
@@ -210,6 +210,10 @@ public class RewriteNow extends CircuitCloneVisitor {
         DBSPExpression function = operator.getFunction();
         cn.apply(function);
         if (cn.found()) {
+            this.compiler.reportWarning(
+                    Objects.requireNonNull(cn.nowExpression).getSourcePosition(), "Inefficient pattern",
+                    "NOW() expression is used in a pattern that could require expensive computations\n"
+                    + "See https://docs.feldera.com/sql/datetime/#now");
             OutputPort input = this.mapped(operator.input());
             DBSPSimpleOperator join = this.createJoin(input.simpleNode(), operator);
             RewriteNowClosure rn = new RewriteNowClosure(this.compiler());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -13,6 +13,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.TestUtil;
+import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuit;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
@@ -410,6 +411,31 @@ public class Regression2Tests extends SqlIoTest {
                  min
                 ----------
                  { 1, 2 }""");
+    }
+
+    @Test
+    public void issue6658() {
+        // now() used in SELECT
+        String sql = """
+                CREATE TABLE transactions (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW window_computation AS
+                SELECT ts > NOW()
+                FROM transactions;""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.options.ioOptions.quiet = false;
+        PrintStream saved = System.err;
+        System.setErr(NullPrintStream.INSTANCE);
+        compiler.submitStatementsForCompilation(sql);
+        System.setErr(saved);
+        TestUtil.assertMessagesContain(compiler, """
+                warning: Inefficient pattern: NOW() expression is used in a pattern that could require expensive computations
+                See https://docs.feldera.com/sql/datetime/#now
+                    6|SELECT ts > NOW()
+                                  ^^^^^
+                    7|FROM transactions;""");
     }
 
     @Test


### PR DESCRIPTION
Fixes #6658

## Checklist

- [x] Unit tests added/updated

Sample output:
```
warning: Inefficient pattern: NOW() expression is used in a pattern that could require expensive computations
See https://docs.feldera.com/sql/datetime/#now
      6|SELECT ts > NOW()
                    ^^^^^
      7|FROM transactions;
```