### PR TITLE
[SQL] GC of tables with keys and LATENESS should never use retain_values, but can use retain_keys when keys have LATENESS

### DIFF
--- a/crates/dbsp/src/operator/dynamic/input.rs
+++ b/crates/dbsp/src/operator/dynamic/input.rs
@@ -781,8 +781,6 @@ impl RootCircuit {
     ///
     /// Retention conditions configured at logical time `t`
     /// are applied starting from logical time `t+1`.
-    ///
-    /// FIXME: see <https://github.com/feldera/feldera/issues/2669>
     // TODO: Add a version that takes a custom hash function.
     #[track_caller]
     pub fn dyn_add_input_map<K, V, U>(
@@ -1970,10 +1968,8 @@ mod test {
         Ok(handle)
     }
 
-    // FIXME: the inputs to these tests are meant to exercise the logic that filters inputs based
-    // on lateness, but it does not currently work correctly (see https://github.com/feldera/feldera/issues/2669).
-    // We therefore don't use waterlines in tests and check for the standard upsert behavior
-    // without filtering.
+    // These tests check the standard upsert behavior without lateness-based filtering;
+    // filtering inputs based on lateness is implemented by `add_input_map_with_waterline`.
     #[test]
     fn map_test_st() {
         let (mut circuit, mut input_handle) = Runtime::init_circuit(1, move |circuit| {
@@ -2033,10 +2029,8 @@ mod test {
         dbsp.kill().unwrap();
     }
 
-    // FIXME: the inputs to these tests are meant to exercise the logic that filters inputs based
-    // on lateness, but it does not currently work correctly (see https://github.com/feldera/feldera/issues/2669).
-    // We therefore don't use waterlines in tests and check for the standard upsert behavior
-    // without filtering.
+    // These tests check the standard upsert behavior without lateness-based filtering;
+    // filtering inputs based on lateness is implemented by `add_input_map_with_waterline`.
     #[test]
     fn map_test_mt1() {
         map_test_mt(1, input_map_updates1, output_map_updates1);

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -606,8 +606,6 @@ impl RootCircuit {
     ///
     /// Retention conditions configured at logical time `t`
     /// are applied starting from logical time `t+1`.
-    ///
-    /// FIXME: see <https://github.com/feldera/feldera/issues/2669>
     // TODO: Add a version that takes a custom hash function.
     #[track_caller]
     pub fn add_input_map<K, V, U, PF>(

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,14 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        - The SQL compiler was incorrectly garbage-collecting input
+          tables with a primary key and a column with LATENESS (#6690).  Such
+          tables can only be GC-ed if the column with LATENESS is part of
+          the primary key.  As a result some programs that used to run
+          with finite state will now have unbounded state.
+
+       ## v0.322.0
+
         - Pipeline API field `deployment_runtime_status_details` is now strongly typed,
           whereas before it was just a generic JSON value type. While `AwaitingApproval`,
           the diff is now located at `deployment_runtime_status_details.approval_diff`
@@ -22,6 +30,8 @@ import TabItem from '@theme/TabItem';
         - Pipelines from this latest version onward will have their GET selector
           `status_with_connectors` connector stats cached, which are now updated along
           with the runtime status details within roughly 1-15s.
+
+       ## v0.319.0
 
         - Cluster monitor events with information on the backing (Kubernetes) resources is
           no longer gated behind unstable feature `cluster_monitor_resources` (deprecated).

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -174,7 +174,9 @@ def unique_pipeline_name(base_name: str) -> str:
     of the commit SHA or 'local' if not in CI. FELDERA_TEST_TAG_SUFFIX distinguishes
     test suites of the same commit running concurrently against one instance.
     """
-    ci_tag = os.getenv("GITHUB_SHA", "local")[:5] + os.getenv("FELDERA_TEST_TAG_SUFFIX", "")
+    ci_tag = os.getenv("GITHUB_SHA", "local")[:5] + os.getenv(
+        "FELDERA_TEST_TAG_SUFFIX", ""
+    )
     name = f"{ci_tag}_{base_name}"
     # The pipeline name becomes a Kubernetes label value (max 63 chars). Fail here
     # with a clear message rather than letting provisioning hit a cryptic 422.

--- a/python/tests/platform/test_pipeline_events.py
+++ b/python/tests/platform/test_pipeline_events.py
@@ -4,7 +4,6 @@ from feldera.enums import PipelineStatus, BootstrapPolicy
 from feldera.rest.errors import FelderaAPIError
 from tests import TEST_CLIENT
 from .helper import gen_pipeline_name
-import time
 
 
 def remove_consecutive_duplicates(v: list[dict]):

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -27,11 +27,16 @@ import java.util.Objects;
 public final class DBSPIntegrateTraceRetainKeysOperator
         extends DBSPBinaryOperator implements IGCOperator
 {
+    /** Selects the Rust function that the operator invokes.
+     * GC applied to an input table requires 'false'; everything else requires 'true'. */
+    public final boolean accumulate;
+
     public DBSPIntegrateTraceRetainKeysOperator(
             CalciteRelNode node, DBSPExpression expression,
-            OutputPort data, OutputPort control) {
-        super(node, "accumulate_integrate_trace_retain_keys", expression,
-                data.outputType(), data.isMultiset(), data, control);
+            OutputPort data, OutputPort control, boolean accumulate) {
+        super(node, accumulate ? "accumulate_integrate_trace_retain_keys" : "integrate_trace_retain_keys",
+                expression, data.outputType(), data.isMultiset(), data, control);
+        this.accumulate = accumulate;
     }
 
     @Override
@@ -43,6 +48,14 @@ public final class DBSPIntegrateTraceRetainKeysOperator
     @Nullable
     public static DBSPIntegrateTraceRetainKeysOperator create(
             CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control) {
+        return create(node, data, dataProjection, control, true);
+    }
+
+    /** Create an operator to retain keys and returns it.  May return null if the keys contain no fields. */
+    @Nullable
+    public static DBSPIntegrateTraceRetainKeysOperator create(
+            CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control,
+            boolean accumulate) {
         DBSPType controlType = control.outputType();
         Utilities.enforce(controlType.is(DBSPTypeTupleBase.class), () -> "Control type is not a tuple: " + controlType);
         DBSPTypeTupleBase controlTuple = controlType.to(DBSPTypeTupleBase.class);
@@ -83,7 +96,7 @@ public final class DBSPIntegrateTraceRetainKeysOperator
         compare = ExpressionCompiler.makeBinaryExpression(
                 node, compare.getType(), DBSPOpcode.OR, compare0, compare);
         DBSPExpression closure = compare.closure(param, controlArg.asParameter());
-        return new DBSPIntegrateTraceRetainKeysOperator(node, closure, data, control);
+        return new DBSPIntegrateTraceRetainKeysOperator(node, closure, data, control, accumulate);
     }
 
     @Override
@@ -94,7 +107,7 @@ public final class DBSPIntegrateTraceRetainKeysOperator
             Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
             return new DBSPIntegrateTraceRetainKeysOperator(
                     this.getRelNode(), toClosure(function),
-                    newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
+                    newInputs.get(0), newInputs.get(1), this.accumulate).copyAnnotations(this);
         }
         return this;
     }
@@ -113,8 +126,9 @@ public final class DBSPIntegrateTraceRetainKeysOperator
     @SuppressWarnings("unused")
     public static DBSPIntegrateTraceRetainKeysOperator fromJson(JsonNode node, JsonDecoder decoder) {
         DBSPSimpleOperator.CommonInfo info = commonInfoFromJson(node, decoder);
+        boolean accumulate = Utilities.getBooleanProperty(node, "accumulate");
         return new DBSPIntegrateTraceRetainKeysOperator(CalciteEmptyRel.INSTANCE,
-                info.getFunction(), info.getInput(0), info.getInput(1))
+                info.getFunction(), info.getInput(0), info.getInput(1), accumulate)
                 .addAnnotations(info.annotations(), DBSPIntegrateTraceRetainKeysOperator.class);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
@@ -27,14 +27,11 @@ import java.util.Objects;
 public final class DBSPIntegrateTraceRetainValuesOperator
         extends DBSPBinaryOperator implements IGCOperator {
 
-    public final boolean accumulate;
-
     public DBSPIntegrateTraceRetainValuesOperator(
             CalciteRelNode node, DBSPExpression function,
-            OutputPort data, OutputPort control, boolean accumulate) {
-        super(node, accumulate ? "accumulate_integrate_trace_retain_values" : "integrate_trace_retain_values",
+            OutputPort data, OutputPort control) {
+        super(node, "accumulate_integrate_trace_retain_values",
                 function, data.outputType(), data.isMultiset(), data, control);
-        this.accumulate = accumulate;
     }
 
     @Override
@@ -43,7 +40,7 @@ public final class DBSPIntegrateTraceRetainValuesOperator
     }
 
     public static DBSPIntegrateTraceRetainValuesOperator create(
-            CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control, boolean accumulate) {
+            CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control) {
         DBSPType controlType = control.outputType();
         Utilities.enforce(controlType.is(DBSPTypeTupleBase.class),
                 () -> "Control type is not a tuple: " + controlType);
@@ -66,13 +63,8 @@ public final class DBSPIntegrateTraceRetainValuesOperator
         compare = ExpressionCompiler.makeBinaryExpression(
                 node, compare.getType(), DBSPOpcode.OR, compare0, compare);
         DBSPExpression closure = compare.closure(param, controlArg.asParameter());
-        return new DBSPIntegrateTraceRetainValuesOperator(node, closure, data, control, accumulate);
+        return new DBSPIntegrateTraceRetainValuesOperator(node, closure, data, control);
     }
-
-    public static DBSPIntegrateTraceRetainValuesOperator create(
-            CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control) {
-        return create(node, data, dataProjection, control, true);
-}
 
     @Override
     public DBSPSimpleOperator with(
@@ -82,7 +74,7 @@ public final class DBSPIntegrateTraceRetainValuesOperator
             Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
             return new DBSPIntegrateTraceRetainValuesOperator(
                     this.getRelNode(), Objects.requireNonNull(function),
-                    newInputs.get(0), newInputs.get(1), this.accumulate);
+                    newInputs.get(0), newInputs.get(1));
         }
         return this;
     }
@@ -101,10 +93,8 @@ public final class DBSPIntegrateTraceRetainValuesOperator
     @SuppressWarnings("unused")
     public static DBSPIntegrateTraceRetainValuesOperator fromJson(JsonNode node, JsonDecoder decoder) {
         DBSPSimpleOperator.CommonInfo info = commonInfoFromJson(node, decoder);
-        boolean accumulate = Utilities.getBooleanProperty(node, "accumulate");
-
         return new DBSPIntegrateTraceRetainValuesOperator(CalciteEmptyRel.INSTANCE,
-                info.getFunction(), info.getInput(0), info.getInput(1), accumulate)
+                info.getFunction(), info.getInput(0), info.getInput(1))
                 .addAnnotations(info.annotations(), DBSPIntegrateTraceRetainValuesOperator.class);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonOuterVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonOuterVisitor.java
@@ -23,7 +23,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWeightValidatorOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
@@ -337,7 +337,7 @@ public class ToJsonOuterVisitor extends CircuitVisitor {
     }
 
     @Override
-    public VisitDecision preorder(DBSPIntegrateTraceRetainValuesOperator operator) {
+    public VisitDecision preorder(DBSPIntegrateTraceRetainKeysOperator operator) {
         if (this.preorder(operator.to(DBSPBinaryOperator.class)).stop())
             return VisitDecision.STOP;
         this.property("accumulate");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -722,7 +722,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || Linq.different(sources, operator.inputs)
                 || function != operator.getFunction()) {
             result = new DBSPIntegrateTraceRetainKeysOperator(operator.getRelNode(), function,
-                    sources.get(0), sources.get(1))
+                    sources.get(0), sources.get(1), operator.accumulate)
                     .copyAnnotations(operator);
         }
         this.map(operator, result);
@@ -738,7 +738,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || Linq.different(sources, operator.inputs)
                 || function != operator.getFunction()) {
             result = new DBSPIntegrateTraceRetainValuesOperator(operator.getRelNode(), function,
-                    sources.get(0), sources.get(1), operator.accumulate)
+                    sources.get(0), sources.get(1))
                     .copyAnnotations(operator);
         }
         this.map(operator, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/StrayGC.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/StrayGC.java
@@ -22,6 +22,22 @@ public class StrayGC extends CircuitWithGraphsVisitor {
         super(compiler, g);
     }
 
+    /** Check that the retain operator invokes the runtime function variant that
+     * matches its data source: input tables require the non-accumulate variant,
+     * everything else the accumulate_ one.  The wrong variant makes the
+     * operator a silent no-op. */
+    void checkAccumulate(DBSPBinaryOperator operator, boolean accumulate) {
+        boolean input = operator.left().operator.is(DBSPInputMapWithWaterlineOperator.class);
+        if (input && accumulate)
+            throw new InternalCompilerError(
+                    "Operator " + operator + " garbage-collects an input table " +
+                    "and must use the non-accumulate variant");
+        if (!input && !accumulate)
+            throw new InternalCompilerError(
+                    "Operator " + operator + " garbage-collects a trace inside the " +
+                    "accumulate framework and must use the accumulate_ variant");
+    }
+
     void check(DBSPBinaryOperator operator) {
         // At least one sibling on the left input must contain an integral
         var left = operator.left();
@@ -45,16 +61,21 @@ public class StrayGC extends CircuitWithGraphsVisitor {
 
     @Override
     public void postorder(DBSPIntegrateTraceRetainValuesOperator operator) {
+        // This operator always uses the accumulate_ variant
+        this.checkAccumulate(operator, true);
         this.check(operator);
     }
 
     @Override
     public void postorder(DBSPIntegrateTraceRetainNValuesOperator operator) {
+        // This operator always uses the accumulate_ variant
+        this.checkAccumulate(operator, true);
         this.check(operator);
     }
 
     @Override
     public void postorder(DBSPIntegrateTraceRetainKeysOperator operator) {
+        this.checkAccumulate(operator, operator.accumulate);
         DBSPOperator left = operator.left().operator;
         if (left.is(DBSPAggregateLinearPostprocessRetainKeysOperator.class) ||
             left.is(DBSPChainAggregateOperator.class) ||

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -1741,19 +1741,58 @@ public class InsertLimiters extends CircuitCloneVisitor {
         if (operator != expansion)
             this.markBound(expansion.outputPort(), extend.outputPort());
 
-        if (INSERT_RETAIN_VALUES && replaceIndexedInput &&
+        if (INSERT_RETAIN_KEYS && replaceIndexedInput &&
                 multisetInput != null &&
+            // Do not GC materialized tables.
                 !multisetInput.getMetadata().materialized) {
-            // Do not GC materialized tables
-            IMaybeMonotoneType projection = me.getMonotoneType().to(MonotoneClosureType.class).getBodyType();
-            // The new input operator produces an indexed Zset, need to adjust the projection
-            projection = new PartiallyMonotoneTuple(
-                    List.of(NonMonotoneType.nonMonotone(indexedOutputType.keyType), projection), true, false);
-            DBSPSimpleOperator retain = DBSPIntegrateTraceRetainValuesOperator.create(
-                    operator.getRelNode(), newSource.getOutput(0),
-                    // For inputs "accumulate" is 'false'.
-                    projection, extend.outputPort(), false);
-            this.addOperator(retain);
+            // The trace of an input with a primary key resolves upserts and deletions,
+            // so it can be garbage-collected only by key, and only using LATENESS
+            // columns that belong to the key: a key pruned this way can never be
+            // legally referenced again, because any subsequent update or deletion
+            // carries the same key and is rejected as late.
+            // A LATENESS column outside the key permits no garbage collection at all:
+            // - a live row (timestamp at or above the waterline) must be retained
+            //   to produce the retraction when its key is updated or deleted;
+            // - a frozen row (timestamp below the waterline) can never be retracted,
+            //   but its presence is what lets the input operator reject writes to
+            //   its key as late; if the row is dropped, the next insert on that key
+            //   is accepted as a brand-new key without a retraction, so the output
+            //   would depend on when compaction runs.
+            List<IMaybeMonotoneType> keyFieldsMonotone = new ArrayList<>();
+            List<Integer> keyWaterlineFields = new ArrayList<>();
+            int latenessIndex = 0;
+            for (IColumnMetadata column: multisetInput.to(IHasColumnsMetadata.class).getColumnsMetadata()) {
+                boolean hasLateness = column.getLateness() != null;
+                if (column.isPrimaryKey()) {
+                    if (hasLateness) {
+                        keyFieldsMonotone.add(new MonotoneType(column.getType()));
+                        keyWaterlineFields.add(latenessIndex);
+                    } else {
+                        keyFieldsMonotone.add(NonMonotoneType.nonMonotone(column.getType()));
+                    }
+                }
+                if (hasLateness)
+                    latenessIndex++;
+            }
+            if (!keyWaterlineFields.isEmpty()) {
+                PartiallyMonotoneTuple keyProjection = new PartiallyMonotoneTuple(keyFieldsMonotone, false, false);
+                IMaybeMonotoneType projection = new PartiallyMonotoneTuple(
+                        List.of(keyProjection, NonMonotoneType.nonMonotone(indexedOutputType.elementType)),
+                        true, false);
+                // Project the waterline to the components that correspond to key columns
+                DBSPVariablePath w = timestamp.getType().ref().var();
+                DBSPExpression keyWaterline = new DBSPRawTupleExpression(
+                        new DBSPTupleExpression(
+                                Linq.map(keyWaterlineFields, f -> w.deepCopy().deref().field(f)),
+                                false));
+                OutputPort control = this.createApply(extend.outputPort(), null, keyWaterline.closure(w));
+                DBSPSimpleOperator retain = DBSPIntegrateTraceRetainKeysOperator.create(
+                        operator.getRelNode(), newSource.getOutput(0),
+                        // For inputs "accumulate" is 'false'.
+                        projection, control, false);
+                if (retain != null)
+                    this.addOperator(retain);
+            }
         }
 
         return result;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MergeGC.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MergeGC.java
@@ -186,7 +186,7 @@ public class MergeGC extends Passes {
             OutputPort apply = InsertLimiters.createApplyN(this.compiler, rights, min);
             this.addOperator(apply.node());
             return new DBSPIntegrateTraceRetainKeysOperator(
-                    first.getRelNode(), first.getClosureFunction(), left, apply);
+                    first.getRelNode(), first.getClosureFunction(), left, apply, first.accumulate);
         }
 
         public MergeRetain(DBSPCompiler compiler, FindMultipleRetainKeys fmk) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -240,7 +240,9 @@ public class CatalogTests extends BaseSQLTests {
             int imww = 0;
             int retain = 0;
 
-            // Check that InputMapWithWaterline is GC-ed
+            // Check that InputMapWithWaterline is NOT GC-ed: the LATENESS
+            // column is not part of the primary key, so every key can still be
+            // updated and the input trace must retain all rows.
             @Override
             public void postorder(DBSPIntegrateTraceRetainValuesOperator node) {
                 this.retain++;
@@ -254,7 +256,7 @@ public class CatalogTests extends BaseSQLTests {
             @Override
             public void endVisit() {
                 Assert.assertEquals(1, this.imww);
-                Assert.assertEquals(1, this.retain);
+                Assert.assertEquals(0, this.retain);
             }
         });
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
@@ -744,16 +744,14 @@ public class IncrementalRegression2Tests extends SqlIoTest {
                         END
                     )
                 FROM T GROUP BY id, bid;
-                """);
+                """).compactAfterEachStep();
         ccs.stepWeightOne("", """
                  id | bid | sum
                 ----------------""");
-        ccs.blockForCompaction();
         ccs.stepWeightOne("INSERT INTO T VALUES(1, 1, 0, 0, 0);", """
                  id | bid | sum
                 ----------------
                  1  | 1   | 1""");
-        ccs.blockForCompaction();
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -52,7 +52,7 @@ public class ProfilingTests extends StreamingTestBase {
             return Linq.map(split, Long::parseLong, Long.class);
         } finally {
             File mainFile = new File(mainFilePath);
-            Utilities.deleteFile(mainFile, true);
+            // Utilities.deleteFile(mainFile, true);
         }
     }
 
@@ -342,7 +342,8 @@ public class ProfilingTests extends StreamingTestBase {
                 CREATE TABLE auction (
                    date_time TIMESTAMP NOT NULL LATENESS INTERVAL 1 MINUTE,
                    expires   TIMESTAMP NOT NULL,
-                   id        INT NOT NULL PRIMARY KEY
+                   id        INT NOT NULL,
+                   PRIMARY KEY (date_time, id)
                 );
 
                 CREATE VIEW V AS
@@ -356,7 +357,7 @@ public class ProfilingTests extends StreamingTestBase {
                         let expire = Timestamp::from_milliseconds(timestamp.milliseconds() + 1000000);
                         timestamp = Timestamp::from_milliseconds(timestamp.milliseconds() + 20000);
                         let auction = zset!(Tup3::new(timestamp, expire, i) => 1);
-                        append_to_map_handle(&auction, &streams.0, |x| Tup1::new(x.2));
+                        append_to_map_handle(&auction, &streams.0, |x| Tup2::new(x.0, x.2));
                         if i % 100 == 0 {
                             let _ = circuit.transaction().expect("could not run circuit");
                             let _ = &read_output_spine(&streams.2);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -5,6 +5,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetai
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPControlledKeyFilterOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPInputMapWithWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainNValuesOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
@@ -778,7 +779,7 @@ public class StreamingTests extends StreamingTestBase {
                 SELECT A.*, B.price, B.date_time AS bid_dateTime
                 FROM auction A, bid B
                 WHERE A.id = B.auction AND B.date_time BETWEEN A.date_time AND A.expires""";
-           CompilerCircuitStream ccs = this.getCCS(sql);
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
         // Insert an auction. No bids => no output
         ccs.step("""
                 INSERT INTO auction VALUES('2024-01-01 00:00:00', '2024-01-01 01:00:00', 0);
@@ -838,6 +839,571 @@ public class StreamingTests extends StreamingTestBase {
                 """, """
                  date_time | expires | id | price | bid_dateTime | weight
                 ----------------------------------------------------------""");
+    }
+
+    /** Asserts that the circuit contains exactly {@code keys}
+     * integrate_trace_retain_keys operators, and no integrate_trace_retain_values
+     * operators, that garbage-collect an input table.  */
+    void checkInputGC(CompilerCircuit cc, int keys) {
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            int retainKeys = 0;
+            int retainValues = 0;
+
+            @Override
+            public void postorder(DBSPIntegrateTraceRetainKeysOperator operator) {
+                if (operator.left().operator.is(DBSPInputMapWithWaterlineOperator.class))
+                    this.retainKeys++;
+            }
+
+            @Override
+            public void postorder(DBSPIntegrateTraceRetainValuesOperator operator) {
+                if (operator.left().operator.is(DBSPInputMapWithWaterlineOperator.class))
+                    this.retainValues++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(keys, this.retainKeys);
+                Assert.assertEquals(0, this.retainValues);
+            }
+        });
+    }
+
+    @Test
+    public void gcUpsertBoundary() {
+        // The LATENESS column is not part of the primary key, so the input
+        // trace is never garbage-collected: any key can still be updated.
+        // Rows whose timestamp is exactly on the waterline are not late and
+        // can be updated and deleted.
+        // The waterline is max over all data of (ts - 100); each step is
+        // filtered with the waterline computed from the previous steps.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL PRIMARY KEY,
+                    ts BIGINT NOT NULL LATENESS 100
+                );
+                CREATE VIEW v AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 0);
+        // Before this step: waterline = minimum, table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0), (2, 100), (3, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  1 |   0 | 1
+                  2 | 100 | 1
+                  3 | 200 | 1""");
+        // Before this step, table contents (rows above the ==== line are
+        // below the waterline):
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 200 - 100
+        //    2 | 100 | on the waterline: still updatable
+        //    3 | 200 |
+        // Updating key 2 retracts the old row.
+        ccs.step("""
+                INSERT INTO t VALUES(2, 300);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  2 | 100 | -1
+                  2 | 300 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 300 - 100
+        //    3 | 200 | on the waterline: still deletable
+        //    2 | 300 |
+        ccs.step("""
+                REMOVE FROM t VALUES(3, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  3 | 200 | -1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 300 - 100
+        //    2 | 300 |
+        ccs.step("""
+                INSERT INTO t VALUES(4, 400);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  4 | 400 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 400 - 100
+        //    2 | 300 | on the waterline
+        //    4 | 400 |
+        // A new key with a timestamp below the waterline is late and ignored.
+        ccs.step("""
+                INSERT INTO t VALUES(5, 100);
+                """, """
+                 id | ts  | weight
+                --------------------""");
+    }
+
+    @Test
+    public void gcDeleteOldRow() {
+        // Deleting a key whose row is below the waterline is ignored: the
+        // deletion itself is late.  Deleting a row at or above the waterline works.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL PRIMARY KEY,
+                    ts BIGINT NOT NULL LATENESS 100
+                );
+                CREATE VIEW v AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 0);
+        // Before this step: waterline = minimum, table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0), (2, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  1 |   0 | 1
+                  2 | 200 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 200 - 100
+        //    2 | 200 |
+        ccs.step("""
+                INSERT INTO t VALUES(3, 250);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  3 | 250 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 250 - 100
+        //    2 | 200 |
+        //    3 | 250 |
+        // Deleting frozen row (1, 0) is ignored.
+        ccs.step("""
+                REMOVE FROM t VALUES(1, 0);
+                """, """
+                 id | ts  | weight
+                --------------------""");
+        // Before this step: waterline = 250 - 100, table contents unchanged.
+        // Row (2, 200) is above the waterline: deleting it works.
+        ccs.step("""
+                REMOVE FROM t VALUES(2, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  2 | 200 | -1""");
+    }
+
+    @Test
+    public void gcUpsertOldRow() {
+        // Updating a key whose row is below the waterline must be ignored:
+        // the update would have to retract the old row, which is behind the
+        // lateness threshold.  See the warning about primary keys and LATENESS
+        // in docs.feldera.com/docs/tutorials/time-series.md: "old" records in
+        // such a table can never be updated or deleted.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL PRIMARY KEY,
+                    ts BIGINT NOT NULL LATENESS 100
+                );
+                CREATE VIEW v AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 0);
+        // Before this step: waterline = minimum, table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0), (2, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  1 |   0 | 1
+                  2 | 200 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 200 - 100
+        //    2 | 200 |
+        ccs.step("""
+                INSERT INTO t VALUES(3, 250);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  3 | 250 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 250 - 100
+        //    2 | 200 |
+        //    3 | 250 |
+        // The update of key 1 is ignored, even though the new timestamp 300
+        // is above the waterline: it would have to retract frozen row (1, 0).
+        ccs.step("""
+                INSERT INTO t VALUES(1, 300);
+                """, """
+                 id | ts  | weight
+                --------------------""");
+    }
+
+    @Test
+    public void gcUpsertOldRowLongLag() {
+        // Like gcUpsertOldRow, but with several steps between the moment the
+        // row falls below the waterline and the attempt to update it, giving
+        // compaction many opportunities to run.  The outcome must not depend
+        // on compaction timing.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL PRIMARY KEY,
+                    ts BIGINT NOT NULL LATENESS 100
+                );
+                CREATE VIEW v AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 0);
+        // Before this step: waterline = minimum, table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0), (2, 200);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  1 |   0 | 1
+                  2 | 200 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 200 - 100
+        //    2 | 200 |
+        ccs.step("""
+                INSERT INTO t VALUES(3, 250);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  3 | 250 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 250 - 100
+        //    2 | 200 |
+        //    3 | 250 |
+        ccs.step("""
+                INSERT INTO t VALUES(4, 260);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  4 | 260 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 260 - 100
+        //    2 | 200 |
+        //    3 | 250 |
+        //    4 | 260 |
+        ccs.step("""
+                INSERT INTO t VALUES(5, 270);
+                """, """
+                 id | ts  | weight
+                --------------------
+                  5 | 270 | 1""");
+        // Before this step, table contents:
+        //   id | ts  |
+        //  ----+-----+
+        //    1 |   0 | frozen
+        //  ================  waterline = 270 - 100
+        //    2 | 200 |
+        //    3 | 250 |
+        //    4 | 260 |
+        //    5 | 270 |
+        // The update of key 1 is ignored, even though the new timestamp 300
+        // is above the waterline: it would have to retract frozen row (1, 0).
+        ccs.step("""
+                INSERT INTO t VALUES(1, 300);
+                """, """
+                 id | ts  | weight
+                --------------------""");
+    }
+
+    @Test
+    public void gcTwoLatenessColumns() {
+        // Neither LATENESS column is part of the primary key, so the input
+        // trace is never garbage-collected.  The waterline is a pair compared
+        // pointwise; a row is frozen when it is below the waterline in ANY
+        // component.  A row fresh in both components stays updatable.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL PRIMARY KEY,
+                    ts1 BIGINT NOT NULL LATENESS 100,
+                    ts2 BIGINT NOT NULL LATENESS 100
+                );
+                CREATE VIEW v AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 0);
+        // Before this step: waterline = (minimum, minimum), table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0, 1000), (2, 1000, 0), (3, 1000, 1000);
+                """, """
+                 id | ts1  | ts2  | weight
+                ----------------------------
+                  1 |    0 | 1000 | 1
+                  2 | 1000 |    0 | 1
+                  3 | 1000 | 1000 | 1""");
+        // Before this step: waterline = (1000 - 100, 1000 - 100).
+        // The waterline pair is compared pointwise; table contents:
+        //   id | ts1  | ts2  |
+        //  ----+------+------+-----------------------------
+        //    1 |    0 | 1000 | ts1 below waterline: frozen
+        //    2 | 1000 |    0 | ts2 below waterline: frozen
+        //    3 | 1000 | 1000 |
+        // Row 3 is at or above the waterline in both components,
+        // so updating key 3 retracts the old row.
+        ccs.step("""
+                INSERT INTO t VALUES(3, 1100, 1100);
+                """, """
+                 id | ts1  | ts2  | weight
+                ----------------------------
+                  3 | 1000 | 1000 | -1
+                  3 | 1100 | 1100 | 1""");
+        // Before this step: waterline = (1100 - 100, 1100 - 100), table contents:
+        //   id | ts1  | ts2  |
+        //  ----+------+------+-----------------------------
+        //    1 |    0 | 1000 | ts1 below waterline: frozen
+        //    2 | 1000 |    0 | ts2 below waterline: frozen
+        //    3 | 1100 | 1100 |
+        // Row 1 is frozen through ts1 alone: the update is ignored, even
+        // though the old ts2 and both new timestamps are fresh.
+        ccs.step("""
+                INSERT INTO t VALUES(1, 1150, 1150);
+                """, """
+                 id | ts1  | ts2  | weight
+                ----------------------------""");
+        // Before this step: waterline = (1100 - 100, 1100 - 100), table contents unchanged.
+        // Row 2 is frozen through ts2 alone: the deletion is ignored.
+        ccs.step("""
+                REMOVE FROM t VALUES(2, 1000, 0);
+                """, """
+                 id | ts1  | ts2  | weight
+                ----------------------------""");
+        // Before this step: waterline = (1100 - 100, 1100 - 100), table contents unchanged
+        ccs.step("""
+                INSERT INTO t VALUES(4, 1200, 1200);
+                """, """
+                 id | ts1  | ts2  | weight
+                ----------------------------
+                  4 | 1200 | 1200 | 1""");
+    }
+
+    @Test
+    public void gcKeyLateness() {
+        // The LATENESS column is the primary key, so the compiler
+        // garbage-collects the input trace by key.  
+        String sql = """
+                CREATE TABLE t (
+                    ts BIGINT NOT NULL PRIMARY KEY LATENESS 100,
+                    v INT
+                );
+                CREATE VIEW vw AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 1);
+        // Before this step: waterline = minimum, table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(0, 1), (100, 1), (200, 1);
+                """, """
+                 ts  | v | weight
+                -------------------
+                   0 | 1 | 1
+                 100 | 1 | 1
+                 200 | 1 | 1""");
+        // Before this step, table contents (rows above the ==== line are
+        // below the waterline):
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //  ================  waterline = 200 - 100
+        //   100 | 1 | on the waterline: still updatable
+        //   200 | 1 |
+        // Updating key 100 retracts the old row.
+        ccs.step("""
+                INSERT INTO t VALUES(100, 2);
+                """, """
+                 ts  | v | weight
+                -------------------
+                 100 | 1 | -1
+                 100 | 2 | 1""");
+        // Before this step, table contents:
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //  ================  waterline = 200 - 100
+        //   100 | 2 |
+        //   200 | 1 |
+        // Updating GC'd key 0 is rejected: the record itself is late.
+        ccs.step("""
+                INSERT INTO t VALUES(0, 5);
+                """, """
+                 ts  | v | weight
+                -------------------""");
+        // Before this step, table contents:
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //  ================  waterline = 200 - 100
+        //   100 | 2 |
+        //   200 | 1 |
+        // Deleting GC'd key 0 is a no-op.
+        ccs.step("""
+                REMOVE FROM t VALUES(0, 1);
+                """, """
+                 ts  | v | weight
+                -------------------""");
+        // Before this step, table contents:
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //  ================  waterline = 200 - 100
+        //   100 | 2 |
+        //   200 | 1 |
+        ccs.step("""
+                INSERT INTO t VALUES(300, 1);
+                """, """
+                 ts  | v | weight
+                -------------------
+                 300 | 1 | 1""");
+        // Before this step, table contents:
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //   100 | 2 | GC'd
+        //  ================  waterline = 300 - 100
+        //   200 | 1 | on the waterline: still deletable
+        //   300 | 1 |
+        ccs.step("""
+                REMOVE FROM t VALUES(200, 1);
+                """, """
+                 ts  | v | weight
+                -------------------
+                 200 | 1 | -1""");
+        // Before this step, table contents:
+        //   ts  | v |
+        //  -----+---+
+        //    0  | 1 | GC'd
+        //   100 | 2 | GC'd
+        //  ================  waterline = 300 - 100
+        //   300 | 1 |
+        ccs.step("""
+                INSERT INTO t VALUES(300, 9);
+                """, """
+                 ts  | v | weight
+                -------------------
+                 300 | 1 | -1
+                 300 | 9 | 1""");
+    }
+
+    @Test
+    public void gcCompositeKeyLateness() {
+        // Composite primary key (id, ts) where only ts has LATENESS, plus a
+        // LATENESS column outside the key.  The input trace is
+        // garbage-collected by key, using only the ts component of the
+        // waterline.
+        String sql = """
+                CREATE TABLE t (
+                    id INT NOT NULL,
+                    ts BIGINT NOT NULL LATENESS 100,
+                    extra BIGINT NOT NULL LATENESS 100,
+                    v INT,
+                    PRIMARY KEY (id, ts)
+                );
+                CREATE VIEW vw AS SELECT * FROM t;""";
+        CompilerCircuitStream ccs = this.getCCS(sql).compactAfterEachStep();
+        this.checkInputGC(ccs, 1);
+        // Before this step: waterline = (minimum, minimum), table is empty
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0, 0, 1), (2, 200, 200, 1);
+                """, """
+                 id | ts  | extra | v | weight
+                --------------------------------
+                  1 |   0 |     0 | 1 | 1
+                  2 | 200 |   200 | 1 | 1""");
+        // Before this step, table ==== line partitions rows by
+        // the ts component of the key, the only one used for GC):
+        //   id | ts  | extra |
+        //  ----+-----+-------+
+        //    1 |   0 |     0 | GC'd
+        //  ========================  waterline = (200 - 100, 200 - 100)
+        //    2 | 200 |   200 |
+        // Updating live key (2, 200) retracts the old row.
+        ccs.step("""
+                INSERT INTO t VALUES(2, 200, 200, 9);
+                """, """
+                 id | ts  | extra | v | weight
+                --------------------------------
+                  2 | 200 |   200 | 1 | -1
+                  2 | 200 |   200 | 9 | 1""");
+        // Before this step:
+        //   id | ts  | extra |
+        //  ----+-----+-------+
+        //    1 |   0 |     0 | GC'd
+        //  ========================  waterline = (200 - 100, 200 - 100)
+        //    2 | 200 |   200 |
+        // Updating GC'd key (1, 0) is rejected: its ts component is late,
+        // even though the extra column is fresh.
+        ccs.step("""
+                INSERT INTO t VALUES(1, 0, 300, 5);
+                """, """
+                 id | ts  | extra | v | weight
+                --------------------------------""");
+        // Before this step, table contents:
+        //   id | ts  | extra |
+        //  ----+-----+-------+
+        //    1 |   0 |     0 | GC'd
+        //  ========================  waterline = (200 - 100, 200 - 100)
+        //    2 | 200 |   200 |
+        // Key (1, 300) is new; it does not collide with GC'd key (1, 0).
+        ccs.step("""
+                INSERT INTO t VALUES(1, 300, 300, 1);
+                """, """
+                 id | ts  | extra | v | weight
+                --------------------------------
+                  1 | 300 |   300 | 1 | 1""");
+        // Before this step, table contents:
+        //   id | ts  | extra |
+        //  ----+-----+-------+
+        //    1 |   0 |     0 | GC'd
+        //  ========================  waterline = (300 - 100, 300 - 100)
+        //    2 | 200 |   200 | on the waterline: deletable
+        //    1 | 300 |   300 |
+        ccs.step("""
+                REMOVE FROM t VALUES(2, 200, 200, 9);
+                """, """
+                 id | ts  | extra | v | weight
+                --------------------------------
+                  2 | 200 |   200 | 9 | -1""");
+    }
+
+    @Test
+    public void gcMaterializedNoRetain() {
+        // Materialized tables are never garbage-collected, so the compiler
+        // must not insert any retain operator for them, even when a primary
+        // key column has LATENESS.
+        String sql = """
+                CREATE TABLE t (
+                    ts BIGINT NOT NULL PRIMARY KEY LATENESS 100,
+                    v INT
+                ) WITH ('materialized' = 'true');
+                CREATE VIEW vw AS SELECT * FROM t;""";
+        CompilerCircuit cc = this.getCC(sql);
+        this.checkInputGC(cc, 0);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/CompilerCircuitStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/CompilerCircuitStream.java
@@ -21,6 +21,7 @@ import java.util.List;
  * Submits the code for compilation by the Rust compiler. */
 public class CompilerCircuitStream extends CompilerCircuit {
     final InputOutputChangeStream stream;
+    boolean compactAfterEachStep;
 
     public CompilerCircuitStream(DBSPCompiler compiler, BaseSQLTests test) {
         this(compiler, new InputOutputChangeStream(), test);
@@ -39,6 +40,12 @@ public class CompilerCircuitStream extends CompilerCircuit {
         super(compiler);
         this.stream = streams;
         test.addRustTestCase(this);
+        this.compactAfterEachStep = false;
+    }
+
+    public CompilerCircuitStream compactAfterEachStep() {
+        this.compactAfterEachStep = true;
+        return this;
     }
 
     public CompilerCircuitStream(
@@ -74,6 +81,8 @@ public class CompilerCircuitStream extends CompilerCircuit {
         DBSPType outputType = this.circuit.getSingleOutputType();
         Change output = TableParser.parseChangeTable(expected, outputType);
         this.stream.addPair(input, output);
+        if (this.compactAfterEachStep)
+            this.blockForCompaction();
     }
 
     /**
@@ -103,6 +112,8 @@ public class CompilerCircuitStream extends CompilerCircuit {
 
     public void step(Change input, Change output) {
         this.stream.addPair(input, output);
+        if (this.compactAfterEachStep)
+            this.blockForCompaction();
     }
 
     /** Execute some insert/delete statements using sqlite and return the produced result.


### PR DESCRIPTION
Fixes #6690 

The correct way to GC a collection with PRIMARY KEY and LATENESS on a field of the primary key is to use a `integrate_trace_retain_keys` operator. The previous implementation was using `integrate_trace_retain_values`, and was unsound: it could delete keys that should be permanently frozen.

Unfortunately this implementation GCs fewer programs.

## Checklist

- [x] Unit tests added/updated
