### PR TITLE
Fix `total_processed_input_records` output connector metric.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -550,12 +550,22 @@ impl OutputEndpointControl {
     ///   checkpoint was taken. Ignored for newly added or modified connectors,
     ///   which should receive a fresh snapshot when `send_snapshot` is set.
     fn new(send_snapshot: bool, snapshot_already_sent: bool) -> Self {
-        // Treat the snapshot as already delivered when no initial snapshot
-        // is desired; also carry the checkpointed value through on restart.
-        let delivered = !send_snapshot || snapshot_already_sent;
         Self {
-            initial_snapshot_sent: AtomicBool::new(delivered),
+            initial_snapshot_sent: AtomicBool::new(!Self::snapshot_pending_at_startup(
+                send_snapshot,
+                snapshot_already_sent,
+            )),
         }
+    }
+
+    /// Whether an endpoint constructed from these settings starts out owing an
+    /// initial snapshot.
+    ///
+    /// Callers that must know this before the endpoint exists (the progress
+    /// counter seeding in `add_output_endpoint`) use this rather than
+    /// duplicating the rule.
+    fn snapshot_pending_at_startup(send_snapshot: bool, snapshot_already_sent: bool) -> bool {
+        send_snapshot && !snapshot_already_sent
     }
 
     /// Returns true if the next `push_output` should emit a snapshot for
@@ -578,6 +588,32 @@ impl OutputEndpointControl {
     fn initial_snapshot_sent(&self) -> bool {
         self.initial_snapshot_sent.load(Ordering::Acquire)
     }
+}
+
+/// Names the output endpoints whose relation the bootstrap re-emits.
+///
+/// The pipeline hands these endpoints output derived from records it processed
+/// before the restart, so they do not start out caught up with the pipeline's
+/// output. `add_output_endpoint` consults the result to seed
+/// `total_processed_input_records`.
+///
+/// The test is on the relation, not the connector. A connector whose own
+/// definition changed while its relation did not receives no re-emission and
+/// stays caught up with every input processed so far, which makes this set
+/// narrower than `ControllerInner::modified_output_endpoints`.
+fn bootstrapped_output_endpoints(
+    outputs: &BTreeMap<Cow<'static, str>, OutputEndpointConfig>,
+    pipeline_diff: Option<&PipelineDiff>,
+) -> HashSet<String> {
+    let Some(diff) = pipeline_diff else {
+        return HashSet::new();
+    };
+
+    outputs
+        .iter()
+        .filter(|(_, output_config)| diff.is_affected_relation(&output_config.stream))
+        .map(|(endpoint_name, _)| endpoint_name.to_string())
+        .collect()
 }
 
 impl Command {
@@ -3059,6 +3095,10 @@ impl CircuitThread {
         let (step_sender, step_receiver) =
             tokio::sync::watch::channel(StepStatus::new(step, StepAction::Idle, None));
         let (checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
+
+        let bootstrapped_output_endpoints =
+            bootstrapped_output_endpoints(&pipeline_config.outputs, pipeline_diff.as_ref());
+
         let (parker, backpressure_thread, command_receiver, controller) = ControllerInner::new(
             pipeline_config,
             circuit.runtime(),
@@ -3071,6 +3111,7 @@ impl CircuitThread {
             &resume_info,
             &output_statistics,
             modified_output_endpoints,
+            bootstrapped_output_endpoints,
             step_receiver,
             checkpoint_receiver,
             incarnation_uuid,
@@ -6827,6 +6868,12 @@ pub struct ControllerInner {
     /// without discarding the carried-over counters in
     /// `initial_statistics`.
     modified_output_endpoints: HashSet<String>,
+
+    /// Output endpoint names whose relation the bootstrap re-emits.
+    /// `add_output_endpoint` uses this to decide whether the endpoint starts
+    /// out caught up with the pipeline's output, which seeds its
+    /// `total_processed_input_records` counter.
+    bootstrapped_output_endpoints: HashSet<String>,
 }
 
 impl Drop for ControllerInner {
@@ -6849,6 +6896,7 @@ impl ControllerInner {
         resume_info: &HashMap<String, (JsonValue, CheckpointInputEndpointMetrics)>,
         output_statistics: &HashMap<String, CheckpointOutputEndpointMetrics>,
         modified_output_endpoints: HashSet<String>,
+        bootstrapped_output_endpoints: HashSet<String>,
         step_receiver: tokio::sync::watch::Receiver<StepStatus>,
         checkpoint_receiver: tokio::sync::watch::Receiver<Option<CheckpointCoordination>>,
         incarnation_uuid: Uuid,
@@ -6906,6 +6954,7 @@ impl ControllerInner {
                 checkpoint_delay_started: Mutex::new(None),
                 checkpoint_started: Mutex::new(None),
                 modified_output_endpoints,
+                bootstrapped_output_endpoints,
             }
         });
 
@@ -7496,6 +7545,36 @@ impl ControllerInner {
 
         let self_weak = Arc::downgrade(self);
 
+        // `connector_definition_changed` is true when the endpoint's config or
+        // associated relation changed across this checkpoint restart. It feeds
+        // the integrated-sink lifecycle decision (re-truncate vs reopen), the
+        // `send_snapshot` re-fire decision, and the progress counter seeding
+        // below.
+        let connector_definition_changed = self.modified_output_endpoints.contains(endpoint_name);
+
+        // Recover "snapshot already delivered" state from the checkpoint so a
+        // `send_snapshot: true` connector does not re-send its snapshot on a
+        // checkpoint restart. When the connector or its relation has changed
+        // across the restart, clear the flag so the fresh snapshot fires;
+        // cumulative counters in `initial_statistics` are preserved
+        // independently.
+        let snapshot_already_sent = !connector_definition_changed
+            && initial_statistics
+                .map(|stats| stats.snapshot_sent)
+                .unwrap_or(false);
+
+        // The endpoint starts out caught up with the pipeline's output unless it is
+        // still owed output derived from records the pipeline has already processed.
+        // Two cases owe such output: the bootstrap re-emits the endpoint's relation,
+        // and an initial snapshot is still pending. A changed connector definition
+        // owes nothing by itself, since an unchanged relation produces no new output
+        // for inputs already processed.
+        let caught_up = !self.bootstrapped_output_endpoints.contains(endpoint_name)
+            && !OutputEndpointControl::snapshot_pending_at_startup(
+                endpoint_config.connector_config.send_snapshot,
+                snapshot_already_sent,
+            );
+
         // Initialize endpoint stats early so that connectors can register
         // batch-progress counters (or other metrics) during construction.
         self.status.add_output(
@@ -7503,6 +7582,7 @@ impl ControllerInner {
             endpoint_name,
             endpoint_config,
             initial_statistics,
+            caught_up,
         );
 
         /// A guard to remove `endpoint` from `status` unless canceled.
@@ -7533,12 +7613,6 @@ impl ControllerInner {
             }
         }
         let guard = RemoveEndpointGuard::new(&self.status, endpoint_id);
-
-        // `connector_definition_changed` is true when the endpoint's config or
-        // associated relation changed across this checkpoint restart. It feeds
-        // both the integrated-sink lifecycle decision (re-truncate vs reopen)
-        // and the `send_snapshot` re-fire decision.
-        let connector_definition_changed = self.modified_output_endpoints.contains(endpoint_name);
 
         let (encoder, command_handler) = if let Some(mut endpoint) = endpoint {
             endpoint
@@ -7683,16 +7757,6 @@ impl ControllerInner {
         };
 
         let parker = Parker::new();
-        // Recover "snapshot already delivered" state from the checkpoint so a
-        // `send_snapshot: true` connector does not re-send its snapshot on a
-        // checkpoint restart. When the connector or its relation has changed
-        // across the restart, clear the flag so the fresh snapshot fires;
-        // cumulative counters in `initial_statistics` are preserved
-        // independently.
-        let snapshot_already_sent = !connector_definition_changed
-            && initial_statistics
-                .map(|stats| stats.snapshot_sent)
-                .unwrap_or(false);
         let endpoint_descr = OutputEndpointDescr::new(
             endpoint_name,
             &stream_name,

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -2458,10 +2458,11 @@ pub struct OutputEndpointMetrics {
     /// of this endpoint is equal to the output of the circuit after
     /// processing `total_processed_input_records` records.
     ///
-    /// The counter never runs ahead of the endpoint's output. It advances only
-    /// once the endpoint has processed every batch derived from those records,
-    /// which means transmitting them, or discarding them while silent
-    /// bootstrapping suppresses the endpoint's output.
+    /// The counter never runs ahead of the endpoint's output. It advances to a
+    /// value `N` only once the endpoint has processed every batch derived from
+    /// the first `N` records received by the pipeline, which means transmitting
+    /// the batch, or discarding it while silent bootstrapping suppresses the
+    /// endpoint's output.
     ///
     /// In a multihost pipeline, this count reflects only the input records
     /// processed on the same host as the output endpoint, which is not usually

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -713,20 +713,32 @@ impl ControllerStatus {
     }
 
     /// Initialize stats for a new output endpoint.
+    ///
+    /// `caught_up` is true when the endpoint's output already agrees with the
+    /// output the pipeline has produced so far, so the endpoint only has to
+    /// handle future output. It is false when the endpoint is still owed output
+    /// derived from records the pipeline has already processed, such as a
+    /// bootstrap re-emission or a pending initial snapshot.
     pub fn add_output(
         &self,
         endpoint_id: &EndpointId,
         endpoint_name: &str,
         config: &OutputEndpointConfig,
         initial_statistics: Option<&CheckpointOutputEndpointMetrics>,
+        caught_up: bool,
     ) {
-        // Initialize the `total_processed_input_records` counter on the new endpoint to `total_processed_records`:
-        // logically the new endpoint is up to speed with the outputs produced by the pipeline so far and only needs to
-        // process any future outputs.
-        let total_processed_records = self
-            .global_metrics
-            .total_processed_records
-            .load(Ordering::Acquire);
+        // Seeding `total_processed_input_records` to `total_processed_records` claims the
+        // endpoint has already delivered the output derived from those records. That holds
+        // only for an endpoint that is caught up. An endpoint still owed output starts at
+        // zero and reaches `total_processed_records` once it has processed the batch
+        // carrying that output, keeping the counter from running ahead of the sink.
+        let total_processed_records = if caught_up {
+            self.global_metrics
+                .total_processed_records
+                .load(Ordering::Acquire)
+        } else {
+            0
+        };
         self.outputs.write().insert(
             *endpoint_id,
             OutputEndpointStatus::new(
@@ -2445,6 +2457,11 @@ pub struct OutputEndpointMetrics {
     /// This metric tracks the end-to-end progress of the pipeline: the output
     /// of this endpoint is equal to the output of the circuit after
     /// processing `total_processed_input_records` records.
+    ///
+    /// The counter never runs ahead of the endpoint's output. It advances only
+    /// once the endpoint has processed every batch derived from those records,
+    /// which means transmitting them, or discarding them while silent
+    /// bootstrapping suppresses the endpoint's output.
     ///
     /// In a multihost pipeline, this count reflects only the input records
     /// processed on the same host as the output endpoint, which is not usually

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2755,7 +2755,7 @@ fn test_external_controller_status_serialization() {
             }
         }))
         .unwrap();
-        status.add_output(&0, "http_output", &output_config, None);
+        status.add_output(&0, "http_output", &output_config, None, true);
 
         // Set output metrics
         if let Some(output) = status.output_status().get(&0) {
@@ -3050,7 +3050,7 @@ fn test_custom_output_connector_metrics_prometheus_output() {
         "format": { "name": "json", "config": {} }
     }))
     .unwrap();
-    status.add_output(&0, "mock_output", &output_config, None);
+    status.add_output(&0, "mock_output", &output_config, None, true);
     status.set_output_custom_metrics(0, Arc::new(MockMetrics));
 
     let mut writer = MetricsWriter::<PrometheusFormatter>::new();
@@ -4947,4 +4947,118 @@ fn a_dropped_reply_or_controller_exit_reports_controller_exit() {
     let error = reply_or_controller_exit(receiver.blocking_recv())
         .expect_err("a dropped reply reports an error");
     assert!(matches!(*error, ControllerError::ControllerExit));
+}
+
+/// An output endpoint that is still owed output must not report the pipeline's
+/// progress before it has delivered that output.
+///
+/// `total_processed_input_records` promises that the endpoint's output equals the
+/// circuit's output after that many input records. Seeding it from the restored
+/// global counter breaks the promise for an endpoint whose relation the bootstrap
+/// re-emits: the counter reaches its target while the re-emitted batch is still
+/// queued, so a reader concludes the sink is up to date before anything reaches it.
+#[test]
+fn test_output_progress_counter_waits_for_owed_output() {
+    use super::stats::ProcessedRecords;
+    use crate::{ControllerStatus, OutputEndpointConfig};
+    use uuid::Uuid;
+
+    // Records the pipeline had processed when the checkpoint was taken.
+    const RESTORED_RECORDS: u64 = 3;
+
+    let config = serde_json::from_value(json!({
+        "name": "test_output_progress_counter",
+        "workers": 1,
+    }))
+    .unwrap();
+    let status = ControllerStatus::new(config, RESTORED_RECORDS, None, Uuid::nil());
+
+    let output_config: OutputEndpointConfig = serde_json::from_value(json!({
+        "stream": "v1",
+        "transport": { "name": "http_output", "config": {} },
+        "format": { "name": "json", "config": {} }
+    }))
+    .unwrap();
+
+    let processed = |endpoint_id| {
+        status
+            .output_status()
+            .get(&endpoint_id)
+            .unwrap()
+            .metrics
+            .total_processed_input_records
+            .load(Ordering::Acquire)
+    };
+
+    // A caught-up endpoint handles only future output, so it adopts the pipeline's
+    // progress right away.
+    status.add_output(&0, "caught_up", &output_config, None, true);
+    assert_eq!(processed(0), RESTORED_RECORDS);
+
+    // An endpoint still owed output starts from zero.
+    status.add_output(&1, "owed_output", &output_config, None, false);
+    assert_eq!(processed(1), 0);
+
+    // Starting behind must not drag `total_completed_records` backwards. The
+    // checkpoint path blocks until that counter reaches the records processed when
+    // the checkpoint started, so a regression here would stall checkpoints rather
+    // than merely misreport progress.
+    status.update_total_completed_records(None);
+    assert_eq!(status.num_total_completed_records(), RESTORED_RECORDS);
+
+    // Queueing the owed output does not count as delivering it.
+    let parker = Parker::new();
+    let unparker = parker.unparker().clone();
+    status.enqueue_batch(1, 2);
+    assert_eq!(processed(1), 0);
+
+    // Processing the batch that carries the owed output brings the endpoint up to
+    // the pipeline's progress.
+    status.output_batch(
+        1,
+        Some(ProcessedRecords {
+            total_processed_input_records: RESTORED_RECORDS,
+            total_processed_steps: 1,
+        }),
+        2,
+        &unparker,
+    );
+    assert_eq!(processed(1), RESTORED_RECORDS);
+}
+
+/// Only a changed relation makes an output endpoint fall behind. A connector whose
+/// own definition changed still emits nothing for inputs already processed, so it
+/// stays caught up and keeps its seeded progress counter.
+#[test]
+fn test_bootstrapped_output_endpoints_ignores_connector_changes() {
+    use super::bootstrapped_output_endpoints;
+    use feldera_types::pipeline_diff::{PipelineDiff, ProgramDiff};
+
+    let output_config = |stream: &str| -> OutputEndpointConfig {
+        serde_json::from_value(json!({
+            "stream": stream,
+            "transport": { "name": "http_output", "config": {} },
+            "format": { "name": "json", "config": {} }
+        }))
+        .unwrap()
+    };
+
+    let outputs = BTreeMap::from([
+        (Cow::from("changed_view"), output_config("v_changed")),
+        (Cow::from("changed_connector"), output_config("v_stable")),
+        (Cow::from("untouched"), output_config("v_stable")),
+    ]);
+
+    let diff = PipelineDiff::new_with_program_diff(
+        ProgramDiff::new().with_modified_views(vec!["v_changed".to_string()]),
+    )
+    .with_modified_output_connectors(vec!["changed_connector".to_string()]);
+
+    assert_eq!(
+        bootstrapped_output_endpoints(&outputs, Some(&diff)),
+        std::collections::HashSet::from(["changed_view".to_string()])
+    );
+
+    // Without a diff nothing is re-emitted, so every endpoint starts caught up.
+    assert!(bootstrapped_output_endpoints(&outputs, None).is_empty());
 }

--- a/crates/feldera-types/src/adapter_stats.rs
+++ b/crates/feldera-types/src/adapter_stats.rs
@@ -274,6 +274,11 @@ pub struct ExternalOutputEndpointMetrics {
     /// of this endpoint is equal to the output of the circuit after
     /// processing `total_processed_input_records` records.
     ///
+    /// The counter never runs ahead of the endpoint's output. It advances only
+    /// once the endpoint has processed every batch derived from those records,
+    /// which means transmitting them, or discarding them while silent
+    /// bootstrapping suppresses the endpoint's output.
+    ///
     /// In a multihost pipeline, this count reflects only the input records
     /// processed on the same host as the output endpoint, which is not usually
     /// meaningful.

--- a/crates/feldera-types/src/adapter_stats.rs
+++ b/crates/feldera-types/src/adapter_stats.rs
@@ -274,10 +274,11 @@ pub struct ExternalOutputEndpointMetrics {
     /// of this endpoint is equal to the output of the circuit after
     /// processing `total_processed_input_records` records.
     ///
-    /// The counter never runs ahead of the endpoint's output. It advances only
-    /// once the endpoint has processed every batch derived from those records,
-    /// which means transmitting them, or discarding them while silent
-    /// bootstrapping suppresses the endpoint's output.
+    /// The counter never runs ahead of the endpoint's output. It advances to a
+    /// value `N` only once the endpoint has processed every batch derived from
+    /// the first `N` records received by the pipeline, which means transmitting
+    /// the batch, or discarding it while silent bootstrapping suppresses the
+    /// endpoint's output.
     ///
     /// In a multihost pipeline, this count reflects only the input records
     /// processed on the same host as the output endpoint, which is not usually

--- a/openapi.json
+++ b/openapi.json
@@ -11054,7 +11054,7 @@
           "total_processed_input_records": {
             "type": "integer",
             "format": "int64",
-            "description": "The number of input records processed by the circuit.\n\nThis metric tracks the end-to-end progress of the pipeline: the output\nof this endpoint is equal to the output of the circuit after\nprocessing `total_processed_input_records` records.\n\nIn a multihost pipeline, this count reflects only the input records\nprocessed on the same host as the output endpoint, which is not usually\nmeaningful.",
+            "description": "The number of input records processed by the circuit.\n\nThis metric tracks the end-to-end progress of the pipeline: the output\nof this endpoint is equal to the output of the circuit after\nprocessing `total_processed_input_records` records.\n\nThe counter never runs ahead of the endpoint's output. It advances only\nonce the endpoint has processed every batch derived from those records,\nwhich means transmitting them, or discarding them while silent\nbootstrapping suppresses the endpoint's output.\n\nIn a multihost pipeline, this count reflects only the input records\nprocessed on the same host as the output endpoint, which is not usually\nmeaningful.",
             "minimum": 0
           },
           "total_processed_steps": {

--- a/openapi.json
+++ b/openapi.json
@@ -11054,7 +11054,7 @@
           "total_processed_input_records": {
             "type": "integer",
             "format": "int64",
-            "description": "The number of input records processed by the circuit.\n\nThis metric tracks the end-to-end progress of the pipeline: the output\nof this endpoint is equal to the output of the circuit after\nprocessing `total_processed_input_records` records.\n\nThe counter never runs ahead of the endpoint's output. It advances only\nonce the endpoint has processed every batch derived from those records,\nwhich means transmitting them, or discarding them while silent\nbootstrapping suppresses the endpoint's output.\n\nIn a multihost pipeline, this count reflects only the input records\nprocessed on the same host as the output endpoint, which is not usually\nmeaningful.",
+            "description": "The number of input records processed by the circuit.\n\nThis metric tracks the end-to-end progress of the pipeline: the output\nof this endpoint is equal to the output of the circuit after\nprocessing `total_processed_input_records` records.\n\nThe counter never runs ahead of the endpoint's output. It advances to a\nvalue `N` only once the endpoint has processed every batch derived from\nthe first `N` records received by the pipeline, which means transmitting\nthe batch, or discarding it while silent bootstrapping suppresses the\nendpoint's output.\n\nIn a multihost pipeline, this count reflects only the input records\nprocessed on the same host as the output endpoint, which is not usually\nmeaningful.",
             "minimum": 0
           },
           "total_processed_steps": {

--- a/python/tests/platform/test_bootstrapping.py
+++ b/python/tests/platform/test_bootstrapping.py
@@ -358,14 +358,6 @@ AS SELECT {view_expr} AS x FROM t1;
             timeout_s=120.0,
             poll_interval_s=1.0,
         )
-        # Transmission lags processing; wait for the count instead of
-        # asserting a single racy read, then check it does not overshoot.
-        wait_for_condition(
-            f"output connector transmits {expected_transmitted_records} records",
-            lambda: transmitted_records() >= expected_transmitted_records,
-            timeout_s=120.0,
-            poll_interval_s=1.0,
-        )
         assert transmitted_records() == expected_transmitted_records
 
     pipeline = PipelineBuilder(
@@ -514,14 +506,6 @@ AS SELECT {view_expr} AS x FROM t1;
         wait_for_condition(
             f"output connector reaches {min_processed_records} processed records",
             lambda: processed_records() >= min_processed_records,
-            timeout_s=120.0,
-            poll_interval_s=1.0,
-        )
-        # Transmission lags processing; wait for the count instead of
-        # asserting a single racy read, then check it does not overshoot.
-        wait_for_condition(
-            f"output connector transmits {expected_transmitted_records} records",
-            lambda: transmitted_records() >= expected_transmitted_records,
             timeout_s=120.0,
             poll_interval_s=1.0,
         )


### PR DESCRIPTION
Undo previous `bootstrapping_test` failure workaround and properly fix connector metric.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
