### PR TITLE
ci: verify artifact checksum before extracting to catch truncated downloads

### DIFF
--- a/.github/actions/download-artifact-retry/action.yml
+++ b/.github/actions/download-artifact-retry/action.yml
@@ -52,8 +52,8 @@ runs:
         artifact_json=$(curl -fsSL \
           -H "Authorization: Bearer ${GH_TOKEN}" \
           -H "Accept: application/vnd.github+json" \
-          "${api}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
-          | jq -c --arg name "${ARTIFACT_NAME}" '.artifacts[] | select(.name == $name)')
+          "${api}/actions/runs/${RUN_ID}/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
+          | jq -c '.artifacts[0] // empty')
 
         if [ -z "$artifact_json" ]; then
           echo "::error::No artifact named '${ARTIFACT_NAME}' found in run ${RUN_ID}"
@@ -61,8 +61,13 @@ runs:
         fi
 
         artifact_id=$(jq -r '.id' <<<"$artifact_json")
-        expected_size=$(jq -r '.size_in_bytes' <<<"$artifact_json")
-        expected_digest=$(jq -r '.digest' <<<"$artifact_json" | sed 's/^sha256://')
+        expected_size=$(jq -r '.size_in_bytes // empty' <<<"$artifact_json")
+        expected_digest=$(jq -r '.digest // empty' <<<"$artifact_json" | sed 's/^sha256://')
+
+        if [ -z "$expected_digest" ] || [ -z "$expected_size" ]; then
+          echo "::error::Artifact '${ARTIFACT_NAME}' has no recorded size/digest to verify against, cannot verify integrity"
+          exit 1
+        fi
 
         zip_path="$(mktemp -d)/${ARTIFACT_NAME}.zip"
         attempt=1
@@ -70,23 +75,29 @@ runs:
         while true; do
           echo "==> Download attempt ${attempt}/${MAX_ATTEMPTS}: ${ARTIFACT_NAME} (expecting ${expected_size} bytes)"
 
-          curl -fsSL \
+          curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -o "$zip_path" \
             "${api}/actions/artifacts/${artifact_id}/zip"
 
-          actual_digest=$(sha256sum "$zip_path" | awk '{print $1}')
+          actual_size=$(wc -c <"$zip_path" | tr -d ' ')
 
-          if [ "$actual_digest" = "$expected_digest" ]; then
-            echo "==> Checksum verified (sha256:${actual_digest})"
-            break
+          if [ "$actual_size" != "$expected_size" ]; then
+            echo "::warning::Size mismatch on attempt ${attempt} for '${ARTIFACT_NAME}' (expected ${expected_size} bytes, got ${actual_size}) — download was truncated"
+          else
+            actual_digest=$(sha256sum "$zip_path" | awk '{print $1}')
+
+            if [ "$actual_digest" = "$expected_digest" ]; then
+              echo "==> Checksum verified (sha256:${actual_digest})"
+              break
+            fi
+
+            echo "::warning::Checksum mismatch on attempt ${attempt} for '${ARTIFACT_NAME}' (expected sha256:${expected_digest}, got sha256:${actual_digest}) — download was corrupted in transit"
           fi
 
-          echo "::warning::Checksum mismatch on attempt ${attempt} for '${ARTIFACT_NAME}' (expected sha256:${expected_digest}, got sha256:${actual_digest}) — download was truncated or corrupted in transit"
-
           if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            echo "::error::Artifact '${ARTIFACT_NAME}' failed checksum verification after ${MAX_ATTEMPTS} attempts"
+            echo "::error::Artifact '${ARTIFACT_NAME}' failed integrity verification after ${MAX_ATTEMPTS} attempts"
             exit 1
           fi
 

--- a/.github/actions/download-artifact-retry/action.yml
+++ b/.github/actions/download-artifact-retry/action.yml
@@ -1,0 +1,100 @@
+name: Download Artifact with Checksum Verification
+description: >
+  Downloads a cross-run artifact directly from the Artifacts API and verifies
+  its SHA256 against the digest GitHub recorded at upload time before
+  extracting, retrying the download on mismatch. Both actions/download-artifact
+  and dawidd6/action-download-artifact await the whole HTTP response into
+  memory without checking its length or checksum, so a truncated response
+  silently surfaces as a corrupt-zip error at extraction time instead of a
+  download error. See https://github.com/actions/download-artifact/issues/454
+  and https://github.com/dawidd6/action-download-artifact/issues/403.
+
+inputs:
+  name:
+    description: Artifact name to download.
+    required: true
+  path:
+    description: Local directory to extract the artifact into.
+    required: true
+  run-id:
+    description: ID of the workflow run that uploaded the artifact.
+    required: true
+  github-token:
+    description: GitHub token with actions:read permission.
+    required: true
+  max-attempts:
+    description: Maximum number of download attempts before failing.
+    required: false
+    default: "3"
+  retry-delay-seconds:
+    description: Seconds to wait between attempts.
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify ${{ inputs.name }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ github.repository }}
+        RUN_ID: ${{ inputs.run-id }}
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        RETRY_DELAY_SECONDS: ${{ inputs.retry-delay-seconds }}
+      run: |
+        set -euo pipefail
+
+        api="https://api.github.com/repos/${REPOSITORY}"
+
+        artifact_json=$(curl -fsSL \
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${api}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+          | jq -c --arg name "${ARTIFACT_NAME}" '.artifacts[] | select(.name == $name)')
+
+        if [ -z "$artifact_json" ]; then
+          echo "::error::No artifact named '${ARTIFACT_NAME}' found in run ${RUN_ID}"
+          exit 1
+        fi
+
+        artifact_id=$(jq -r '.id' <<<"$artifact_json")
+        expected_size=$(jq -r '.size_in_bytes' <<<"$artifact_json")
+        expected_digest=$(jq -r '.digest' <<<"$artifact_json" | sed 's/^sha256://')
+
+        zip_path="$(mktemp -d)/${ARTIFACT_NAME}.zip"
+        attempt=1
+
+        while true; do
+          echo "==> Download attempt ${attempt}/${MAX_ATTEMPTS}: ${ARTIFACT_NAME} (expecting ${expected_size} bytes)"
+
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -o "$zip_path" \
+            "${api}/actions/artifacts/${artifact_id}/zip"
+
+          actual_digest=$(sha256sum "$zip_path" | awk '{print $1}')
+
+          if [ "$actual_digest" = "$expected_digest" ]; then
+            echo "==> Checksum verified (sha256:${actual_digest})"
+            break
+          fi
+
+          echo "::warning::Checksum mismatch on attempt ${attempt} for '${ARTIFACT_NAME}' (expected sha256:${expected_digest}, got sha256:${actual_digest}) — download was truncated or corrupted in transit"
+
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::Artifact '${ARTIFACT_NAME}' failed checksum verification after ${MAX_ATTEMPTS} attempts"
+            exit 1
+          fi
+
+          attempt=$((attempt + 1))
+          sleep "${RETRY_DELAY_SECONDS}"
+        done
+
+        rm -rf "${DEST_PATH}"
+        mkdir -p "${DEST_PATH}"
+        unzip -q "$zip_path" -d "${DEST_PATH}"
+        rm -rf "$(dirname "$zip_path")"

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -62,12 +62,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: ./.github/actions/download-artifact-retry
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
-          run_id: ${{ github.event.inputs.run_id || github.run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.inputs.run_id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Remove if https://github.com/actions/upload-artifact/issues/38 ever gets fixed
       - name: Make binaries executable
@@ -145,12 +145,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: ./.github/actions/download-artifact-retry
         with:
           name: feldera-test-binaries-x86_64-unknown-linux-gnu
           path: build
-          run_id: ${{ github.event.inputs.run_id || github.run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.inputs.run_id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Remove if https://github.com/actions/upload-artifact/issues/38 ever gets fixed
       - name: Make binaries executable

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -36,20 +36,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Test Binaries
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: ./.github/actions/download-artifact-retry
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
-          run_id: ${{ github.run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Compiler Binaries
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: ./.github/actions/download-artifact-retry
         with:
           name: feldera-sql-compiler
           path: sql-build
-          run_id: ${{ github.run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Remove if https://github.com/actions/upload-artifact/issues/38 ever gets fixed
       - name: Make binaries executable


### PR DESCRIPTION
Adapter Tests / Test Adapters (aarch64) failed on a run with ADM-ZIP: Invalid or unsupported zip format. No END header found. The artifact itself was completely fine, correct size, correct SHA256, valid zip. So it wasn't a corrupt upload.

Turns out dawidd6/action-download-artifact (and the official actions/download-artifact has the same bug, see actions/download-artifact#454 (https://github.com/actions/download-artifact/issues/454)) awaits the whole HTTP response into memory but never checks its length or checksum before writing it to disk and extracting. If the response gets truncated in transit, it just silently writes a partial file and the corruption only shows up later as an opaque zip-parsing error.

This replaces that action with a composite action (.github/actions/download-artifact-retry) that downloads the artifact directly, compares its SHA256 against the digest GitHub recorded at upload time, and retries (up to 3x) on mismatch. A real mismatch now logs expected sha256:X, got sha256:Y instead of a generic zip error.

Testing: The composite action's script ran directly against a real run/artifact on feldera/feldera (metadata lookup → download → checksum match → extraction) and extracted correctly. A forced checksum mismatch confirmed the retry-then-fail-with-a-clear-error path triggers as expected.