### PR TITLE
[CI] Stop at first failed integration test

### DIFF
--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Python runtime tests
         if: ${{ vars.CI_DRY_RUN != 'true' && !contains(vars.CI_SKIP_JOBS, 'runtime-pytest') }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/runtime --timeout=3600 -vv ${{ vars.PYTEST_EXTRA }}
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/runtime --timeout=3600 --maxfail=1 -vv ${{ vars.PYTEST_EXTRA }}
         working-directory: python
         env:
           PYTHONPATH: ${{ github.workspace }}/python
@@ -59,7 +59,7 @@ jobs:
 
       - name: Python workload tests
         if: ${{ vars.CI_DRY_RUN != 'true' && !contains(vars.CI_SKIP_JOBS, 'runtime-workload') }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/workloads --timeout=3600 -vv ${{ vars.PYTEST_EXTRA }}
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/workloads --timeout=3600 --maxfail=1 -vv ${{ vars.PYTEST_EXTRA }}
         working-directory: python
         env:
           PYTHONPATH: ${{ github.workspace }}/python

--- a/python/tests/runtime_aggtest/run.sh
+++ b/python/tests/runtime_aggtest/run.sh
@@ -31,5 +31,6 @@ if [ "${RUNTIME_AGGTEST_JOBS:-1}" -le 1 ]; then
   for t in "${TESTS[@]}"; do run_one "$t"; done
 else
   echo "Running tests in parallel: ${RUNTIME_AGGTEST_JOBS} jobs"
-  printf '%s\n' "${TESTS[@]}" | xargs -P "${RUNTIME_AGGTEST_JOBS}" -I{} bash -e -c 'echo "Running: {}"; uv run --locked "$PYTHONPATH/tests/runtime_aggtest/{}"'
+  # exit 255 tells xargs to stop launching new jobs after the first failure
+  printf '%s\n' "${TESTS[@]}" | xargs -P "${RUNTIME_AGGTEST_JOBS}" -I{} bash -e -c 'echo "Running: {}"; uv run --locked "$PYTHONPATH/tests/runtime_aggtest/{}" || exit 255'
 fi


### PR DESCRIPTION
Today python integration tests continue to run after a failure; each test is slow, involving recompilation of pipelines.
With this change they will fail at the first failed test.