### PR TITLE
[SQL] Remove unneeded http5 dependencies from maven file pom.xml

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.target>19</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <calcite.version>1.43.0</calcite.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <janino.version>3.1.12</janino.version>
         <project.version>0.325.0</project.version>
         <avatica.version>1.28.0</avatica.version>
@@ -349,6 +349,18 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents.client5</groupId>
+                    <artifactId>httpclient5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents.core5</groupId>
+                    <artifactId>httpcore5-h2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents.core5</groupId>
+                    <artifactId>httpcore5</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -81,10 +81,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -598,21 +594,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                    postal_code     VARCHAR(6));
                 CREATE TABLE T(street VARCHAR, city VARCHAR, year INT);
                 CREATE VIEW V AS SELECT address_typ(T.street, city, 'CA', 94087) as address, T.year as year FROM T;""");
-    }
-
-    @Test
-    public void rawCalciteTest() throws SQLException {
-        Connection connection = DriverManager.getConnection("jdbc:calcite:");
-        String query = "SELECT timestampdiff(MONTH, TIMESTAMP'2021-02-28 12:00:00', TIMESTAMP'2021-03-28 11:59:59')";
-        try (PreparedStatement ps = connection.prepareStatement(query)) {
-            ps.execute();
-            try (ResultSet resultSet = ps.getResultSet()) {
-                while (resultSet.next()) {
-                    int result = resultSet.getInt(1);
-                    Assert.assertEquals(0, result);
-                }
-            }
-        }
     }
 
     @Test


### PR DESCRIPTION
Calcite depends on Avatica which pulls in httpclient. This should never be used by the SQL compiler, so I just removed these dependencies.
