### PR TITLE
[codex] Continue Avro validation after missing nullable fields

### DIFF
--- a/crates/adapters/src/format/avro/schema.rs
+++ b/crates/adapters/src/format/avro/schema.rs
@@ -74,7 +74,7 @@ pub fn validate_struct_schema(
             // Allow nullable fields to be missing in the Avro schema. This is useful to, e.g.,
             // support inputs encoded using older versions of the schema missing some fields.
             if field.columntype.nullable {
-                return Ok(());
+                continue;
             } else {
                 return Err(format!(
                     "column '{}' is missing in the Avro schema",
@@ -669,8 +669,9 @@ impl AvroSchemaBuilder {
 
 #[cfg(test)]
 mod test {
-    use super::{AvroSchemaBuilder, is_valid_avro_fullname, schema_json};
+    use super::{AvroSchemaBuilder, is_valid_avro_fullname, schema_json, validate_struct_schema};
     use apache_avro::{Schema as AvroSchema, schema::Name};
+    use feldera_adapterlib::catalog::AvroSchemaRefs;
     use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
     use std::collections::BTreeMap;
 
@@ -751,5 +752,25 @@ mod test {
                 "'{invalid}' should be rejected"
             );
         }
+    }
+
+    #[test]
+    fn missing_nullable_field_does_not_stop_validation() {
+        let avro_schema =
+            AvroSchema::parse_str(r#"{"type":"record","name":"input","fields":[]}"#).unwrap();
+        let struct_schema = vec![
+            Field::new(
+                SqlIdentifier::new("optional", false),
+                ColumnType::bigint(true),
+            ),
+            Field::new(
+                SqlIdentifier::new("required", false),
+                ColumnType::bigint(false),
+            ),
+        ];
+
+        let error = validate_struct_schema(&avro_schema, &AvroSchemaRefs::new(), &struct_schema)
+            .unwrap_err();
+        assert_eq!(error, "column 'required' is missing in the Avro schema");
     }
 }


### PR DESCRIPTION
## Summary

- continue validating later SQL columns when a nullable column is absent from the Avro schema
- add a regression covering a missing nullable column followed by a missing required column

## Root cause

`validate_struct_schema` returned success for the entire record when it encountered one missing nullable column. This skipped validation of every subsequent column, allowing missing required or incompatible columns to pass startup validation and fail later while parsing data.

## Impact

Missing nullable columns remain supported for schema evolution, while all other declared SQL columns are still checked for compatibility.

## Validation

- `cargo test -p dbsp_adapters format::avro:: --lib` (46 passed on current upstream main)
- `cargo test -p dbsp_adapters missing_nullable_field_does_not_stop_validation --lib` (passed on the published fork branch)
- `cargo fmt --all -- --check`
