### PR TITLE
connectors: dynamodb_output: support conditional writes

### DIFF
--- a/crates/adapters/src/integrated/dynamodb/helpers.rs
+++ b/crates/adapters/src/integrated/dynamodb/helpers.rs
@@ -4,7 +4,11 @@ use std::time::{Duration, Instant};
 use anyhow::{Result as AnyResult, anyhow, bail};
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::error::DisplayErrorContext;
-use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem, WriteRequest};
+use aws_sdk_dynamodb::operation::transact_write_items::TransactWriteItemsError;
+use aws_sdk_dynamodb::types::{
+    AttributeValue, CancellationReason, Delete, DeleteRequest, Put, PutRequest, TransactWriteItem,
+    WriteRequest,
+};
 use aws_types::region::Region;
 use dbsp::circuit::tokio::TOKIO;
 use feldera_types::transport::dynamodb::DynamoDBWriterConfig;
@@ -76,40 +80,166 @@ pub(crate) async fn write_batch_chunk(
 }
 
 /// Converts a `WriteRequest` (put or delete) into a `TransactWriteItem` for use in `TransactWriteItems`.
+///
+/// `put_condition`/`delete_condition` are optional DynamoDB condition expressions
+/// attached to the put and delete respectively. A put covers both inserts and
+/// upserts, so `put_condition` gates every value write.
 pub(crate) fn to_transact_item(
     table: &str,
     request: &WriteRequest,
+    put_condition: Option<&str>,
+    delete_condition: Option<&str>,
 ) -> AnyResult<TransactWriteItem> {
     match (request.put_request(), request.delete_request()) {
-        (Some(put_request), None) => Ok(TransactWriteItem::builder()
-            .put(
-                Put::builder()
-                    .table_name(table)
-                    .set_item(Some(put_request.item().clone()))
-                    .build()?,
-            )
-            .build()),
-        (None, Some(delete_request)) => Ok(TransactWriteItem::builder()
-            .delete(
-                Delete::builder()
-                    .table_name(table)
-                    .set_key(Some(delete_request.key().clone()))
-                    .build()?,
-            )
-            .build()),
+        (Some(request), None) => transact_put(table, request, put_condition),
+        (None, Some(request)) => transact_delete(table, request, delete_condition),
         _ => bail!("expected exactly one put or delete request"),
     }
 }
 
+fn transact_put(
+    table: &str,
+    request: &PutRequest,
+    condition: Option<&str>,
+) -> AnyResult<TransactWriteItem> {
+    let put = Put::builder()
+        .table_name(table)
+        .set_item(Some(request.item().clone()));
+    let put = match condition {
+        Some(condition) => put.condition_expression(condition),
+        None => put,
+    };
+    Ok(TransactWriteItem::builder().put(put.build()?).build())
+}
+
+fn transact_delete(
+    table: &str,
+    request: &DeleteRequest,
+    condition: Option<&str>,
+) -> AnyResult<TransactWriteItem> {
+    let delete = Delete::builder()
+        .table_name(table)
+        .set_key(Some(request.key().clone()));
+    let delete = match condition {
+        Some(condition) => delete.condition_expression(condition),
+        None => delete,
+    };
+    Ok(TransactWriteItem::builder().delete(delete.build()?).build())
+}
+
+/// DynamoDB `CancellationReason` code for an item whose condition expression was
+/// not met. Such an item is a permanent, expected rejection: retrying it is
+/// pointless, so the connector drops it and retries the rest of the transaction.
+const CONDITION_CHECK_FAILED: &str = "ConditionalCheckFailed";
+
+/// `CancellationReason` code for an item that had no error of its own. It was
+/// rolled back only because a sibling item cancelled the transaction, so it is
+/// kept and retried.
+const NO_ERROR: &str = "None";
+
+/// Classifies each item of a cancelled transaction from its `CancellationReason`
+/// and decides what to retry.
+struct CancellationOutcome {
+    /// Items to resubmit: those with no error of their own, plus those rejected
+    /// for a transient reason (throttling / conflict).
+    kept: Vec<TransactWriteItem>,
+    /// Count of items dropped because their condition was not met.
+    condition_failed: usize,
+    /// A kept item was rejected for a transient reason, so the resubmission is a
+    /// genuine retry that should back off and count against `max_retries`.
+    has_retryable: bool,
+    /// Codes of items that failed permanently for a reason other than a condition
+    /// check (for example `ValidationError`). Their presence makes the whole
+    /// transaction unrecoverable.
+    hard_failures: Vec<String>,
+}
+
+/// Splits the items of a cancelled transaction by their per-item cancellation
+/// reason. `reasons[i]` describes `items[i]` (DynamoDB returns them in request
+/// order). Returns `None` when the counts disagree, in which case the caller
+/// falls back to retrying the whole transaction with `items` left unchanged.
+fn partition_by_cancellation_reason(
+    items: &mut Vec<TransactWriteItem>,
+    reasons: &[CancellationReason],
+) -> Option<CancellationOutcome> {
+    if reasons.len() != items.len() {
+        return None;
+    }
+
+    let items = std::mem::take(items);
+    let mut outcome = CancellationOutcome {
+        kept: Vec::with_capacity(items.len()),
+        condition_failed: 0,
+        has_retryable: false,
+        hard_failures: Vec::new(),
+    };
+
+    // DynamoDB returns cancellation reasons in the same order as the submitted
+    // transaction items, so each reason can be paired by position.
+    for (item, reason) in items.into_iter().zip(reasons) {
+        match reason.code() {
+            Some(CONDITION_CHECK_FAILED) => outcome.condition_failed += 1,
+            None | Some(NO_ERROR) => outcome.kept.push(item),
+            Some(code) if is_retryable_cancellation_code(code) => {
+                outcome.has_retryable = true;
+                outcome.kept.push(item);
+            }
+            Some(code) => outcome.hard_failures.push(code.to_string()),
+        }
+    }
+
+    Some(outcome)
+}
+
+/// Whether a per-item cancellation code denotes a transient failure worth
+/// retrying, as opposed to a permanent one.
+fn is_retryable_cancellation_code(code: &str) -> bool {
+    matches!(
+        code,
+        "TransactionConflict" | "ThrottlingError" | "ProvisionedThroughputExceeded"
+    )
+}
+
+/// Outcome of a transactional chunk that DynamoDB accepted (possibly after
+/// dropping items that failed their condition).
+pub(crate) struct TransactChunkOutcome {
+    /// Number of retry attempts the chunk cost.
+    pub retries: u64,
+    /// Items dropped because their condition expression was not met. These were
+    /// never written, so the caller must exclude them from records-written.
+    pub suppressed: u64,
+}
+
+/// Records and bytes actually written for a chunk of `rows` items totalling
+/// `bytes`, after excluding the `suppressed` items that failed their condition.
+///
+/// Per-item byte sizes are not retained past the flush, so the written byte
+/// count is the chunk's `bytes` scaled by the fraction of rows that landed.
+pub(crate) fn written_totals(rows: usize, bytes: usize, suppressed: u64) -> (u64, u64) {
+    let written = rows.saturating_sub(suppressed as usize);
+    let written_bytes = if rows > 0 {
+        (bytes as u128 * written as u128 / rows as u128) as u64
+    } else {
+        0
+    };
+    (written as u64, written_bytes)
+}
+
 /// Sends one pre-chunked `TransactWriteItems` request, retrying on failure with backoff.
+///
+/// On cancellation, items that failed their condition are dropped and the rest
+/// are resubmitted. Only transient failures back off and count toward
+/// `max_retries`. The returned [`TransactChunkOutcome`] reports how many items
+/// the condition suppressed so the caller can avoid counting them as written.
 pub(crate) async fn write_transact_chunk(
     client: Client,
     endpoint_name: String,
-    transact_items: Vec<TransactWriteItem>,
+    mut transact_items: Vec<TransactWriteItem>,
     max_retries: Option<usize>,
     metrics: &DynamoDBOutputMetrics,
-) -> AnyResult<u64> {
+) -> AnyResult<TransactChunkOutcome> {
     let mut retry = 0usize;
+    let mut suppressed = 0u64;
 
     loop {
         let call_start = Instant::now();
@@ -120,31 +250,114 @@ pub(crate) async fn write_transact_chunk(
             .await;
         metrics.record_write_call_latency(call_start.elapsed());
 
-        match result {
-            Ok(_) => return Ok(retry as u64),
-            Err(error) => {
-                // Count every failed TransactWriteItems attempt; these are
-                // retried below (or dropped once retries are exhausted).
-                metrics.record_transact_write_failure();
-                let exhausted = max_retries.is_some_and(|max| retry >= max);
-                // Render the underlying DynamoDB error into the message via
-                // `DisplayErrorContext`; the bare `SdkError` `Display`  would
-                // otherwise hide the real cause when shown with `{}`.
-                let error = anyhow!(
-                    "dynamodb output connector '{endpoint_name}' TransactWriteItems request \
-                     with {} item(s) failed (attempt {}), {}: {}",
-                    transact_items.len(),
-                    retry + 1,
-                    if exhausted { "giving up" } else { "retrying" },
-                    DisplayErrorContext(&error),
-                );
-                warn!("{error:#}");
-                if exhausted {
-                    // A transaction is all-or-nothing, so every item is dropped.
-                    metrics.record_failed_items(transact_items.len() as u64);
-                    return Err(error);
+        let error = match result {
+            Ok(_) => {
+                return Ok(TransactChunkOutcome {
+                    retries: retry as u64,
+                    suppressed,
+                });
+            }
+            Err(error) => error,
+        };
+
+        // A cancelled transaction carries a per-item reason list. Use it to drop
+        // items whose condition was not met and retry only the rest. Any other
+        // error (or a cancellation without reasons) falls through to the
+        // whole-transaction retry below.
+        if let Some(TransactWriteItemsError::TransactionCanceledException(cancelled)) =
+            error.as_service_error()
+        {
+            let reasons = cancelled.cancellation_reasons();
+            if !reasons.is_empty()
+                && let Some(outcome) =
+                    partition_by_cancellation_reason(&mut transact_items, reasons)
+            {
+                if !outcome.hard_failures.is_empty() {
+                    // A permanent, non-condition failure (for example a
+                    // validation error) cancels the transaction.
+                    // Every item is dropped, including those whose condition happened
+                    // to fail.
+                    let failed =
+                        outcome.kept.len() + outcome.hard_failures.len() + outcome.condition_failed;
+                    metrics.record_transact_write_failure();
+                    metrics.record_failed_items(failed as u64);
+                    bail!(
+                        "dynamodb output connector '{endpoint_name}' TransactWriteItems request \
+                         cancelled by unrecoverable item error(s) [{}], dropping {failed} item(s): \
+                         {}",
+                        outcome.hard_failures.join(", "),
+                        DisplayErrorContext(&error),
+                    );
+                }
+
+                // Past the unrecoverable check the surviving items will be
+                // written, so the condition failures are genuine suppressions.
+                if outcome.condition_failed > 0 {
+                    suppressed += outcome.condition_failed as u64;
+                    metrics.record_condition_check_failures(outcome.condition_failed as u64);
+                }
+
+                if outcome.kept.is_empty() {
+                    // Every remaining item failed its condition: nothing left to write.
+                    return Ok(TransactChunkOutcome {
+                        retries: retry as u64,
+                        suppressed,
+                    });
+                }
+
+                let dropped_any = outcome.condition_failed > 0;
+                transact_items = outcome.kept;
+
+                if outcome.has_retryable {
+                    // Transient contention on a kept item; back off, retry and count it.
+                    metrics.record_transact_write_failure();
+                    if max_retries.is_some_and(|max| retry >= max) {
+                        metrics.record_failed_items(transact_items.len() as u64);
+                        bail!(
+                            "dynamodb output connector '{endpoint_name}' gave up on {} \
+                             transaction item(s) after {retry} retries: {}",
+                            transact_items.len(),
+                            DisplayErrorContext(&error),
+                        );
+                    }
+                    retry += 1;
+                    warn!(
+                        "dynamodb output connector '{endpoint_name}' retrying {} transaction \
+                         item(s) after transient cancellation (attempt {retry})",
+                        transact_items.len(),
+                    );
+                    tokio::time::sleep(backoff_delay(retry)).await;
+                    continue;
+                }
+
+                if dropped_any {
+                    // Sibling items were dropped for failing their condition;  so resubmit
+                    // the now-smaller set immediately.
+                    continue;
                 }
             }
+        }
+
+        // Whole-transaction failure: no usable per-item reasons, so retry the
+        // entire request with backoff.
+        metrics.record_transact_write_failure();
+        let exhausted = max_retries.is_some_and(|max| retry >= max);
+        // Render the underlying DynamoDB error into the message via
+        // `DisplayErrorContext`; the bare `SdkError` `Display` would otherwise
+        // hide the real cause when shown with `{}`.
+        let error = anyhow!(
+            "dynamodb output connector '{endpoint_name}' TransactWriteItems request \
+             with {} item(s) failed (attempt {}), {}: {}",
+            transact_items.len(),
+            retry + 1,
+            if exhausted { "giving up" } else { "retrying" },
+            DisplayErrorContext(&error),
+        );
+        warn!("{error:#}");
+        if exhausted {
+            // A transaction is all-or-nothing, so every item is dropped.
+            metrics.record_failed_items(transact_items.len() as u64);
+            return Err(error);
         }
 
         retry += 1;
@@ -215,5 +428,100 @@ pub(crate) fn make_client(config: &DynamoDBWriterConfig) -> Client {
             aws_config::default_provider::credentials::default_provider().await
         });
         Client::from_conf(config_builder.credentials_provider(provider).build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_dynamodb::types::Put;
+
+    /// A throwaway transact item; the partition logic never inspects its contents.
+    fn put_item(id: &str) -> TransactWriteItem {
+        TransactWriteItem::builder()
+            .put(
+                Put::builder()
+                    .table_name("t")
+                    .set_item(Some(HashMap::from([(
+                        "id".to_string(),
+                        AttributeValue::N(id.to_string()),
+                    )])))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+    }
+
+    fn reason(code: &str) -> CancellationReason {
+        CancellationReason::builder().code(code).build()
+    }
+
+    #[test]
+    fn condition_failures_are_dropped_and_counted() {
+        let mut items = vec![put_item("1"), put_item("2")];
+        let reasons = vec![reason(CONDITION_CHECK_FAILED), reason(NO_ERROR)];
+
+        let outcome = partition_by_cancellation_reason(&mut items, &reasons).unwrap();
+        assert_eq!(outcome.condition_failed, 1);
+        assert_eq!(outcome.kept.len(), 1);
+        assert!(!outcome.has_retryable);
+        assert!(outcome.hard_failures.is_empty());
+    }
+
+    #[test]
+    fn all_condition_failures_leave_nothing_to_retry() {
+        let mut items = vec![put_item("1"), put_item("2")];
+        let reasons = vec![
+            reason(CONDITION_CHECK_FAILED),
+            reason(CONDITION_CHECK_FAILED),
+        ];
+
+        let outcome = partition_by_cancellation_reason(&mut items, &reasons).unwrap();
+        assert_eq!(outcome.condition_failed, 2);
+        assert!(outcome.kept.is_empty());
+    }
+
+    #[test]
+    fn transient_reason_marks_retry_and_keeps_item() {
+        let mut items = vec![put_item("1")];
+        let reasons = vec![reason("TransactionConflict")];
+
+        let outcome = partition_by_cancellation_reason(&mut items, &reasons).unwrap();
+        assert!(outcome.has_retryable);
+        assert_eq!(outcome.kept.len(), 1);
+        assert_eq!(outcome.condition_failed, 0);
+    }
+
+    #[test]
+    fn permanent_non_condition_reason_is_a_hard_failure() {
+        let mut items = vec![put_item("1"), put_item("2")];
+        let reasons = vec![reason("ValidationError"), reason(CONDITION_CHECK_FAILED)];
+
+        let outcome = partition_by_cancellation_reason(&mut items, &reasons).unwrap();
+        assert_eq!(outcome.hard_failures, vec!["ValidationError".to_string()]);
+        assert_eq!(outcome.condition_failed, 1);
+    }
+
+    #[test]
+    fn reason_count_mismatch_falls_back_to_whole_transaction_retry() {
+        let mut items = vec![put_item("1"), put_item("2")];
+        let reasons = vec![reason(NO_ERROR)];
+
+        assert!(partition_by_cancellation_reason(&mut items, &reasons).is_none());
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn written_totals_exclude_suppressed_items() {
+        // Nothing suppressed: the whole chunk counts.
+        assert_eq!(written_totals(5, 100, 0), (5, 100));
+        // Half the rows suppressed: records exact, bytes scaled by written fraction.
+        assert_eq!(written_totals(2, 100, 1), (1, 50));
+        // Every row suppressed: nothing written.
+        assert_eq!(written_totals(2, 100, 2), (0, 0));
+        // Defensive: suppressed exceeding rows saturates to zero rather than wrapping.
+        assert_eq!(written_totals(2, 100, 3), (0, 0));
+        // Empty chunk: no division by zero.
+        assert_eq!(written_totals(0, 0, 0), (0, 0));
     }
 }

--- a/crates/adapters/src/integrated/dynamodb/metrics.rs
+++ b/crates/adapters/src/integrated/dynamodb/metrics.rs
@@ -58,6 +58,13 @@ pub(crate) struct DynamoDBOutputMetrics {
     /// value points to a view that does not satisfy the connector's uniqueness
     /// requirement.
     duplicate_keys_skipped: AtomicU64,
+
+    /// Writes discarded because their configured condition expression was not
+    /// met (for example an `attribute_not_exists` guard on an existing key).
+    /// This is the intended, non-error path of conditional writes: the count is
+    /// how many writes the condition suppressed, such as duplicates prevented
+    /// across a pipeline restart.
+    condition_check_failures: AtomicU64,
 }
 
 impl DynamoDBOutputMetrics {
@@ -104,6 +111,12 @@ impl DynamoDBOutputMetrics {
     /// Record an output record skipped due to a non-unique key.
     pub(super) fn record_duplicate_key_skip(&self) {
         self.duplicate_keys_skipped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add `count` writes discarded because their condition expression was not met.
+    pub(super) fn record_condition_check_failures(&self, count: u64) {
+        self.condition_check_failures
+            .fetch_add(count, Ordering::Relaxed);
     }
 }
 
@@ -155,6 +168,13 @@ impl ConnectorMetrics for DynamoDBOutputMetrics {
                 "Total number of output records skipped because their key was not unique.",
                 ValueType::Counter,
                 self.duplicate_keys_skipped.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "dynamodb_output_condition_check_failures_total",
+                "Total number of writes discarded because their configured condition expression \
+                 was not met.",
+                ValueType::Counter,
+                self.condition_check_failures.load(Ordering::Relaxed) as f64,
             ),
         ]
     }

--- a/crates/adapters/src/integrated/dynamodb/output.rs
+++ b/crates/adapters/src/integrated/dynamodb/output.rs
@@ -78,6 +78,10 @@ pub(crate) struct DynamoDBWorker {
     write_mode: DynamoDBWriteMode,
     batch_size: usize,
     max_retries: Option<u8>,
+    /// Condition expression applied to every put (transactional mode only).
+    put_condition: Option<String>,
+    /// Condition expression applied to every delete (transactional mode only).
+    delete_condition: Option<String>,
     client: Client,
     key_schema: Relation,
     value_schema: Relation,
@@ -144,6 +148,8 @@ impl DynamoDBWorker {
             write_mode: config.write_mode,
             batch_size: config.effective_batch_size(),
             max_retries: config.max_retries,
+            put_condition: config.put_condition_expression.clone(),
+            delete_condition: config.delete_condition_expression.clone(),
             client,
             key_schema: key_schema.clone(),
             value_schema: value_schema.clone(),
@@ -267,6 +273,8 @@ impl DynamoDBWorker {
         let endpoint_name = self.endpoint_name.clone();
         let table = self.table.clone();
         let write_mode = self.write_mode;
+        let put_condition = self.put_condition.clone();
+        let delete_condition = self.delete_condition.clone();
         let max_retries: Option<usize> = self.max_retries.map(|n| n as usize);
         self.metrics.record_write_chunk();
         let task_metrics = self.metrics.clone();
@@ -276,22 +284,31 @@ impl DynamoDBWorker {
             async move {
                 let _permit = permit;
                 let start = Instant::now();
-                let result: AnyResult<u64> = match write_mode {
-                    DynamoDBWriteMode::Batch => {
-                        helpers::write_batch_chunk(
-                            client,
-                            endpoint_name.clone(),
-                            table,
-                            requests,
-                            max_retries,
-                            &task_metrics,
-                        )
-                        .await
-                    }
+                let result: AnyResult<helpers::TransactChunkOutcome> = match write_mode {
+                    DynamoDBWriteMode::Batch => helpers::write_batch_chunk(
+                        client,
+                        endpoint_name.clone(),
+                        table,
+                        requests,
+                        max_retries,
+                        &task_metrics,
+                    )
+                    .await
+                    .map(|retries| helpers::TransactChunkOutcome {
+                        retries,
+                        suppressed: 0,
+                    }),
                     DynamoDBWriteMode::Transactional => {
                         let transact_items = requests
                             .iter()
-                            .map(|r| helpers::to_transact_item(&table, r))
+                            .map(|r| {
+                                helpers::to_transact_item(
+                                    &table,
+                                    r,
+                                    put_condition.as_deref(),
+                                    delete_condition.as_deref(),
+                                )
+                            })
                             .collect::<AnyResult<Vec<_>>>()?;
                         helpers::write_transact_chunk(
                             client,
@@ -312,14 +329,19 @@ impl DynamoDBWorker {
                     "dynamodb: flushed batch",
                 );
                 // Count rows and bytes as written only once the chunk lands in
-                // DynamoDB; a failed chunk drops its items rather than recording
-                // progress.
+                // DynamoDB. A failed chunk drops its items rather than recording
+                // progress, and items suppressed by a condition expression were
+                // never written, so they are excluded here. Per-item byte sizes
+                // are not retained past the flush, so the suppressed bytes are
+                // estimated by the written fraction of the chunk.
                 match result {
-                    Ok(retries) => {
-                        task_records_written.fetch_add(rows as u64, Ordering::Relaxed);
-                        task_bytes_written.fetch_add(bytes as u64, Ordering::Relaxed);
-                        task_metrics.record_retries(retries);
-                        Ok(retries)
+                    Ok(outcome) => {
+                        let (written, written_bytes) =
+                            helpers::written_totals(rows, bytes, outcome.suppressed);
+                        task_records_written.fetch_add(written, Ordering::Relaxed);
+                        task_bytes_written.fetch_add(written_bytes, Ordering::Relaxed);
+                        task_metrics.record_retries(outcome.retries);
+                        Ok(outcome.retries)
                     }
                     Err(error) => Err(error),
                 }

--- a/crates/adapters/src/integrated/dynamodb/test.rs
+++ b/crates/adapters/src/integrated/dynamodb/test.rs
@@ -39,7 +39,7 @@ use crate::format::Encoder;
 use crate::static_compile::seroutput::SerBatchImpl;
 use crate::test::{TestStruct, test_circuit_with_index, wait};
 
-use super::helpers::make_client;
+use super::helpers::{make_client, to_transact_item};
 use super::metrics::DynamoDBOutputMetrics;
 use super::output::{DynamoDBOutputEndpoint, DynamoDBWorker};
 
@@ -323,6 +323,8 @@ fn config(batch_size: usize) -> DynamoDBWriterConfig {
         max_concurrent_requests: 16,
         threads: 1,
         max_retries: Some(10),
+        put_condition_expression: None,
+        delete_condition_expression: None,
     }
 }
 
@@ -351,6 +353,8 @@ fn endpoint_config(
         max_concurrent_requests: 16,
         threads,
         max_retries: Some(10),
+        put_condition_expression: None,
+        delete_condition_expression: None,
     }
 }
 
@@ -1178,6 +1182,46 @@ fn encoder_json_to_attribute_value_encodes_nested_values() {
     assert!(item.get("map").unwrap().is_m());
 }
 
+#[test]
+fn to_transact_item_attaches_conditions_per_operation() {
+    use aws_sdk_dynamodb::types::{DeleteRequest, PutRequest, WriteRequest};
+
+    let item = HashMap::from([("id".to_string(), AttributeValue::N("1".to_string()))]);
+    let put = WriteRequest::builder()
+        .put_request(PutRequest::builder().set_item(Some(item)).build().unwrap())
+        .build();
+    let delete = WriteRequest::builder()
+        .delete_request(
+            DeleteRequest::builder()
+                .set_key(Some(HashMap::from([(
+                    "id".to_string(),
+                    AttributeValue::N("1".to_string()),
+                )])))
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    // A put carries the put condition; a delete carries the delete condition.
+    let transact_put =
+        to_transact_item("t", &put, Some("attribute_not_exists(id)"), Some("bogus")).unwrap();
+    assert_eq!(
+        transact_put.put().unwrap().condition_expression(),
+        Some("attribute_not_exists(id)")
+    );
+
+    let transact_delete =
+        to_transact_item("t", &delete, Some("bogus"), Some("attribute_exists(id)")).unwrap();
+    assert_eq!(
+        transact_delete.delete().unwrap().condition_expression(),
+        Some("attribute_exists(id)")
+    );
+
+    // No condition attached when none is configured.
+    let unconditional = to_transact_item("t", &put, None, None).unwrap();
+    assert_eq!(unconditional.put().unwrap().condition_expression(), None);
+}
+
 fn dynamodb_endpoint_url() -> Option<String> {
     const DEFAULT_DYNAMODB_ENDPOINT: &str = "http://127.0.0.1:8000";
 
@@ -1507,6 +1551,172 @@ fn dynamodb_delete() {
     assert_eq!(attr_n(&rows[0], "id"), "3");
     assert_eq!(attr_s(&rows[0], "sort"), "c");
     assert_eq!(attr_s(&rows[0], "s"), "three");
+}
+
+/// Builds a single-threaded transactional endpoint carrying the given condition
+/// expressions, retaining `metrics` so the test can inspect the suppressed-write
+/// count. A single worker keeps every item in one transaction, exercising the
+/// discard-and-retry path when part of that transaction fails its condition.
+fn dynamodb_conditional_endpoint(
+    table: &str,
+    endpoint_url: Option<&str>,
+    put_condition: Option<&str>,
+    delete_condition: Option<&str>,
+    metrics: Arc<DynamoDBOutputMetrics>,
+) -> DynamoDBOutputEndpoint {
+    let mut config = endpoint_config(table.to_string(), endpoint_url.map(str::to_string), 1);
+    config.write_mode = DynamoDBWriteMode::Transactional;
+    config.batch_size = None;
+    config.put_condition_expression = put_condition.map(str::to_string);
+    config.delete_condition_expression = delete_condition.map(str::to_string);
+    DynamoDBOutputEndpoint::new_with_metrics(
+        EndpointId::default(),
+        "test_endpoint",
+        &config,
+        &Some(key_relation()),
+        &value_relation(),
+        Weak::new(),
+        true,
+        metrics,
+    )
+    .unwrap()
+}
+
+/// Writes an item directly, standing in for a row left by an earlier pipeline run.
+fn seed_item(client: &Client, table: &str, id: i32, sort: &str, marker: &str) {
+    TOKIO
+        .block_on(
+            client
+                .put_item()
+                .table_name(table)
+                .item("id", AttributeValue::N(id.to_string()))
+                .item("sort", AttributeValue::S(sort.to_string()))
+                .item("s", AttributeValue::S(marker.to_string()))
+                .send(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn dynamodb_conditional_put_skips_existing_row() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("conditional_put_skip");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+
+    // A row already present, as if written before a pipeline restart.
+    seed_item(&client, &table, 1, "a", "original");
+
+    let metrics = Arc::new(DynamoDBOutputMetrics::default());
+    let mut endpoint = dynamodb_conditional_endpoint(
+        &table,
+        endpoint_url.as_deref(),
+        Some("attribute_not_exists(id)"),
+        None,
+        metrics.clone(),
+    );
+
+    // One transaction: re-emit the existing key with a new value (must be
+    // suppressed) alongside a genuinely new key (must land). The whole
+    // transaction is first cancelled by the existing key; the connector drops
+    // that item and retries the rest.
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "reprocessed"), 1),
+            (record(2, "b", Some(20), "fresh"), 1),
+        ]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 2);
+    // The existing row was left untouched.
+    assert_eq!(attr_n(&rows[0], "id"), "1");
+    assert_eq!(attr_s(&rows[0], "s"), "original");
+    // The new row was written.
+    assert_eq!(attr_n(&rows[1], "id"), "2");
+    assert_eq!(attr_s(&rows[1], "s"), "fresh");
+
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_condition_check_failures_total"),
+        1.0
+    );
+}
+
+#[test]
+fn dynamodb_conditional_put_writes_all_new_rows() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("conditional_put_all_new");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+
+    let metrics = Arc::new(DynamoDBOutputMetrics::default());
+    let mut endpoint = dynamodb_conditional_endpoint(
+        &table,
+        endpoint_url.as_deref(),
+        Some("attribute_not_exists(id)"),
+        None,
+        metrics.clone(),
+    );
+
+    // No key exists yet, so the condition holds for every put.
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "one"), 1),
+            (record(2, "b", Some(20), "two"), 1),
+        ]),
+    );
+
+    let rows = scan_table(&client, &table);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(attr_s(&rows[0], "s"), "one");
+    assert_eq!(attr_s(&rows[1], "s"), "two");
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_condition_check_failures_total"),
+        0.0
+    );
+}
+
+#[test]
+fn dynamodb_conditional_delete_skips_absent_row() {
+    let endpoint_url = dynamodb_endpoint_url();
+    let client = dynamodb_client(endpoint_url.as_deref());
+    wait_for_dynamodb(&client);
+
+    let table = test_table_name("conditional_delete");
+    let _table_guard = TempDynamoTable::new(&client, &table, true);
+
+    seed_item(&client, &table, 1, "a", "original");
+
+    let metrics = Arc::new(DynamoDBOutputMetrics::default());
+    let mut endpoint = dynamodb_conditional_endpoint(
+        &table,
+        endpoint_url.as_deref(),
+        None,
+        Some("attribute_exists(id)"),
+        metrics.clone(),
+    );
+
+    // Delete the existing key (condition holds) and a key that was never written
+    // (condition fails, delete suppressed).
+    encode_endpoint_batch(
+        &mut endpoint,
+        &build_batch(vec![
+            (record(1, "a", Some(10), "original"), -1),
+            (record(2, "b", Some(20), "absent"), -1),
+        ]),
+    );
+
+    assert!(scan_table(&client, &table).is_empty());
+    assert_eq!(
+        dynamodb_metric(&metrics, "dynamodb_output_condition_check_failures_total"),
+        1.0
+    );
 }
 
 #[test]

--- a/crates/feldera-types/src/transport/dynamodb.rs
+++ b/crates/feldera-types/src/transport/dynamodb.rs
@@ -143,6 +143,37 @@ pub struct DynamoDBWriterConfig {
     #[serde(default = "default_max_retries")]
     #[schema(default = default_max_retries)]
     pub max_retries: Option<u8>,
+
+    /// [Condition expression] evaluated before each put (insert or upsert).
+    ///
+    /// When the condition is false, the record is skipped without failing the
+    /// connector. This option requires `transactional` [`write_mode`].
+    ///
+    /// The condition gates every value write, and the connector cannot tell a
+    /// replayed insert from a legitimate update: both arrive as puts. A guard
+    /// such as `attribute_not_exists(id)` therefore also suppresses updates to
+    /// existing keys, not just replayed duplicates. Choose the expression
+    /// accordingly.
+    ///
+    /// The connector does not currently support `ExpressionAttributeNames` or
+    /// `ExpressionAttributeValues`, so the expression cannot use placeholders.
+    ///
+    /// [Condition expression]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html
+    /// [`write_mode`]: Self::write_mode
+    #[serde(default)]
+    pub put_condition_expression: Option<String>,
+
+    /// [Condition expression] evaluated before each delete.
+    ///
+    /// When the condition is false, the delete is skipped without failing the
+    /// connector. This option requires `transactional` [`write_mode`]. The
+    /// expression cannot use `ExpressionAttributeNames` or
+    /// `ExpressionAttributeValues` placeholders.
+    ///
+    /// [Condition expression]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html
+    /// [`write_mode`]: Self::write_mode
+    #[serde(default)]
+    pub delete_condition_expression: Option<String>,
 }
 
 impl DynamoDBWriterConfig {
@@ -202,6 +233,25 @@ impl DynamoDBWriterConfig {
                 );
             }
         }
+        for (field, expression) in [
+            ("put_condition_expression", &self.put_condition_expression),
+            (
+                "delete_condition_expression",
+                &self.delete_condition_expression,
+            ),
+        ] {
+            if let Some(expression) = expression {
+                if expression.trim().is_empty() {
+                    return Err(format!("{field} cannot be empty"));
+                }
+                if self.write_mode != DynamoDBWriteMode::Transactional {
+                    return Err(format!(
+                        "{field} requires the 'transactional' write mode; conditional writes \
+                         are not supported for 'batch' writes"
+                    ));
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -232,6 +282,8 @@ mod tests {
             max_concurrent_requests: 16,
             threads: 1,
             max_retries: Some(10u8),
+            put_condition_expression: None,
+            delete_condition_expression: None,
         }
     }
 
@@ -337,6 +389,39 @@ mod tests {
             .validate()
             .is_ok()
         );
+    }
+
+    #[test]
+    fn condition_requires_transactional_write_mode() {
+        // A put condition in batch mode is rejected.
+        let batch = DynamoDBWriterConfig {
+            put_condition_expression: Some("attribute_not_exists(id)".to_string()),
+            ..config(DynamoDBWriteMode::Batch, None)
+        };
+        assert!(batch.validate().is_err());
+
+        // The same condition is accepted in transactional mode.
+        let transactional = DynamoDBWriterConfig {
+            put_condition_expression: Some("attribute_not_exists(id)".to_string()),
+            ..config(DynamoDBWriteMode::Transactional, None)
+        };
+        assert!(transactional.validate().is_ok());
+
+        // A delete condition in batch mode is rejected as well.
+        let batch_delete = DynamoDBWriterConfig {
+            delete_condition_expression: Some("attribute_exists(id)".to_string()),
+            ..config(DynamoDBWriteMode::Batch, None)
+        };
+        assert!(batch_delete.validate().is_err());
+    }
+
+    #[test]
+    fn blank_condition_is_rejected() {
+        let cfg = DynamoDBWriterConfig {
+            put_condition_expression: Some("   ".to_string()),
+            ..config(DynamoDBWriteMode::Transactional, None)
+        };
+        assert!(cfg.validate().is_err());
     }
 
     #[test]

--- a/docs.feldera.com/docs/connectors/sinks/dynamodb.md
+++ b/docs.feldera.com/docs/connectors/sinks/dynamodb.md
@@ -30,6 +30,8 @@ the index must include both columns.
 | `max_concurrent_requests`        | integer | `64`      | Maximum number of DynamoDB write requests in flight per worker thread at any one time. The connector blocks the encoding thread when this limit is reached, applying backpressure to the pipeline.                                                                                                                                                                                                      |
 | `threads`                        | integer | `1`       | Number of parallel worker threads used to encode and write disjoint key ranges. Each thread makes its own DynamoDB API calls. Increasing this value can improve throughput for large batches.                                                                                                                                                                                                           |
 | `max_retries`                    | integer | `10`      | Maximum number of retries for a failed or partially-applied DynamoDB write. For `batch` mode, retries apply to items returned as unprocessed in a successful response. For `transactional` mode, retries apply to failed `TransactWriteItems` calls. Set to `null` to retry indefinitely. Transient errors such as throttling are handled separately by the AWS SDK and do not count toward this limit. |
+| `put_condition_expression`       | string  |           | Optional [condition expression](#conditional-writes) evaluated before every put. Available only in `transactional` mode.                                                                                                                                                                                                                                                                               |
+| `delete_condition_expression`    | string  |           | Optional [condition expression](#conditional-writes) evaluated before every delete. Available only in `transactional` mode.                                                                                                                                                                                                                                                                            |
 
 [*]: Required fields
 
@@ -54,6 +56,46 @@ API. This mode:
 
 - Guarantees atomicity for each transaction chunk of up to 100 items
 - Is substantially slower than batch mode due to the overhead of ACID transactions
+
+## Conditional writes
+
+Transactional mode can ask DynamoDB to check a condition before changing an
+item. Set `put_condition_expression` for inserts and upserts, or
+`delete_condition_expression` for deletes. The condition is evaluated against
+the item currently stored under the same key. When it is false, the connector
+skips that change and continues writing the other records in the transaction.
+
+Conditions can prevent unwanted overwrites, limit deletes to items in an
+expected state, or make replayed input harmless. For example:
+
+- `attribute_not_exists(id)` writes only when the key is not already present.
+- `attribute_exists(id)` writes or deletes only when the item already exists.
+- `attribute_exists(id) AND attribute_not_exists(archived_at)` combines checks
+  when more than one property matters.
+
+:::warning
+
+`put_condition_expression` gates every put, and the connector cannot
+distinguish a replayed insert from a legitimate update: both are puts. A guard
+such as `attribute_not_exists(id)` therefore suppresses updates to existing
+keys as well as replayed duplicates. Use it only when the view is
+insert-only, or when dropping updates is intended.
+
+:::
+
+```json
+{
+  "write_mode": "transactional",
+  "put_condition_expression": "attribute_not_exists(id)",
+  "delete_condition_expression": "attribute_exists(id)"
+}
+```
+
+The connector currently accepts only the condition expression itself. It does
+not accept DynamoDB `ExpressionAttributeNames` or `ExpressionAttributeValues`,
+so aliases such as `#status` and value placeholders such as `:expected` cannot
+be resolved. Attribute names used directly in an expression must not be
+[DynamoDB reserved words](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html).
 
 ## Item-size limit
 

--- a/openapi.json
+++ b/openapi.json
@@ -9086,6 +9086,11 @@
             "nullable": true,
             "minimum": 0
           },
+          "delete_condition_expression": {
+            "type": "string",
+            "description": "[Condition expression] evaluated before each delete.\n\nWhen the condition is false, the delete is skipped without failing the\nconnector. This option requires `transactional` [`write_mode`]. The\nexpression cannot use `ExpressionAttributeNames` or\n`ExpressionAttributeValues` placeholders.\n\n[Condition expression]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html\n[`write_mode`]: Self::write_mode",
+            "nullable": true
+          },
           "endpoint_url": {
             "type": "string",
             "description": "Optional endpoint URL, for example when using a local\nDynamoDB-compatible service.",
@@ -9110,6 +9115,11 @@
             "default": 10,
             "nullable": true,
             "minimum": 0
+          },
+          "put_condition_expression": {
+            "type": "string",
+            "description": "[Condition expression] evaluated before each put (insert or upsert).\n\nWhen the condition is false, the record is skipped without failing the\nconnector. This option requires `transactional` [`write_mode`].\n\nThe condition gates every value write, and the connector cannot tell a\nreplayed insert from a legitimate update: both arrive as puts. A guard\nsuch as `attribute_not_exists(id)` therefore also suppresses updates to\nexisting keys, not just replayed duplicates. Choose the expression\naccordingly.\n\nThe connector does not currently support `ExpressionAttributeNames` or\n`ExpressionAttributeValues`, so the expression cannot use placeholders.\n\n[Condition expression]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html\n[`write_mode`]: Self::write_mode",
+            "nullable": true
           },
           "region": {
             "type": "string",


### PR DESCRIPTION
Adds support for conditional writes in the dynamodb output connector.

Allows users to specify DynamoDB conditions to attach to their records. Users can specify different conditions for put and delete requests.

Conditional writes are only supported in `transactional` mode. DynamoDB transactions are all-or-nothing, so if a condition fails the whole transaction is cancelled. Rather than failing to write the entire transaction batch, on condition failure, we drop the items whose condition failed, and retry the rest.

### Describe Manual Test Plan

Integration tests

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

