### PR TITLE
[datagen] Fix a deadlock in datagen.

### DIFF
--- a/crates/adapters/src/test/datagen.rs
+++ b/crates/adapters/src/test/datagen.rs
@@ -181,6 +181,58 @@ fn test_transaction() {
     wait_for_data(endpoint.as_ref(), &consumer);
 }
 
+/// Regression test: a datagen connector must answer a `Queue` that arrives
+/// immediately after an `Extend`, even at end-of-input.
+///
+/// `Unparker::unpark` coalesces wake-ups into a single token, so an `Extend`
+/// followed right away by a `Queue` (exactly what the controller does when it
+/// resumes inputs at a concurrent-bootstrap cutover: the backpressure thread
+/// `extend()`s the reader and the circuit thread immediately `queue()`s it)
+/// reaches the generator as one wake-up. A command loop that handled only one
+/// command per wake-up would process the `Extend`, re-park (the generator is
+/// already at end-of-input, so it has no work), and strand the `Queue` with no
+/// pending token. `extended()` would never be called and the controller's input
+/// step would hang forever waiting for the connector.
+#[test]
+fn test_eoi_extend_queue_burst_no_deadlock() {
+    let config = serde_json::from_value(json!({
+        "stream": "test_input",
+        "transport": {
+            "name": "datagen",
+            "config": { "plan": [{ "limit": 10, "fields": {} }] }
+        }
+    }))
+    .unwrap();
+    let (endpoint, consumer, _zset) =
+        mk_pipeline::<TestStruct2, TestStruct2>(config, TestStruct2::schema()).unwrap();
+
+    // Drive the generator to end-of-input and flush its rows, leaving its worker
+    // thread parked and waiting for the next command.
+    wait_for_data(endpoint.as_ref(), &consumer);
+    assert!(consumer.state().eoi);
+    thread::sleep(Duration::from_millis(200)); // let the worker reach `park()`
+    let baseline = consumer.state().n_extended;
+
+    // The cutover burst: `Extend` then `Queue`, back to back, so their unparks
+    // coalesce into one wake-up.
+    endpoint.extend();
+    endpoint.queue(false);
+
+    // The `Queue` must be answered with `extended()`. Before the fix the worker
+    // handled only the `Extend`, re-parked, and stranded the `Queue`, deadlocking
+    // here. Fail fast rather than hang the test suite.
+    for _ in 0..500 {
+        if consumer.state().n_extended > baseline {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "datagen did not answer Queue after an Extend+Queue burst at end-of-input; \
+         the controller's input step would deadlock"
+    );
+}
+
 #[test]
 fn test_limit_increment() {
     let config = serde_json::from_value(json!({

--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -610,12 +610,24 @@ impl InputGenerator {
         let mut completed = VecDeque::new();
         let mut transaction_size = 0;
         loop {
-            match command_receiver.try_recv()? {
+            // Handle every command that is currently available before parking.
+            // The unparker coalesces wake-ups into a single token, so parking
+            // after handling just one command can strand a pending command (for
+            // example an Extend immediately followed by a Queue when inputs resume
+            // after a concurrent-bootstrap cutover) and deadlock the controller's
+            // input step, which blocks waiting for the Queue response.
+            let processed_command = match command_receiver.try_recv()? {
                 Some(command @ InputReaderCommand::Replay { .. }) => {
                     unreachable!("{command:?} must be at the beginning of the command stream")
                 }
-                Some(InputReaderCommand::Extend) => running = true,
-                Some(InputReaderCommand::Pause) => running = false,
+                Some(InputReaderCommand::Extend) => {
+                    running = true;
+                    true
+                }
+                Some(InputReaderCommand::Pause) => {
+                    running = false;
+                    true
+                }
                 Some(InputReaderCommand::Queue { .. }) => {
                     let mut total = BufferSize::empty();
                     let mut hasher = consumer.hasher();
@@ -702,10 +714,11 @@ impl InputGenerator {
                         transaction_size = 0;
                     }
                     consumer.extended(total, Some(resume), watermarks);
+                    true
                 }
                 Some(InputReaderCommand::Disconnect) => break,
-                None => (),
-            }
+                None => false,
+            };
 
             while let Ok(completion) = completion_receiver.try_recv() {
                 let batch = &completion.batch;
@@ -728,7 +741,10 @@ impl InputGenerator {
                     running = false;
                     consumer.eoi();
                 }
-            } else {
+            } else if !processed_command {
+                // Only park when the command channel is drained. If we handled a
+                // command this iteration there may be more queued behind a
+                // coalesced wake-up, so loop back and drain them before sleeping.
                 parker.park();
             }
         }


### PR DESCRIPTION
The datagen could park after retrieving just one command from the queue. It could then get stuck in park() if there was more than one command queued. The solution is to drain the entire queue before parking.

### Describe Manual Test Plan

Ran into this when working on concurrent bootstrapping demo (concurrent bootstrapping triggers the bug). Verified that the bug no longer happens in the same scenario. 

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
