### PR TITLE
[nexmark] Fix harness race that aborts the benchmark near the last batch

### DIFF
--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -112,15 +112,21 @@ fn spawn_source_producer(
                 input_handle.append(&mut events);
                 num_events += batch_count as u64;
 
-                step_done_tx.send(batch_count).unwrap();
                 // If we're unable to fetch a full batch, then we're done.
+                //
+                // Announce exhaustion before the step-done message that releases
+                // the coordinator: the coordinator polls `source_exhausted_rx`
+                // with `try_recv`, so it only observes exhaustion reliably if it
+                // is published before the message the coordinator waits on.
                 if batch_count < batch_size {
+                    source_exhausted_tx.send(InputStats { num_events }).unwrap();
+                    step_done_tx.send(batch_count).unwrap();
                     break batch_count;
                 }
+                step_done_tx.send(batch_count).unwrap();
                 step_do_rx.recv().unwrap();
             };
 
-            source_exhausted_tx.send(InputStats { num_events }).unwrap();
             step_done_tx.send(last_batch_count).unwrap();
         })
         .unwrap();


### PR DESCRIPTION
The benchmark harness could panic with "sending on a closed channel" once the event source ran dry, killing the run mid-query:

    thread 'benchmark_consumer' panicked at crates/nexmark/benches/nexmark/main.rs:76:39:
    called `Result::unwrap()` on an `Err` value: SendError { .. }
    thread 'main' panicked at crates/nexmark/benches/nexmark/main.rs:307:6:
    called `Result::unwrap()` on an `Err` value: sending on a closed channel

The producer published exhaustion after the step-done message that releases the coordinator, but the coordinator only polls the exhaustion channel with `try_recv`.  When the producer was descheduled between those two sends for longer than a DBSP transaction, the coordinator missed exhaustion, looped, and sent on `source_step_tx` after the producer had already exited.  That error returns from `coordinate_input_and_steps`, dropping `dbsp_step_done_rx`, so the consumer thread panics on its own send as well.

Publish exhaustion before the step-done message the coordinator waits on, which orders it ahead of the coordinator's next poll.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
