### PR TITLE
[adapters] Fix subscribe-at-latest race in fault-tolerant Kafka input

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -250,7 +250,45 @@ impl KafkaFtInputReaderInner {
         Ok(offsets.iter().copied().map(Offset::Offset).collect())
     }
 
-    #[allow(clippy::borrowed_box)]
+    /// Resolves `start_from: latest` to a concrete end offset per partition.
+    ///
+    /// The caller must invoke this synchronously, before `open()` returns, so
+    /// that the start position is pinned to the log end as it stands at open
+    /// time.  Assigning the symbolic [`Offset::End`] instead defers resolution
+    /// to librdkafka's fetch thread, which runs after `open()` returns: any
+    /// records a producer appends in that window would raise the resolved
+    /// watermark above them, so the connector would start past them and never
+    /// deliver them.
+    ///
+    /// This is useful because some tests assume that partition
+    /// offsets have been resolved after the open call returns;
+    /// otherwise, it's difficult to tell when that has been done.
+    fn fetch_latest_offsets(
+        &self,
+        config: &KafkaInputConfig,
+        n_partitions: usize,
+    ) -> AnyResult<Vec<Offset>> {
+        let partitions = config
+            .partitions
+            .clone()
+            .unwrap_or((0..n_partitions as i32).collect());
+
+        partitions
+            .iter()
+            .copied()
+            .map(|partition| {
+                let (_low, high) = self
+                    .kafka_consumer
+                    .fetch_watermarks(&config.topic, partition, METADATA_TIMEOUT)
+                    .map_err(|e| {
+                        anyhow!("error fetching watermarks for partition '{partition}': {e}")
+                    })?;
+                Ok(Offset::Offset(high))
+            })
+            .collect()
+    }
+
+    #[allow(clippy::borrowed_box, clippy::too_many_arguments)]
     fn poller_thread(
         &self,
         config: Arc<KafkaInputConfig>,
@@ -259,6 +297,7 @@ impl KafkaFtInputReaderInner {
         n_partitions: usize,
         command_receiver: UnboundedReceiver<InputReaderCommand>,
         resume_info: Option<Metadata>,
+        latest_offsets: Option<Vec<Offset>>,
     ) -> AnyResult<()> {
         let topic = &config.topic;
 
@@ -292,7 +331,8 @@ impl KafkaFtInputReaderInner {
                 KafkaStartFromConfig::Earliest => {
                     iter::repeat_n(Offset::Beginning, n_partitions).collect()
                 }
-                KafkaStartFromConfig::Latest => iter::repeat_n(Offset::End, n_partitions).collect(),
+                KafkaStartFromConfig::Latest => latest_offsets
+                    .expect("latest start offsets are resolved in KafkaFtInputReader::new"),
                 KafkaStartFromConfig::Offsets(offsets) => {
                     if n_partitions != offsets.len() {
                         bail!(
@@ -857,6 +897,23 @@ impl KafkaFtInputReader {
         });
         *inner.kafka_consumer.context().endpoint.lock().unwrap() = Arc::downgrade(&inner);
 
+        let n_partitions = config
+            .partitions
+            .as_deref()
+            .map(|p| p.len())
+            .unwrap_or(partition_count);
+
+        // Pin `start_from: latest` to a concrete end offset now, on the caller's
+        // thread, so the position is fixed before the poller thread runs and
+        // before any records a producer may append once `open()` returns.  A
+        // checkpoint (`resume_info`) supersedes `start_from`, so skip it then.
+        let latest_offsets =
+            if resume_info.is_none() && matches!(config.start_from, KafkaStartFromConfig::Latest) {
+                Some(inner.fetch_latest_offsets(config, n_partitions)?)
+            } else {
+                None
+            };
+
         let (command_sender, command_receiver) = unbounded_channel();
         let poller_handle = thread::Builder::new()
             .name("kafka-input-poller".to_string())
@@ -869,13 +926,10 @@ impl KafkaFtInputReader {
                         config.clone(),
                         &consumer,
                         parser,
-                        config
-                            .partitions
-                            .as_deref()
-                            .map(|p| p.len())
-                            .unwrap_or(partition_count),
+                        n_partitions,
                         command_receiver,
                         resume_info,
+                        latest_offsets,
                     ) {
                         consumer.error(true, e, None);
                     }

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -1929,7 +1929,6 @@ fn test_kafka_input_offset_earliest_2() {
 }
 
 #[test]
-#[ignore = "flaky, see https://github.com/feldera/feldera/issues/6728"]
 fn test_kafka_input_offset_latest() {
     test_offset(
         testdata(),
@@ -1940,7 +1939,6 @@ fn test_kafka_input_offset_latest() {
 }
 
 #[test]
-#[ignore = "flaky, see https://github.com/feldera/feldera/issues/6728"]
 fn test_kafka_input_offset_latest_2() {
     test_offset(
         testdata(),
@@ -2295,7 +2293,6 @@ fn test_input_partition(
 }
 
 #[test]
-#[ignore = "flaky, see https://github.com/feldera/feldera/issues/6728"]
 fn test_input_partitions_latest() {
     let topic = "test_input_partitions0";
     let data = vec![


### PR DESCRIPTION
Fixes #6731

The FT Kafka reader assigned `start_from: latest` partitions with the symbolic `Offset::End`. librdkafka resolves `End` to a concrete high watermark lazily, on its fetch thread, after `open()` returns. A record a producer appends in that window raises the watermark above itself, so the connector starts past it and never delivers it. The test_kafka_input_offset_latest{,_2} and test_input_partitions_latest tests hit exactly this and hung for the full 10-minute timeout, surfacing on the slower GKE runners (issue #6728).

KafkaFtInputReader::new now resolves `latest` to a concrete end offset synchronously, before `open()` returns, as the `offsets` and `timestamp` modes already do. Capturing the watermark on the caller's thread pins it to the log end before any post-start records, so every such record is delivered.

Re-enable the three tests quarantined for this race.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
