### PR TITLE
ci: give the constant-table pipeline honest memory bounds

### DIFF
--- a/python/tests/runtime_aggtest/aggtst_base.py
+++ b/python/tests/runtime_aggtest/aggtst_base.py
@@ -8,7 +8,7 @@ from typing import Dict, TypeAlias
 from feldera import Pipeline, PipelineBuilder
 from feldera.enums import CompilationProfile
 from feldera.rest.errors import FelderaAPIError
-from feldera.runtime_config import RuntimeConfig
+from feldera.runtime_config import Resources, RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 from tests import TEST_CLIENT, unique_pipeline_name
 
@@ -277,6 +277,9 @@ class TstAccumulator:
                     hosts=FELDERA_TEST_NUM_HOSTS,
                     provisioning_timeout_secs=180,
                     logging="debug",
+                    # Honest request so k8s does not pack aggtest pipelines
+                    # onto nodes without headroom and evict them mid-test.
+                    resources=Resources(memory_mb_min=3072),
                 ),
             ).create_or_replace()
 

--- a/python/tests/workloads/test_constant-table.py
+++ b/python/tests/workloads/test_constant-table.py
@@ -1,4 +1,5 @@
 import unittest
+from feldera.runtime_config import Resources
 from feldera.testutils import ViewSpec, run_workload, unique_pipeline_name
 
 # The compiler compiles `where t.company_id in <long list of constant values>` queries
@@ -51,7 +52,13 @@ views = [
 class TestConstantTable(unittest.TestCase):
     def test_constant_table(self):
         run_workload(
-            unique_pipeline_name("constant-table"), tables, views, transaction=True
+            unique_pipeline_name("constant-table"),
+            tables,
+            views,
+            transaction=True,
+            # Peaks close to 4 GB; an honest request keeps k8s from
+            # OOM-killing the pipeline mid-test.
+            resources=Resources(memory_mb_min=6000),
         )
 
 


### PR DESCRIPTION
Two memory-request fixes for pipeline evictions on the GKE runners:

- `constant-table` workload: a merge-queue run's pipeline used 3.8 GB against the 1 GiB default request and got evicted (`ci-arm64`, 2026-07-26 02:10 UTC, recurred 03:00 UTC on the next queue run). Same treatment as now-test and aggregate-join in #6725: `memory_mb_min` only, no `memory_mb_max` (a max would cap the DataFusion ad-hoc pool at 5%).
- All python aggtests: `Resources(memory_mb_min=3072)` in the shared `aggtst_base.py` RuntimeConfig, so k8s stops packing aggtest pipelines onto nodes without headroom.