### PR TITLE
[adapters] Make `/stats` query parameters public.

### DIFF
--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -74,7 +74,7 @@ use feldera_types::format::json::JsonEncoderConfig;
 use feldera_types::pipeline_diff::PipelineDiff;
 use feldera_types::query_params::{
     ActivateParams, ApproveParameters, MetricsFormat, MetricsParameters, SamplyProfileGetParams,
-    SamplyProfileParams,
+    SamplyProfileParams, StatsParams,
 };
 use feldera_types::runtime_status::{
     BootstrapConfig, BootstrapPolicy, ConnectorStats, ExtendedRuntimeStatus,
@@ -1735,16 +1735,6 @@ async fn query(
     } else {
         adhoc_websocket(controller, request, stream).await
     }
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct StatsParams {
-    /// When `true`, include the most recent error messages for each endpoint
-    /// in the response (up to `MAX_CONNECTOR_ERRORS` per list). Default is
-    /// `false` so that callers polling `/stats` keep getting a lightweight
-    /// response. This selector is intended for the support-bundle collector.
-    #[serde(default)]
-    include_connector_errors: bool,
 }
 
 #[get("/stats")]

--- a/crates/feldera-types/src/query_params.rs
+++ b/crates/feldera-types/src/query_params.rs
@@ -85,3 +85,14 @@ pub struct ApproveParameters {
     #[serde(default)]
     pub concurrent_bootstrap: bool,
 }
+
+/// Query parameters to the `/stats` endpoint.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct StatsParams {
+    /// When `true`, include the most recent error messages for each endpoint
+    /// in the response (up to `MAX_CONNECTOR_ERRORS` per list). Default is
+    /// `false` so that callers polling `/stats` keep getting a lightweight
+    /// response. This selector is intended for the support-bundle collector.
+    #[serde(default)]
+    pub include_connector_errors: bool,
+}


### PR DESCRIPTION
This makes it easier for other code to use these parameters.