### PR TITLE
Handle Kafka tombstone messages

### DIFF
--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -242,6 +242,12 @@ impl TestProducer {
         self.producer.flush(Timeout::Never).unwrap();
     }
 
+    pub fn send_tombstone(&self, key: &[u8], topic: &str) {
+        let record = BaseRecord::<[u8], (), ()>::to(topic).key(key);
+        self.producer.send(record).unwrap();
+        self.producer.flush(Timeout::Never).unwrap();
+    }
+
     pub fn send_to_topic_partition(&self, data: &[Vec<TestStruct>], topic: &str, partition: i32) {
         for batch in data {
             let mut writer = CsvWriterBuilder::new()

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -1255,9 +1255,11 @@ impl PartitionReceiver {
                     }
 
                     let timestamp = message.timestamp().to_millis().unwrap_or(i64::MIN);
-                    let payload = message.payload().unwrap_or(&[]);
-                    let metadata = self.create_metadata(&message);
-                    let (buffer, errors) = parser.parse(payload, metadata);
+                    let (buffer, errors) = match message.payload() {
+                        Some(payload) => parser.parse(payload, self.create_metadata(&message)),
+                        // Skip tombstones; keep offsets.
+                        None => (None, Vec::new()),
+                    };
                     self.n_bytes
                         .fetch_add(buffer.len().bytes, Ordering::Relaxed);
                     self.messages

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -509,6 +509,45 @@ fn test_input(topic: &str, batch_sizes: &[u32]) {
     }
 }
 
+#[test]
+fn test_input_tombstone() {
+    init_test_logger();
+
+    let topic = "kafka_tombstone_ft";
+    let _kafka_resources = KafkaResources::create_topics(&[(topic, 1)]);
+
+    let (endpoint, receiver, reader) = create_reader(topic, None, false);
+    reader.extend();
+
+    let producer = TestProducer::new();
+    producer.send_message(b"m0", topic, None);
+    producer.send_tombstone(b"deleted-key", topic);
+    producer.send_message(b"", topic, None);
+    producer.send_message(b"m3", topic, None);
+
+    receiver.expect_buffering(3);
+    reader.queue(false);
+
+    let metadata = Metadata {
+        offsets: vec![0..4],
+    };
+    receiver.expect(vec![ConsumerCall::Extended {
+        num_records: 3,
+        metadata: serde_json::to_value(&metadata).unwrap(),
+    }]);
+    assert_eq!(take_flushed(&receiver), vec!["m0", "", "m3"]);
+
+    drop(endpoint);
+    drop(receiver);
+    drop(reader);
+
+    let (_endpoint, receiver, reader) = create_reader(topic, None, false);
+    receiver.inner.drop_buffered.store(true, Ordering::Release);
+    reader.replay(serde_json::to_value(&metadata).unwrap(), RmpValue::Nil);
+    receiver.expect(vec![ConsumerCall::Replayed { num_records: 3 }]);
+    assert_eq!(take_flushed(&receiver), vec!["m0", "", "m3"]);
+}
+
 /// A configured header filter drops non-matching messages before parsing, and
 /// the drop decision is deterministic across replay: a fresh reader replaying
 /// the checkpointed offset range reproduces exactly the admitted records.


### PR DESCRIPTION
Kafka topics can have "tombstone" messages, which are messages with an empty payload. These are valid messages, but will fail and emit an error when attempting to parse as avro.

Technically the current behaviour is still correct, the tombstone message gets skipped successfully, but can just handle properly.

### Describe Manual Test Plan

Setup Feldera and Redpanda, send a tombstone message, verify no error logs

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
