### PR TITLE
[adapters] Refresh ad-hoc snapshot before ending fault-tolerant replay

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2627,6 +2627,15 @@ struct CircuitThread {
     /// pre-existing views stay live; `Synchronize` during the brief
     /// stop-the-world cutover window.
     concurrent_phase: ConcurrentPhase,
+
+    /// Set when journal replay has just finished but the ad-hoc snapshot has not
+    /// yet been refreshed with the replayed state, so `restoring` must stay set
+    /// (the pipeline keeps reporting `Replaying` and rejecting ad-hoc queries)
+    /// until a step runs [Self::update_snapshot]. The step that exhausts the
+    /// journal is usually mid-transaction, so it cannot refresh the snapshot
+    /// itself; this defers clearing `restoring` to the next transaction-boundary
+    /// step. Analogous to the concurrent-bootstrap `Finalizing` phase.
+    replay_finalize: bool,
 }
 
 /// Phase of a concurrent bootstrap driven by [`CircuitThread`].
@@ -3085,6 +3094,7 @@ impl CircuitThread {
             pending_step_metadata: None,
             replay_consumed: false,
             concurrent_phase,
+            replay_finalize: false,
         })
     }
 
@@ -3214,7 +3224,10 @@ impl CircuitThread {
             match trigger.trigger(
                 self.last_checkpoint(),
                 self.last_checkpoint_sync(),
-                self.replaying(),
+                // `replay_finalize` keeps forcing steps after the journal is
+                // exhausted until a step refreshes the ad-hoc snapshot with the
+                // replayed state (see `step` and `clear_restoring`).
+                self.replaying() || self.replay_finalize,
                 // `status.bootstrap_in_progress` is cleared one transaction after circuit bootstrapping is complete,
                 // which is required to initialize the output snapshots.
                 // We want the trigger to trigger that extra transaction; therefore we pass `status.bootstrap_in_progress`
@@ -3443,10 +3456,24 @@ impl CircuitThread {
             .map_err(|_| ControllerError::dbsp_panic())
     }
 
+    /// Clears the `restoring` flag (so the pipeline reports `Running` and admits
+    /// ad-hoc queries) and starts the backpressure thread so input can flow.
+    /// Both operations are idempotent (`backpressure_thread.start` no-ops after
+    /// the first call), so this is safe to call every step.
+    fn clear_restoring(&mut self) {
+        self.controller.restoring.store(false, Ordering::Release);
+        self.backpressure_thread.start();
+    }
+
     fn finish_replaying(&mut self) {
-        if !self.replaying() {
-            self.controller.restoring.store(false, Ordering::Release);
-            self.backpressure_thread.start();
+        // Clear `restoring` (and release backpressure) once there is nothing
+        // left to replay, EXCEPT while `replay_finalize` is pending: after an
+        // actual replay we keep `restoring` set until a step refreshes the
+        // ad-hoc snapshot with the replayed state (see `step`); otherwise the
+        // pipeline would report `Running` and admit ad-hoc queries against the
+        // stale pre-replay snapshot.
+        if !self.replaying() && !self.replay_finalize {
+            self.clear_restoring();
         }
     }
 
@@ -3511,6 +3538,16 @@ impl CircuitThread {
                     .with_category("Step")
                     .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
                     .in_scope(|| self.update_snapshot());
+
+                // If we just finished replaying, this transaction-boundary step
+                // has now refreshed the ad-hoc snapshot with the replayed state,
+                // so it is finally safe to clear `restoring` and admit ad-hoc
+                // queries. Deferred from the step that exhausted the journal,
+                // which is typically mid-transaction and skips `update_snapshot`.
+                if self.replay_finalize {
+                    self.replay_finalize = false;
+                    self.clear_restoring();
+                }
             }
 
             // If bootstrapping has completed, clear self.bootstrapping, but don't update the status flag
@@ -3552,7 +3589,15 @@ impl CircuitThread {
         self.push_output(processed_records);
         let replay_consumed = self.replay_consumed;
         if let Some(ft) = self.ft.as_mut() {
+            let was_replaying = ft.is_replaying();
             ft.next_step(replay_consumed)?;
+            // Replay just finished this step. Keep `restoring` set until a
+            // subsequent transaction-boundary step refreshes the ad-hoc
+            // snapshot with the replayed state (this step is typically
+            // mid-transaction and skipped `update_snapshot`).
+            if was_replaying && !ft.is_replaying() {
+                self.replay_finalize = true;
+            }
             self.finish_replaying();
         }
         self.controller.unpark_backpressure();

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -3373,6 +3373,36 @@ mod test_http_helpers {
         bootstrap_config: BootstrapConfig,
         persistent_output_ids: &'static [Option<&'static str>],
     ) -> TestServer {
+        start_test_server_with_state(
+            config_str,
+            deployment_id,
+            bootstrap_config,
+            persistent_output_ids,
+            false,
+        )
+        .await
+        .0
+    }
+
+    /// Like [start_test_server_with_options], but also returns the
+    /// [ServerState] so a test can reach the controller directly (e.g. to
+    /// simulate an ungraceful crash via [crash_pipeline]).
+    ///
+    /// When `with_program_ir` is set, a minimal (empty) `program_ir` is injected
+    /// into the pipeline config. The test circuit is a Rust closure with no
+    /// compiled program, so its checkpoint normally carries no program info,
+    /// which makes `compute_pipeline_diff` fail and forces the journal to be
+    /// discarded on restart (no replay). Injecting an identical empty
+    /// `program_ir` makes the diff empty across a same-program restart, so the
+    /// journal is replayed -- required to exercise the fault-tolerant replay
+    /// path in-process.
+    pub(super) async fn start_test_server_with_state(
+        config_str: &str,
+        deployment_id: Uuid,
+        bootstrap_config: BootstrapConfig,
+        persistent_output_ids: &'static [Option<&'static str>],
+        with_program_ir: bool,
+    ) -> (TestServer, WebData<ServerState>) {
         let mut config_file = NamedTempFile::new().unwrap();
         config_file.write_all(config_str.as_bytes()).unwrap();
 
@@ -3407,7 +3437,13 @@ mod test_http_helpers {
             host_id: None,
         };
 
-        let config = parse_config(&args.config_file).unwrap();
+        let mut config = parse_config(&args.config_file).unwrap();
+        if with_program_ir {
+            config.program_ir = Some(feldera_types::config::ProgramIr {
+                mir: std::collections::HashMap::new(),
+                program_schema: serde_json::json!({ "inputs": [], "outputs": [] }),
+            });
+        }
         let builder = ControllerBuilder::new(&config).unwrap();
         thread::spawn(move || {
             bootstrap(
@@ -3423,6 +3459,7 @@ mod test_http_helpers {
             )
         });
 
+        let state_ret = state.clone();
         let server =
             actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
 
@@ -3433,7 +3470,20 @@ mod test_http_helpers {
             sleep(Duration::from_millis(200));
         }
 
-        server
+        (server, state_ret)
+    }
+
+    /// Simulate an ungraceful crash of a fault-tolerant pipeline: terminate the
+    /// circuit WITHOUT writing a checkpoint (unlike `/suspend`), so the journal
+    /// tail must be replayed on the next restart, and wait for the storage lock
+    /// to be released so a new server can reopen the same storage directory.
+    pub(super) async fn crash_pipeline(state: &WebData<ServerState>, storage_dir: &Path) {
+        let controller = state.take_controller().expect("controller present");
+        tokio::task::spawn_blocking(move || controller.stop())
+            .await
+            .unwrap()
+            .expect("controller stops cleanly");
+        wait_for_storage_unlock(storage_dir).await;
     }
 
     pub(super) fn flatten_and_sort_batches(data: &[Vec<TestStruct>]) -> Vec<TestStruct> {
@@ -3753,9 +3803,9 @@ mod test_http {
         ensure_default_crypto_provider,
         server::test_http_helpers::{
             adhoc_query_count, assert_no_file_output, batch_num_records, commit_transaction,
-            pause_pipeline, send_input, send_input_no_wait, start_pipeline,
-            start_test_server_with_options, start_transaction, suspend_pipeline, test_batches,
-            wait_for_file_output,
+            crash_pipeline, pause_pipeline, send_input, send_input_no_wait, start_pipeline,
+            start_test_server_with_options, start_test_server_with_state, start_transaction,
+            suspend_pipeline, test_batches, wait_for_file_output,
         },
         test::{
             TestStruct, async_wait, generate_test_batches,
@@ -4222,6 +4272,96 @@ outputs:
         assert_eq!(
             count, 10,
             "ad-hoc query observed a stale snapshot after the pipeline reported Running"
+        );
+
+        suspend_pipeline(&server, Some(&storage_dir)).await;
+    }
+
+    /// Regression test for the fault-tolerant *replay* path, the analogue of
+    /// [test_concurrent_bootstrap_adhoc_snapshot]: after a restart that replays
+    /// the journal, an ad-hoc query must observe the replayed state.
+    ///
+    /// The ad-hoc snapshot is refreshed only by a circuit step (`update_snapshot`
+    /// inside `step`) and is not part of the checkpoint. If the pipeline reports
+    /// `Running` (clears `restoring`) as soon as the journal is exhausted, before
+    /// a step has refreshed the snapshot with the replayed state, an ad-hoc query
+    /// reads the stale (empty) pre-replay snapshot and returns 0.
+    ///
+    /// We crash the pipeline WITHOUT a checkpoint so the restart must replay,
+    /// then query once right after `Running` -- no polling and no post-restart
+    /// input (feeding any would trigger a step and mask the bug).
+    #[actix_web::test]
+    async fn test_ft_replay_adhoc_snapshot() {
+        ensure_default_crypto_provider();
+
+        let tempdir = TempDir::new().unwrap();
+        let storage_dir = tempdir.path().join("storage");
+        let output_path = tempdir.path().join("output.csv");
+        std::fs::create_dir(&storage_dir).unwrap();
+
+        let config_str = format!(
+            r#"
+name: test
+workers: 1
+storage_config:
+    path: "{}"
+storage: true
+fault_tolerance: latest_checkpoint
+clock_resolution_usecs:
+inputs:
+outputs:
+    test_output1:
+        stream: test_output1
+        transport:
+            name: file_output
+            config:
+                path: "{}"
+        format:
+            name: csv
+            config: {{}}
+"#,
+            storage_dir.display(),
+            output_path.display()
+        );
+
+        let batch = test_batches(0, 10);
+
+        // Start the fault-tolerant pipeline and ingest 10 rows. The input step is
+        // journaled; `send_input` waits for it to complete.
+        let (server, state) = start_test_server_with_state(
+            &config_str,
+            Uuid::new_v4(),
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            &[Some("v0")],
+            true,
+        )
+        .await;
+        start_pipeline(&server).await;
+        send_input(&server, &batch).await;
+        wait_for_file_output(&output_path, &batch).await;
+
+        // Crash WITHOUT a checkpoint: the journaled input survives and must be
+        // replayed on restart (the `checkpoint_before = false` case).
+        crash_pipeline(&state, &storage_dir).await;
+        drop(server);
+
+        // Restart: reopen the initial (step 0) checkpoint and REPLAY the journal.
+        // `start_pipeline` waits for `Running`, reached only after `restoring`
+        // clears. Once `Running`, the ad-hoc snapshot must already hold the 10
+        // replayed rows -- queried once, with no polling and no new input.
+        let (server, _state) = start_test_server_with_state(
+            &config_str,
+            Uuid::new_v4(),
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            &[Some("v0")],
+            true,
+        )
+        .await;
+        start_pipeline(&server).await;
+        let count = adhoc_query_count(&server, "SELECT COUNT(*) AS c FROM test_output1").await;
+        assert_eq!(
+            count, 10,
+            "ad-hoc query observed a stale snapshot after fault-tolerant replay"
         );
 
         suspend_pipeline(&server, Some(&storage_dir)).await;


### PR DESCRIPTION
After a fault-tolerant restart, `restoring` was cleared (reporting the pipeline `Running` and admitting ad-hoc queries) on the step that exhausted the journal. That step is typically mid-transaction, so its `update_snapshot` is skipped and the fully-replayed state reaches the ad-hoc snapshot only one step later. An ad-hoc query issued right after `Running` therefore observed the stale pre-replay snapshot (e.g. an empty table). This flaked `test_ft_basic_http_get_input` and related fault-tolerance tests in cloud CI.

Defer clearing `restoring` until a post-replay transaction-boundary step has refreshed the snapshot with the replayed state, via a `replay_finalize` phase that keeps the step trigger firing until the refresh runs. This mirrors the concurrent-bootstrap `Finalizing` phase, which already guards the analogous post-cutover snapshot refresh.

Add `test_ft_replay_adhoc_snapshot`: an in-process regression test that crashes a fault-tolerant pipeline without a checkpoint, restarts to force journal replay, and asserts the replayed rows are visible to an ad-hoc query issued as soon as the pipeline reports `Running`. It fails deterministically without the fix.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
