### PR TITLE
Fix several controller races.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3985,17 +3985,15 @@ impl CircuitThread {
                 CheckpointRequest::Scheduled => (),
                 CheckpointRequest::CheckpointCommand(callback) => callback(result.clone()),
                 CheckpointRequest::SuspendCommand(callback) => {
-                    // Terminate the circuit only on a *successful* suspend. A
-                    // failed suspend leaves the circuit intact and running; the
-                    // `/suspend` handler reports it as `PipelinePhase::Failed`
-                    // and stops the pipeline. Not marking `Terminated` here is
-                    // what keeps `/status` from masking the failure as a clean
-                    // `Suspended` during teardown: `get_status` reads the live
-                    // controller state before the phase, so a terminated
-                    // controller with desired status `Suspended` always reads
-                    // back as `Suspended` (see `terminated_status`).
+                    // Terminate the circuit only on a *successful* suspend, and
+                    // record that the suspend is the reason: that is what lets
+                    // `/status` tell a completed suspend apart from a pipeline
+                    // that died (see `terminated_status`). A failed suspend
+                    // leaves the circuit intact and running; the `/suspend`
+                    // handler reports it as `PipelinePhase::Failed` and stops the
+                    // pipeline.
                     match &result {
-                        Ok(_) => self.controller.status.set_state(PipelineState::Terminated),
+                        Ok(_) => self.controller.status.set_suspended(),
                         Err(e) => self.controller.error(e.clone(), None),
                     }
                     callback(result.clone().map(|_| ()))

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -598,6 +598,33 @@ impl Command {
     }
 }
 
+/// Returns a command's reply, or [ControllerError::ControllerExit] if the reply
+/// channel closed without one.
+///
+/// [Command::flush] answers every command the circuit thread can still see, but
+/// it cannot answer one it never sees:
+///
+/// - A command that arrives after `flush_commands_and_requests` has run sits in
+///   the channel until [CircuitThread] is dropped, which drops the command and
+///   with it the callback holding the reply channel.
+///
+/// - A circuit thread that unwinds on a panic drops its queued commands and
+///   pending checkpoint requests without flushing them at all.
+///
+/// Either way the caller is left holding a channel that will never produce an
+/// answer, so it must report that the controller is gone. Treating it as
+/// unreachable panics the waiter instead, and for `/suspend` that panic is
+/// swallowed by the task it runs in, leaving the pipeline with no outcome
+/// recorded at all.
+fn reply_or_controller_exit<T, E>(
+    reply: Result<Result<T, E>, oneshot::error::RecvError>,
+) -> Result<T, E>
+where
+    E: From<ControllerError>,
+{
+    reply.unwrap_or_else(|_| Err(E::from(ControllerError::ControllerExit)))
+}
+
 impl Controller {
     #[cfg(test)]
     pub(crate) fn with_test_config<F>(
@@ -1098,7 +1125,7 @@ impl Controller {
                 error!("checkpoint result could not be sent");
             }
         }));
-        receiver.await.unwrap()
+        reply_or_controller_exit(receiver.await)
     }
 
     pub async fn async_graph_profile(&self) -> Result<GraphProfile, ControllerError> {
@@ -1108,7 +1135,7 @@ impl Controller {
                 error!("`/dump_profile` result could not be sent");
             }
         }));
-        receiver.await.unwrap()
+        reply_or_controller_exit(receiver.await)
     }
 
     pub async fn async_json_profile(&self) -> Result<DbspProfile, ControllerError> {
@@ -1118,7 +1145,7 @@ impl Controller {
                 error!("`/dump_json_profile` result could not be sent");
             }
         }));
-        receiver.await.unwrap()
+        reply_or_controller_exit(receiver.await)
     }
 
     pub async fn async_samply_profile(
@@ -1298,7 +1325,7 @@ impl Controller {
                 }
             }),
         );
-        receiver.await.unwrap()
+        reply_or_controller_exit(receiver.await)
     }
 
     /// Checkpoints the pipeline.
@@ -1306,8 +1333,10 @@ impl Controller {
     /// This is a blocking wrapper around [Self::start_checkpoint].
     pub fn checkpoint(&self) -> Result<Checkpoint, Arc<ControllerError>> {
         let (sender, receiver) = oneshot::channel();
-        self.start_checkpoint(Box::new(move |result| sender.send(result).unwrap()));
-        receiver.blocking_recv().unwrap()
+        self.start_checkpoint(Box::new(move |result| {
+            let _ = sender.send(result);
+        }));
+        reply_or_controller_exit(receiver.blocking_recv())
     }
 
     /// Triggers a suspend operation. `cb` will be called when it completes.
@@ -1323,8 +1352,10 @@ impl Controller {
     /// This is a blocking wrapper around [Self::start_suspend].
     pub fn suspend(&self) -> Result<(), Arc<ControllerError>> {
         let (sender, receiver) = oneshot::channel();
-        self.start_suspend(Box::new(move |result| sender.send(result).unwrap()));
-        receiver.blocking_recv().unwrap()
+        self.start_suspend(Box::new(move |result| {
+            let _ = sender.send(result);
+        }));
+        reply_or_controller_exit(receiver.blocking_recv())
     }
 
     pub async fn async_suspend(&self) -> Result<(), Arc<ControllerError>> {
@@ -1334,7 +1365,7 @@ impl Controller {
                 error!("suspend result could not be sent");
             }
         }));
-        receiver.await.unwrap()
+        reply_or_controller_exit(receiver.await)
     }
 
     /// Returns whether this pipeline supports suspend-and-resume.  The result
@@ -2107,7 +2138,7 @@ impl Controller {
                     error!("`/rebalance` result could not be sent");
                 }
             })));
-        receiver.await.unwrap()?;
+        reply_or_controller_exit(receiver.await)?;
         self.inner.request_step();
         Ok(())
     }
@@ -2121,7 +2152,7 @@ impl Controller {
                 }
             })));
         self.inner.circuit_thread_unparker.unpark();
-        receiver.await.unwrap()?;
+        reply_or_controller_exit(receiver.await)?;
         Ok(())
     }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -173,6 +173,14 @@ pub struct GlobalControllerMetrics {
     /// State of the pipeline: running, paused, or terminating.
     state: Atomic<PipelineState>,
 
+    /// Whether [PipelineState::Terminated] means "a suspend completed
+    /// successfully" rather than "the pipeline died".
+    ///
+    /// The state alone does not say why the circuit stopped, and the two cases
+    /// need opposite reports: a completed suspend is the outcome the user asked
+    /// for, while any other termination is a failure.
+    suspended: AtomicBool,
+
     /// The pipeline has been resumed from a checkpoint and is currently bootstrapping
     /// new and modified views.
     bootstrap_in_progress: AtomicBool,
@@ -310,6 +318,7 @@ impl GlobalControllerMetrics {
         let initial_start_time = initial_start_time.unwrap_or(start_time);
         Self {
             state: Atomic::new(PipelineState::Paused),
+            suspended: AtomicBool::new(false),
             bootstrap_in_progress: AtomicBool::new(false),
             concurrent_bootstrap_phase: Atomic::new(ConcurrentBootstrapPhase::Inactive),
             commit_progress: Mutex::new(None),
@@ -339,6 +348,22 @@ impl GlobalControllerMetrics {
 
     pub fn get_state(&self) -> PipelineState {
         self.state.load(Ordering::Acquire)
+    }
+
+    /// Whether the pipeline reached [PipelineState::Terminated] because a
+    /// suspend completed successfully.
+    pub fn suspended(&self) -> bool {
+        self.suspended.load(Ordering::Acquire)
+    }
+
+    /// Terminates the pipeline because a suspend completed successfully.
+    ///
+    /// Records the reason before the state, so that an observer that sees
+    /// [PipelineState::Terminated] also sees why.
+    fn set_suspended(&self) {
+        self.suspended.store(true, Ordering::Release);
+        self.state
+            .store(PipelineState::Terminated, Ordering::Release);
     }
 
     fn input_batch(&self, amt: BufferSize) -> u64 {
@@ -758,6 +783,12 @@ impl ControllerStatus {
 
     pub fn unset_step_requested(&self) -> bool {
         self.global_metrics.unset_step_requested()
+    }
+
+    /// Terminates the pipeline because a suspend completed successfully; see
+    /// `GlobalControllerMetrics::suspended()`.
+    pub fn set_suspended(&self) {
+        self.global_metrics.set_suspended();
     }
 
     pub fn bootstrap_in_progress(&self) -> bool {

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -4910,3 +4910,41 @@ fn test_postprocessor_on_delta_output_fails() {
         "error should name the unsupported transport, got: {error}"
     );
 }
+
+/// A command whose reply channel closes without a reply must report that the
+/// controller is gone, not panic.
+///
+/// [`Command::flush`] answers every command the circuit thread can still see when
+/// it exits, but a command that arrives while the thread is already tearing down
+/// is never seen, and neither is anything queued when the thread unwinds on a
+/// panic: those commands are dropped unanswered. `/suspend` awaits its reply
+/// inside a spawned task whose `JoinHandle` is discarded, so panicking there is
+/// silent and leaves the pipeline with no outcome recorded at all.
+#[test]
+fn a_dropped_reply_or_controller_exit_reports_controller_exit() {
+    use crate::controller::{Command, ControllerError, reply_or_controller_exit};
+    use std::sync::Arc;
+
+    type SuspendReply = oneshot::Receiver<Result<(), Arc<ControllerError>>>;
+    fn suspend_command() -> (Command, SuspendReply) {
+        let (sender, receiver) = oneshot::channel();
+        let command = Command::Suspend(Box::new(move |result| {
+            let _ = sender.send(result);
+        }));
+        (command, receiver)
+    }
+
+    // Flushed: the caller is told the controller exited.
+    let (command, receiver) = suspend_command();
+    command.flush();
+    let error =
+        reply_or_controller_exit(receiver.blocking_recv()).expect_err("a flush reports an error");
+    assert!(matches!(*error, ControllerError::ControllerExit));
+
+    // Dropped unanswered: the caller must be told the same thing.
+    let (command, receiver) = suspend_command();
+    drop(command);
+    let error = reply_or_controller_exit(receiver.blocking_recv())
+        .expect_err("a dropped reply reports an error");
+    assert!(matches!(*error, ControllerError::ControllerExit));
+}

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -1594,22 +1594,22 @@ async fn status_handler(
 /// A successful suspend terminates the circuit before the server installs
 /// [`PipelinePhase::Suspended`] and deallocates the controller (see `/suspend`),
 /// so a status poll landing in that window observes the still-registered
-/// controller in `Terminated`. When a suspend was requested the pipeline is
-/// converging to `Suspended`, so report that clean status rather than a
-/// spurious `PipelineTerminated` error that the pipeline manager would record
-/// as a failed execution.
+/// controller in `Terminated`. Report the clean `Suspended` status the user asked
+/// for rather than a spurious `PipelineTerminated` error that the pipeline
+/// manager would record as a failed execution.
 ///
-/// This branch is reached only for a *successful* suspend: a failed suspend
-/// deliberately leaves the circuit running (see the `SuspendCommand` handler in
-/// `controller.rs`) so that it never masquerades here as a clean `Suspended`;
-/// the `/suspend` handler reports it as [`PipelinePhase::Failed`] instead. Any
-/// termination without a suspend request is an unexpected, fatal termination
-/// and stays an error.
+/// `suspended` must say that a suspend is what terminated the circuit (see
+/// `GlobalControllerMetrics::suspended`), not merely that one was requested. A
+/// circuit that dies while a suspend is pending also lands here, and reporting
+/// that as a clean `Suspended` would have the pipeline manager record a
+/// successful suspend for a pipeline that wrote no checkpoint, and later resume
+/// from a checkpoint that does not exist.
 fn terminated_status(
+    suspended: bool,
     runtime_desired_status: RuntimeDesiredStatus,
     storage_status_details: Option<StorageStatusDetails>,
 ) -> Result<ExtendedRuntimeStatus, ExtendedRuntimeStatusError> {
-    if matches!(runtime_desired_status, RuntimeDesiredStatus::Suspended) {
+    if suspended {
         Ok(ExtendedRuntimeStatus {
             runtime_status: RuntimeStatus::Suspended,
             runtime_status_details: json!(""),
@@ -1720,9 +1720,11 @@ fn get_status(
                     RuntimeStatus::Running,
                     storage_status_details,
                 )),
-                PipelineState::Terminated => {
-                    terminated_status(runtime_desired_status, storage_status_details)
-                }
+                PipelineState::Terminated => terminated_status(
+                    controller.status().global_metrics.suspended(),
+                    runtime_desired_status,
+                    storage_status_details,
+                ),
             };
         }
         None => {
@@ -3460,19 +3462,93 @@ mod test_http_helpers {
     /// `PipelinePhase::Suspended`, so `terminated_status` must report a clean
     /// `Suspended` while a suspend is in progress instead of the spurious
     /// `PipelineTerminated` error that flaked `suspend_and_resume_demos`.
-    ///
-    /// A *failed* suspend never reaches `terminated_status`: the `SuspendCommand`
-    /// handler leaves the circuit running instead of terminating it, and the
-    /// `/suspend` handler reports the failure as `PipelinePhase::Failed`.
     #[test]
     fn terminated_status_reports_suspended_while_suspending() {
-        let status = terminated_status(RuntimeDesiredStatus::Suspended, None)
+        let status = terminated_status(true, RuntimeDesiredStatus::Suspended, None)
             .expect("a suspending pipeline must not surface PipelineTerminated");
         assert!(matches!(status.runtime_status, RuntimeStatus::Suspended));
 
-        // An unexpected termination (no suspend requested) stays a fatal error.
-        let error = terminated_status(RuntimeDesiredStatus::Running, None)
+        // An unexpected termination stays a fatal error.
+        let error = terminated_status(false, RuntimeDesiredStatus::Running, None)
             .expect_err("an unexpected termination must remain PipelineTerminated");
+        assert_eq!(error.error.error_code.as_ref(), "PipelineTerminated");
+    }
+
+    /// A completed suspend must read back as `Suspended` while the controller is
+    /// still registered.
+    ///
+    /// The `/suspend` task records [`PipelinePhase::Suspended`] only after
+    /// `async_suspend` returns, so a poll in between sees a live controller whose
+    /// circuit is already `Terminated`. Reporting that as a fatal
+    /// `PipelineTerminated` is what flaked `suspend_and_resume_demos`.
+    /// Suspending the controller directly, without going through `/suspend`,
+    /// leaves the state in exactly that window.
+    #[actix_web::test]
+    async fn completed_suspend_is_reported_before_the_phase_is_recorded() {
+        ensure_default_crypto_provider();
+
+        let tempdir = TempDir::new().unwrap();
+        let storage_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&storage_dir).unwrap();
+        let config_str = format!(
+            r#"
+name: test
+workers: 2
+storage_config:
+    path: "{}"
+storage: true
+clock_resolution_usecs:
+inputs:
+outputs:
+"#,
+            storage_dir.display()
+        );
+        let (_server, state) = start_test_server_with_state(
+            &config_str,
+            Uuid::now_v7(),
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            &[Some("v0")],
+            false,
+        )
+        .await;
+
+        state
+            .controller()
+            .expect("controller present")
+            .async_suspend()
+            .await
+            .expect("suspend succeeds");
+
+        // The window: the controller is still registered and the phase still says
+        // the pipeline is initialized.
+        assert!(matches!(
+            state.phase(),
+            PipelinePhase::InitializationComplete
+        ));
+        assert!(state.controller().is_ok());
+
+        let status = get_status(&state, false).expect("a completed suspend is not an error");
+        assert!(
+            matches!(status.runtime_status, RuntimeStatus::Suspended),
+            "a completed suspend read back as {:?}",
+            status.runtime_status
+        );
+    }
+
+    /// A circuit that dies while a suspend is pending must not be reported as a
+    /// clean suspend.
+    ///
+    /// Requesting a suspend does not make the termination a suspend: the circuit
+    /// thread also terminates the pipeline when it exits with an error that
+    /// `is_fatal_controller_error` does not classify as fatal, and then nothing
+    /// has written a checkpoint. Reporting `Suspended` would have the pipeline
+    /// manager record a successful suspend and later resume from a checkpoint
+    /// that does not exist, so only the reason recorded by the `SuspendCommand`
+    /// handler may produce it.
+    #[test]
+    fn terminated_status_reports_a_death_during_suspend_as_an_error() {
+        let error = terminated_status(false, RuntimeDesiredStatus::Suspended, None)
+            .expect_err("a pipeline that died while suspending must not report a clean suspend");
         assert_eq!(error.error.error_code.as_ref(), "PipelineTerminated");
     }
 
@@ -3545,7 +3621,7 @@ outputs:
         .unwrap();
 
         // Baseline: a healthy pipeline reports a status, not an error.
-        assert!(get_status(&state).is_ok());
+        assert!(get_status(&state, false).is_ok());
 
         // Rewind to just before the bootstrap tail publishes its result.
         let controller = state.abandon_controller().expect("controller present");
@@ -3561,8 +3637,8 @@ outputs:
             "the bootstrap tail published a controller that a failure invalidated"
         );
 
-        let error =
-            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        let error = get_status(&state, false)
+            .expect_err("a pipeline that hit a fatal error must report an error");
         assert_ne!(
             error.error.error_code.as_ref(),
             "ControllerMissingAfterInitialization",
@@ -3595,8 +3671,8 @@ outputs:
         let weak = Arc::downgrade(&state.clone().into_inner());
         error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
 
-        let error =
-            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        let error = get_status(&state, false)
+            .expect_err("a pipeline that hit a fatal error must report an error");
         assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
     }
 
@@ -3629,8 +3705,8 @@ outputs:
         // having no suspend error of its own to report.
         assert!(state.suspended(None).is_none());
 
-        let error =
-            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        let error = get_status(&state, false)
+            .expect_err("a pipeline that hit a fatal error must report an error");
         assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
     }
 

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -171,6 +171,17 @@ impl PipelinePhase {
             PipelinePhase::Initializing(InitializationState::AwaitingApproval(_))
         )
     }
+
+    /// True if the pipeline never leaves this phase: it has failed or has been
+    /// suspended, and either way it never runs again.
+    fn is_terminal(&self) -> bool {
+        match self {
+            PipelinePhase::InitializationError(_)
+            | PipelinePhase::Failed(_)
+            | PipelinePhase::Suspended => true,
+            PipelinePhase::Initializing(_) | PipelinePhase::InitializationComplete => false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -466,8 +477,38 @@ impl ServerState {
         self.phase.lock().unwrap().clone()
     }
 
+    /// Records `phase`, unless a terminal phase was already recorded: the first
+    /// terminal phase is final (see [`PipelinePhase::is_terminal`]).
+    ///
+    /// Several threads publish phases concurrently, so without this rule the
+    /// last writer wins even when it knows less:
+    ///
+    /// - The circuit thread reports that initialization is complete and then
+    ///   immediately starts stepping the circuit (see `CircuitThread::run`), so a
+    ///   fatal error can reach `error_handler` while `do_bootstrap` is still
+    ///   finishing.  Overwriting that failure with
+    ///   [`PipelinePhase::InitializationComplete`] strands the pipeline in a
+    ///   phase claiming initialization succeeded even though `error_handler` has
+    ///   already deallocated the controller, which `/status` then reports as
+    ///   `ControllerMissingAfterInitialization` forever.
+    ///
+    /// - The `/suspend` task treats an already-terminal phase as its cue to stop
+    ///   waiting for a controller, and it reaches its own `set_phase` with no
+    ///   suspend error to report.  Overwriting a recorded failure with
+    ///   [`PipelinePhase::Suspended`] reports a clean suspend for a pipeline that
+    ///   failed without writing a checkpoint.
     pub fn set_phase(&self, phase: PipelinePhase) {
-        *self.phase.lock().unwrap() = phase;
+        {
+            let mut current = self.phase.lock().unwrap();
+            if current.is_terminal() {
+                return;
+            }
+            *current = phase;
+        }
+        // Notify without holding the phase lock: `controller()` reports a missing
+        // controller by reading the phase, so it takes the controller lock and
+        // then the phase lock.  Nothing may hold the phase lock while acquiring
+        // another.
         self.desired_status_change.notify_waiters();
     }
 }
@@ -1113,11 +1154,19 @@ fn error_handler(state: &Weak<ServerState>, error: Arc<ControllerError>, tag: Op
         error!("{error}");
     }
 
-    if is_fatal_controller_error(&error)
-        && let Ok(controller) = state.take_controller()
-    {
+    if is_fatal_controller_error(&error) {
+        // Record the failure before deallocating the controller, and record it
+        // even when there is no controller to deallocate.  `do_bootstrap`
+        // publishes the controller and the phase separately, and the circuit
+        // thread runs concurrently with both, so gating the phase update on
+        // `take_controller` either drops the error (it arrived before the
+        // controller was published) or leaves `/status` briefly reporting a
+        // controller-less `InitializationComplete` as
+        // `ControllerMissingAfterInitialization`, masking `error`.
         state.set_phase(PipelinePhase::Failed(error));
-        controller.initiate_stop();
+        if let Ok(controller) = state.take_controller() {
+            controller.initiate_stop();
+        }
     }
 }
 
@@ -3287,9 +3336,14 @@ impl StoredStatus {
 /// off.
 #[cfg(test)]
 mod test_http_helpers {
-    use super::{ServerArgs, ServerState, bootstrap, build_app, parse_config, terminated_status};
+    use super::{
+        ServerArgs, ServerState, bootstrap, build_app, error_handler, get_status, parse_config,
+        terminated_status,
+    };
     use crate::{
+        ControllerError,
         controller::ControllerBuilder,
+        ensure_default_crypto_provider,
         server::{InitializationState, PipelinePhase},
         test::{TestStruct, async_wait, http::TestHttpSender, test_circuit},
     };
@@ -3315,11 +3369,12 @@ mod test_http_helpers {
         fs::File,
         io::Write,
         path::Path,
+        sync::Arc,
         thread,
         thread::sleep,
         time::{Duration, Instant},
     };
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
     use uuid::Uuid;
 
     /// A successful suspend terminates the circuit before the server reports
@@ -3340,6 +3395,157 @@ mod test_http_helpers {
         let error = terminated_status(RuntimeDesiredStatus::Running, None)
             .expect_err("an unexpected termination must remain PipelineTerminated");
         assert_eq!(error.error.error_code.as_ref(), "PipelineTerminated");
+    }
+
+    /// `/status` must report a fatal controller error that arrives after the
+    /// controller is published but before the phase is.
+    ///
+    /// The circuit thread reports initialization complete and then immediately
+    /// enters its step loop (see `CircuitThread::run`), so a fatal error from its
+    /// first steps races the tail of `do_bootstrap`, which publishes the
+    /// controller and the phase in two separate steps.  An error landing between
+    /// them leaves the controller deallocated, so the phase must stay `Failed`
+    /// rather than being overwritten with `InitializationComplete`: `/status`
+    /// reports a controller-less `InitializationComplete` as the fatal
+    /// `ControllerMissingAfterInitialization`, which masks the real error and
+    /// makes the pipeline manager record that instead.
+    #[test]
+    fn fatal_error_during_bootstrap_tail_is_reported() {
+        ensure_default_crypto_provider();
+
+        let tempdir = TempDir::new().unwrap();
+        let storage_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&storage_dir).unwrap();
+        let config_str = format!(
+            r#"
+name: test
+workers: 2
+storage_config:
+    path: "{}"
+storage: true
+clock_resolution_usecs:
+inputs:
+outputs:
+"#,
+            storage_dir.display()
+        );
+        let mut config_file = NamedTempFile::new().unwrap();
+        config_file.write_all(config_str.as_bytes()).unwrap();
+        let config = parse_config(config_file.path().display().to_string()).unwrap();
+        let builder = ControllerBuilder::new(&config).unwrap();
+
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Paused,
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            Uuid::now_v7(),
+            None,
+            None,
+            None,
+            None,
+        ));
+
+        {
+            let state = state.clone();
+            thread::spawn(move || {
+                bootstrap(
+                    builder,
+                    Box::new(|workers| {
+                        Ok(test_circuit::<TestStruct>(
+                            workers,
+                            &TestStruct::schema(),
+                            &[None],
+                        ))
+                    }),
+                    state,
+                )
+            })
+        }
+        .join()
+        .unwrap();
+
+        // Baseline: a healthy pipeline reports a status, not an error.
+        assert!(get_status(&state).is_ok());
+
+        // The circuit thread reports a fatal error after `set_controller` but
+        // before the bootstrap tail publishes the phase.
+        let weak = Arc::downgrade(&state.clone().into_inner());
+        error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
+        // ... and then the bootstrap tail runs its last statement.
+        state.set_phase(PipelinePhase::InitializationComplete);
+
+        let error =
+            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        assert_ne!(
+            error.error.error_code.as_ref(),
+            "ControllerMissingAfterInitialization",
+            "the bootstrap tail masked the fatal error"
+        );
+        assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
+    }
+
+    /// `/status` must report a fatal controller error that arrives before the
+    /// controller is published.
+    ///
+    /// The circuit thread can fail before `do_bootstrap` reaches
+    /// `set_controller`, so recording the failure cannot depend on there being a
+    /// controller to deallocate; otherwise the error is dropped and the pipeline
+    /// goes on to report itself as initialized.
+    #[test]
+    fn fatal_error_before_controller_is_published_is_reported() {
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Paused,
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            Uuid::now_v7(),
+            None,
+            None,
+            None,
+            None,
+        ));
+
+        let weak = Arc::downgrade(&state.clone().into_inner());
+        error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
+        state.set_phase(PipelinePhase::InitializationComplete);
+
+        let error =
+            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
+    }
+
+    /// A suspend that overlaps a fatal controller error must not report a clean
+    /// suspend.
+    ///
+    /// The `/suspend` task waits for a controller to suspend and treats a
+    /// terminal phase as its cue to stop waiting.  It then reaches its own
+    /// `set_phase` with no suspend error of its own to report, so
+    /// `PipelinePhase::Suspended` must not replace the recorded failure: the
+    /// pipeline failed and wrote no checkpoint, and the pipeline manager would
+    /// otherwise record a successful suspend and later try to resume from it.
+    #[test]
+    fn suspend_does_not_overwrite_a_fatal_error() {
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Suspended,
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            Uuid::now_v7(),
+            None,
+            None,
+            None,
+            None,
+        ));
+
+        let weak = Arc::downgrade(&state.clone().into_inner());
+        error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
+        // What the `/suspend` task writes once it stops waiting for a controller.
+        state.set_phase(PipelinePhase::Suspended);
+
+        let error =
+            get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
+        assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
     }
 
     pub(super) async fn get_stats(server: &TestServer) -> ExternalControllerStatus {

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -483,24 +483,25 @@ impl ServerState {
 
     /// Publishes `controller` as the result of a successful initialization.
     ///
-    /// Returns false without publishing anything if the pipeline has already
+    /// Hands `controller` back without publishing it if the pipeline has already
     /// reached a terminal phase, which happens when the circuit thread reports a
     /// fatal error while `do_bootstrap` is still finishing: the circuit thread
     /// reports that initialization is complete and then starts stepping the
     /// circuit right away (see `CircuitThread::run`).  Publishing a controller
     /// that a failure has already invalidated would claim the pipeline is
-    /// runnable when it is not.
-    fn complete_initialization(&self, controller: Controller) -> bool {
+    /// runnable when it is not, and the caller owns stopping the circuit that
+    /// controller belongs to, because nothing else can reach it any more.
+    fn complete_initialization(&self, controller: Controller) -> Result<(), Controller> {
         let published = {
             let mut lifecycle = self.lifecycle.lock().unwrap();
             if lifecycle.set_phase(PipelinePhase::InitializationComplete) {
                 lifecycle.controller = Some(controller);
-                true
+                Ok(())
             } else {
-                false
+                Err(controller)
             }
         };
-        if published {
+        if published.is_ok() {
             self.desired_status_change.notify_waiters();
         }
         published
@@ -1389,13 +1390,21 @@ fn do_bootstrap(
     // Publish under `desired_status` so that `/start` and `/pause` either run
     // before this and are picked up by the `match` above, or run after and find
     // the controller.
-    let initialized = state.complete_initialization(controller);
+    let published = state.complete_initialization(controller);
     drop(desired_status);
 
-    if initialized {
-        info!("Pipeline initialization complete");
-    } else {
-        warn!("Pipeline failed while initialization was being completed");
+    match published {
+        Ok(()) => info!("Pipeline initialization complete"),
+        Err(controller) => {
+            // The failure that refused publication was recorded before the
+            // controller existed, so `fail` had no controller to stop. A circuit
+            // whose step fails keeps stepping (see `CircuitThread::step_circuit`),
+            // so stop it here: this is the last reference to it, and without this
+            // it runs on, holding the storage lock, after the pipeline has been
+            // reported dead.
+            warn!("Pipeline failed while initialization was being completed");
+            controller.initiate_stop();
+        }
     }
 
     Ok(())
@@ -3633,7 +3642,7 @@ outputs:
 
         // The bootstrap tail then finishes, and must not claim success.
         assert!(
-            !state.complete_initialization(controller),
+            state.complete_initialization(controller).is_err(),
             "the bootstrap tail published a controller that a failure invalidated"
         );
 
@@ -3645,6 +3654,81 @@ outputs:
             "the bootstrap tail masked the fatal error"
         );
         assert_eq!(error.error.error_code.as_ref(), "DbspPanic");
+    }
+
+    /// Initialization whose result is refused must stop the circuit it built.
+    ///
+    /// The failure that refuses publication was recorded before the controller
+    /// existed, so `fail` had no controller to stop, and a circuit whose step
+    /// fails keeps stepping (see `CircuitThread::step_circuit`). The bootstrap() tail
+    /// holds the only remaining reference to that circuit, so dropping it instead
+    /// of stopping it leaves the circuit running with nobody able to reach it,
+    /// still holding the storage lock that the next pipeline process needs.
+    #[actix_web::test]
+    async fn a_refused_bootstrap_result_stops_the_circuit() {
+        ensure_default_crypto_provider();
+
+        let tempdir = TempDir::new().unwrap();
+        let storage_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&storage_dir).unwrap();
+        let config_str = format!(
+            r#"
+name: test
+workers: 2
+storage_config:
+    path: "{}"
+storage: true
+clock_resolution_usecs:
+inputs:
+outputs:
+"#,
+            storage_dir.display()
+        );
+        let mut config_file = NamedTempFile::new().unwrap();
+        config_file.write_all(config_str.as_bytes()).unwrap();
+        let config = parse_config(config_file.path().display().to_string()).unwrap();
+        let builder = ControllerBuilder::new(&config).unwrap();
+
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Paused,
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            Uuid::now_v7(),
+            None,
+            None,
+            None,
+            None,
+        ));
+
+        // Record the failure before initialization starts, so the tail is
+        // certain to refuse the controller it builds.
+        let weak = Arc::downgrade(&state.clone().into_inner());
+        error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
+
+        let bootstrap_state = state.clone();
+        tokio::task::spawn_blocking(move || {
+            bootstrap(
+                builder,
+                Box::new(|workers| {
+                    Ok(test_circuit::<TestStruct>(
+                        workers,
+                        &TestStruct::schema(),
+                        &[None],
+                    ))
+                }),
+                bootstrap_state,
+            )
+        })
+        .await
+        .unwrap();
+
+        // Nothing was published and the failure stands.
+        assert!(state.controller().is_err());
+        assert!(matches!(state.phase(), PipelinePhase::Failed(_)));
+
+        // The circuit was stopped, so it has let go of the storage lock.
+        wait_for_storage_unlock(&storage_dir).await;
     }
 
     /// `/status` must report a fatal controller error that arrives before the

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -105,7 +105,6 @@ use std::ffi::OsStr;
 use std::hash::{BuildHasherDefault, DefaultHasher, Hash, Hasher};
 use std::io::ErrorKind;
 use std::mem::take;
-use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -271,19 +270,13 @@ pub(crate) struct ServerState {
     /// Notified when `desired_status` or `phase` changes.
     desired_status_change: Arc<Notify>,
 
-    /// `phase` nests inside `controller`.
-    ///
-    /// Use `controller()`, `take_controller()`, `set_controller()` to access.
-    ///
-    /// This lock is only held momentarily.
-    controller: Mutex<Option<Controller>>,
-
     /// Leaf lock (no more locks may be taken while holding it).
     ///
-    /// Use `phase()` and `set_phase()` to access.
+    /// Use `controller()`, `phase()` and the [Lifecycle] transitions to
+    /// access.
     ///
     /// This lock is only held momentarily.
-    phase: Mutex<PipelinePhase>,
+    lifecycle: Mutex<Lifecycle>,
 
     /// Leaf lock.
     checkpoint_state: Mutex<CheckpointState>,
@@ -342,6 +335,41 @@ pub(crate) struct ServerState {
     leases: Mutex<HashMap<Step, Lease>>,
 }
 
+/// Pipeline phase + controller.
+///
+/// `controller` and `phase` answer one question between them, so they are
+/// guarded together: several threads publish them concurrently, and updating
+/// them separately lets an observer see a pair that never legitimately occurs.
+///
+/// Every transition that changes both fields does so in one critical section
+/// (see [`ServerState::complete_initialization`], [`ServerState::fail`] and
+/// [`ServerState::suspended`]), so the pair is always consistent and
+/// [`ServerState::lifecycle`] can read it without coordinating with the writers.
+#[derive(Clone)]
+struct Lifecycle {
+    /// Tracks the health of the pipeline.
+    phase: PipelinePhase,
+
+    /// The controller, once initialization has produced one and before a
+    /// failure or a suspend has deallocated it.
+    controller: Option<Controller>,
+}
+
+impl Lifecycle {
+    /// Records `phase`, unless a terminal phase was already recorded: the first
+    /// terminal phase is final (see [`PipelinePhase::is_terminal`]), because a
+    /// thread that reports a later phase is not necessarily better informed.
+    ///
+    /// Returns whether the phase was recorded.
+    fn set_phase(&mut self, phase: PipelinePhase) -> bool {
+        if self.phase.is_terminal() {
+            return false;
+        }
+        self.phase = phase;
+        true
+    }
+}
+
 /// Leases on snapshots of particular steps.
 ///
 /// A lease gives the coordinator the ability to read tables within a step with
@@ -370,10 +398,12 @@ impl ServerState {
         // Max 10 errors per minute
         let rate_limiter = TokenBucketRateLimiter::new(10, Duration::from_secs(60));
         Self {
-            phase: Mutex::new(phase),
+            lifecycle: Mutex::new(Lifecycle {
+                phase,
+                controller: None,
+            }),
             desired_status_change: Arc::default(),
             metadata: md,
-            controller: Mutex::new(None),
             checkpoint_state: Default::default(),
             sync_checkpoint_state: Default::default(),
             desired_status: Mutex::new(desired_status),
@@ -406,11 +436,14 @@ impl ServerState {
         )
     }
 
-    /// Generate an appropriate error when `state.controller` is set to
-    /// `None`, which can mean that the pipeline is initializing, failed to
-    /// initialize, has been shut down or failed.
-    fn missing_controller_error(&self) -> PipelineError {
-        match self.phase() {
+    /// Generate an appropriate error when the controller is `None`, which can
+    /// mean that the pipeline is initializing, failed to initialize, has been
+    /// shut down or failed.
+    ///
+    /// Takes `phase` rather than reading it, because the callers hold the
+    /// `runtime` lock and it is not reentrant.
+    fn missing_controller_error(phase: &PipelinePhase) -> PipelineError {
+        match phase {
             PipelinePhase::Initializing(_) => PipelineError::Initializing,
             PipelinePhase::InitializationError(e) => {
                 PipelineError::InitializationError { error: e.clone() }
@@ -435,30 +468,95 @@ impl ServerState {
 
     /// Grabs a clone of the controller, or an error if there isn't one.
     fn controller(&self) -> Result<Controller, PipelineError> {
-        self.controller
-            .lock()
-            .unwrap()
-            .deref()
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| self.missing_controller_error())
+        let lifecycle = self.lifecycle.lock().unwrap();
+        lifecycle
+            .controller
+            .clone()
+            .ok_or_else(|| Self::missing_controller_error(&lifecycle.phase))
     }
 
-    /// Removes the controller and returns it, or an error if there wasn't one.
+    /// Reads the phase and the controller together, so the caller sees a
+    /// consistent pair.
+    fn lifecycle(&self) -> Lifecycle {
+        self.lifecycle.lock().unwrap().clone()
+    }
+
+    /// Publishes `controller` as the result of a successful initialization.
     ///
-    /// This only makes sense when we're terminating.
-    fn take_controller(&self) -> Result<Controller, PipelineError> {
-        self.controller
-            .lock()
-            .unwrap()
-            .deref_mut()
-            .take()
-            .ok_or_else(|| self.missing_controller_error())
+    /// Returns false without publishing anything if the pipeline has already
+    /// reached a terminal phase, which happens when the circuit thread reports a
+    /// fatal error while `do_bootstrap` is still finishing: the circuit thread
+    /// reports that initialization is complete and then starts stepping the
+    /// circuit right away (see `CircuitThread::run`).  Publishing a controller
+    /// that a failure has already invalidated would claim the pipeline is
+    /// runnable when it is not.
+    fn complete_initialization(&self, controller: Controller) -> bool {
+        let published = {
+            let mut lifecycle = self.lifecycle.lock().unwrap();
+            if lifecycle.set_phase(PipelinePhase::InitializationComplete) {
+                lifecycle.controller = Some(controller);
+                true
+            } else {
+                false
+            }
+        };
+        if published {
+            self.desired_status_change.notify_waiters();
+        }
+        published
     }
 
-    /// Sets the controller.  This should only be done once.
-    fn set_controller(&self, controller: Controller) {
-        *self.controller.lock().unwrap() = Some(controller);
+    /// Records that the pipeline failed with `error`, and returns the controller
+    /// to stop if one was still allocated.
+    ///
+    /// Recording the failure and deallocating the controller in one step keeps
+    /// `/status` from ever seeing a failed pipeline that still advertises a
+    /// controller, or a controller-less pipeline that still advertises
+    /// [`PipelinePhase::InitializationComplete`].
+    fn fail(&self, error: Arc<ControllerError>) -> Option<Controller> {
+        let (recorded, controller) = {
+            let mut lifecycle = self.lifecycle.lock().unwrap();
+            let recorded = lifecycle.set_phase(PipelinePhase::Failed(error));
+            (recorded, lifecycle.controller.take())
+        };
+        if recorded {
+            self.desired_status_change.notify_waiters();
+        }
+        controller
+    }
+
+    /// Records the outcome of a suspend, and returns the controller to stop if
+    /// one was still allocated.
+    ///
+    /// `error` is the suspend's own failure, if it had one.  A pipeline that
+    /// already failed keeps that failure: a suspend gives up waiting for a
+    /// controller as soon as the phase turns terminal, so it arrives here with
+    /// nothing of its own to report even though no checkpoint was written.
+    fn suspended(&self, error: Option<Arc<ControllerError>>) -> Option<Controller> {
+        let phase = match error {
+            Some(error) => PipelinePhase::Failed(error),
+            None => PipelinePhase::Suspended,
+        };
+        let (recorded, controller) = {
+            let mut lifecycle = self.lifecycle.lock().unwrap();
+            let recorded = lifecycle.set_phase(phase);
+            (recorded, lifecycle.controller.take())
+        };
+        if recorded {
+            self.desired_status_change.notify_waiters();
+        }
+        controller
+    }
+
+    /// Deallocates the controller without recording why, so that a test can
+    /// simulate a pipeline process dying without reporting anything.
+    ///
+    /// Production code deallocates the controller only as part of recording a
+    /// terminal phase, which is what keeps the two consistent; see
+    /// [`Lifecycle`].
+    #[cfg(test)]
+    fn abandon_controller(&self) -> Option<Controller> {
+        self.lifecycle.lock().unwrap().controller.take()
     }
 
     fn desired_status(&self) -> RuntimeDesiredStatus {
@@ -474,42 +572,27 @@ impl ServerState {
     }
 
     fn phase(&self) -> PipelinePhase {
-        self.phase.lock().unwrap().clone()
+        self.lifecycle.lock().unwrap().phase.clone()
     }
 
-    /// Records `phase`, unless a terminal phase was already recorded: the first
-    /// terminal phase is final (see [`PipelinePhase::is_terminal`]).
+    /// Records `phase` and leaves the controller as it is.
     ///
-    /// Several threads publish phases concurrently, so without this rule the
-    /// last writer wins even when it knows less:
+    /// Use this for the phases that report progress through initialization, and
+    /// for an initialization failure: none of them allocate or deallocate the
+    /// controller.  The transitions that do are
+    /// [`Self::complete_initialization`], [`Self::fail`] and
+    /// [`Self::suspended`], which update the phase and the controller together.
     ///
-    /// - The circuit thread reports that initialization is complete and then
-    ///   immediately starts stepping the circuit (see `CircuitThread::run`), so a
-    ///   fatal error can reach `error_handler` while `do_bootstrap` is still
-    ///   finishing.  Overwriting that failure with
-    ///   [`PipelinePhase::InitializationComplete`] strands the pipeline in a
-    ///   phase claiming initialization succeeded even though `error_handler` has
-    ///   already deallocated the controller, which `/status` then reports as
-    ///   `ControllerMissingAfterInitialization` forever.
-    ///
-    /// - The `/suspend` task treats an already-terminal phase as its cue to stop
-    ///   waiting for a controller, and it reaches its own `set_phase` with no
-    ///   suspend error to report.  Overwriting a recorded failure with
-    ///   [`PipelinePhase::Suspended`] reports a clean suspend for a pipeline that
-    ///   failed without writing a checkpoint.
+    /// See [`Lifecycle::set_phase`] for what happens if a terminal phase was
+    /// already recorded.
     pub fn set_phase(&self, phase: PipelinePhase) {
-        {
-            let mut current = self.phase.lock().unwrap();
-            if current.is_terminal() {
-                return;
-            }
-            *current = phase;
+        // Bind the result rather than testing it inline: a temporary lock guard in
+        // an `if` condition lives until the end of the `if`, and `lifecycle` is a
+        // leaf lock, so the notification below must not run while it is held.
+        let recorded = self.lifecycle.lock().unwrap().set_phase(phase);
+        if recorded {
+            self.desired_status_change.notify_waiters();
         }
-        // Notify without holding the phase lock: `controller()` reports a missing
-        // controller by reading the phase, so it takes the controller lock and
-        // then the phase lock.  Nothing may hold the phase lock while acquiring
-        // another.
-        self.desired_status_change.notify_waiters();
     }
 }
 
@@ -1154,19 +1237,10 @@ fn error_handler(state: &Weak<ServerState>, error: Arc<ControllerError>, tag: Op
         error!("{error}");
     }
 
-    if is_fatal_controller_error(&error) {
-        // Record the failure before deallocating the controller, and record it
-        // even when there is no controller to deallocate.  `do_bootstrap`
-        // publishes the controller and the phase separately, and the circuit
-        // thread runs concurrently with both, so gating the phase update on
-        // `take_controller` either drops the error (it arrived before the
-        // controller was published) or leaves `/status` briefly reporting a
-        // controller-less `InitializationComplete` as
-        // `ControllerMissingAfterInitialization`, masking `error`.
-        state.set_phase(PipelinePhase::Failed(error));
-        if let Ok(controller) = state.take_controller() {
-            controller.initiate_stop();
-        }
+    if is_fatal_controller_error(&error)
+        && let Some(controller) = state.fail(error)
+    {
+        controller.initiate_stop();
     }
 }
 
@@ -1312,11 +1386,17 @@ fn do_bootstrap(
         RuntimeDesiredStatus::Paused | RuntimeDesiredStatus::Suspended => controller.pause(),
         RuntimeDesiredStatus::Running => controller.start(),
     };
-    state.set_controller(controller);
+    // Publish under `desired_status` so that `/start` and `/pause` either run
+    // before this and are picked up by the `match` above, or run after and find
+    // the controller.
+    let initialized = state.complete_initialization(controller);
     drop(desired_status);
 
-    info!("Pipeline initialization complete");
-    state.set_phase(PipelinePhase::InitializationComplete);
+    if initialized {
+        info!("Pipeline initialization complete");
+    } else {
+        warn!("Pipeline failed while initialization was being completed");
+    }
 
     Ok(())
 }
@@ -1569,9 +1649,12 @@ fn get_status(
         None
     };
 
-    // Current status
-    match state.controller() {
-        Ok(controller) => {
+    // Current status.  Read the phase and the controller as one consistent pair:
+    // a controller is present only while the pipeline has not reached a terminal
+    // phase, so the controller's own view is authoritative whenever it is set.
+    let Lifecycle { phase, controller } = state.lifecycle();
+    match controller {
+        Some(controller) => {
             fn inner_status(
                 runtime_desired_status: RuntimeDesiredStatus,
                 controller: &Controller,
@@ -1642,13 +1725,13 @@ fn get_status(
                 }
             };
         }
-        Err(_) => {
+        None => {
             // Controller isn't set.
         }
     };
 
-    // The controller is not set: acquire the phase read lock
-    match state.phase() {
+    // The controller is not set, so the phase says why.
+    match phase {
         PipelinePhase::Initializing(inner) => match inner {
             InitializationState::Starting => Ok(ExtendedRuntimeStatus {
                 runtime_status: RuntimeStatus::Initializing,
@@ -2315,18 +2398,14 @@ async fn suspend(state: WebData<ServerState>) -> Result<impl Responder, Pipeline
                     };
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                // A failed suspend leaves the pipeline unsuspended: report it as
-                // a fatal error so the pipeline manager records the failure
-                // rather than a clean suspend. The circuit is deliberately left
-                // running on failure (see the `SuspendCommand` handler in
+                // A failed suspend leaves the pipeline unsuspended: `suspended`
+                // reports it as a fatal error so the pipeline manager records the
+                // failure rather than a clean suspend. The circuit is deliberately
+                // left running on failure (see the `SuspendCommand` handler in
                 // `controller.rs`), so `/status` never observed a `Terminated`
-                // circuit to mask as `Suspended`; this phase is what the poll
-                // sees once the controller is deallocated below.
-                state.set_phase(match suspend_error {
-                    Some(error) => PipelinePhase::Failed(error),
-                    None => PipelinePhase::Suspended,
-                });
-                if let Ok(controller) = state.take_controller()
+                // circuit to mask as `Suspended`; this phase is what the poll sees
+                // once the controller is deallocated.
+                if let Some(controller) = state.suspended(suspend_error)
                     && let Err(error) = controller.async_stop().await
                 {
                     error!("stopping controller failed ({error})");
@@ -3468,12 +3547,19 @@ outputs:
         // Baseline: a healthy pipeline reports a status, not an error.
         assert!(get_status(&state).is_ok());
 
-        // The circuit thread reports a fatal error after `set_controller` but
-        // before the bootstrap tail publishes the phase.
+        // Rewind to just before the bootstrap tail publishes its result.
+        let controller = state.abandon_controller().expect("controller present");
+
+        // The circuit thread reports a fatal error, which must be recorded even
+        // though there is no controller to deallocate yet.
         let weak = Arc::downgrade(&state.clone().into_inner());
         error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
-        // ... and then the bootstrap tail runs its last statement.
-        state.set_phase(PipelinePhase::InitializationComplete);
+
+        // The bootstrap tail then finishes, and must not claim success.
+        assert!(
+            !state.complete_initialization(controller),
+            "the bootstrap tail published a controller that a failure invalidated"
+        );
 
         let error =
             get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
@@ -3508,7 +3594,6 @@ outputs:
 
         let weak = Arc::downgrade(&state.clone().into_inner());
         error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
-        state.set_phase(PipelinePhase::InitializationComplete);
 
         let error =
             get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
@@ -3519,8 +3604,8 @@ outputs:
     /// suspend.
     ///
     /// The `/suspend` task waits for a controller to suspend and treats a
-    /// terminal phase as its cue to stop waiting.  It then reaches its own
-    /// `set_phase` with no suspend error of its own to report, so
+    /// terminal phase as its cue to stop waiting.  It then reaches `suspended`
+    /// with no suspend error of its own to report, so
     /// `PipelinePhase::Suspended` must not replace the recorded failure: the
     /// pipeline failed and wrote no checkpoint, and the pipeline manager would
     /// otherwise record a successful suspend and later try to resume from it.
@@ -3540,8 +3625,9 @@ outputs:
 
         let weak = Arc::downgrade(&state.clone().into_inner());
         error_handler(&weak, Arc::new(ControllerError::DbspPanic), None);
-        // What the `/suspend` task writes once it stops waiting for a controller.
-        state.set_phase(PipelinePhase::Suspended);
+        // What the `/suspend` task records once it stops waiting for a controller,
+        // having no suspend error of its own to report.
+        assert!(state.suspended(None).is_none());
 
         let error =
             get_status(&state).expect_err("a pipeline that hit a fatal error must report an error");
@@ -3701,7 +3787,7 @@ outputs:
     /// tail must be replayed on the next restart, and wait for the storage lock
     /// to be released so a new server can reopen the same storage directory.
     pub(super) async fn crash_pipeline(state: &WebData<ServerState>, storage_dir: &Path) {
-        let controller = state.take_controller().expect("controller present");
+        let controller = state.abandon_controller().expect("controller present");
         tokio::task::spawn_blocking(move || controller.stop())
             .await
             .unwrap()


### PR DESCRIPTION
The first commit in this series addresses a bug that manifested in CI. Unfortunately, the bug only masks the real failure, which is yet to be investigated.

The remaining commits address similar or related bugs found by claude in adversarial mode.

Every commit in the series is independent and can be reviewed separately.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
