### PR TITLE
[web-console] Implement bi-directional search bar for logs tab and profiler metrics

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,7 +77,7 @@ ENV PATH="$HOME/.cargo/bin:$PATH"
 ## Install Bun.js
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
 ENV PATH="$HOME/.bun/bin:$PATH"
-RUN $HOME/.bun/bin/bun install --global @hey-api/openapi-ts
+RUN $HOME/.bun/bin/bun install --global @hey-api/openapi-ts @biomejs/biome
 
 ## Install Claude Code
 RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/docs.feldera.com/docs/operations/visualizing-profiles.md
+++ b/docs.feldera.com/docs/operations/visualizing-profiles.md
@@ -232,6 +232,24 @@ future we may allow searching by attributes as well.)
 
 ![Searching for nodes](search.png)
 
+Pressing `Ctrl-F` (`Cmd-F` on macOS) after clicking anywhere in the
+dataflow graph moves the keyboard focus to this search box.
+
+### Searching through metrics, issues and logs
+
+The bottom right has a search button (a magnifying glass) at
+its right end.  It searches the tab that is currently shown:
+
+| Tab     | What the search matches                                                                                             |
+|---------|---------------------------------------------------------------------------------------------------------------------|
+| Metrics | The title of a metrics block or a "top nodes" row, a metric label or identifier               |
+| Logs    | Any log line containing the text                                                                                     |
+| Issues  | Any issue row containing the text                       |
+
+Pressing `Ctrl-F` (`Cmd-F` on macOS) anywhere outside the graph opens
+this search box and selects its contents, so a second `Ctrl-F` starts a
+new query without deleting the old one.
+
 ### Cross-referencing with SQL
 
 Some, but not all, nodes of the dataflow graph can be directly linked

--- a/js-packages/common-ui/package.json
+++ b/js-packages/common-ui/package.json
@@ -53,7 +53,8 @@
     "prepare": "bun run prepack",
     "prepack": "svelte-kit sync && svelte-package && publint",
     "check": "svelte-kit sync && svelte-check --threshold error",
-    "check:watch": "svelte-kit sync && svelte-check --threshold error --watch"
+    "check:watch": "svelte-kit sync && svelte-check --threshold error --watch",
+    "format": "biome check --write ."
   },
   "sideEffects": ["**/*.css"],
   "svelte": "./dist/index.js",

--- a/js-packages/common-ui/src/lib/LogList.svelte
+++ b/js-packages/common-ui/src/lib/LogList.svelte
@@ -7,21 +7,22 @@
   externally-owned `search` state; they wire the search input wherever fits their layout.
 -->
 <script lang="ts">
-  import { untrack, type Snippet } from 'svelte'
-  import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte'
   import stripAnsi from 'strip-ansi'
+  import { type Snippet, untrack } from 'svelte'
+  import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte'
   import ANSIDecoratedText from './ANSIDecoratedText.svelte'
-  import ScrollDownFab from './ScrollDownFab.svelte'
-  import { useReverseScrollContainer } from './useReverseScrollContainer.svelte'
-  import { virtualSelect } from './userSelect'
-  import { sliceLinesForCopy, type CopySlice } from './logCopy'
+  import { type CopySlice, sliceLinesForCopy } from './logCopy'
   import {
     applySearchHighlight,
+    countOccurrences,
     emptySearchState,
     findMatchOffsets,
     findOccurrence,
     type SearchState
   } from './logSearch'
+  import ScrollDownFab from './ScrollDownFab.svelte'
+  import { useReverseScrollContainer } from './useReverseScrollContainer.svelte'
+  import { virtualSelect } from './userSelect'
 
   interface Props {
     /** Lines to render, one per row. Hosts pre-split their source into lines. */
@@ -51,13 +52,12 @@
      * joins the selected `lines` with `\n`; rows that already carry a trailing newline
      * need an override that joins with `''` (see {@link sliceLinesForCopy}). */
     getCopyContent?: (slice: CopySlice) => string
-    /** Invoked when the user presses Ctrl-F / Cmd-F while focus is inside the log list.
-     *  Hosts typically focus their search input here. When omitted, the browser's native
-     *  find-in-page is left to handle the shortcut. */
-    onSearchShortcut?: () => void
     /** Fired whenever stick-to-bottom toggles: `true` when the view re-anchors to the
      *  bottom, `false` when the user scrolls up off the bottom. */
     onStickToBottomChange?: (stickToBottom: boolean) => void
+    /** Fired with the number of lines matching the current search pattern (0 when the search
+     *  is cleared). Hosts use it to enable/disable their search nav buttons. */
+    onMatchCountChange?: (count: number) => void
   }
 
   let {
@@ -70,8 +70,8 @@
     style,
     header,
     getCopyContent,
-    onSearchShortcut,
-    onStickToBottomChange
+    onStickToBottomChange,
+    onMatchCountChange
   }: Props = $props()
 
   // Reverse-scroll lives here (not in wrappers) so search behaviour and auto-scroll behaviour
@@ -103,6 +103,13 @@
   const matchedIndex = $derived(
     search.pattern ? findOccurrence(lines, search.pattern, search.occurrenceIndex) : -1
   )
+
+  // Report the match count so the host can enable/disable its search nav buttons. Recomputes
+  // as the pattern changes or streaming appends lines that match.
+  const matchCount = $derived(countOccurrences(lines, search.pattern))
+  $effect(() => {
+    onMatchCountChange?.(matchCount)
+  })
 
   function paintHighlight() {
     if (!scrollContainer || matchedIndex < 0 || !search.pattern) {
@@ -140,10 +147,14 @@
   $effect(() => {
     const pattern = search.pattern
     const occ = search.occurrenceIndex
-    if (!pattern) return
+    if (!pattern) {
+      return
+    }
     untrack(() => {
       const idx = findOccurrence(lines, pattern, occ)
-      if (idx < 0) return
+      if (idx < 0) {
+        return
+      }
       // Drop stick-to-bottom so a streaming log doesn't scroll away from the match the user
       // jumped to. They regain auto-scroll by scrolling back to the bottom themselves.
       reverseScroll.stickToBottom = false
@@ -182,20 +193,6 @@
     use:virtualSelect={{
       getRoot: (node) => node.firstElementChild!,
       getCopyContent: getCopyContent ?? defaultGetCopyContent
-    }}
-    onkeydown={(e) => {
-      // Ctrl-F (Win/Linux) or Cmd-F (Mac) — redirect to host's search input. Only intercept
-      // when the host supplied a handler; otherwise the browser's find-in-page is left alone.
-      if (
-        onSearchShortcut &&
-        (e.key === 'f' || e.key === 'F') &&
-        (e.ctrlKey || e.metaKey) &&
-        !e.altKey &&
-        !e.shiftKey
-      ) {
-        e.preventDefault()
-        onSearchShortcut()
-      }
     }}
   >
     <Virtualizer

--- a/js-packages/common-ui/src/lib/LogList.svelte
+++ b/js-packages/common-ui/src/lib/LogList.svelte
@@ -7,21 +7,22 @@
   externally-owned `search` state; they wire the search input wherever fits their layout.
 -->
 <script lang="ts">
-  import { untrack, type Snippet } from 'svelte'
-  import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte'
   import stripAnsi from 'strip-ansi'
+  import { type Snippet, untrack } from 'svelte'
+  import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte'
   import ANSIDecoratedText from './ANSIDecoratedText.svelte'
-  import ScrollDownFab from './ScrollDownFab.svelte'
-  import { useReverseScrollContainer } from './useReverseScrollContainer.svelte'
-  import { virtualSelect } from './userSelect'
-  import { sliceLinesForCopy, type CopySlice } from './logCopy'
+  import { type CopySlice, sliceLinesForCopy } from './logCopy'
   import {
     applySearchHighlight,
+    countOccurrences,
     emptySearchState,
     findMatchOffsets,
     findOccurrence,
     type SearchState
   } from './logSearch'
+  import ScrollDownFab from './ScrollDownFab.svelte'
+  import { useReverseScrollContainer } from './useReverseScrollContainer.svelte'
+  import { virtualSelect } from './userSelect'
 
   interface Props {
     /** Lines to render, one per row. Hosts pre-split their source into lines. */
@@ -51,13 +52,12 @@
      * joins the selected `lines` with `\n`; rows that already carry a trailing newline
      * need an override that joins with `''` (see {@link sliceLinesForCopy}). */
     getCopyContent?: (slice: CopySlice) => string
-    /** Invoked when the user presses Ctrl-F / Cmd-F while focus is inside the log list.
-     *  Hosts typically focus their search input here. When omitted, the browser's native
-     *  find-in-page is left to handle the shortcut. */
-    onSearchShortcut?: () => void
     /** Fired whenever stick-to-bottom toggles: `true` when the view re-anchors to the
      *  bottom, `false` when the user scrolls up off the bottom. */
     onStickToBottomChange?: (stickToBottom: boolean) => void
+    /** Fired with the number of lines matching the current search pattern (0 when the search
+     *  is cleared). Hosts use it to enable/disable their search nav buttons. */
+    onMatchCountChange?: (count: number) => void
   }
 
   let {
@@ -70,8 +70,8 @@
     style,
     header,
     getCopyContent,
-    onSearchShortcut,
-    onStickToBottomChange
+    onStickToBottomChange,
+    onMatchCountChange
   }: Props = $props()
 
   // Reverse-scroll lives here (not in wrappers) so search behaviour and auto-scroll behaviour
@@ -104,6 +104,13 @@
     search.pattern ? findOccurrence(lines, search.pattern, search.occurrenceIndex) : -1
   )
 
+  // Report the match count so the host can enable/disable its search nav buttons. Recomputes
+  // as the pattern changes or streaming appends lines that match.
+  const matchCount = $derived(countOccurrences(lines, search.pattern))
+  $effect(() => {
+    onMatchCountChange?.(matchCount)
+  })
+
   function paintHighlight() {
     if (!scrollContainer || matchedIndex < 0 || !search.pattern) {
       applySearchHighlight(highlightName, null, [])
@@ -131,10 +138,14 @@
   $effect(() => {
     const pattern = search.pattern
     const occ = search.occurrenceIndex
-    if (!pattern) return
+    if (!pattern) {
+      return
+    }
     untrack(() => {
       const idx = findOccurrence(lines, pattern, occ)
-      if (idx < 0) return
+      if (idx < 0) {
+        return
+      }
       // Drop stick-to-bottom so a streaming log doesn't scroll away from the match the user
       // jumped to. They regain auto-scroll by scrolling back to the bottom themselves.
       reverseScroll.stickToBottom = false
@@ -169,20 +180,6 @@
     use:virtualSelect={{
       getRoot: (node) => node.firstElementChild!,
       getCopyContent: getCopyContent ?? defaultGetCopyContent
-    }}
-    onkeydown={(e) => {
-      // Ctrl-F (Win/Linux) or Cmd-F (Mac) — redirect to host's search input. Only intercept
-      // when the host supplied a handler; otherwise the browser's find-in-page is left alone.
-      if (
-        onSearchShortcut &&
-        (e.key === 'f' || e.key === 'F') &&
-        (e.ctrlKey || e.metaKey) &&
-        !e.altKey &&
-        !e.shiftKey
-      ) {
-        e.preventDefault()
-        onSearchShortcut()
-      }
     }}
   >
     <Virtualizer

--- a/js-packages/common-ui/src/lib/SearchBar.svelte
+++ b/js-packages/common-ui/src/lib/SearchBar.svelte
@@ -1,0 +1,205 @@
+<!--
+  SearchBar: shared "search within the active view" widget for the pipeline Logs tab and the
+  profiler bundle viewer. Renders inline as a search-icon button that opens a popup with the query
+  input, a match counter, and prev/next nav buttons.
+
+  Presentational only: the host owns the query and runs the search. `results` is the single source
+  of truth — the counter, the host's highlight, and the nav buttons all derive from it, and Escape
+  / editing / closing call `onclear` so they clear together.
+
+  Hosts open the search by wiring Ctrl/Cmd-F to the exported `activate()`; the widget handles no
+  shortcut itself. The popup closes only via `toggle()`, Escape, the close button, or blur when
+  empty — never on outside click.
+-->
+<script lang="ts">
+  import { tick } from 'svelte'
+  import searchIcon from './icons/search.svg?raw'
+  import type { SearchDirection, SearchProgress } from './logSearch'
+
+  interface Props {
+    /** The query text. Bindable so the host reads what was typed. */
+    value: string
+    placeholder?: string
+    title?: string
+    /** The single source of truth for the committed search — see {@link SearchProgress}.
+     *  `null` (no active search) hides the counter and disables the nav buttons; the host must
+     *  reset it to `null` on `onclear` so the counter, highlight, and buttons clear together. */
+    results?: SearchProgress | null
+    /** The underlying input element, exposed so hosts can focus it (e.g. on Ctrl/Cmd-F from
+     *  the results view). */
+    inputEl?: HTMLInputElement
+    /** Whether the popup is open. Bindable so hosts can open it programmatically (Ctrl/Cmd-F). */
+    open?: boolean
+    /** Extra classes for the outer (relative) container. */
+    class?: string
+    /** Extra classes for the input (width, ...). */
+    inputClass?: string
+    /** Advance to the next match — Enter or the down button. */
+    onnext: () => void
+    /** Step back to the previous match — Shift-Enter or the up button. */
+    onprevious: () => void
+    /** Drop the committed search (highlight + counter + nav). Called on Escape, on edit, and on
+     *  close; the host must reset its results to `null`. */
+    onclear?: () => void
+  }
+
+  let {
+    value = $bindable(''),
+    placeholder,
+    title,
+    results = null,
+    inputEl = $bindable(),
+    open = $bindable(false),
+    class: className = '',
+    inputClass = '',
+    onnext,
+    onprevious,
+    onclear
+  }: Props = $props()
+
+  const hasResults = $derived(!!results && results.total > 0)
+  const counterText = $derived(
+    !results ? '' : results.total > 0 ? `${results.current} of ${results.total}` : 'No results'
+  )
+
+  // The element that had the focus when the popup opened; closing returns focus there (with `preventScroll`
+  // so the viewport doesn't jump), so keyboard nav resumes where the user left off.
+  //
+  // The search-icon button uses `onmousedown preventDefault` so clicking it doesn't steal focus:
+  // Chrome focuses a <button> on click (Firefox doesn't), which would otherwise make the button
+  // the `opener` instead of the content the user was in.
+  let opener: HTMLElement | null = null
+
+  // Open the popup and focus/select the query, or just refocus it if already open. Hosts wire
+  // Ctrl/Cmd-F here, so the shortcut opens-or-refocuses and never closes the search.
+  export async function activate() {
+    if (!open) {
+      opener = document.activeElement as HTMLElement | null
+      open = true
+      await tick()
+    }
+    inputEl?.focus()
+    inputEl?.select()
+  }
+
+  // Trigger-button click: close if open, else open.
+  export async function toggle() {
+    if (open) {
+      close()
+    } else {
+      await activate()
+    }
+  }
+
+  // Clear the field and drop any displayed results (highlight + counter).
+  function reset() {
+    value = ''
+    onclear?.()
+  }
+
+  function close() {
+    open = false
+    reset()
+    opener?.focus({ preventScroll: true })
+    opener = null
+  }
+
+  // Commit the current query and step to the next / previous match.
+  function submit(direction: SearchDirection) {
+    if (direction === 'prev') {
+      onprevious()
+    } else {
+      onnext()
+    }
+  }
+
+  function onkeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submit(e.shiftKey ? 'prev' : 'next')
+    } else if (e.key === 'Escape') {
+      close()
+    }
+  }
+
+  // Editing the query invalidates the displayed results — drop them (the host resets `results`
+  // to null, which clears the counter, the highlight, and the nav buttons together).
+  function oninput() {
+    if (results) {
+      onclear?.()
+    }
+  }
+
+  // An empty field losing focus closes the popup; a field with text stays open so focus can move to
+  // the nav / close buttons. No focus-restore here — blur means focus is already moving on.
+  function onblur() {
+    if (!value) {
+      open = false
+      reset()
+      opener = null
+    }
+  }
+</script>
+
+<div class="relative flex items-center {className}">
+  <button
+    type="button"
+    class="btn-icon p-0.5 text-[16px] hover:preset-tonal-surface"
+    class:preset-tonal-surface={open}
+    onclick={toggle}
+    onmousedown={(e) => e.preventDefault()}
+    aria-label="Search"
+    aria-expanded={open}
+    {title}
+  >
+    {@html searchIcon}
+  </button>
+
+  {#if open}
+    <!-- Anchored just below the button's top-right, growing leftward from its right edge. -->
+    <div
+      class="absolute top-9 right-1 z-20 flex items-center gap-1 rounded border border-surface-200-800 bg-surface-50-950 p-1 shadow-md"
+    >
+      <input
+        bind:this={inputEl}
+        bind:value
+        type="text"
+        {placeholder}
+        {title}
+        {onkeydown}
+        {oninput}
+        {onblur}
+        class="input {inputClass}"
+      />
+      <!-- Fixed-width slot (shrink-0 so flex keeps it reserved even when the text is empty),
+           so the nav buttons don't shift as the counter text appears/changes. -->
+      <span class="w-14 px-1 shrink-0 text-sm whitespace-nowrap text-surface-600-400 text-right">{counterText}</span>
+      <button
+        type="button"
+        class="fd fd-arrow-down btn-icon rotate-180 p-0 hover:not-disabled:preset-tonal-surface disabled:opacity-30"
+        onclick={() => submit('prev')}
+        disabled={!hasResults}
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+      >
+      </button>
+      <button
+        type="button"
+        class="fd fd-arrow-down btn-icon p-0 hover:not-disabled:preset-tonal-surface disabled:opacity-30"
+        onclick={() => submit('next')}
+        disabled={!hasResults}
+        aria-label="Next match"
+        title="Next match (Enter)"
+      >
+      </button>
+      <button
+        type="button"
+        class="fd fd-x btn-icon p-0 ml-2 hover:preset-tonal-surface"
+        onclick={close}
+        aria-label="Close search"
+        title="Close search (Esc to clear)"
+      >
+      </button>
+    </div>
+  {/if}
+</div>

--- a/js-packages/common-ui/src/lib/SearchBar.svelte
+++ b/js-packages/common-ui/src/lib/SearchBar.svelte
@@ -21,7 +21,7 @@
     value: string
     placeholder?: string
     title?: string
-    /** The single source of truth for the committed search — see {@link SearchProgress}.
+    /** The single source of truth for the submitted search — see {@link SearchProgress}.
      *  `null` (no active search) hides the counter and disables the nav buttons; the host must
      *  reset it to `null` on `onclear` so the counter, highlight, and buttons clear together. */
     results?: SearchProgress | null
@@ -38,7 +38,7 @@
     onnext: () => void
     /** Step back to the previous match — Shift-Enter or the up button. */
     onprevious: () => void
-    /** Drop the committed search (highlight + counter + nav). Called on Escape, on edit, and on
+    /** Drop the submitted search (highlight + counter + nav). Called on Escape, on edit, and on
      *  close; the host must reset its results to `null`. */
     onclear?: () => void
   }
@@ -104,7 +104,7 @@
     opener = null
   }
 
-  // Commit the current query and step to the next / previous match.
+  // Submit the current query and step to the next / previous match.
   function submit(direction: SearchDirection) {
     if (direction === 'prev') {
       onprevious()

--- a/js-packages/common-ui/src/lib/icons/search.svg
+++ b/js-packages/common-ui/src/lib/icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21 21-4.3-4.3M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z"/></svg>

--- a/js-packages/common-ui/src/lib/index.ts
+++ b/js-packages/common-ui/src/lib/index.ts
@@ -32,6 +32,7 @@ export {
   findOccurrence,
   isFindShortcut,
   searchPatternsEqual,
+  positiveMod,
   type LineMatcher,
   type MatchRange,
   type SearchDirection,

--- a/js-packages/common-ui/src/lib/index.ts
+++ b/js-packages/common-ui/src/lib/index.ts
@@ -26,13 +26,19 @@ export {
   advanceSearch,
   applySearchHighlight,
   compileSearchPattern,
+  countOccurrences,
   emptySearchState,
   findMatchOffsets,
   findOccurrence,
+  isFindShortcut,
   searchPatternsEqual,
   type LineMatcher,
   type MatchRange,
+  type SearchDirection,
   type SearchPattern,
+  type SearchProgress,
   type SearchState
 } from './logSearch'
+export { default as SearchBar } from './SearchBar.svelte'
+export { useShortcut } from './useShortcut.svelte'
 export { sliceLinesForCopy, type CopySlice } from './logCopy'

--- a/js-packages/common-ui/src/lib/logSearch.ts
+++ b/js-packages/common-ui/src/lib/logSearch.ts
@@ -26,13 +26,33 @@ export type SearchState = {
 /** The starting state — no pattern, cursor at zero. */
 export const emptySearchState: SearchState = { pattern: null, occurrenceIndex: 0 }
 
+/** Direction a "submit search" interaction moves the cursor: `next` (Enter) steps forward,
+ *  `prev` (Shift-Enter) steps backward. */
+export type SearchDirection = 'next' | 'prev'
+
+/** True for the browser "find in page" shortcut (Ctrl-F / Cmd-F, no other modifiers). */
+export function isFindShortcut(e: KeyboardEvent): boolean {
+  return (e.key === 'f' || e.key === 'F') && (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey
+}
+
+/**
+ * The state for a committed in-view search.
+ */
+export type SearchProgress = { current: number; total: number }
+
 /** True when two patterns describe the same search — used by hosts to decide whether
  *  pressing Enter should advance to the next match (same pattern) or jump to the first
  *  match of a new pattern (different pattern). */
 export function searchPatternsEqual(a: SearchPattern | null, b: SearchPattern | null): boolean {
-  if (a === b) return true
-  if (!a || !b) return false
-  if (a.kind !== b.kind) return false
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  if (a.kind !== b.kind) {
+    return false
+  }
   if (a.kind === 'substring' && b.kind === 'substring') {
     return a.query === b.query && !!a.caseSensitive === !!b.caseSensitive
   }
@@ -43,19 +63,24 @@ export function searchPatternsEqual(a: SearchPattern | null, b: SearchPattern | 
 }
 
 /**
- * Compute the next {@link SearchState} for a "submit search" interaction (typically Enter
- * on the panel's search input).
+ * Compute the next {@link SearchState} for advancing a search.
  *   - `next = null` (or an empty pattern): clear the search.
- *   - `next` equals the current pattern: advance to the next match (`occurrenceIndex + 1`).
- *   - `next` differs from the current pattern: jump to the first match of the new pattern.
- *
- * Centralising this here keeps every host's submit handler identical and ensures the
- * cursor semantics stay consistent across log views.
+ *   - `next` equals the current pattern: step the cursor one match in `direction`
+ *     (`occurrenceIndex ± 1`). {@link findOccurrence} wraps the index, so no bounds check.
+ *   - `next` differs from the current pattern: jump to the first match of the new pattern,
+ *     regardless of direction.
  */
-export function advanceSearch(state: SearchState, next: SearchPattern | null): SearchState {
-  if (!next) return emptySearchState
+export function advanceSearch(
+  state: SearchState,
+  next: SearchPattern | null,
+  direction: SearchDirection = 'next'
+): SearchState {
+  if (!next) {
+    return emptySearchState
+  }
   if (searchPatternsEqual(state.pattern, next)) {
-    return { pattern: state.pattern, occurrenceIndex: state.occurrenceIndex + 1 }
+    const step = direction === 'prev' ? -1 : 1
+    return { pattern: state.pattern, occurrenceIndex: state.occurrenceIndex + step }
   }
   return { pattern: next, occurrenceIndex: 0 }
 }
@@ -69,7 +94,9 @@ export type MatchRange = readonly [start: number, end: number]
 
 export function compileSearchPattern(pattern: SearchPattern): LineMatcher {
   if (pattern.kind === 'substring') {
-    if (!pattern.query) return null
+    if (!pattern.query) {
+      return null
+    }
     if (pattern.caseSensitive) {
       const q = pattern.query
       return (line) => line.includes(q)
@@ -78,7 +105,9 @@ export function compileSearchPattern(pattern: SearchPattern): LineMatcher {
     return (line) => line.toLowerCase().includes(q)
   }
   if (pattern.kind === 'regex') {
-    if (!pattern.source) return null
+    if (!pattern.source) {
+      return null
+    }
     try {
       const re = new RegExp(pattern.source, pattern.flags)
       return (line) => re.test(line)
@@ -101,7 +130,9 @@ export function compileSearchPattern(pattern: SearchPattern): LineMatcher {
 export function findMatchOffsets(line: string, pattern: SearchPattern): MatchRange[] {
   const offsets: MatchRange[] = []
   if (pattern.kind === 'substring') {
-    if (!pattern.query) return offsets
+    if (!pattern.query) {
+      return offsets
+    }
     const haystack = pattern.caseSensitive ? line : line.toLowerCase()
     const needle = pattern.caseSensitive ? pattern.query : pattern.query.toLowerCase()
     let idx = haystack.indexOf(needle)
@@ -112,7 +143,9 @@ export function findMatchOffsets(line: string, pattern: SearchPattern): MatchRan
     return offsets
   }
   if (pattern.kind === 'regex') {
-    if (!pattern.source) return offsets
+    if (!pattern.source) {
+      return offsets
+    }
     let re: RegExp
     try {
       const flags = pattern.flags ?? ''
@@ -191,7 +224,9 @@ export function applySearchHighlight(
   for (const [s, e] of offsets) {
     const startPos = locate(s)
     const endPos = locate(e)
-    if (!startPos || !endPos) continue
+    if (!startPos || !endPos) {
+      continue
+    }
     const r = new Range()
     r.setStart(startPos.node, startPos.offset)
     r.setEnd(endPos.node, endPos.offset)
@@ -220,13 +255,43 @@ export function findOccurrence(
   occurrenceIndex: number
 ): number {
   const matcher = compileSearchPattern(pattern)
-  if (!matcher) return -1
+  if (!matcher) {
+    return -1
+  }
   const matches: number[] = []
   for (let i = 0; i < lines.length; i++) {
-    if (matcher(lines[i])) matches.push(i)
+    if (matcher(lines[i])) {
+      matches.push(i)
+    }
   }
-  if (matches.length === 0) return -1
+  if (matches.length === 0) {
+    return -1
+  }
   const n = matches.length
   const wrapped = ((occurrenceIndex % n) + n) % n
   return matches[wrapped]
+}
+
+/**
+ * Count the matching lines for `pattern` — the number of "next match" steps before the cursor
+ * wraps. Hosts use this to enable/disable the search nav buttons (0 - nothing to navigate).
+ *
+ * One match per line: multiple substrings on the same line count once, matching
+ * {@link findOccurrence}. Returns `0` for an empty or invalid pattern.
+ */
+export function countOccurrences(lines: readonly string[], pattern: SearchPattern | null): number {
+  if (!pattern) {
+    return 0
+  }
+  const matcher = compileSearchPattern(pattern)
+  if (!matcher) {
+    return 0
+  }
+  let count = 0
+  for (const line of lines) {
+    if (matcher(line)) {
+      count++
+    }
+  }
+  return count
 }

--- a/js-packages/common-ui/src/lib/logSearch.ts
+++ b/js-packages/common-ui/src/lib/logSearch.ts
@@ -30,13 +30,27 @@ export const emptySearchState: SearchState = { pattern: null, occurrenceIndex: 0
  *  `prev` (Shift-Enter) steps backward. */
 export type SearchDirection = 'next' | 'prev'
 
+/**
+ * Euclidean modulo: `index` folded into `[0, length)`, from either end.
+ *
+ * JavaScript's `%` is a remainder, not a modulo — it keeps the sign of the dividend, so `-1 % 3`
+ * is `-1` rather than `2`. Callers can therefore step an index past either bound without a
+ * bounds check.
+ *
+ * `length` must be positive; `0` yields `NaN`.
+ */
+export function positiveMod(index: number, length: number): number {
+  return ((index % length) + length) % length
+}
+
 /** True for the browser "find in page" shortcut (Ctrl-F / Cmd-F, no other modifiers). */
 export function isFindShortcut(e: KeyboardEvent): boolean {
   return (e.key === 'f' || e.key === 'F') && (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey
 }
 
 /**
- * The state for a committed in-view search.
+ * The state for a submitted in-view search: which match the cursor is on (counting from 1) and how many
+ * matches the query has.
  */
 export type SearchProgress = { current: number; total: number }
 
@@ -267,9 +281,7 @@ export function findOccurrence(
   if (matches.length === 0) {
     return -1
   }
-  const n = matches.length
-  const wrapped = ((occurrenceIndex % n) + n) % n
-  return matches[wrapped]
+  return matches[positiveMod(occurrenceIndex, matches.length)]
 }
 
 /**

--- a/js-packages/common-ui/src/lib/useShortcut.svelte.ts
+++ b/js-packages/common-ui/src/lib/useShortcut.svelte.ts
@@ -1,0 +1,34 @@
+/**
+ * Register a keyboard shortcut on the window while a scope is active.
+ *
+ * App-level shortcuts (Ctrl/Cmd-F to open search, and the like) are a scope concern, not a focus
+ * concern: they must fire regardless of which element holds focus. A capture-phase window listener
+ * delivers that reliably, where routing the key through a focused container is browser-fragile.
+ *
+ * Call during component initialization (it sets up an `$effect`). Pass `isActive` as a getter so
+ * the listener attaches only while the scope is shown (e.g. the current tab) and detaches
+ * otherwise; the effect re-runs whenever the values it reads change.
+ *
+ * @param matches   predicate identifying the shortcut (e.g. `isFindShortcut`)
+ * @param handler   runs when the shortcut fires; the default is already prevented
+ * @param isActive  whether the shortcut is currently in scope (default: always)
+ */
+export function useShortcut(
+  matches: (e: KeyboardEvent) => boolean,
+  handler: (e: KeyboardEvent) => void,
+  isActive: () => boolean = () => true
+): void {
+  $effect(() => {
+    if (!isActive()) {
+      return
+    }
+    const onKeydown = (e: KeyboardEvent) => {
+      if (matches(e)) {
+        e.preventDefault()
+        handler(e)
+      }
+    }
+    window.addEventListener('keydown', onKeydown, { capture: true })
+    return () => window.removeEventListener('keydown', onKeydown, { capture: true })
+  })
+}

--- a/js-packages/profiler-layout/src/lib/components/BundleLogsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/BundleLogsView.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { advanceSearch, emptySearchState, LogList, type SearchState } from 'common-ui'
+  import {
+    advanceSearch,
+    countOccurrences,
+    emptySearchState,
+    LogList,
+    type SearchState
+  } from 'common-ui'
   import type { LookupCoordinator } from '../functions/lookup'
 
   interface Props {
@@ -10,29 +16,30 @@
      *  pattern → first match, empty query → clear. */
     lookup?: LookupCoordinator
     lookupTabId?: string
-    /** Forwarded to {@link LogList}; invoked on Ctrl-F / Cmd-F inside the list so the host
-     *  can focus its search input. */
-    onSearchShortcut?: () => void
   }
 
-  let { logText, lookup, lookupTabId = 'Logs', onSearchShortcut }: Props = $props()
+  let { logText, lookup, lookupTabId = 'Logs' }: Props = $props()
 
   // SearchState lives here so any host that uses BundleLogsView
   // gets the search-on-tab behaviour through LookupCoordinator.
   // LogList is purely the renderer; it accepts the state as a prop.
   let search: SearchState = $state(emptySearchState)
 
+  // LogList expects pre-split lines — the bundle view's source is a single string blob.
+  const lines = $derived(logText ? logText.split('\n') : [])
+
   $effect(() => {
     if (!lookup) {
       return
     }
-    return lookup.register(lookupTabId, (query) => {
-      search = advanceSearch(search, query ? { kind: 'substring', query } : null)
+    return lookup.register(lookupTabId, (query, direction) => {
+      const pattern = query ? ({ kind: 'substring', query } as const) : null
+      search = advanceSearch(search, pattern, direction)
+      const total = countOccurrences(lines, pattern)
+      const current = total > 0 ? (((search.occurrenceIndex % total) + total) % total) + 1 : 0
+      return { current, total }
     })
   })
-
-  // LogList expects pre-split lines — the bundle view's source is a single string blob.
-  const lines = $derived(logText ? logText.split('\n') : [])
 </script>
 
 {#if !logText}
@@ -40,5 +47,5 @@
     No logs available in this bundle
   </div>
 {:else}
-  <LogList {lines} {search} {onSearchShortcut} showLineNumbers class="bg-white-dark rounded" />
+  <LogList {lines} {search} showLineNumbers class="bg-white-dark rounded" />
 {/if}

--- a/js-packages/profiler-layout/src/lib/components/BundleLogsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/BundleLogsView.svelte
@@ -4,7 +4,8 @@
     countOccurrences,
     emptySearchState,
     LogList,
-    type SearchState
+    type SearchState,
+    positiveMod
   } from 'common-ui'
   import type { LookupCoordinator } from '../functions/lookup'
 
@@ -36,7 +37,7 @@
       const pattern = query ? ({ kind: 'substring', query } as const) : null
       search = advanceSearch(search, pattern, direction)
       const total = countOccurrences(lines, pattern)
-      const current = total > 0 ? (((search.occurrenceIndex % total) + total) % total) + 1 : 0
+      const current = total > 0 ? positiveMod(search.occurrenceIndex, total) + 1 : 0
       return { current, total }
     })
   })

--- a/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
@@ -34,7 +34,7 @@
   import { buildGlobalMetrics, type GlobalMetrics } from '../functions/globalMetrics'
   import type { LookupCoordinator, SearchProgress } from '../functions/lookup'
   import { buildSearchTargets, matchTargets } from '../functions/metricsSearch'
-  import type { SearchDirection } from 'common-ui'
+  import { positiveMod, type SearchDirection } from 'common-ui'
 
   interface Props {
     mode: MetricsMode
@@ -146,7 +146,7 @@
       searchQuery = query
     }
     const n = ids.length
-    matchCursor = ((matchCursor % n) + n) % n
+    matchCursor = positiveMod(matchCursor, n)
     const el = containerEl.querySelector<HTMLElement>(`[data-block-id="${ids[matchCursor]}"]`)
     el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
     return { current: matchCursor + 1, total: n }

--- a/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/MetricsView.svelte
@@ -32,7 +32,9 @@
   import MetricsDistributionBlock from './metrics/blocks/MetricsDistributionBlock.svelte'
   import { buildBlocks, type RenderableBlock } from './metrics/dispatch'
   import { buildGlobalMetrics, type GlobalMetrics } from '../functions/globalMetrics'
-  import type { LookupCoordinator } from '../functions/lookup'
+  import type { LookupCoordinator, SearchProgress } from '../functions/lookup'
+  import { buildSearchTargets, matchTargets } from '../functions/metricsSearch'
+  import type { SearchDirection } from 'common-ui'
 
   interface Props {
     mode: MetricsMode
@@ -51,8 +53,15 @@
     onSearchNode?: (query: string) => void
   }
 
-  const { mode, tooltipData, rootNodeId, globalMetrics, showAdvanced, lookup, onSearchNode }: Props =
-    $props()
+  const {
+    mode,
+    tooltipData,
+    rootNodeId,
+    globalMetrics,
+    showAdvanced,
+    lookup,
+    onSearchNode
+  }: Props = $props()
 
   // Pipeline-wide totals for the overview's "Global stats" tile. Empty (so the tile is hidden) on
   // any non-overview view or when the bundle carried no stats.
@@ -80,6 +89,21 @@
   )
   const showAttributesView = $derived(mode === 'overview' || mode === 'node')
 
+  const genericTable = $derived(
+    tooltipData && 'genericTable' in tooltipData ? tooltipData.genericTable : null
+  )
+
+  // Scroll targets the search can jump to in the current view, in DOM order; each carries a
+  // `data-block-id` anchor (see {@link buildSearchTargets}).
+  const searchTargets = $derived(
+    buildSearchTargets({
+      showAttributesView,
+      globalEntries: globalMetricEntries,
+      blocks,
+      topNodeRows: genericTable?.rows ?? []
+    })
+  )
+
   let containerEl: HTMLDivElement | undefined = $state()
 
   // Container-width-driven column count. A ResizeObserver tracks the scroll container's
@@ -98,47 +122,40 @@
     return () => observer.disconnect()
   })
 
-  // Search priorities: block title, then metric label, then metric id. Always returns the
-  // *block* to scroll to — metrics in distribution blocks share grid cells with their
-  // siblings and don't have a single DOM anchor, so block-level is the reliable target.
-  function findMatchingBlockId(query: string): string | null {
-    const q = query.trim().toLowerCase()
-    if (!q || blocks.length === 0) return null
-    for (const b of blocks) {
-      if (b.title?.toLowerCase().includes(q)) return b.id
-    }
-    for (const b of blocks) {
-      for (const e of b.entries) {
-        if (e.label.toLowerCase().includes(q)) return b.id
-      }
-    }
-    for (const b of blocks) {
-      for (const e of b.entries) {
-        if (e.row.metric.toLowerCase().includes(q)) return b.id
-      }
-    }
-    return null
-  }
+  // Search cursor. A new query starts at the first match; repeating the same query steps the
+  // cursor (Enter / down → next, Shift-Enter / up → previous), wrapping modulo the match count.
+  // Imperative — no $state on purpose
+  let searchQuery = ''
+  let matchCursor = 0
 
-  // Imperative handler. Each Enter on the panel's search input calls this directly via the
-  // lookup coordinator, so identical queries still re-fire (unlike a reactive `$effect` on a
-  // query prop, where Svelte would dedupe equal values).
-  function runSearch(query: string) {
-    if (!containerEl) return
-    const matchId = findMatchingBlockId(query)
-    if (!matchId) return
-    const el = containerEl.querySelector<HTMLElement>(`[data-block-id="${matchId}"]`)
+  // Called imperatively on every submit, so pressing Enter again on the same query advances to the
+  // next match rather than being ignored. Matches are the full target list in DOM order,
+  // so a new query starts at the first match from the top.
+  // Returns the match count so the layout can enable/disable the nav buttons.
+  function runSearch(query: string, direction: SearchDirection): SearchProgress {
+    if (!containerEl) return { current: 0, total: 0 }
+    const ids = matchTargets(searchTargets, query)
+    if (ids.length === 0) {
+      searchQuery = query
+      return { current: 0, total: 0 }
+    }
+    if (query === searchQuery) {
+      matchCursor += direction === 'prev' ? -1 : 1
+    } else {
+      matchCursor = 0
+      searchQuery = query
+    }
+    const n = ids.length
+    matchCursor = ((matchCursor % n) + n) % n
+    const el = containerEl.querySelector<HTMLElement>(`[data-block-id="${ids[matchCursor]}"]`)
     el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+    return { current: matchCursor + 1, total: n }
   }
 
   $effect(() => {
     if (!lookup) return
     return lookup.register('Metrics', runSearch)
   })
-
-  const genericTable = $derived(
-    tooltipData && 'genericTable' in tooltipData ? tooltipData.genericTable : null
-  )
 </script>
 
 {#snippet attributesView()}
@@ -205,8 +222,8 @@
           </tr>
         </thead>
         <tbody>
-          {#each genericTable.rows as row}
-            <tr class="border-t border-surface-200-800">
+          {#each genericTable.rows as row, i}
+            <tr class="border-t border-surface-200-800" data-block-id="top-node-{i}">
               <td class="px-2 py-1">
                 <button
                   type="button"

--- a/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
@@ -25,7 +25,7 @@
   const { profileData, dataflowData, programCode, callbacks, class: className }: Props = $props()
 
   // DOM element references
-  let element: HTMLDivElement | undefined = $state()
+  let rootElement: HTMLDivElement | undefined = $state()
   let graphContainer: HTMLDivElement | undefined = $state()
   let navigatorContainer: HTMLDivElement | undefined = $state()
 
@@ -34,7 +34,7 @@
   let pointerOnGraph = $state(false)
   $effect(() => {
     const onPointerDown = (e: PointerEvent) => {
-      pointerOnGraph = !!element && element.contains(e.target as Node | null)
+      pointerOnGraph = !!rootElement && rootElement.contains(e.target as Node | null)
     }
     window.addEventListener('pointerdown', onPointerDown, { capture: true })
     return () => window.removeEventListener('pointerdown', onPointerDown, { capture: true })
@@ -135,7 +135,7 @@
   })
 </script>
 
-<div bind:this={element} class="visualizer-wrapper {className || ''}" data-testid="visualizer-diagram">
+<div bind:this={rootElement} class="visualizer-wrapper {className || ''}" data-testid="visualizer-diagram">
   <!-- Main graph visualization (full size) -->
   <div bind:this={graphContainer} class="visualizer-graph"></div>
 

--- a/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
@@ -25,8 +25,25 @@
   const { profileData, dataflowData, programCode, callbacks, class: className }: Props = $props()
 
   // DOM element references
+  let element: HTMLDivElement | undefined = $state()
   let graphContainer: HTMLDivElement | undefined = $state()
   let navigatorContainer: HTMLDivElement | undefined = $state()
+
+  // Tracked from pointerdown rather than DOM focus because the visualizer consumes its own pointer
+  // events, so the graph never holds a focusable target.
+  let pointerOnGraph = $state(false)
+  $effect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      pointerOnGraph = !!element && element.contains(e.target as Node | null)
+    }
+    window.addEventListener('pointerdown', onPointerDown, { capture: true })
+    return () => window.removeEventListener('pointerdown', onPointerDown, { capture: true })
+  })
+
+  /** Whether the graph is the user's current focus. */
+  export function isFocused(): boolean {
+    return pointerOnGraph
+  }
 
   // Visualizer instance and profile data (combined as their lifecycle is connected)
   let instance = $state<{ visualizer: Visualizer; profile: CircuitProfile } | null>(null)
@@ -118,7 +135,7 @@
   })
 </script>
 
-<div class="visualizer-wrapper {className || ''}" data-testid="visualizer-diagram">
+<div bind:this={element} class="visualizer-wrapper {className || ''}" data-testid="visualizer-diagram">
   <!-- Main graph visualization (full size) -->
   <div bind:this={graphContainer} class="visualizer-graph"></div>
 

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -2,12 +2,16 @@
   import { Switch } from '@skeletonlabs/skeleton-svelte'
   import type { ZipItem } from 'but-unzip'
   import {
+    isFindShortcut,
     PersistentContent,
+    SearchBar,
+    type SearchDirection,
     SegmentedControl,
     Select,
     type TabSpec,
     TabsPanel,
-    usePersistentRect
+    usePersistentRect,
+    useShortcut
   } from 'common-ui'
   import { Pane, PaneGroup, PaneResizer } from 'paneforge'
   import type {
@@ -22,7 +26,7 @@
   import { type Snippet, untrack } from 'svelte'
   import type { TriageResults } from 'triage-types'
   import type { GlobalMetrics } from '../functions/globalMetrics'
-  import { createLookupCoordinator } from '../functions/lookup'
+  import { createLookupCoordinator, type SearchProgress } from '../functions/lookup'
   import { type AnalysisView, isNodeView, metricsModeOf } from '../functions/metricsMode'
   import { severityLabel, uniqueCategories, uniqueSeverities } from '../functions/triage'
   import type { MetricsMode } from './MetricsView.svelte'
@@ -110,13 +114,30 @@
   const issueSeverities = $derived(uniqueSeverities(triageResults.results))
   let nodeSearchQuery = $state('')
   let lookupQuery = $state('')
-  // Bound to the shared analysis-panel lookup <input>. Tabs (e.g. the log list) can request
-  // focus via the `onSearchShortcut` callback threaded through `analysisTabProps`.
-  let searchInputEl: HTMLInputElement | undefined = $state()
-  const onAnalysisSearchShortcut = () => {
-    searchInputEl?.focus()
-    searchInputEl?.select()
-  }
+  // The single source of truth for committed search results, shared by the counter, the match
+  // highlight, and the nav buttons:
+  //   - `null`         → no active search (nothing highlighted, nothing to navigate).
+  //   - `{ total: 0 }` → searched, but the query matched nothing ("No results").
+  //   - `total > 0`    → `current` (1-based) of `total` matches.
+  // Editing or clearing the query must set this back to `null` so all three reset together.
+  let lookupProgress = $state<SearchProgress | null>(null)
+  let searchBar: ReturnType<typeof SearchBar> | undefined = $state()
+  let nodeSearchInput: HTMLInputElement | undefined = $state()
+
+  // Ctrl/Cmd-F targets the "Search node" input while focused on the circuit diagram, otherwise the
+  // active tab's search. Inactive on Config (no in-tab search), so native find runs there.
+  useShortcut(
+    isFindShortcut,
+    () => {
+      if (profilerDiagram?.isFocused()) {
+        nodeSearchInput?.focus()
+        nodeSearchInput?.select()
+      } else {
+        searchBar?.activate()
+      }
+    },
+    () => currentTab !== 'Config'
+  )
   let highlightRanges: SourcePositionRange[] = $state([])
 
   // The graph panel's diagram is hoisted to a <PersistentContent> overlay so it survives the
@@ -248,15 +269,21 @@
     }
   }
 
-  function handleLookup() {
-    if (lookupQuery) {
-      lookup.execute(currentTab, lookupQuery)
-    }
+  function handleLookup(direction: SearchDirection = 'next') {
+    lookupProgress = lookupQuery ? lookup.execute(currentTab, lookupQuery, direction) : null
+  }
+
+  // Drop the active tab's committed results: run its search with an empty query to clear the
+  // highlight, then null the progress.
+  function resetLookup() {
+    lookup.execute(currentTab, '', 'next')
+    lookupProgress = null
   }
 
   $effect(() => {
     currentTab
     lookupQuery = ''
+    lookupProgress = null
   })
 
   // SQL panel tab state. Single-tab; bound state is required by TabsPanel.
@@ -283,8 +310,7 @@
     triageResults,
     issueSeverityFilter,
     issueCategoryFilter,
-    onSearchNode: (query) => profilerDiagram?.search(query),
-    onSearchShortcut: onAnalysisSearchShortcut
+    onSearchNode: (query) => profilerDiagram?.search(query)
   })
   const analysisTabs = $derived<TabSpec<AnalysisTabProps>[]>([
     {
@@ -321,10 +347,12 @@
 
 <!-- ── Graph panel (dataflow graph) ────────────────────────────────────────── -->
 {#snippet graphPanel()}
+  <!-- Clip only with a profile: without one the panel is short and clipping would hide the
+       "Load profile" dropdown that overflows it. -->
   <div
-    class="flex flex-col overflow-hidden rounded-container bg-surface-50-950 {hasProfile
-      ? 'h-full'
-      : ''}"
+    class="flex flex-col rounded-container bg-surface-50-950 {hasProfile
+      ? 'h-full overflow-hidden'
+      : 'overflow-visible'}"
   >
     <!-- Header -->
     <div class="flex flex-shrink-0 flex-wrap items-center gap-2 p-4">
@@ -333,11 +361,18 @@
       {#if hasProfile}
         <div class="ml-auto">
           <input
+            bind:this={nodeSearchInput}
             bind:value={nodeSearchQuery}
             type="text"
             placeholder="Search node"
             title="Search for a node by ID, by table or view name, or by a substring of a persistent ID"
-            onkeydown={(e) => e.key === 'Enter' && handleSearch()}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                handleSearch()
+              } else if (e.key === 'Escape') {
+                nodeSearchInput?.blur()
+              }
+            }}
             class="input h-6 w-36 text-sm"
           />
         </div>
@@ -414,18 +449,20 @@
         {/each}
       </Select>
     {/if}
-    <input
-      bind:this={searchInputEl}
+    <SearchBar
+      bind:this={searchBar}
       bind:value={lookupQuery}
-      type="text"
       placeholder={currentTab === 'Logs'
         ? 'Search logs'
         : currentTab === 'Issues'
           ? 'Search issues'
           : 'Search metrics'}
-      title="Search within active tab (Enter to jump, Ctrl/Cmd-F to focus)"
-      onkeydown={(e) => e.key === 'Enter' && handleLookup()}
-      class="input h-6 w-28 text-sm"
+      title="Search within active tab (Enter / Shift+Enter to step matches, Ctrl/Cmd-F to toggle)"
+      results={lookupProgress}
+      onnext={() => handleLookup('next')}
+      onprevious={() => handleLookup('prev')}
+      onclear={resetLookup}
+      inputClass="h-8 w-40 text-sm"
     />
   </div>
 {/snippet}

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -114,7 +114,7 @@
   const issueSeverities = $derived(uniqueSeverities(triageResults.results))
   let nodeSearchQuery = $state('')
   let lookupQuery = $state('')
-  // The single source of truth for committed search results, shared by the counter, the match
+  // The single source of truth for submitted search results, shared by the counter, the match
   // highlight, and the nav buttons:
   //   - `null`         → no active search (nothing highlighted, nothing to navigate).
   //   - `{ total: 0 }` → searched, but the query matched nothing ("No results").
@@ -273,7 +273,7 @@
     lookupProgress = lookupQuery ? lookup.execute(currentTab, lookupQuery, direction) : null
   }
 
-  // Drop the active tab's committed results: run its search with an empty query to clear the
+  // Drop the active tab's submitted results: run its search with an empty query to clear the
   // highlight, then null the progress.
   function resetLookup() {
     lookup.execute(currentTab, '', 'next')
@@ -457,7 +457,7 @@
         : currentTab === 'Issues'
           ? 'Search issues'
           : 'Search metrics'}
-      title="Search within active tab (Enter / Shift+Enter to step matches, Ctrl/Cmd-F to toggle)"
+      title="Search within active tab (Enter / Shift+Enter to step matches, Esc to clear, Ctrl/Cmd-F to toggle)"
       results={lookupProgress}
       onnext={() => handleLookup('next')}
       onprevious={() => handleLookup('prev')}

--- a/js-packages/profiler-layout/src/lib/components/TriageResultsView.svelte
+++ b/js-packages/profiler-layout/src/lib/components/TriageResultsView.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import type { SearchDirection } from 'common-ui'
   import { SvelteSet } from 'svelte/reactivity'
   import { slide } from 'svelte/transition'
   import type { Severity, TriageResults } from 'triage-types'
-  import type { LookupCoordinator } from '../functions/lookup'
+  import type { LookupCoordinator, SearchProgress } from '../functions/lookup'
   import { getCategory, severityLabel, severityOrder } from '../functions/triage'
 
   interface Props {
@@ -35,29 +36,41 @@
     )
   )
 
-  function runSearch(query: string) {
+  function matchesQuery(index: number, q: string): boolean {
+    const r = visibleResults[index]
+    return (
+      r.rule.toLowerCase().includes(q) ||
+      r.message.toLowerCase().includes(q) ||
+      JSON.stringify(r.details).toLowerCase().includes(q)
+    )
+  }
+
+  // Move the cursor to the next / previous matching row, wrapping at the ends, and scroll it
+  // into view. Returns the match count so the layout can enable/disable the nav buttons.
+  function runSearch(query: string, direction: SearchDirection): SearchProgress {
     if (!query) {
       lastMatchIndex = -1
-      return
+      return { current: 0, total: 0 }
     }
     const q = query.toLowerCase()
-    const startSearch = lastMatchIndex + 1
-    const total = visibleResults.length
-
-    for (let i = 0; i < total; i++) {
-      const idx = (startSearch + i) % total
-      const r = visibleResults[idx]
-      if (
-        r.rule.toLowerCase().includes(q) ||
-        r.message.toLowerCase().includes(q) ||
-        JSON.stringify(r.details).toLowerCase().includes(q)
-      ) {
-        lastMatchIndex = idx
-        rowElements[idx]?.scrollIntoView({ block: 'center' })
-        return
+    const matches: number[] = []
+    for (let i = 0; i < visibleResults.length; i++) {
+      if (matchesQuery(i, q)) {
+        matches.push(i)
       }
     }
-    lastMatchIndex = -1
+    if (matches.length === 0) {
+      lastMatchIndex = -1
+      return { current: 0, total: 0 }
+    }
+    // First match strictly after (next) / before (prev) the current cursor, wrapping around.
+    const idx =
+      direction === 'prev'
+        ? (matches.filter((m) => m < lastMatchIndex).at(-1) ?? matches.at(-1)!)
+        : (matches.find((m) => m > lastMatchIndex) ?? matches[0])
+    lastMatchIndex = idx
+    rowElements[idx]?.scrollIntoView({ block: 'center' })
+    return { current: matches.indexOf(idx) + 1, total: matches.length }
   }
 
   $effect(() => {

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { NodeAttributes, TooltipRow } from 'profiler-lib'
+import { describe, expect, it } from 'vitest'
 import { buildBlocks } from './dispatch.js'
 
 function row(metric: string): TooltipRow {
@@ -21,12 +21,7 @@ function makeAttrs(metrics: string[]): NodeAttributes {
 describe('buildBlocks', () => {
   it('orders metrics lexicographically inside each block (case-insensitive)', () => {
     // Metric IDs span categories; the order is intentionally scrambled to confirm the sort.
-    const attrs = makeAttrs([
-      'zeta_seconds',
-      'Alpha_count',
-      'gamma_size',
-      'alpha_total'
-    ])
+    const attrs = makeAttrs(['zeta_seconds', 'Alpha_count', 'gamma_size', 'alpha_total'])
     const blocks = buildBlocks(attrs, /* showAdvanced */ true)
     // All metrics fall into the same "Other" bucket (no descriptions registered),
     // so we expect a single block whose entries are alphabetised by label.

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
@@ -55,8 +55,7 @@ export function buildBlocks(attrs: NodeAttributes, showAdvanced: boolean): Rende
   const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true })
   for (const entries of byCategory.values()) {
     entries.sort(
-      (a, b) =>
-        collator.compare(a.label, b.label) || collator.compare(a.row.metric, b.row.metric)
+      (a, b) => collator.compare(a.label, b.label) || collator.compare(a.row.metric, b.row.metric)
     )
   }
 

--- a/js-packages/profiler-layout/src/lib/components/tabs/LogsTab.svelte
+++ b/js-packages/profiler-layout/src/lib/components/tabs/LogsTab.svelte
@@ -2,7 +2,7 @@
   import BundleLogsView from '../BundleLogsView.svelte'
   import type { AnalysisTabProps } from './MetricsTab.svelte'
 
-  let { logText, lookup, onSearchShortcut }: AnalysisTabProps = $props()
+  let { logText, lookup }: AnalysisTabProps = $props()
 </script>
 
-<BundleLogsView {logText} {lookup} {onSearchShortcut} />
+<BundleLogsView {logText} {lookup} />

--- a/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
+++ b/js-packages/profiler-layout/src/lib/components/tabs/MetricsTab.svelte
@@ -30,8 +30,6 @@
     issueCategoryFilter: string
     /** Links the metrics node title back to (searches for) the node in the diagram. */
     onSearchNode?: (query: string) => void
-    /** Called when the user presses the search shortcut inside the tab. */
-    onSearchShortcut?: () => void
   }
 </script>
 

--- a/js-packages/profiler-layout/src/lib/functions/lookup.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/lookup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLookupCoordinator, noMatches } from './lookup'
+
+describe('createLookupCoordinator', () => {
+  it('forwards query and direction to the active tab handler and returns its progress', () => {
+    const coordinator = createLookupCoordinator()
+    const logs = vi.fn().mockReturnValue({ current: 2, total: 3 })
+    coordinator.register('Logs', logs)
+
+    expect(coordinator.execute('Logs', 'error', 'next')).toEqual({ current: 2, total: 3 })
+    expect(logs).toHaveBeenCalledWith('error', 'next')
+  })
+
+  it('routes only to the active tab, leaving other tabs untouched', () => {
+    const coordinator = createLookupCoordinator()
+    const logs = vi.fn().mockReturnValue({ current: 1, total: 1 })
+    const metrics = vi.fn().mockReturnValue({ current: 1, total: 2 })
+    coordinator.register('Logs', logs)
+    coordinator.register('Metrics', metrics)
+
+    expect(coordinator.execute('Metrics', 'q', 'prev')).toEqual({ current: 1, total: 2 })
+    expect(metrics).toHaveBeenCalledWith('q', 'prev')
+    expect(logs).not.toHaveBeenCalled()
+  })
+
+  it('defaults the direction to "next"', () => {
+    const coordinator = createLookupCoordinator()
+    const handler = vi.fn().mockReturnValue(noMatches)
+    coordinator.register('Logs', handler)
+
+    coordinator.execute('Logs', 'q')
+    expect(handler).toHaveBeenCalledWith('q', 'next')
+  })
+
+  it('returns noMatches for an unknown tab without throwing', () => {
+    const coordinator = createLookupCoordinator()
+    expect(coordinator.execute('Nope', 'q', 'next')).toEqual(noMatches)
+  })
+
+  it('unregisters via the returned disposer', () => {
+    const coordinator = createLookupCoordinator()
+    const handler = vi.fn().mockReturnValue({ current: 1, total: 5 })
+    const dispose = coordinator.register('Logs', handler)
+
+    expect(coordinator.execute('Logs', 'q', 'next')).toEqual({ current: 1, total: 5 })
+    dispose()
+    expect(coordinator.execute('Logs', 'q', 'next')).toEqual(noMatches)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/lookup.ts
+++ b/js-packages/profiler-layout/src/lib/functions/lookup.ts
@@ -1,3 +1,7 @@
+import type { SearchDirection, SearchProgress } from 'common-ui'
+
+export type { SearchProgress }
+
 /**
  * Coordinates the single "search within the active tab" input shared by the
  * analysis panel (the tabbed Metrics / Logs / Issues panel of the profile
@@ -5,21 +9,36 @@
  *
  * Only one tab is visible at a time, but they don't know about each other. Each
  * tab calls `register(tabId, fn)` on mount to say "when the user searches while
- * I'm active, call this." The layout calls `execute(activeTabId, query)` when
- * the user submits the input; the coordinator forwards the query to just the
- * active tab's handler. This keeps the tabs decoupled — the input lives in the
- * layout, the search behavior lives in each tab.
+ * I'm active, call this." The layout calls `execute(activeTabId, query, direction)`
+ * when the user submits the input; the coordinator forwards to just the active
+ * tab's handler and returns the handler's match count, which the layout uses to
+ * enable/disable the search nav buttons. This keeps the tabs decoupled — the input
+ * lives in the layout, the search behavior lives in each tab.
  */
+
+/** No match — the empty result returned for an unknown tab. */
+export const noMatches: SearchProgress = { current: 0, total: 0 }
+
+/** A tab's search handler: move the cursor in `direction` for `query` and report the resulting
+ *  position. */
+export type LookupHandler = (query: string, direction: SearchDirection) => SearchProgress
+
 export function createLookupCoordinator() {
-  const handlers = new Map<string, (query: string) => void>()
+  const handlers = new Map<string, LookupHandler>()
 
   return {
-    register(tabId: string, fn: (query: string) => void): () => void {
+    register(tabId: string, fn: LookupHandler): () => void {
       handlers.set(tabId, fn)
       return () => handlers.delete(tabId)
     },
-    execute(activeTabId: string, query: string) {
-      handlers.get(activeTabId)?.(query)
+    /** Forward the query to the active tab's handler; returns its match position, or
+     *  {@link noMatches} when no tab is registered under `activeTabId`. */
+    execute(
+      activeTabId: string,
+      query: string,
+      direction: SearchDirection = 'next'
+    ): SearchProgress {
+      return handlers.get(activeTabId)?.(query, direction) ?? noMatches
     }
   }
 }

--- a/js-packages/profiler-layout/src/lib/functions/metricsSearch.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/metricsSearch.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSearchTargets,
+  type GlobalEntry,
+  type MetricBlock,
+  matchTargets,
+  type TopNodeRow
+} from './metricsSearch'
+
+const globalEntries: GlobalEntry[] = [
+  { key: 'total_input_records', label: 'Input records' },
+  { key: 'total_input_bytes', label: 'Input bytes' }
+]
+
+const blocks: MetricBlock[] = [
+  {
+    id: 'block-throughput',
+    title: 'Throughput',
+    entries: [{ label: 'Records/s', row: { metric: 'records_per_sec' } }]
+  }
+]
+
+const topNodeRows: TopNodeRow[] = [
+  { stub: { text: 'JoinNode' }, cells: [{ operation: 'join' }] },
+  { stub: { text: 'FilterNode' }, cells: [{ operation: 'filter' }] }
+]
+
+describe('buildSearchTargets', () => {
+  it('includes the Global stats tile before node blocks in the overview', () => {
+    const targets = buildSearchTargets({
+      showAttributesView: true,
+      globalEntries,
+      blocks,
+      topNodeRows: []
+    })
+    expect(targets.map((t) => t.id)).toEqual(['global-metrics', 'block-throughput'])
+    expect(targets[0]).toMatchObject({
+      title: 'Global stats',
+      labels: ['Input records', 'Input bytes']
+    })
+  })
+
+  it('omits the Global stats tile when there are no global entries (e.g. single-node view)', () => {
+    const targets = buildSearchTargets({
+      showAttributesView: true,
+      globalEntries: [],
+      blocks,
+      topNodeRows: []
+    })
+    expect(targets.map((t) => t.id)).toEqual(['block-throughput'])
+  })
+
+  it('builds one target per row for the top-nodes view, anchored by row index', () => {
+    const targets = buildSearchTargets({
+      showAttributesView: false,
+      globalEntries,
+      blocks,
+      topNodeRows
+    })
+    expect(targets).toEqual([
+      { id: 'top-node-0', title: 'JoinNode', labels: ['join'], keys: [] },
+      { id: 'top-node-1', title: 'FilterNode', labels: ['filter'], keys: [] }
+    ])
+  })
+})
+
+describe('matchTargets', () => {
+  const overview = buildSearchTargets({
+    showAttributesView: true,
+    globalEntries,
+    blocks,
+    topNodeRows: []
+  })
+  const topNodes = buildSearchTargets({
+    showAttributesView: false,
+    globalEntries,
+    blocks,
+    topNodeRows
+  })
+
+  it('matches the Global stats tile by its entry label', () => {
+    expect(matchTargets(overview, 'input records')).toEqual(['global-metrics'])
+  })
+
+  it('matches the Global stats tile by its title', () => {
+    expect(matchTargets(overview, 'global')).toEqual(['global-metrics'])
+  })
+
+  it('matches a top-nodes row by node name and by operation', () => {
+    expect(matchTargets(topNodes, 'filter')).toEqual(['top-node-1'])
+    expect(matchTargets(topNodes, 'join')).toEqual(['top-node-0'])
+  })
+
+  it('ranks title matches ahead of label/key matches, deduped', () => {
+    // "records" hits the Global stats entry label and the block's label + metric key. The block
+    // title does not contain it, so global-metrics (label tier) comes before block-throughput.
+    expect(matchTargets(overview, 'records')).toEqual(['global-metrics', 'block-throughput'])
+  })
+
+  it('returns no matches for an empty query or when nothing matches', () => {
+    expect(matchTargets(overview, '   ')).toEqual([])
+    expect(matchTargets(topNodes, 'nonexistent')).toEqual([])
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/metricsSearch.ts
+++ b/js-packages/profiler-layout/src/lib/functions/metricsSearch.ts
@@ -1,0 +1,90 @@
+// Search over the Metrics tab's three views (overview "Global stats" tile, per-node metric blocks,
+// and the "Top nodes" table). The view builds a flat list of scroll targets in DOM order; the
+// matcher ranks them so the panel's search input can cycle through matches.
+
+/** A scrollable match target. `id` is the element's `data-block-id`; the three text tiers are
+ *  ranked title first, then secondary labels, then keys. */
+export type SearchTarget = { id: string; title?: string; labels: string[]; keys: string[] }
+
+/** Minimal structural shapes taken from the component's derived data (kept loose on purpose so
+ *  this module does not depend on profiler-lib / tooltip types). */
+export type MetricBlock = {
+  id: string
+  title?: string
+  entries: { label: string; row: { metric: string } }[]
+}
+export type GlobalEntry = { key: string; label: string }
+export type TopNodeRow = { stub: { text: string }; cells: { operation: string }[] }
+
+/**
+ * Build the ordered list of search targets for the currently shown Metrics view.
+ *
+ * Attributes view (overview / single node): the "Global stats" tile first (overview only, when it
+ * has entries), then each node metric block. Top-nodes view: one target per table row.
+ */
+export function buildSearchTargets(view: {
+  showAttributesView: boolean
+  globalEntries: GlobalEntry[]
+  blocks: MetricBlock[]
+  topNodeRows: TopNodeRow[]
+}): SearchTarget[] {
+  if (view.showAttributesView) {
+    const targets: SearchTarget[] = []
+    if (view.globalEntries.length > 0) {
+      targets.push({
+        id: 'global-metrics',
+        title: 'Global stats',
+        labels: view.globalEntries.map((e) => e.label),
+        keys: view.globalEntries.map((e) => e.key)
+      })
+    }
+    for (const b of view.blocks) {
+      targets.push({
+        id: b.id,
+        title: b.title,
+        labels: b.entries.map((e) => e.label),
+        keys: b.entries.map((e) => e.row.metric)
+      })
+    }
+    return targets
+  }
+  return view.topNodeRows.map((row, i) => ({
+    id: `top-node-${i}`,
+    title: row.stub.text,
+    labels: row.cells.map((c) => c.operation),
+    keys: []
+  }))
+}
+
+/**
+ * Return every target's id whose text contains `query` (case-insensitive), most-relevant first and
+ * deduped: all title matches, then label matches, then key matches. Empty query → no matches.
+ */
+export function matchTargets(targets: SearchTarget[], query: string): string[] {
+  const q = query.trim().toLowerCase()
+  if (!q || targets.length === 0) {
+    return []
+  }
+  const ids: string[] = []
+  const add = (id: string) => {
+    if (!ids.includes(id)) {
+      ids.push(id)
+    }
+  }
+  for (const t of targets) {
+    if (t.title?.toLowerCase().includes(q)) {
+      add(t.id)
+    }
+  }
+  for (const t of targets) {
+    if (t.labels.some((l) => l.toLowerCase().includes(q))) {
+      add(t.id)
+    }
+  }
+  for (const t of targets) {
+    if (t.keys.some((k) => k.toLowerCase().includes(q))) {
+      add(t.id)
+    }
+  }
+  return ids
+}

--- a/js-packages/profiler-layout/src/lib/index.ts
+++ b/js-packages/profiler-layout/src/lib/index.ts
@@ -16,12 +16,12 @@ export {
   TriageResultsView
 }
 export type { ZipItem } from 'but-unzip'
-export { createLoadGuard } from './functions/loadGuard'
-export { createLookupCoordinator, type LookupCoordinator } from './functions/lookup'
-export type { ProcessedProfile } from './functions/processZipBundle'
-export { getSuitableProfiles, processProfileFiles } from './functions/processZipBundle'
 export {
   buildGlobalMetrics,
   type GlobalMetricEntry,
   type GlobalMetrics
 } from './functions/globalMetrics'
+export { createLoadGuard } from './functions/loadGuard'
+export { createLookupCoordinator, type LookupCoordinator } from './functions/lookup'
+export type { ProcessedProfile } from './functions/processZipBundle'
+export { getSuitableProfiles, processProfileFiles } from './functions/processZipBundle'

--- a/js-packages/web-console/src/assets/icons/feldera-material-icons/search.svg
+++ b/js-packages/web-console/src/assets/icons/feldera-material-icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="#C533B9" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21 21-4.3-4.3M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z"/></svg>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
@@ -12,16 +12,16 @@
   const {
     logs,
     search = emptySearchState,
-    onSearchShortcut,
-    onStickToBottomChange
+    onStickToBottomChange,
+    onMatchCountChange
   }: {
     logs: { rows: string[]; totalSkippedBytes: number; firstRowIndex: number }
     /** Current search state (see {@link SearchState}), advanced by the host. */
     search?: SearchState
-    /** Forwarded to {@link LogList}; invoked on Ctrl-F / Cmd-F inside the list. */
-    onSearchShortcut?: () => void
     /** Forwarded to {@link LogList}; fires when stick-to-bottom toggles. */
     onStickToBottomChange?: (stickToBottom: boolean) => void
+    /** Forwarded to {@link LogList}; reports the current search match count. */
+    onMatchCountChange?: (count: number) => void
   } = $props()
 
   const getCopyContent = (slice: CopySlice) =>
@@ -35,8 +35,8 @@
   {search}
   streaming
   {getCopyContent}
-  {onSearchShortcut}
   {onStickToBottomChange}
+  {onMatchCountChange}
   class="bg-white-dark rounded pl-2"
 >
   {#snippet header()}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -33,7 +33,16 @@
     extractProgramErrors,
     numConnectorsWithProblems
   } from '$lib/compositions/health/systemErrors'
-  import { TabsPanel, advanceSearch, emptySearchState, type SearchState } from 'common-ui'
+  import {
+    TabsPanel,
+    SearchBar,
+    advanceSearch,
+    emptySearchState,
+    isFindShortcut,
+    useShortcut,
+    type SearchDirection,
+    type SearchState
+  } from 'common-ui'
 
   let {
     pipeline,
@@ -147,34 +156,54 @@
 
   const runtimeErrorsCount = $derived(connectorsWithErrorsCount + memoryPressureErrorCount)
 
-  // Local input binding. The committed search (what the list actually runs) lives in
-  // `logSearch` and only advances on Enter — so typing doesn't search as-you-type.
+  // Log search lives here, with the toolbar that hosts the search bar. The committed search
+  // (what the list runs) advances only on submit, so typing doesn't search as-you-type. The
+  // log list reports its match count so the counter and nav buttons stay in sync.
   let logSearchInput = $state('')
   let logSearch: SearchState = $state(emptySearchState)
-  // Bound to the search <input> so Ctrl-F / Cmd-F inside the log list can focus it.
-  let logSearchInputEl: HTMLInputElement | undefined = $state()
-  const onLogSearchShortcut = () => {
-    logSearchInputEl?.focus()
-    logSearchInputEl?.select()
-  }
+  let logMatchCount = $state(0)
+  let searchBar: ReturnType<typeof SearchBar> | undefined = $state()
+  // Single source of truth for the search bar: derived from the committed `logSearch`. No
+  // committed pattern → null (counter hidden, nav disabled, nothing highlighted).
+  const searchResults = $derived.by(() => {
+    if (!logSearch.pattern) return null
+    const total = logMatchCount
+    const current = total > 0 ? (((logSearch.occurrenceIndex % total) + total) % total) + 1 : 0
+    return { current, total }
+  })
 
-  // Enter on the search input: empty input clears, same pattern cycles to the next match,
-  // new pattern jumps to the first match.
-  const submitLogSearch = () => {
+  // Submit: empty input clears, same pattern steps one match in `direction`, new pattern jumps
+  // to the first match.
+  const submitLogSearch = (direction: SearchDirection = 'next') => {
     logSearch = advanceSearch(
       logSearch,
-      logSearchInput ? { kind: 'substring', query: logSearchInput } : null
+      logSearchInput ? { kind: 'substring', query: logSearchInput } : null,
+      direction
     )
   }
-  // Escape clears the input and the highlight — submitting an empty query resets `logSearch`
-  // to `emptySearchState` (pattern null), which un-highlights the list.
-  const clearLogSearch = () => {
-    logSearchInput = ''
-    submitLogSearch()
+  // Drop the committed search (highlight + counter). The search bar owns and clears the input
+  // text itself; this only resets what the log list is searching for.
+  const resetLogSearch = () => {
+    logSearch = emptySearchState
   }
 
+  // Ctrl-F / Cmd-F opens (or refocuses) the log search whenever the Logs tab is shown, regardless
+  // of which element holds focus.
+  useShortcut(
+    isFindShortcut,
+    () => searchBar?.activate(),
+    () => currentTab === 'Logs'
+  )
+
   // Updating individual properties in an $effect avoids unnecessary reactive updates within tab components
-  let tabProps = $state({ metrics, pipeline, errors, deleted, logSearch, onLogSearchShortcut })
+  let tabProps = $state({
+    metrics,
+    pipeline,
+    errors,
+    deleted,
+    logSearch,
+    onLogMatchCountChange: (count: number) => (logMatchCount = count)
+  })
   $effect(() => {
     tabProps.metrics = metrics
   })
@@ -236,18 +265,17 @@
 {/snippet}
 
 {#snippet TabBarEndLogs()}
-  <div class="ml-auto flex gap-2">
-    <input
-      bind:this={logSearchInputEl}
+  <div class="ml-auto flex items-center gap-2">
+    <SearchBar
+      bind:this={searchBar}
       bind:value={logSearchInput}
-      type="text"
       placeholder="Search logs"
-      title="Search within logs (Enter to jump to next match, Esc to clear, Ctrl/Cmd-F to focus from the log list)"
-      onkeydown={(e) => {
-        if (e.key === 'Enter') submitLogSearch()
-        else if (e.key === 'Escape') clearLogSearch()
-      }}
-      class="input ml-auto h-8 w-28 text-sm sm:w-32"
+      title="Search logs (Enter / Shift+Enter to step matches, Esc to clear, Ctrl/Cmd-F to toggle)"
+      results={searchResults}
+      onnext={() => submitLogSearch('next')}
+      onprevious={() => submitLogSearch('prev')}
+      onclear={resetLogSearch}
+      inputClass="h-8 w-40 text-sm"
     />
     {@render PipelineInfoHeader()}
   </div>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -34,7 +34,16 @@
     extractProgramErrors,
     numConnectorsWithProblems
   } from '$lib/compositions/health/systemErrors'
-  import { TabsPanel, advanceSearch, emptySearchState, type SearchState } from 'common-ui'
+  import {
+    TabsPanel,
+    SearchBar,
+    advanceSearch,
+    emptySearchState,
+    isFindShortcut,
+    useShortcut,
+    type SearchDirection,
+    type SearchState
+  } from 'common-ui'
 
   let {
     pipeline,
@@ -156,34 +165,54 @@
 
   const runtimeErrorsCount = $derived(connectorsWithErrorsCount + memoryPressureErrorCount)
 
-  // Local input binding. The committed search (what the list actually runs) lives in
-  // `logSearch` and only advances on Enter — so typing doesn't search as-you-type.
+  // Log search lives here, with the toolbar that hosts the search bar. The committed search
+  // (what the list runs) advances only on submit, so typing doesn't search as-you-type. The
+  // log list reports its match count so the counter and nav buttons stay in sync.
   let logSearchInput = $state('')
   let logSearch: SearchState = $state(emptySearchState)
-  // Bound to the search <input> so Ctrl-F / Cmd-F inside the log list can focus it.
-  let logSearchInputEl: HTMLInputElement | undefined = $state()
-  const onLogSearchShortcut = () => {
-    logSearchInputEl?.focus()
-    logSearchInputEl?.select()
-  }
+  let logMatchCount = $state(0)
+  let searchBar: ReturnType<typeof SearchBar> | undefined = $state()
+  // Single source of truth for the search bar: derived from the committed `logSearch`. No
+  // committed pattern → null (counter hidden, nav disabled, nothing highlighted).
+  const searchResults = $derived.by(() => {
+    if (!logSearch.pattern) return null
+    const total = logMatchCount
+    const current = total > 0 ? (((logSearch.occurrenceIndex % total) + total) % total) + 1 : 0
+    return { current, total }
+  })
 
-  // Enter on the search input: empty input clears, same pattern cycles to the next match,
-  // new pattern jumps to the first match.
-  const submitLogSearch = () => {
+  // Submit: empty input clears, same pattern steps one match in `direction`, new pattern jumps
+  // to the first match.
+  const submitLogSearch = (direction: SearchDirection = 'next') => {
     logSearch = advanceSearch(
       logSearch,
-      logSearchInput ? { kind: 'substring', query: logSearchInput } : null
+      logSearchInput ? { kind: 'substring', query: logSearchInput } : null,
+      direction
     )
   }
-  // Escape clears the input and the highlight — submitting an empty query resets `logSearch`
-  // to `emptySearchState` (pattern null), which un-highlights the list.
-  const clearLogSearch = () => {
-    logSearchInput = ''
-    submitLogSearch()
+  // Drop the committed search (highlight + counter). The search bar owns and clears the input
+  // text itself; this only resets what the log list is searching for.
+  const resetLogSearch = () => {
+    logSearch = emptySearchState
   }
 
+  // Ctrl-F / Cmd-F opens (or refocuses) the log search whenever the Logs tab is shown, regardless
+  // of which element holds focus.
+  useShortcut(
+    isFindShortcut,
+    () => searchBar?.activate(),
+    () => currentTab === 'Logs'
+  )
+
   // Updating individual properties in an $effect avoids unnecessary reactive updates within tab components
-  let tabProps = $state({ metrics, pipeline, errors, deleted, logSearch, onLogSearchShortcut })
+  let tabProps = $state({
+    metrics,
+    pipeline,
+    errors,
+    deleted,
+    logSearch,
+    onLogMatchCountChange: (count: number) => (logMatchCount = count)
+  })
   $effect(() => {
     tabProps.metrics = metrics
   })
@@ -245,18 +274,17 @@
 {/snippet}
 
 {#snippet TabBarEndLogs()}
-  <div class="ml-auto flex gap-2">
-    <input
-      bind:this={logSearchInputEl}
+  <div class="ml-auto flex items-center gap-2">
+    <SearchBar
+      bind:this={searchBar}
       bind:value={logSearchInput}
-      type="text"
       placeholder="Search logs"
-      title="Search within logs (Enter to jump to next match, Esc to clear, Ctrl/Cmd-F to focus from the log list)"
-      onkeydown={(e) => {
-        if (e.key === 'Enter') submitLogSearch()
-        else if (e.key === 'Escape') clearLogSearch()
-      }}
-      class="input ml-auto h-8 w-28 text-sm sm:w-32"
+      title="Search logs (Enter / Shift+Enter to step matches, Esc to clear, Ctrl/Cmd-F to toggle)"
+      results={searchResults}
+      onnext={() => submitLogSearch('next')}
+      onprevious={() => submitLogSearch('prev')}
+      onclear={resetLogSearch}
+      inputClass="h-8 w-40 text-sm"
     />
     {@render PipelineInfoHeader()}
   </div>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -41,6 +41,7 @@
     emptySearchState,
     isFindShortcut,
     useShortcut,
+    positiveMod,
     type SearchDirection,
     type SearchState
   } from 'common-ui'
@@ -165,19 +166,21 @@
 
   const runtimeErrorsCount = $derived(connectorsWithErrorsCount + memoryPressureErrorCount)
 
-  // Log search lives here, with the toolbar that hosts the search bar. The committed search
-  // (what the list runs) advances only on submit, so typing doesn't search as-you-type. The
-  // log list reports its match count so the counter and nav buttons stay in sync.
+  // Log search lives here, with the toolbar that hosts the search bar. `logSearchInput` is the
+  // text in the box; `logSearch` is the submitted search query.
+  // The two diverge while the user types, because a query takes effect only when submitted,
+  // not as-you-type. The log list reports its match count so the counter
+  // and nav buttons stay in sync.
   let logSearchInput = $state('')
   let logSearch: SearchState = $state(emptySearchState)
   let logMatchCount = $state(0)
   let searchBar: ReturnType<typeof SearchBar> | undefined = $state()
-  // Single source of truth for the search bar: derived from the committed `logSearch`. No
-  // committed pattern → null (counter hidden, nav disabled, nothing highlighted).
+  // Single source of truth for the search bar, derived from the submitted `logSearch`. Nothing
+  // submitted - null (counter hidden, nav disabled, nothing highlighted).
   const searchResults = $derived.by(() => {
     if (!logSearch.pattern) return null
     const total = logMatchCount
-    const current = total > 0 ? (((logSearch.occurrenceIndex % total) + total) % total) + 1 : 0
+    const current = total > 0 ? positiveMod(logSearch.occurrenceIndex, total) + 1 : 0
     return { current, total }
   })
 
@@ -190,7 +193,7 @@
       direction
     )
   }
-  // Drop the committed search (highlight + counter). The search bar owns and clears the input
+  // Drop the submitted search (highlight + counter). The search bar owns and clears the input
   // text itself; this only resets what the log list is searching for.
   const resetLogSearch = () => {
     logSearch = emptySearchState

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
@@ -1,15 +1,17 @@
 /**
  * Real-wiring tests for the Logs-tab search experience in MonitoringPanel:
  *
- *   <input> (search bar in the Logs tab bar)
- *        ↳ logSearch ────▶ TabLogs ▶ LogsStreamList ▶ LogList (virtualised)
- *        ↳ onLogSearchShortcut ◀── Ctrl/Cmd-F handler in LogList
+ *   SearchBar (popup overlay, owned by TabLogs)
+ *        ↳ logSearch ────▶ LogsStreamList ▶ LogList (virtualised)
+ *        ↳ focusInput() ◀── Ctrl/Cmd-F handler in LogList
  *
  * The test mounts the production `MonitoringPanel` and feeds it 1 000 log lines (each line
  * is just its own 1-based line number — so a search for "42" deterministically hits lines
  * 42, 142, 242, ...) through a mocked `pipelineLogsStream`. Every component in the
- * search-input → LogList chain is the real one — nothing is re-wired in the test
- * file itself.
+ * SearchBar → LogList chain is the real one — nothing is re-wired in the test file itself.
+ *
+ * The search is a popup: collapsed it is just a search-icon button, so tests open it first
+ * (click the button, or trigger Ctrl/Cmd-F which opens + focuses it).
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -119,6 +121,13 @@ async function expectRowMounted(rowIndex: number) {
     .toBeTruthy()
 }
 
+// The search bar is collapsed to an icon button by default; open its popup and wait for the
+// query input to appear.
+async function openSearch() {
+  ;(page.getByRole('button', { name: 'Search' }).element() as HTMLButtonElement).click()
+  await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+}
+
 // --- Tests -------------------------------------------------------------------
 
 describe('MonitoringPanel — log-search wiring', () => {
@@ -132,6 +141,7 @@ describe('MonitoringPanel — log-search wiring', () => {
 
   it('Enter on the search input scrolls to each "42" occurrence in order', async () => {
     await mountLogsTab()
+    await openSearch()
 
     const input = page.getByPlaceholder('Search logs')
     await input.fill('42')
@@ -150,8 +160,30 @@ describe('MonitoringPanel — log-search wiring', () => {
     await expectRowMounted(241)
   })
 
-  it('Escape clears the input and removes the highlight', async () => {
+  it('editing the query after a search removes the highlight and disables nav', async () => {
     await mountLogsTab()
+    await openSearch()
+
+    const input = page.getByPlaceholder('Search logs')
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(true)
+    const next = page.getByRole('button', { name: 'Next match' })
+    expect((next.element() as HTMLButtonElement).disabled).toBe(false)
+    await expect.element(page.getByText(/\d+ of \d+/)).toBeInTheDocument()
+
+    // Type more — the committed results must be dropped as one: highlight gone, counter gone,
+    // and nav disabled (single source of truth).
+    await userEvent.keyboard('7')
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)
+    await expect.element(page.getByText(/\d+ of \d+/)).not.toBeInTheDocument()
+    await expect.poll(() => (next.element() as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('Escape closes the popup and removes the highlight', async () => {
+    await mountLogsTab()
+    await openSearch()
 
     const input = page.getByPlaceholder('Search logs')
     await input.fill('42')
@@ -163,10 +195,57 @@ describe('MonitoringPanel — log-search wiring', () => {
       .toBe(true)
 
     await userEvent.keyboard('{Escape}')
-    expect((input.element() as HTMLInputElement).value).toBe('')
-    await expect
-      .poll(() => CSS.highlights.has('feldera-log-list-search'), { timeout: ROW_MOUNT_TIMEOUT_MS })
-      .toBe(false)
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)
+  })
+
+  it('Ctrl+F opens, Esc closes and returns focus to the container, Ctrl+F reopens', async () => {
+    await mountLogsTab()
+
+    // The reported flow: focus the log container, then drive the search entirely by keyboard.
+    const scrollContainer = document.querySelector<HTMLElement>('.log-list-scroll')!
+    scrollContainer.focus()
+
+    // Ctrl+F opens the search (handled at the window level, so it works regardless of focus).
+    await userEvent.keyboard('{Control>}f{/Control}')
+    const input = page.getByPlaceholder('Search logs')
+    expect(document.activeElement).toBe(input.element())
+
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+
+    // Esc closes the popup and hands focus back to the log container (so Arrow keys scroll it).
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(scrollContainer)
+
+    // Ctrl+F reopens — the whole point of the fix.
+    await userEvent.keyboard('{Control>}f{/Control}')
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+  })
+
+  it('Ctrl+F reopens the search even when focus is not on the log container', async () => {
+    // Regression guard for the Chrome failure: reopening must not depend on where focus sits. The
+    // window-level shortcut handler makes Ctrl+F reach the search bar wherever focus landed (e.g.
+    // on the toolbar trigger button after a mouse-open, which Chrome focuses on click).
+    await mountLogsTab()
+
+    // Open via the toolbar search button (real mouse click, so Chrome's focus-on-click applies).
+    await userEvent.click(page.getByRole('button', { name: 'Search', exact: true }))
+    const input = page.getByPlaceholder('Search logs')
+    await expect.element(input).toBeInTheDocument()
+
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+
+    // Regardless of what holds focus now, Ctrl+F reopens the search.
+    await userEvent.keyboard('{Control>}f{/Control}')
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
   })
 
   it('Ctrl+F from the log list focuses the search input; typing + Enter searches', async () => {

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
@@ -190,7 +190,7 @@ describe('MonitoringPanel — log-search wiring', () => {
     expect((next.element() as HTMLButtonElement).disabled).toBe(false)
     await expect.element(page.getByText(/\d+ of \d+/)).toBeInTheDocument()
 
-    // Type more — the committed results must be dropped as one: highlight gone, counter gone,
+    // Type more — the submitted results must be dropped as one: highlight gone, counter gone,
     // and nav disabled (single source of truth).
     await userEvent.keyboard('7')
     await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
@@ -1,15 +1,17 @@
 /**
  * Real-wiring tests for the Logs-tab search experience in MonitoringPanel:
  *
- *   <input> (search bar in the Logs tab bar)
- *        ↳ logSearch ────▶ TabLogs ▶ LogsStreamList ▶ LogList (virtualised)
- *        ↳ onLogSearchShortcut ◀── Ctrl/Cmd-F handler in LogList
+ *   SearchBar (popup overlay, owned by TabLogs)
+ *        ↳ logSearch ────▶ LogsStreamList ▶ LogList (virtualised)
+ *        ↳ focusInput() ◀── Ctrl/Cmd-F handler in LogList
  *
  * The test mounts the production `MonitoringPanel` and feeds it 1 000 log lines (each line
  * is just its own 1-based line number — so a search for "42" deterministically hits lines
  * 42, 142, 242, ...) through a mocked `pipelineLogsStream`. Every component in the
- * search-input → LogList chain is the real one — nothing is re-wired in the test
- * file itself.
+ * SearchBar → LogList chain is the real one — nothing is re-wired in the test file itself.
+ *
+ * The search is a popup: collapsed it is just a search-icon button, so tests open it first
+ * (click the button, or trigger Ctrl/Cmd-F which opens + focuses it).
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -136,6 +138,13 @@ async function expectRowMounted(rowIndex: number) {
     .toBeTruthy()
 }
 
+// The search bar is collapsed to an icon button by default; open its popup and wait for the
+// query input to appear.
+async function openSearch() {
+  ;(page.getByRole('button', { name: 'Search' }).element() as HTMLButtonElement).click()
+  await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+}
+
 // --- Tests -------------------------------------------------------------------
 
 describe('MonitoringPanel — log-search wiring', () => {
@@ -149,6 +158,7 @@ describe('MonitoringPanel — log-search wiring', () => {
 
   it('Enter on the search input scrolls to each "42" occurrence in order', async () => {
     await mountLogsTab()
+    await openSearch()
 
     const input = page.getByPlaceholder('Search logs')
     await input.fill('42')
@@ -167,8 +177,30 @@ describe('MonitoringPanel — log-search wiring', () => {
     await expectRowMounted(241)
   })
 
-  it('Escape clears the input and removes the highlight', async () => {
+  it('editing the query after a search removes the highlight and disables nav', async () => {
     await mountLogsTab()
+    await openSearch()
+
+    const input = page.getByPlaceholder('Search logs')
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(true)
+    const next = page.getByRole('button', { name: 'Next match' })
+    expect((next.element() as HTMLButtonElement).disabled).toBe(false)
+    await expect.element(page.getByText(/\d+ of \d+/)).toBeInTheDocument()
+
+    // Type more — the committed results must be dropped as one: highlight gone, counter gone,
+    // and nav disabled (single source of truth).
+    await userEvent.keyboard('7')
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)
+    await expect.element(page.getByText(/\d+ of \d+/)).not.toBeInTheDocument()
+    await expect.poll(() => (next.element() as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('Escape closes the popup and removes the highlight', async () => {
+    await mountLogsTab()
+    await openSearch()
 
     const input = page.getByPlaceholder('Search logs')
     await input.fill('42')
@@ -180,10 +212,57 @@ describe('MonitoringPanel — log-search wiring', () => {
       .toBe(true)
 
     await userEvent.keyboard('{Escape}')
-    expect((input.element() as HTMLInputElement).value).toBe('')
-    await expect
-      .poll(() => CSS.highlights.has('feldera-log-list-search'), { timeout: ROW_MOUNT_TIMEOUT_MS })
-      .toBe(false)
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)
+  })
+
+  it('Ctrl+F opens, Esc closes and returns focus to the container, Ctrl+F reopens', async () => {
+    await mountLogsTab()
+
+    // The reported flow: focus the log container, then drive the search entirely by keyboard.
+    const scrollContainer = document.querySelector<HTMLElement>('.log-list-scroll')!
+    scrollContainer.focus()
+
+    // Ctrl+F opens the search (handled at the window level, so it works regardless of focus).
+    await userEvent.keyboard('{Control>}f{/Control}')
+    const input = page.getByPlaceholder('Search logs')
+    expect(document.activeElement).toBe(input.element())
+
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+
+    // Esc closes the popup and hands focus back to the log container (so Arrow keys scroll it).
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(scrollContainer)
+
+    // Ctrl+F reopens — the whole point of the fix.
+    await userEvent.keyboard('{Control>}f{/Control}')
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+  })
+
+  it('Ctrl+F reopens the search even when focus is not on the log container', async () => {
+    // Regression guard for the Chrome failure: reopening must not depend on where focus sits. The
+    // window-level shortcut handler makes Ctrl+F reach the search bar wherever focus landed (e.g.
+    // on the toolbar trigger button after a mouse-open, which Chrome focuses on click).
+    await mountLogsTab()
+
+    // Open via the toolbar search button (real mouse click, so Chrome's focus-on-click applies).
+    await userEvent.click(page.getByRole('button', { name: 'Search', exact: true }))
+    const input = page.getByPlaceholder('Search logs')
+    await expect.element(input).toBeInTheDocument()
+
+    await input.fill('42')
+    await userEvent.keyboard('{Enter}')
+    await expectRowMounted(41)
+
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+
+    // Regardless of what holds focus now, Ctrl+F reopens the search.
+    await userEvent.keyboard('{Control>}f{/Control}')
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
   })
 
   it('Ctrl+F from the log list focuses the search input; typing + Enter searches', async () => {

--- a/js-packages/web-console/src/lib/components/pipelines/editor/SearchBar.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/SearchBar.svelte.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Component tests for the shared SearchBar (common-ui). Runs in the browser project: the
+ * component renders real elements and we drive real keyboard + click events. Collapsed it is
+ * just a search-icon button; open it shows the query input, an "x of X" counter, and nav
+ * buttons.
+ */
+
+import { SearchBar } from 'common-ui'
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-svelte'
+
+function renderBar(props?: {
+  value?: string
+  open?: boolean
+  results?: { current: number; total: number } | null
+  onnext?: () => void
+  onprevious?: () => void
+  onclear?: () => void
+}) {
+  const handlers = {
+    onnext: props?.onnext ?? vi.fn(),
+    onprevious: props?.onprevious ?? vi.fn(),
+    onclear: props?.onclear ?? vi.fn()
+  }
+  render(SearchBar, {
+    value: props?.value ?? 'query',
+    placeholder: 'Search logs',
+    open: props?.open ?? true,
+    // Distinguish "not provided" (default to one match) from an explicit `null` (no search).
+    results: props && 'results' in props ? props.results : { current: 1, total: 1 },
+    ...handlers
+  })
+  return handlers
+}
+
+const searchButton = () =>
+  page.getByRole('button', { name: 'Search', exact: true }).element() as HTMLButtonElement
+const input = () => page.getByPlaceholder('Search logs').element() as HTMLInputElement
+const nextButton = () =>
+  page.getByRole('button', { name: 'Next match' }).element() as HTMLButtonElement
+const prevButton = () =>
+  page.getByRole('button', { name: 'Previous match' }).element() as HTMLButtonElement
+const closeButton = () =>
+  page.getByRole('button', { name: 'Close search' }).element() as HTMLButtonElement
+
+const pressKey = (key: string, opts: { shiftKey?: boolean } = {}) => {
+  input().dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...opts })
+  )
+}
+
+// Type into the input the way a user would: set the value and fire an `input` event so both
+// the `bind:value` and the component's edit handler run.
+const typeInto = (text: string) => {
+  const el = input()
+  el.value = text
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('SearchBar.svelte', () => {
+  it('is collapsed to just the search button until opened', async () => {
+    renderBar({ open: false })
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    searchButton().click()
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+  })
+
+  it('Enter advances to the next match', () => {
+    const { onnext, onprevious } = renderBar()
+    pressKey('Enter')
+    expect(onnext).toHaveBeenCalledTimes(1)
+    expect(onprevious).not.toHaveBeenCalled()
+  })
+
+  it('Shift+Enter steps back to the previous match', () => {
+    const { onnext, onprevious } = renderBar()
+    pressKey('Enter', { shiftKey: true })
+    expect(onprevious).toHaveBeenCalledTimes(1)
+    expect(onnext).not.toHaveBeenCalled()
+  })
+
+  it('Escape closes the popup and clears the search', async () => {
+    const { onclear } = renderBar()
+    pressKey('Escape')
+    expect(onclear).toHaveBeenCalledTimes(1)
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+  })
+
+  it('the down button advances, the up button steps back', () => {
+    const { onnext, onprevious } = renderBar()
+    nextButton().click()
+    prevButton().click()
+    expect(onnext).toHaveBeenCalledTimes(1)
+    expect(onprevious).toHaveBeenCalledTimes(1)
+  })
+
+  it('derives counter + nav state from `results` — one source of truth', async () => {
+    // total 0 → "No results", nav disabled.
+    renderBar({ results: { current: 0, total: 0 } })
+    await expect.element(page.getByText('No results')).toBeInTheDocument()
+    expect(nextButton().disabled).toBe(true)
+    expect(prevButton().disabled).toBe(true)
+  })
+
+  it('shows "x of X" and enables nav when there are matches', async () => {
+    renderBar({ results: { current: 2, total: 5 } })
+    await expect.element(page.getByText('2 of 5')).toBeInTheDocument()
+    expect(nextButton().disabled).toBe(false)
+    expect(prevButton().disabled).toBe(false)
+  })
+
+  it('shows no counter and disables nav when results is null (no active search)', async () => {
+    renderBar({ results: null })
+    await expect.element(page.getByText('No results')).not.toBeInTheDocument()
+    expect(nextButton().disabled).toBe(true)
+    expect(prevButton().disabled).toBe(true)
+  })
+
+  it('editing the query while results are shown calls onclear (host resets results)', () => {
+    const { onclear } = renderBar({ value: 'q', results: { current: 2, total: 5 } })
+    typeInto('qq')
+    expect(onclear).toHaveBeenCalled()
+  })
+
+  it('Escape closes the popup and calls onclear', async () => {
+    const { onclear } = renderBar({ value: 'q', results: { current: 2, total: 5 } })
+    pressKey('Escape')
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    expect(onclear).toHaveBeenCalled()
+  })
+
+  it('closing the popup clears the field, hides it, and calls onclear', async () => {
+    const { onclear } = renderBar({ value: 'q', results: { current: 2, total: 5 } })
+    searchButton().click() // toggle closed
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    expect(onclear).toHaveBeenCalled()
+
+    searchButton().click() // reopen — field starts empty
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+    await expect.poll(() => input().value).toBe('')
+  })
+
+  it('the close (x) button hides the popup and calls onclear', async () => {
+    const { onclear } = renderBar({ value: 'q', results: { current: 2, total: 5 } })
+    closeButton().click()
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+    expect(onclear).toHaveBeenCalled()
+  })
+
+  it('blurring an empty field closes the popup', async () => {
+    renderBar({ value: '', results: null })
+    input().dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    await expect.element(page.getByPlaceholder('Search logs')).not.toBeInTheDocument()
+  })
+
+  it('blurring a non-empty field keeps the popup open', async () => {
+    renderBar({ value: 'q', results: { current: 2, total: 5 } })
+    input().dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    await expect.element(page.getByPlaceholder('Search logs')).toBeInTheDocument()
+  })
+})

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -51,7 +51,7 @@
   }: {
     pipeline: { current: ExtendedPipeline }
     deleted?: boolean
-    /** Committed search state, owned by the monitoring panel (which hosts the search bar in
+    /** Submitted search state, owned by the monitoring panel (which hosts the search bar in
      *  its toolbar). */
     logSearch?: SearchState
     /** Reports the current match count so the panel can drive its search counter/nav buttons. */

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -47,14 +47,15 @@
     pipeline,
     deleted = false,
     logSearch = emptySearchState,
-    onLogSearchShortcut
+    onLogMatchCountChange
   }: {
     pipeline: { current: ExtendedPipeline }
     deleted?: boolean
+    /** Committed search state, owned by the monitoring panel (which hosts the search bar in
+     *  its toolbar). */
     logSearch?: SearchState
-    /** Invoked when the user presses Ctrl-F / Cmd-F inside the log list — the monitoring
-     *  panel uses this to focus its search input. */
-    onLogSearchShortcut?: () => void
+    /** Reports the current match count so the panel can drive its search counter/nav buttons. */
+    onLogMatchCountChange?: (count: number) => void
   } = $props()
   let pipelineName = $derived(pipeline.current.name)
 
@@ -325,7 +326,7 @@
     <LogsStreamList
       logs={pipelineLogs}
       search={logSearch}
-      onSearchShortcut={onLogSearchShortcut}
+      onMatchCountChange={onLogMatchCountChange}
       {onStickToBottomChange}
     ></LogsStreamList>
   {/key}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
@@ -9,9 +9,11 @@ import {
   advanceSearch,
   applySearchHighlight,
   compileSearchPattern,
+  countOccurrences,
   emptySearchState,
   findMatchOffsets,
   findOccurrence,
+  isFindShortcut,
   type SearchPattern,
   searchPatternsEqual
 } from 'common-ui'
@@ -59,6 +61,63 @@ describe('advanceSearch', () => {
   it('resets the cursor to the first match on a new pattern', () => {
     const state = { pattern: substr('a'), occurrenceIndex: 5 }
     expect(advanceSearch(state, substr('b'))).toEqual({ pattern: substr('b'), occurrenceIndex: 0 })
+  })
+
+  it('steps the cursor backward on the same pattern with direction "prev"', () => {
+    const state = { pattern: substr('a'), occurrenceIndex: 3 }
+    expect(advanceSearch(state, substr('a'), 'prev')).toEqual({
+      pattern: substr('a'),
+      occurrenceIndex: 2
+    })
+  })
+
+  it('ignores direction on a new pattern (always the first match)', () => {
+    const state = { pattern: substr('a'), occurrenceIndex: 5 }
+    expect(advanceSearch(state, substr('b'), 'prev')).toEqual({
+      pattern: substr('b'),
+      occurrenceIndex: 0
+    })
+  })
+
+  it('defaults to stepping forward when no direction is given', () => {
+    const state = { pattern: substr('a'), occurrenceIndex: 1 }
+    expect(advanceSearch(state, substr('a')).occurrenceIndex).toBe(2)
+  })
+})
+
+describe('countOccurrences', () => {
+  const lines = ['alpha', 'beta', 'gamma', 'alpha again']
+
+  it('counts matching lines (one match per line, matching findOccurrence)', () => {
+    expect(countOccurrences(lines, substr('alpha'))).toBe(2)
+    expect(countOccurrences(lines, substr('a'))).toBe(4) // every line contains "a"
+  })
+
+  it('returns 0 for a null, empty, or non-matching pattern', () => {
+    expect(countOccurrences(lines, null)).toBe(0)
+    expect(countOccurrences(lines, substr(''))).toBe(0)
+    expect(countOccurrences(lines, substr('zzz'))).toBe(0)
+  })
+
+  it('respects case sensitivity', () => {
+    expect(countOccurrences(['ABC', 'abc'], substr('abc', true))).toBe(1)
+    expect(countOccurrences(['ABC', 'abc'], substr('abc', false))).toBe(2)
+  })
+})
+
+describe('isFindShortcut', () => {
+  const ev = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init)
+
+  it('matches Ctrl-F and Cmd-F (case-insensitive key)', () => {
+    expect(isFindShortcut(ev({ key: 'f', ctrlKey: true }))).toBe(true)
+    expect(isFindShortcut(ev({ key: 'F', metaKey: true }))).toBe(true)
+  })
+
+  it('rejects plain "f", other keys, and extra modifiers', () => {
+    expect(isFindShortcut(ev({ key: 'f' }))).toBe(false)
+    expect(isFindShortcut(ev({ key: 'g', ctrlKey: true }))).toBe(false)
+    expect(isFindShortcut(ev({ key: 'f', ctrlKey: true, shiftKey: true }))).toBe(false)
+    expect(isFindShortcut(ev({ key: 'f', ctrlKey: true, altKey: true }))).toBe(false)
   })
 })
 

--- a/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
@@ -15,7 +15,8 @@ import {
   findOccurrence,
   isFindShortcut,
   type SearchPattern,
-  searchPatternsEqual
+  searchPatternsEqual,
+  positiveMod
 } from 'common-ui'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -44,6 +45,29 @@ describe('searchPatternsEqual', () => {
     expect(searchPatternsEqual(re('x'), re('x', ''))).toBe(true) // undefined flags ≡ ''
     expect(searchPatternsEqual(re('x', 'i'), re('x'))).toBe(false)
     expect(searchPatternsEqual(re('x'), substr('x'))).toBe(false)
+  })
+})
+
+describe('positiveMod', () => {
+  it('leaves an in-range cursor alone', () => {
+    expect(positiveMod(0, 3)).toBe(0)
+    expect(positiveMod(2, 3)).toBe(2)
+  })
+
+  it('wraps forward past the last match', () => {
+    expect(positiveMod(3, 3)).toBe(0)
+    expect(positiveMod(7, 3)).toBe(1)
+  })
+
+  it('wraps backward before the first match (plain % would give a negative index)', () => {
+    expect(-1 % 3).toBe(-1) // the reason the Euclidean form is needed
+    expect(positiveMod(-1, 3)).toBe(2)
+    expect(positiveMod(-4, 3)).toBe(2)
+  })
+
+  it('collapses onto the only match for a single-match search', () => {
+    expect(positiveMod(-5, 1)).toBe(0)
+    expect(positiveMod(5, 1)).toBe(0)
   })
 })
 


### PR DESCRIPTION
This adds a re-usable searchbar implementation

Switch what search bar Ctrl+F focuses in profiler based on context

The new search bar can be opened with a dedicated button or Ctrl+F and has buttons for forward and backward navigation, and responds to Enter and Shift+Enter shortcuts

Extend search to include top nodes, global profile stats
https://github.com/feldera/feldera/issues/6508

<img width="1221" height="293" alt="image" src="https://github.com/user-attachments/assets/ba33d5c0-2b4d-40e5-b9ed-294c3e5cc733" />

[Screencast From 2026-07-20 14-49-47.webm](https://github.com/user-attachments/assets/d575e159-1780-47b7-9ca0-e3fbd99645f8)
