### PR TITLE
Add crm telemetry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,7 @@
         "prettier": "3.8.1",
         "prettier-plugin-svelte": "3.5.0",
         "prettier-plugin-tailwindcss": "0.7.2",
+        "product-fruits": "^1.1.0",
         "profiler-layout": "workspace:*",
         "profiler-lib": "workspace:*",
         "runed": "0.37.1",
@@ -1802,6 +1803,8 @@
     "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "product-fruits": ["product-fruits@1.1.0", "", {}, "sha512-eDNdYrf4zJDbu2RSWJ10UxX1QdESqYFfrsOjwfrQG4oJvj88b540geS+lhHeKoEVLA9QEPZlWX9M+sKQois+bA=="],
 
     "profiler-app": ["profiler-app@workspace:js-packages/profiler-app"],
 

--- a/crates/pipeline-manager/src/api/endpoints/config.rs
+++ b/crates/pipeline-manager/src/api/endpoints/config.rs
@@ -68,8 +68,12 @@ impl BuildInformation {
 
 #[derive(Serialize, ToSchema)]
 pub(crate) struct Configuration {
-    /// Telemetry key.
-    pub telemetry: String,
+    /// PostHog telemetry key. Empty when disabled.
+    pub posthog: String,
+    /// ConceptualHQ analytics key. Empty when disabled.
+    pub conceptualhq: String,
+    /// Product Fruits workspace code for in-app onboarding. Empty when disabled.
+    pub product_fruits: String,
     /// Feldera edition: "Open source" or "Enterprise"
     pub edition: String,
     /// The version corresponding to the type of `edition`.
@@ -106,7 +110,9 @@ impl Configuration {
         let license_check = LicenseCheck::validate(state).await.unwrap_or_default();
 
         Configuration {
-            telemetry: state.config.telemetry.clone(),
+            posthog: state.config.telemetry.clone(),
+            conceptualhq: state.config.conceptualhq.clone(),
+            product_fruits: state.config.product_fruits.clone(),
             edition: if cfg!(feature = "feldera-enterprise") {
                 "Enterprise"
             } else {

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -1077,6 +1077,8 @@ mod test {
             allowed_origins: None,
             demos_dir: vec![],
             telemetry: "".to_owned(),
+            conceptualhq: "".to_owned(),
+            product_fruits: "".to_owned(),
             support_data_collection_frequency: 15,
             support_data_retention: 3,
             authorized_groups: vec![],

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -863,12 +863,26 @@ pub struct ApiServerConfig {
     #[arg(long, default_values_t = default_demos_dir())]
     pub demos_dir: Vec<String>,
 
-    /// Telemetry key.
+    /// PostHog telemetry key.
     ///
-    /// If a telemetry key is set, anonymous usage data will be collected
-    /// and sent to our telemetry service.
+    /// If a key is set, anonymous usage data will be collected
+    /// and sent to our PostHog telemetry service.
     #[arg(long, default_value = "", env = "FELDERA_TELEMETRY")]
     pub telemetry: String,
+
+    /// ConceptualHQ analytics key.
+    ///
+    /// If set, the WebConsole loads ConceptualHQ analytics to identify the
+    /// signed-in user and track sign-in events. Leave empty to disable.
+    #[arg(long, default_value = "", env = "FELDERA_CONCEPTUALHQ")]
+    pub conceptualhq: String,
+
+    /// Product Fruits workspace code.
+    ///
+    /// If set, the WebConsole loads Product Fruits for in-app onboarding
+    /// (tours, hints, surveys). Leave empty to disable.
+    #[arg(long, default_value = "", env = "FELDERA_PRODUCT_FRUITS")]
+    pub product_fruits: String,
 
     /// Support data collection frequency (in seconds).
     ///
@@ -965,6 +979,8 @@ impl ApiServerConfig {
             dev_mode: false,
             allowed_origins: None,
             telemetry: "test".to_string(),
+            conceptualhq: "".to_string(),
+            product_fruits: "".to_string(),
             demos_dir: vec!["demos".to_string()],
             dump_openapi: false,
             issuer_tenant: false,

--- a/js-packages/web-console/package.json
+++ b/js-packages/web-console/package.json
@@ -72,6 +72,7 @@
     "prettier": "3.8.1",
     "prettier-plugin-svelte": "3.5.0",
     "prettier-plugin-tailwindcss": "0.7.2",
+    "product-fruits": "^1.1.0",
     "profiler-layout": "workspace:*",
     "profiler-lib": "workspace:*",
     "runed": "0.37.1",

--- a/js-packages/web-console/src/lib/components/layout/Footer.svelte
+++ b/js-packages/web-console/src/lib/components/layout/Footer.svelte
@@ -15,7 +15,7 @@
     <FelderaLogoBlackDetail class="h-8 pl-4 opacity-40"></FelderaLogoBlackDetail>
   {/if}
   <div class="flex flex-col gap-1 md:flex-row">
-    <BookADemo class="btn justify-start px-4 hover:bg-surface-50-950">
+    <BookADemo class="btn justify-start px-4 hover:bg-surface-50-950" triggerLocation="footer">
       <!-- svelte-ignore block_empty -->
       {#snippet icon()}{/snippet}
       Book a demo

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -299,7 +299,8 @@
           <CreatePipelineButton inputClass="max-w-64" btnClass="preset-filled-surface-50-950"
           ></CreatePipelineButton>
         </div>
-        <BookADemo class="btn-icon preset-filled-surface-50-950"></BookADemo>
+        <BookADemo class="btn-icon preset-filled-surface-50-950" triggerLocation="pipeline_editor"
+        ></BookADemo>
         <Tooltip class="">Book a demo</Tooltip>
       {/if}
     {/snippet}

--- a/js-packages/web-console/src/lib/components/other/BookADemo.svelte
+++ b/js-packages/web-console/src/lib/components/other/BookADemo.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
+  import { captureEvent } from '$lib/services/analytics'
   import type { Snippet } from '$lib/types/svelte'
 
   const {
     class: _class,
     children,
-    icon = defaultIcon
-  }: { class?: string; children?: Snippet; icon?: Snippet } = $props()
+    icon = defaultIcon,
+    triggerLocation
+  }: { class?: string; children?: Snippet; icon?: Snippet; triggerLocation?: string } = $props()
+
+  const calendlyUrl = 'https://calendly.com/d/cqnj-p63-mbq/feldera-demo'
 </script>
 
 {#snippet defaultIcon()}
@@ -14,9 +18,11 @@
 
 <a
   class={_class}
-  href="https://calendly.com/d/cqnj-p63-mbq/feldera-demo"
+  href={calendlyUrl}
   target="_blank"
   rel="noreferrer"
+  onclick={() =>
+    captureEvent('calendly_opened', { url: calendlyUrl, trigger_location: triggerLocation })}
 >
   {@render icon()}
   {@render children?.()}

--- a/js-packages/web-console/src/lib/components/other/DemoTile.svelte
+++ b/js-packages/web-console/src/lib/components/other/DemoTile.svelte
@@ -2,14 +2,14 @@
   import { useTryPipeline } from '$lib/compositions/pipelines/useTryPipeline'
   import type { Demo } from '$lib/services/pipelineManager'
 
-  let { demo }: { demo: Demo | null } = $props()
+  let { demo, triggerLocation }: { demo: Demo | null; triggerLocation?: string } = $props()
   const tryPipeline = useTryPipeline()
 </script>
 
 {#if demo}
   <div class="flex flex-col card border border-surface-100-900 p-4">
     <div class="text-sm text-surface-700-300">{demo.type}</div>
-    <button class="text-left" onclick={() => tryPipeline(demo)}>
+    <button class="text-left" onclick={() => tryPipeline(demo, triggerLocation)}>
       <span class="py-2 font-semibold">{demo.title}</span>
       <!-- <span class="fd fd-arrow-right inline-block w-2 text-[20px]"></span> -->
     </button>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
@@ -75,6 +75,8 @@ const HIDDEN_TABS = [
   'Health'
 ]
 
+const ROW_MOUNT_TIMEOUT_MS = 2000
+
 let mounted: { unmount: () => Promise<void> } | undefined
 let mountTarget: HTMLDivElement | undefined
 
@@ -102,13 +104,19 @@ async function mountLogsTab() {
 
   // Wait until the first log row has been mounted by the virtualiser — proves the
   // streaming pipeline parsed → pushed → rendered the lines we enqueued.
-  await expect.poll(() => document.querySelector('[data-rowindex]')).toBeTruthy()
+  await expect
+    .poll(() => document.querySelector('[data-rowindex]'), { timeout: ROW_MOUNT_TIMEOUT_MS })
+    .toBeTruthy()
 }
 
 // data-rowindex on each line is its position in the rows array (zero-based).
 // Line "N" is at row-index N-1.
 async function expectRowMounted(rowIndex: number) {
-  await expect.poll(() => document.querySelector(`[data-rowindex="${rowIndex}"]`)).toBeTruthy()
+  await expect
+    .poll(() => document.querySelector(`[data-rowindex="${rowIndex}"]`), {
+      timeout: ROW_MOUNT_TIMEOUT_MS
+    })
+    .toBeTruthy()
 }
 
 // --- Tests -------------------------------------------------------------------
@@ -150,11 +158,15 @@ describe('MonitoringPanel — log-search wiring', () => {
     await userEvent.keyboard('{Enter}')
     await expectRowMounted(41)
     // The match is painted via the CSS Custom Highlight API under LogList's fixed name.
-    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(true)
+    await expect
+      .poll(() => CSS.highlights.has('feldera-log-list-search'), { timeout: ROW_MOUNT_TIMEOUT_MS })
+      .toBe(true)
 
     await userEvent.keyboard('{Escape}')
     expect((input.element() as HTMLInputElement).value).toBe('')
-    await expect.poll(() => CSS.highlights.has('feldera-log-list-search')).toBe(false)
+    await expect
+      .poll(() => CSS.highlights.has('feldera-log-list-search'), { timeout: ROW_MOUNT_TIMEOUT_MS })
+      .toBe(false)
   })
 
   it('Ctrl+F from the log list focuses the search input; typing + Enter searches', async () => {

--- a/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -68,6 +68,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
     isPipelineShutdown
   } from '$lib/functions/pipelines/status'
   import { resolve } from '$lib/functions/svelte'
+  import { captureEvent } from '$lib/services/analytics'
   import type { PipelineAction } from '$lib/services/pipelineManager'
   import type { Snippet } from '$lib/types/svelte'
 
@@ -849,7 +850,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
         class="block pt-2 underline"
         href="https://calendly.com/d/cqnj-p63-mbq/feldera-demo"
         target="_blank"
-        rel="noreferrer">Upgrade</a
+        rel="noreferrer"
+        onclick={() =>
+          captureEvent('calendly_opened', {
+            url: 'https://calendly.com/d/cqnj-p63-mbq/feldera-demo'
+          })}>Upgrade</a
       >
     </Popover>
   {/if}

--- a/js-packages/web-console/src/lib/compositions/configCache.spec.ts
+++ b/js-packages/web-console/src/lib/compositions/configCache.spec.ts
@@ -54,7 +54,7 @@ const baseConfig = {
   edition: 'Open source',
   revision: 'abc123',
   runtime_revision: 'rt123',
-  telemetry: '',
+  posthog: '',
   version: '0.0.0'
 } as unknown as Configuration
 

--- a/js-packages/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
+++ b/js-packages/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
@@ -1,13 +1,24 @@
 import { goto } from '$app/navigation'
-import { useUpdatePipelineList } from '$lib/compositions/pipelines/usePipelineList.svelte'
+import {
+  usePipelineList,
+  useUpdatePipelineList
+} from '$lib/compositions/pipelines/usePipelineList.svelte'
 import { resolve } from '$lib/functions/svelte'
+import { captureEvent } from '$lib/services/analytics'
 import type { Demo } from '$lib/services/manager'
 import { usePipelineManager } from '../usePipelineManager.svelte'
 
 export const useTryPipeline = () => {
   const { updatePipelines } = useUpdatePipelineList()
+  const pipelineList = usePipelineList()
   const api = usePipelineManager()
-  return async (pipeline: Omit<Demo, 'title'>) => {
+  return async (pipeline: Omit<Demo, 'title'>, trigger_location?: string) => {
+    const already_created = (pipelineList.pipelines ?? []).some((p) => p.name === pipeline.name)
+    captureEvent('demo_opened', {
+      demo: pipeline.name,
+      already_created,
+      trigger_location
+    })
     try {
       const newPipeline = await api.postPipeline({
         name: pipeline.name,

--- a/js-packages/web-console/src/lib/services/analytics.spec.ts
+++ b/js-packages/web-console/src/lib/services/analytics.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// vi.mock is hoisted above imports, so its factory may only touch vars created
+// with vi.hoisted (also hoisted), not plain module-level consts.
+const { capture, trackConceptualHq } = vi.hoisted(() => ({
+  capture: vi.fn(),
+  trackConceptualHq: vi.fn()
+}))
+vi.mock('posthog-js', () => ({ default: { capture } }))
+vi.mock('$lib/services/conceptualHq', () => ({ trackConceptualHq }))
+
+import { captureEvent } from './analytics'
+
+afterEach(() => {
+  capture.mockClear()
+  trackConceptualHq.mockClear()
+})
+
+describe('captureEvent', () => {
+  it('forwards the event and properties to both PostHog and ConceptualHQ', () => {
+    const props = { demo: 'fraud', already_created: true, source: 'home' }
+    captureEvent('demo_opened', props)
+    expect(capture).toHaveBeenCalledExactlyOnceWith('demo_opened', props)
+    expect(trackConceptualHq).toHaveBeenCalledExactlyOnceWith('demo_opened', props)
+  })
+
+  it('forwards events with no properties to both backends', () => {
+    captureEvent('signin')
+    expect(capture).toHaveBeenCalledExactlyOnceWith('signin', undefined)
+    expect(trackConceptualHq).toHaveBeenCalledExactlyOnceWith('signin', undefined)
+  })
+})

--- a/js-packages/web-console/src/lib/services/analytics.ts
+++ b/js-packages/web-console/src/lib/services/analytics.ts
@@ -1,0 +1,14 @@
+import posthog from 'posthog-js'
+
+import { trackConceptualHq } from '$lib/services/conceptualHq'
+
+/**
+ * Report a product-analytics event to every configured backend (PostHog and
+ * ConceptualHQ). Each backend no-ops when its integration is disabled, so
+ * callers fire unconditionally. Use snake_case event names and property keys for consistency
+ * across both tools.
+ */
+export const captureEvent = (event: string, properties?: Record<string, unknown>) => {
+  posthog.capture(event, properties)
+  trackConceptualHq(event, properties)
+}

--- a/js-packages/web-console/src/lib/services/conceptualHq.spec.ts
+++ b/js-packages/web-console/src/lib/services/conceptualHq.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+const profile: UserProfile = { id: 'user-1', email: 'a@b.com', name: 'Ann' }
+
+// Only `conceptualhq` is read; the rest is filler to satisfy the type.
+const config = (conceptualhq: string) => ({ conceptualhq }) as Configuration
+
+// Fake DOM that records the injected <script>, so we can assert on it without a
+// real document. `getElementsByTagName` must return an existing script whose
+// parent receives the insert.
+const stubDom = () => {
+  const script: Record<string, unknown> = {}
+  const insertBefore = vi.fn()
+  const existing = { parentNode: { insertBefore } }
+  vi.stubGlobal('document', {
+    createElement: () => script,
+    getElementsByTagName: () => [existing]
+  })
+  return { script, insertBefore }
+}
+
+// Each case re-imports a fresh module so the one-shot `initialized` flag and
+// `window.ca` start clean.
+const freshModule = async (browser: boolean) => {
+  vi.resetModules()
+  vi.stubGlobal('window', browser ? {} : undefined)
+  return import('./conceptualHq')
+}
+
+// Queue entries are `arguments` objects; normalize to plain arrays for assertions.
+const queued = () => (window.ca?.q ?? []).map((a) => Array.from(a))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('initConceptualHq', () => {
+  it('injects the loader keyed by config, then identifies and tracks signin', async () => {
+    const { script } = stubDom()
+    const { initConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), profile)
+
+    expect(script.src).toBe('https://oqiset.feldera.com/analytics/loader-v1.js?key=my-key&v=1.1.0')
+    expect(queued()).toEqual([
+      ['identify', 'a@b.com', { email: 'a@b.com', name: 'Ann' }],
+      ['track', 'signin']
+    ])
+  })
+
+  it('does not track signup (OIDC login cannot distinguish it)', async () => {
+    stubDom()
+    const { initConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), profile)
+    expect(queued().some((call) => call[1] === 'signup')).toBe(false)
+  })
+
+  it('falls back to the user id when email is missing', async () => {
+    stubDom()
+    const { initConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), { id: 'user-1' })
+    expect(queued()[0]).toEqual(['identify', 'user-1', { email: undefined, name: undefined }])
+  })
+
+  it('is idempotent: a second call after success is a no-op', async () => {
+    stubDom()
+    const { initConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), profile)
+    const afterFirst = queued().length
+    initConceptualHq(config('my-key'), profile)
+    expect(queued().length).toBe(afterFirst)
+  })
+
+  it('does nothing when the key is empty', async () => {
+    stubDom()
+    const { initConceptualHq } = await freshModule(true)
+    initConceptualHq(config(''), profile)
+    expect(window.ca).toBeUndefined()
+  })
+
+  it('does nothing outside the browser', async () => {
+    stubDom()
+    const { initConceptualHq } = await freshModule(false)
+    // Must not throw when `window` is undefined.
+    expect(() => initConceptualHq(config('my-key'), profile)).not.toThrow()
+  })
+})

--- a/js-packages/web-console/src/lib/services/conceptualHq.spec.ts
+++ b/js-packages/web-console/src/lib/services/conceptualHq.spec.ts
@@ -87,3 +87,36 @@ describe('initConceptualHq', () => {
     expect(() => initConceptualHq(config('my-key'), profile)).not.toThrow()
   })
 })
+
+describe('trackConceptualHq', () => {
+  it('enqueues a track call with properties once the loader is installed', async () => {
+    stubDom()
+    const { initConceptualHq, trackConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), profile)
+    const before = queued().length
+    trackConceptualHq('demo_opened', { demo: 'x', already_created: true })
+    expect(queued().slice(before)).toEqual([
+      ['track', 'demo_opened', { demo: 'x', already_created: true }]
+    ])
+  })
+
+  it('omits the properties argument when none are given', async () => {
+    stubDom()
+    const { initConceptualHq, trackConceptualHq } = await freshModule(true)
+    initConceptualHq(config('my-key'), profile)
+    const before = queued().length
+    trackConceptualHq('some_event')
+    expect(queued().slice(before)).toEqual([['track', 'some_event']])
+  })
+
+  it('is a no-op when analytics is disabled (loader never installed)', async () => {
+    const { trackConceptualHq } = await freshModule(true)
+    expect(() => trackConceptualHq('demo_opened', { demo: 'x' })).not.toThrow()
+    expect(window.ca).toBeUndefined()
+  })
+
+  it('is a no-op outside the browser', async () => {
+    const { trackConceptualHq } = await freshModule(false)
+    expect(() => trackConceptualHq('demo_opened')).not.toThrow()
+  })
+})

--- a/js-packages/web-console/src/lib/services/conceptualHq.ts
+++ b/js-packages/web-console/src/lib/services/conceptualHq.ts
@@ -1,0 +1,84 @@
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+/**
+ * ConceptualHQ command queue. Before the loader script arrives, `window.ca`
+ * enqueues each call as `[command, ...args]`; the loader replays the queue once
+ * ready. Calls use the queue form, `ca('identify', ...)` / `ca('track', ...)`,
+ * which is what the async stub supports (the `ca.identify(...)` method form only
+ * exists after the loader has replaced the stub).
+ */
+type ConceptualAnalytics = ((command: string, ...args: unknown[]) => void) & {
+  q: unknown[][]
+  l?: number
+}
+
+declare global {
+  interface Window {
+    ConceptualAnalytics?: string
+    ca?: ConceptualAnalytics
+  }
+}
+
+// Feldera's ConceptualHQ instance. The key is the per-deployment variable and
+// travels through `/config`; the host and loader version are fixed here, the
+// same way the PostHog `api_host` is hardcoded.
+const LOADER_BASE = 'https://oqiset.feldera.com/analytics/loader-v1.js'
+const LOADER_VERSION = '1.1.0'
+
+let initialized = false
+
+/**
+ * Install the `window.ca` command queue and inject the ConceptualHQ loader.
+ * Mirrors the vendor snippet: define the queue stub, stamp the load time, then
+ * append the loader script keyed by the deployment's analytics key. Returns the
+ * `ca` handle so callers enqueue without re-reading the global.
+ */
+const loadConceptualAnalytics = (key: string): ConceptualAnalytics => {
+  window.ConceptualAnalytics = 'ca'
+  let ca = window.ca
+  if (!ca) {
+    const queue: unknown[][] = []
+    ca = Object.assign((...args: unknown[]) => queue.push(args), { q: queue })
+    window.ca = ca
+  }
+  ca.l = Date.now()
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `${LOADER_BASE}?key=${encodeURIComponent(key)}&v=${LOADER_VERSION}`
+  const firstScript = document.getElementsByTagName('script')[0]
+  firstScript.parentNode?.insertBefore(script, firstScript)
+
+  return ca
+}
+
+/**
+ * Initialize ConceptualHQ analytics for the signed-in user. The analytics key
+ * is served by the pipeline-manager in `/config` (`config.conceptualhq`), the
+ * same path the PostHog key travels, so deployments configure it without
+ * rebuilding the console.
+ *
+ * Identifies the user (keyed on email to match PostHog identity) and tracks a
+ * `signin` event.
+ *
+ * Idempotent: repeated calls (warm-cache reconcile, re-navigation) are ignored
+ * after the first success. No-op when the key is empty or outside the browser.
+ */
+export const initConceptualHq = (config: Configuration, profile: UserProfile) => {
+  if (initialized || !config.conceptualhq || typeof window === 'undefined') {
+    return
+  }
+  initialized = true
+
+  const ca = loadConceptualAnalytics(config.conceptualhq)
+
+  const userId = profile.email || profile.id
+  if (userId) {
+    ca('identify', userId, {
+      email: profile.email ?? undefined,
+      name: profile.name ?? undefined
+    })
+  }
+  ca('track', 'signin')
+}

--- a/js-packages/web-console/src/lib/services/conceptualHq.ts
+++ b/js-packages/web-console/src/lib/services/conceptualHq.ts
@@ -54,10 +54,7 @@ const loadConceptualAnalytics = (key: string): ConceptualAnalytics => {
 }
 
 /**
- * Initialize ConceptualHQ analytics for the signed-in user. The analytics key
- * is served by the pipeline-manager in `/config` (`config.conceptualhq`), the
- * same path the PostHog key travels, so deployments configure it without
- * rebuilding the console.
+ * Initialize ConceptualHQ analytics for the signed-in user.
  *
  * Identifies the user (keyed on email to match PostHog identity) and tracks a
  * `signin` event.
@@ -81,4 +78,21 @@ export const initConceptualHq = (config: Configuration, profile: UserProfile) =>
     })
   }
   ca('track', 'signin')
+}
+
+/**
+ * Track an event in ConceptualHQ. No-op when the loader was never installed
+ * (analytics disabled) or outside the browser, so callers fire unconditionally.
+ * Prefer the shared `captureEvent` in `analytics.ts` over calling this directly,
+ * so PostHog and ConceptualHQ stay in sync.
+ */
+export const trackConceptualHq = (event: string, properties?: Record<string, unknown>) => {
+  if (typeof window === 'undefined' || !window.ca) {
+    return
+  }
+  if (properties) {
+    window.ca('track', event, properties)
+  } else {
+    window.ca('track', event)
+  }
 }

--- a/js-packages/web-console/src/lib/services/manager/types.gen.ts
+++ b/js-packages/web-console/src/lib/services/manager/types.gen.ts
@@ -641,10 +641,22 @@ export type Configuration = {
    */
   changelog_url: string
   /**
+   * ConceptualHQ analytics key. Empty when disabled.
+   */
+  conceptualhq: string
+  /**
    * Feldera edition: "Open source" or "Enterprise"
    */
   edition: string
   license_validity?: LicenseValidity | null
+  /**
+   * PostHog telemetry key. Empty when disabled.
+   */
+  posthog: string
+  /**
+   * Product Fruits workspace code for in-app onboarding. Empty when disabled.
+   */
+  product_fruits: string
   /**
    * Specific revision corresponding to the edition `version` (e.g., git commit hash).
    */
@@ -653,10 +665,6 @@ export type Configuration = {
    * Specific revision corresponding to the default runtime version of the platform (e.g., git commit hash).
    */
   runtime_revision: string
-  /**
-   * Telemetry key.
-   */
-  telemetry: string
   /**
    * List of unstable features that are enabled.
    */

--- a/js-packages/web-console/src/lib/services/posthog.spec.ts
+++ b/js-packages/web-console/src/lib/services/posthog.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+// vi.mock is hoisted above imports, so its factory may only touch vars created
+// with vi.hoisted (also hoisted), not plain module-level consts.
+const { init, identify, capture } = vi.hoisted(() => ({
+  init: vi.fn(),
+  identify: vi.fn(),
+  capture: vi.fn()
+}))
+vi.mock('posthog-js', () => ({ default: { init, identify, capture } }))
+
+const profile: UserProfile = { id: 'user-1', email: 'a@b.com', name: 'Ann' }
+
+// Only `posthog` is read; the rest is filler to satisfy the type.
+const config = (posthog: string) => ({ posthog }) as Configuration
+
+// Each case re-imports a fresh module so the one-shot `initialized` flag resets.
+const freshModule = async (browser: boolean) => {
+  vi.resetModules()
+  init.mockClear()
+  identify.mockClear()
+  capture.mockClear()
+  vi.stubGlobal('window', browser ? {} : undefined)
+  return import('./posthog')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('initPosthog', () => {
+  it('starts the SDK, identifies the user, and captures signin', async () => {
+    const { initPosthog } = await freshModule(true)
+    initPosthog(config('ph-key'), profile)
+    expect(init).toHaveBeenCalledExactlyOnceWith('ph-key', {
+      api_host: 'https://us.i.posthog.com',
+      person_profiles: 'identified_only',
+      capture_pageview: false,
+      capture_pageleave: false
+    })
+    expect(identify).toHaveBeenCalledExactlyOnceWith('a@b.com', {
+      email: 'a@b.com',
+      name: 'Ann',
+      auth_id: 'user-1'
+    })
+    expect(capture).toHaveBeenCalledExactlyOnceWith('signin')
+  })
+
+  it('captures signin even when the profile has no email (skips identify)', async () => {
+    const { initPosthog } = await freshModule(true)
+    initPosthog(config('ph-key'), { id: 'user-1' })
+    expect(identify).not.toHaveBeenCalled()
+    expect(capture).toHaveBeenCalledExactlyOnceWith('signin')
+  })
+
+  it('is idempotent: a second call reports signin once', async () => {
+    const { initPosthog } = await freshModule(true)
+    initPosthog(config('ph-key'), profile)
+    initPosthog(config('ph-key'), profile)
+    expect(init).toHaveBeenCalledOnce()
+    expect(capture).toHaveBeenCalledOnce()
+  })
+
+  it('does nothing when the key is empty', async () => {
+    const { initPosthog } = await freshModule(true)
+    initPosthog(config(''), profile)
+    expect(init).not.toHaveBeenCalled()
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('does nothing outside the browser', async () => {
+    const { initPosthog } = await freshModule(false)
+    initPosthog(config('ph-key'), profile)
+    expect(init).not.toHaveBeenCalled()
+  })
+})

--- a/js-packages/web-console/src/lib/services/posthog.ts
+++ b/js-packages/web-console/src/lib/services/posthog.ts
@@ -1,0 +1,40 @@
+import posthog from 'posthog-js'
+
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+let initialized = false
+
+/**
+ * Initialize PostHog for the signed-in user: start the SDK, identify the user,
+ * and report a `signin` event. The telemetry key is served by the
+ * pipeline-manager in `/config` (`config.posthog`), so deployments configure it
+ * without rebuilding the console.
+ *
+ * Mirrors `initConceptualHq`: idempotent via its own `initialized` guard, so the
+ * warm-cache reconcile and `invalidateAll()` re-runs report `signin` once per
+ * session. No-op when the key is empty or outside the browser.
+ */
+export const initPosthog = (config: Configuration, profile: UserProfile) => {
+  if (initialized || !config.posthog || typeof window === 'undefined') {
+    return
+  }
+  initialized = true
+
+  posthog.init(config.posthog, {
+    api_host: 'https://us.i.posthog.com',
+    person_profiles: 'identified_only',
+    capture_pageview: false,
+    capture_pageleave: false
+  })
+
+  if (profile.email) {
+    posthog.identify(profile.email, {
+      email: profile.email,
+      name: profile.name,
+      auth_id: profile.id
+    })
+  }
+
+  posthog.capture('signin')
+}

--- a/js-packages/web-console/src/lib/services/productFruits.spec.ts
+++ b/js-packages/web-console/src/lib/services/productFruits.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+// Capture calls to the underlying loader without injecting its <script>.
+const init = vi.fn()
+vi.mock('product-fruits', () => ({ productFruits: { init, safeExec: vi.fn() } }))
+
+// The one-shot `initialized` flag is module-level, so each case re-imports a
+// fresh module with its own stubbed `window` global.
+const freshModule = async (browser: boolean) => {
+  vi.resetModules()
+  init.mockClear()
+  vi.stubGlobal('window', browser ? {} : undefined)
+  return import('./productFruits')
+}
+
+const profile: UserProfile = { id: 'user-1', email: 'a@b.com', name: 'Ann' }
+
+// Only `product_fruits` is read; the rest is filler to satisfy the type.
+const config = (product_fruits: string) => ({ product_fruits }) as Configuration
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('toProductFruitsUser', () => {
+  it('keys username on email so identity matches PostHog', async () => {
+    const { toProductFruitsUser } = await freshModule(true)
+    expect(toProductFruitsUser(profile)).toEqual({
+      username: 'a@b.com',
+      email: 'a@b.com',
+      firstname: 'Ann'
+    })
+  })
+
+  it('falls back to id, then to anonymous, when email is missing', async () => {
+    const { toProductFruitsUser } = await freshModule(true)
+    expect(toProductFruitsUser({ id: 'user-1' }).username).toBe('user-1')
+    expect(toProductFruitsUser({}).username).toBe('anonymous')
+  })
+})
+
+describe('initProductFruits', () => {
+  beforeEach(() => {
+    init.mockClear()
+  })
+
+  it('initializes once with the workspace code, language, and user', async () => {
+    const { initProductFruits } = await freshModule(true)
+    initProductFruits(config('wc-code'), profile)
+    expect(init).toHaveBeenCalledExactlyOnceWith('wc-code', 'en', {
+      username: 'a@b.com',
+      email: 'a@b.com',
+      firstname: 'Ann'
+    })
+  })
+
+  it('is idempotent: a second call after success is a no-op', async () => {
+    const { initProductFruits } = await freshModule(true)
+    initProductFruits(config('wc-code'), profile)
+    initProductFruits(config('wc-code'), profile)
+    expect(init).toHaveBeenCalledOnce()
+  })
+
+  it('does nothing when the workspace code is empty', async () => {
+    const { initProductFruits } = await freshModule(true)
+    initProductFruits(config(''), profile)
+    expect(init).not.toHaveBeenCalled()
+  })
+
+  it('does nothing outside the browser', async () => {
+    const { initProductFruits } = await freshModule(false)
+    initProductFruits(config('wc-code'), profile)
+    expect(init).not.toHaveBeenCalled()
+  })
+})

--- a/js-packages/web-console/src/lib/services/productFruits.ts
+++ b/js-packages/web-console/src/lib/services/productFruits.ts
@@ -1,0 +1,40 @@
+import { type ProductFruitsUserObject, productFruits } from 'product-fruits'
+
+import type { Configuration } from '$lib/services/manager'
+import type { UserProfile } from '$lib/types/auth'
+
+/**
+ * User interface language passed to Product Fruits. The console ships English
+ * only, so this is fixed until localization exists.
+ */
+const language = 'en'
+
+let initialized = false
+
+/**
+ * Map an authenticated user's profile to the identity Product Fruits expects.
+ * `username` is the sole required field; we key it on the email that PostHog
+ * also identifies on so onboarding progress stays tied to one person, and fall
+ * back to the user id when no email is present.
+ */
+export const toProductFruitsUser = (profile: UserProfile): ProductFruitsUserObject => ({
+  username: profile.email || profile.id || 'anonymous',
+  email: profile.email ?? undefined,
+  firstname: profile.name ?? undefined
+})
+
+/**
+ * Initialize Product Fruits for the signed-in user.
+ *
+ * Idempotent: repeated calls (warm-cache reconcile, re-navigation) are ignored
+ * after the first success, so it is safe to call from
+ * `initializeConfigDependencies`. No-op when the workspace code is empty or when
+ * running outside the browser.
+ */
+export const initProductFruits = (config: Configuration, profile: UserProfile) => {
+  if (initialized || !config.product_fruits || typeof window === 'undefined') {
+    return
+  }
+  initialized = true
+  productFruits.init(config.product_fruits, language, toProductFruitsUser(profile))
+}

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/(pipelines)/create/+page.ts
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/(pipelines)/create/+page.ts
@@ -29,5 +29,5 @@ export async function load({ url, parent }) {
     goto(resolve(`/`))
     return
   }
-  await useTryPipeline()(pipeline)
+  await useTryPipeline()(pipeline, 'url')
 }

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
@@ -226,7 +226,9 @@
         }}
       ></CreatePipelineButton>
     </div>
-    <BookADemo class="btn self-center preset-filled-primary-500">Book a demo</BookADemo>
+    <BookADemo class="btn self-center preset-filled-primary-500" triggerLocation="nav_drawer"
+      >Book a demo</BookADemo
+    >
     <NavigationExtras inline></NavigationExtras>
   </OverlayDrawer>
   <OverlayDrawer

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+page.svelte
@@ -74,7 +74,8 @@
         <CreatePipelineButton inputClass="max-w-64" btnClass="preset-filled-surface-50-950"
         ></CreatePipelineButton>
       </div>
-      <BookADemo class="btn preset-filled-primary-500">Book a demo</BookADemo>
+      <BookADemo class="btn preset-filled-primary-500" triggerLocation="home">Book a demo</BookADemo
+      >
     {/if}
   {/snippet}
 </AppHeader>
@@ -204,7 +205,7 @@
                 class="grid grid-cols-1 gap-x-6 gap-y-5 py-2 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5"
               >
                 {#each demos.current.slice(0, maxShownDemos) as demo}
-                  <DemoTile {demo}></DemoTile>
+                  <DemoTile {demo} triggerLocation="home"></DemoTile>
                 {/each}
                 <div class="flex flex-col card p-4">
                   <div class="text-sm text-surface-500"></div>

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/demos/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/demos/+page.svelte
@@ -56,7 +56,9 @@
         <CreatePipelineButton inputClass="max-w-64" btnClass="preset-filled-surface-50-950"
         ></CreatePipelineButton>
       </div>
-      <BookADemo class="btn preset-filled-primary-500">Book a demo</BookADemo>
+      <BookADemo class="btn preset-filled-primary-500" triggerLocation="demos"
+        >Book a demo</BookADemo
+      >
     {/if}
   {/snippet}
 </AppHeader>
@@ -70,7 +72,7 @@
     {#each demos.current.filter((demo) => {
       return !demo || demosType === 'All' || demo.type === demosType
     }) as demo}
-      <DemoTile {demo}></DemoTile>
+      <DemoTile {demo} triggerLocation="demos"></DemoTile>
     {/each}
   </div>
   <Footer></Footer>

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/health/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/health/+page.svelte
@@ -258,7 +258,9 @@
         <CreatePipelineButton inputClass="max-w-64" btnClass="preset-filled-surface-50-950"
         ></CreatePipelineButton>
       </div>
-      <BookADemo class="btn preset-filled-primary-500">Book a demo</BookADemo>
+      <BookADemo class="btn preset-filled-primary-500" triggerLocation="health"
+        >Book a demo</BookADemo
+      >
     {/if}
   {/snippet}
 </AppHeader>

--- a/js-packages/web-console/src/routes/+layout.ts
+++ b/js-packages/web-console/src/routes/+layout.ts
@@ -26,8 +26,10 @@ import {
   setSelectedTenant,
   triggerOidcLogin
 } from '$lib/services/auth'
+import { initConceptualHq } from '$lib/services/conceptualHq'
 import type { Configuration, SessionInfo } from '$lib/services/manager'
 import { client } from '$lib/services/manager/client.gen'
+import { initProductFruits } from '$lib/services/productFruits'
 import type { AuthDetails } from '$lib/types/auth'
 import type { LayoutLoad } from './$types'
 
@@ -83,10 +85,10 @@ export const trailingSlash = 'always'
  */
 
 const initPosthog = async (config: Configuration) => {
-  if (!config.telemetry) {
+  if (!config.posthog) {
     return
   }
-  posthog.init(config.telemetry, {
+  posthog.init(config.posthog, {
     api_host: 'https://us.i.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: false,
@@ -451,6 +453,8 @@ function initializeConfigDependencies(auth: AuthDetails, config: Configuration) 
         })
       }
     })
+    initProductFruits(config, auth.profile)
+    initConceptualHq(config, auth.profile)
   }
 
   {

--- a/js-packages/web-console/src/routes/+layout.ts
+++ b/js-packages/web-console/src/routes/+layout.ts
@@ -29,6 +29,7 @@ import {
 import { initConceptualHq } from '$lib/services/conceptualHq'
 import type { Configuration, SessionInfo } from '$lib/services/manager'
 import { client } from '$lib/services/manager/client.gen'
+import { initPosthog } from '$lib/services/posthog'
 import { initProductFruits } from '$lib/services/productFruits'
 import type { AuthDetails } from '$lib/types/auth'
 import type { LayoutLoad } from './$types'
@@ -83,18 +84,6 @@ export const trailingSlash = 'always'
  * double-fetching page-level resources, so be careful when adding new
  * branches that call `invalidateAll()` unconditionally.
  */
-
-const initPosthog = async (config: Configuration) => {
-  if (!config.posthog) {
-    return
-  }
-  posthog.init(config.posthog, {
-    api_host: 'https://us.i.posthog.com',
-    person_profiles: 'identified_only',
-    capture_pageview: false,
-    capture_pageleave: false
-  })
-}
 
 export type LayoutData = {
   auth: AuthDetails
@@ -444,15 +433,7 @@ function buildLayoutData(
  */
 function initializeConfigDependencies(auth: AuthDetails, config: Configuration) {
   if (typeof auth === 'object' && 'logout' in auth) {
-    initPosthog(config).then(() => {
-      if (auth.profile.email) {
-        posthog.identify(auth.profile.email, {
-          email: auth.profile.email,
-          name: auth.profile.name,
-          auth_id: auth.profile.id
-        })
-      }
-    })
+    initPosthog(config, auth.profile)
     initProductFruits(config, auth.profile)
     initConceptualHq(config, auth.profile)
   }

--- a/openapi.json
+++ b/openapi.json
@@ -8162,7 +8162,9 @@
       "Configuration": {
         "type": "object",
         "required": [
-          "telemetry",
+          "posthog",
+          "conceptualhq",
+          "product_fruits",
           "edition",
           "version",
           "revision",
@@ -8183,6 +8185,10 @@
             "type": "string",
             "description": "URL that navigates to the changelog of the current version"
           },
+          "conceptualhq": {
+            "type": "string",
+            "description": "ConceptualHQ analytics key. Empty when disabled."
+          },
           "edition": {
             "type": "string",
             "description": "Feldera edition: \"Open source\" or \"Enterprise\""
@@ -8195,6 +8201,14 @@
             ],
             "nullable": true
           },
+          "posthog": {
+            "type": "string",
+            "description": "PostHog telemetry key. Empty when disabled."
+          },
+          "product_fruits": {
+            "type": "string",
+            "description": "Product Fruits workspace code for in-app onboarding. Empty when disabled."
+          },
           "revision": {
             "type": "string",
             "description": "Specific revision corresponding to the edition `version` (e.g., git commit hash)."
@@ -8202,10 +8216,6 @@
           "runtime_revision": {
             "type": "string",
             "description": "Specific revision corresponding to the default runtime version of the platform (e.g., git commit hash)."
-          },
-          "telemetry": {
-            "type": "string",
-            "description": "Telemetry key."
           },
           "unstable_features": {
             "type": "string",


### PR DESCRIPTION
Add hooks for Product Fruits (user guiding) and ConceptualHQ (conversion measurement telemetry), added conversion-related tracking of events for scheduling a demo through Calendly and trying canned demos.

The goal of the PR is to capture events of user pressing the "Schedule a demo" link on try.feldera.com and navigating to explore the canned demos, as well as some metadata around that (where did the user click the button, was the demo pipeline tried before), and send them to both PostHog and ConceptualHQ.

Integration with Product Fruits is needed to set up user-guiding experiences for try.feldera.com. Its initialization is similar to PostHog and ConceptualHQ, so I decided to roll all three together, making sure the code is organized nicely. PostHog was already getting initialized, I only re-located relevant code for more consistency.
 
In the GET /config API response I renamed 'telemetry' to 'posthog' which is its actual contents. pipeline-manager and web-console update in lockstep so that's not a problem; the configuration option is still called 'telemetry' so existing deployments wouldn't change.