### PR TITLE
[py] Fix `listen` output races

### DIFF
--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -31,7 +31,7 @@ from tests import (
     TEST_CLIENT,
     unique_pipeline_name,
 )
-from tests.utils import wait_for_condition
+from tests.utils import wait_for_condition, wait_for_records
 
 API_PREFIX = "/v0"
 
@@ -301,6 +301,7 @@ __all__ = [
     "delete",
     "wait_for_program_success",
     "wait_for_condition",
+    "wait_for_records",
     "unique_pipeline_name",
     "extract_object_by_name",
     "gen_pipeline_name",

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -21,7 +21,7 @@ from feldera.testutils import (
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
-from .helper import wait_for_condition
+from .helper import wait_for_condition, wait_for_records
 
 
 class TestPipeline(SharedTestPipeline):
@@ -112,15 +112,18 @@ class TestPipeline(SharedTestPipeline):
 
         self.pipeline.resume()
         self.pipeline.input_json("tbl", [{"id": i} for i in range(10)])
-        self.pipeline.wait_for_idle()
-
-        all = all_stream.to_dict()
-        odd = odd_stream.to_dict()
-        even = even_stream.to_dict()
 
         expected_all = list(self.pipeline.query("select * from v0"))
         expected_odd = list(self.pipeline.query('select * from "V0"'))
         expected_even = list(self.pipeline.query('select * from "DATE"'))
+
+        wait_for_records(all_stream, len(expected_all))
+        wait_for_records(odd_stream, len(expected_odd))
+        wait_for_records(even_stream, len(expected_even))
+
+        all = all_stream.to_dict()
+        odd = odd_stream.to_dict()
+        even = even_stream.to_dict()
 
         def extract_ids(x):
             return sorted(i["id"] for i in x)
@@ -307,7 +310,7 @@ class TestPipeline(SharedTestPipeline):
         self.pipeline.resume()
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 100)
         df = out.to_pandas()
         assert df.shape[0] == 100
         self.pipeline.stop(force=True)
@@ -320,7 +323,7 @@ class TestPipeline(SharedTestPipeline):
         self.pipeline.resume()
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 100)
         df = out.to_pandas()
         assert df.shape[0] == 100
         self.pipeline.stop(force=True)
@@ -332,7 +335,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("average_scores")
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 100)
         df = out.to_pandas()
         assert df.shape[0] == 100
         self.pipeline.stop(force=True)
@@ -426,7 +429,9 @@ class TestPipeline(SharedTestPipeline):
         # Feed JSON as strings, receive output from `average_view` and `json_view`
         self.pipeline.input_json("json_table", input_strings)
 
-        self.pipeline.wait_for_idle()
+        wait_for_records(average_out, len(expected_average))
+        wait_for_records(variant_out, len(expected_variant))
+        wait_for_records(json_out, len(expected_strings))
         # Outputs may arrive in any order, so compare ignoring order.
         self.assertCountEqual(expected_average, average_out.to_dict())
         self.assertCountEqual(expected_variant, variant_out.to_dict())
@@ -435,6 +440,7 @@ class TestPipeline(SharedTestPipeline):
         # Feed VARIANT, read strongly typed columns. Since output columns have the same
         # shape as inputs, output and input should be identical.
         self.pipeline.input_json("variant_table", input_json)
+        wait_for_records(typed_out, len(expected_typed))
         self.assertCountEqual(expected_typed, typed_out.to_dict())
         self.pipeline.stop(True)
 
@@ -444,7 +450,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v0")
         self.pipeline.resume()
         self.pipeline.input_json("tbl", data=data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         out_data = out.to_dict()
         expected = []
         for d in data:
@@ -490,7 +496,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v0")
         self.pipeline.resume()
         self.pipeline.input_json("tbl", data, update_format="insert_delete")
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 1)
         out_data = out.to_dict()
         expected = [dict(data["insert"], insert_delete=1)]
         assert out_data == expected
@@ -502,7 +508,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v0")
         self.pipeline.resume()
         self.pipeline.input_json("tbl", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         out_data = out.to_dict()
         expected = [dict(row, insert_delete=1) for row in data]
         assert out_data == expected
@@ -515,7 +521,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v0")
         self.pipeline.resume()
         self.pipeline.input_json("tbl", data, update_format="insert_delete")
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 1)
         out_data = out.to_dict()
         expected = [dict(data["insert"], insert_delete=1)]
         assert out_data == expected
@@ -545,7 +551,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_timestamp")
         self.pipeline.resume()
         self.pipeline.input_pandas("tbl_timestamp", df)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, 3)
         df_out = out.to_pandas()
         assert df_out.shape[0] == 3
         self.pipeline.stop(force=True)
@@ -561,7 +567,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_binary")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_binary", data=data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(expected_data))
         got = out.to_dict()
         assert expected_data == got
         self.pipeline.stop(force=True)
@@ -579,7 +585,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_decimal")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_decimal", data=data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(expected))
         got = out.to_dict()
         assert expected == got
         self.pipeline.stop(force=True)
@@ -594,7 +600,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_array")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_array", data=data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         got = out.to_dict()
         expected = [{"c1": [1, 2, 3], "insert_delete": 1}]
         assert got == expected
@@ -614,7 +620,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_struct")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_struct", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         got = out.to_dict()
         expected = [{"c1": {"f1": 1, "f2": "a"}, "insert_delete": 1}]
         assert got == expected
@@ -640,7 +646,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_datetime")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_datetime", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(expected))
         got = out.to_dict()
         assert expected == got
         self.pipeline.stop(force=True)
@@ -669,7 +675,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_simple")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_simple", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         got = out.to_dict()
         expected = []
         for d in data:
@@ -690,7 +696,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_map")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_map", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(expected))
         got = out.to_dict()
         assert expected == got
         self.pipeline.stop(force=True)
@@ -700,7 +706,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_map")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_map", {"c1": {"a": 1, "b": 2}})
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(expected))
         got = out.to_dict()
         assert expected == got
         self.pipeline.stop(force=True)
@@ -717,7 +723,7 @@ class TestPipeline(SharedTestPipeline):
         out = self.pipeline.listen("v_uuid")
         self.pipeline.resume()
         self.pipeline.input_json("tbl_uuid", data)
-        self.pipeline.wait_for_idle()
+        wait_for_records(out, len(data))
         got = out.to_dict()
         # Compare only the UUID values
         got_uuids = sorted([row["c0"] for row in got])
@@ -918,12 +924,12 @@ class TestPipeline(SharedTestPipeline):
         )
 
         # Verify egress data includes both values with insert_delete markers
-        self.pipeline.wait_for_idle()
-        egress_result = out.to_dict()
         expected_egress = [
             {"c1": "test_value", "insert_delete": 1},
             {"c1": "test_value_2", "insert_delete": 1},
         ]
+        wait_for_records(out, len(expected_egress))
+        egress_result = out.to_dict()
         self.assertCountEqual(egress_result, expected_egress)
 
     def test_listen_non_existent_view_paused(self):

--- a/python/tests/runtime/lateness/test_issue4457.py
+++ b/python/tests/runtime/lateness/test_issue4457.py
@@ -3,7 +3,7 @@ import unittest
 from pandas import Timestamp
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT
-from tests.platform.helper import PipelineTestCase
+from tests.platform.helper import PipelineTestCase, wait_for_records
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
@@ -40,8 +40,8 @@ class TestIssue_4457(PipelineTestCase):
             "test_events",
             [{"id": "a", "a": "test4", "t": "2025-05-20 21:00:17.920"}],
         )
-        pipeline.wait_for_idle()
 
+        wait_for_records(out, 1)
         output = out.to_dict()
         assert output == [
             {
@@ -56,6 +56,9 @@ class TestIssue_4457(PipelineTestCase):
             "test_events",
             [{"id": "a", "a": "test5", "t": "2025-03-20 21:00:17.920"}],
         )
+        # The late record is expected to be dropped, so there is no record to
+        # wait for. Idleness is the only signal that the pipeline is done with
+        # the input and nothing is going to arrive.
         pipeline.wait_for_idle()
 
         output = out.to_dict()

--- a/python/tests/runtime/test_spreadsheet.py
+++ b/python/tests/runtime/test_spreadsheet.py
@@ -2,10 +2,9 @@
 
 import unittest
 
-import time
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT
-from tests.platform.helper import PipelineTestCase
+from tests.platform.helper import PipelineTestCase, wait_for_records
 
 
 def make_value(id: int, raw: str, computed: str) -> dict:
@@ -41,11 +40,6 @@ class TestUDF(PipelineTestCase):
         out = pipeline.listen("spreadsheet_view")
         pipeline.resume()
 
-        # What is the right way to wait for ingestion to complete?
-        time.sleep(2)
-        pipeline.stop(force=True)
-
-        output = sorted(out.to_dict(), key=lambda x: x["id"])
         expected = [
             make_value(0, "=A39999999", "42"),
             make_value(1, "=A0", "42"),
@@ -71,6 +65,11 @@ class TestUDF(PipelineTestCase):
             make_value(222, '=LEFT("apple", 3)', "app"),
             make_value(1039999974, "42", "42"),
         ]
+
+        wait_for_records(out, len(expected))
+        pipeline.stop(force=True)
+
+        output = sorted(out.to_dict(), key=lambda x: x["id"])
         assert output == expected
 
 

--- a/python/tests/runtime/test_transactions.py
+++ b/python/tests/runtime/test_transactions.py
@@ -2,7 +2,7 @@ import unittest
 
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT
-from tests.platform.helper import PipelineTestCase
+from tests.platform.helper import PipelineTestCase, wait_for_records
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
@@ -46,6 +46,7 @@ class TestTransactions(PipelineTestCase):
         pipeline.commit_transaction()
         pipeline.wait_for_completion()
 
+        wait_for_records(out, 3)
         output = out.to_dict()
         assert output == [
             {
@@ -88,6 +89,7 @@ class TestTransactions(PipelineTestCase):
         pipeline.commit_transaction()
         pipeline.wait_for_completion()
 
+        wait_for_records(out1, 15)
         output = out1.to_dict()
         assert output == [
             {
@@ -152,6 +154,7 @@ class TestTransactions(PipelineTestCase):
             },
         ]
 
+        wait_for_records(out2, 6)
         output = out2.to_dict()
         assert output == [
             {
@@ -180,6 +183,8 @@ class TestTransactions(PipelineTestCase):
             },
         ]
 
+        # No wait here: out3 is asserted to stay empty, and the waits above give
+        # it every chance to receive the records its siblings already saw.
         output = out3.to_dict()
         assert output == []
 

--- a/python/tests/runtime/test_udf.py
+++ b/python/tests/runtime/test_udf.py
@@ -1,7 +1,8 @@
+from datetime import date, datetime, time
 from decimal import Decimal
+import json
 import unittest
 
-from pandas import Timedelta, Timestamp
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT
 from tests.platform.helper import PipelineTestCase
@@ -254,10 +255,11 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
             ),
         ).create_or_replace()
 
-        # TODO: use .query() instead
-        pipeline.start_paused()
-        out = pipeline.listen("v")
-        pipeline.resume()
+        pipeline.start()
+
+        # A VARIANT holding a JSON string, as opposed to a JSON object. The
+        # distinction decides how the ad-hoc layer renders it below.
+        variant = '{"foo": "bar"}'
 
         pipeline.input_json(
             "t",
@@ -275,7 +277,7 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
                     "ts": "2024-09-25 13:05:00",
                     "a": [1, 2, 3, 4, 5],
                     "m": {"foo": "bar"},
-                    "v": '{"foo": "bar"}',
+                    "v": variant,
                     "b": True,
                     "dc": "123.45",
                     "s": "foobar",
@@ -284,42 +286,66 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
             wait=True,
         )
 
-        output = out.to_dict()
-        assert output == [
+        # `wait=True` above establishes that the circuit processed the input.
+        # Arrow IPC rather than JSON, because JSON cannot carry VARBINARY or DECIMAL
+        # faithfully (https://github.com/feldera/feldera/issues/4219).
+        #
+        # Columns are unnamed in the view, so they arrive as EXPR$0..EXPR$31 in
+        # SELECT-list order. Every UDF is the identity, hence each pair of
+        # columns repeats one input value.
+        rows = list(pipeline.query_arrow_dicts("SELECT * FROM v"))
+        assert rows == [
             {
+                # bool2bool, nbool2nbool
                 "EXPR$0": True,
                 "EXPR$1": True,
-                "EXPR$10": 0.5,
-                "EXPR$11": 0.5,
-                "EXPR$12": 1e-05,
-                "EXPR$13": 1e-05,
-                "EXPR$14": [],
-                "EXPR$15": [],
-                "EXPR$16": Timestamp("2024-09-25 00:00:00"),
-                "EXPR$17": Timestamp("2024-09-25 00:00:00"),
-                "EXPR$18": Timestamp("2024-09-25 13:05:00"),
-                "EXPR$19": Timestamp("2024-09-25 13:05:00"),
+                # i2i, ni2ni
                 "EXPR$2": 1,
-                "EXPR$20": Timedelta("0 days 13:05:00"),
-                "EXPR$21": Timedelta("0 days 13:05:00"),
-                "EXPR$22": [1, 2, 3, 4, 5],
-                "EXPR$23": [1, 2, 3, 4, 5],
-                "EXPR$24": {"foo": "bar"},
-                "EXPR$25": {"foo": "bar"},
-                "EXPR$26": '{"foo": "bar"}',
-                "EXPR$27": '{"foo": "bar"}',
-                "EXPR$28": Decimal("123.45"),
-                "EXPR$29": Decimal("123.45"),
                 "EXPR$3": 1,
-                "EXPR$30": "foobar",
-                "EXPR$31": "foobar",
+                # ti2ti, nti2nti
                 "EXPR$4": -2,
                 "EXPR$5": -2,
+                # si2si, nsi2nsi
                 "EXPR$6": 3,
                 "EXPR$7": 3,
+                # bi2bi, nbi2nbi
                 "EXPR$8": -4,
                 "EXPR$9": -4,
-                "insert_delete": 1,
+                # r2r, nr2nr
+                "EXPR$10": 0.5,
+                "EXPR$11": 0.5,
+                # d2d, nd2nd
+                "EXPR$12": 1e-05,
+                "EXPR$13": 1e-05,
+                # bin2bin, nbin2nbin
+                "EXPR$14": b"",
+                "EXPR$15": b"",
+                # date2date, ndate2ndate
+                "EXPR$16": date(2024, 9, 25),
+                "EXPR$17": date(2024, 9, 25),
+                # ts2ts, nts2nts
+                "EXPR$18": datetime(2024, 9, 25, 13, 5),
+                "EXPR$19": datetime(2024, 9, 25, 13, 5),
+                # t2t, nt2nt
+                "EXPR$20": time(13, 5),
+                "EXPR$21": time(13, 5),
+                # arr2arr, narr2narr
+                "EXPR$22": [1, 2, 3, 4, 5],
+                "EXPR$23": [1, 2, 3, 4, 5],
+                # map2map, nmap2nmap. Arrow preserves MAP order, so a map
+                # arrives as a list of key-value tuples.
+                "EXPR$24": [("foo", "bar")],
+                "EXPR$25": [("foo", "bar")],
+                # var2var, nvar2nvar. The ad-hoc layer renders a VARIANT as its
+                # JSON text; the text of a JSON string is that string quoted.
+                "EXPR$26": json.dumps(variant),
+                "EXPR$27": json.dumps(variant),
+                # dec2dec, ndec2ndec
+                "EXPR$28": Decimal("123.45"),
+                "EXPR$29": Decimal("123.45"),
+                # str2str, nstr2nstr
+                "EXPR$30": "foobar",
+                "EXPR$31": "foobar",
             }
         ]
 

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -8,7 +8,11 @@ import time
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from feldera.output_handler import OutputHandler
 
 
 MINIO_BUCKET = os.environ.get("CI_MINIO_BUCKET", "ci-tests")
@@ -605,3 +609,38 @@ def wait_for_condition(
             )
             return
         time.sleep(poll_interval_s)
+
+
+def wait_for_records(
+    handler: "OutputHandler",
+    count: int,
+    timeout_s: float | None = 60.0,
+    poll_interval_s: float = 0.1,
+) -> None:
+    """Poll a listener until it has buffered at least ``count`` records.
+
+    A listener receives its records over an HTTP stream that a background
+    thread reads, so nothing the pipeline reports implies those records have
+    reached this process. A completion token promises only that the chunk was
+    handed to the output connector, and pipeline-side idleness says nothing at
+    all about the client. Reading the handler does not wait either, so call
+    this first.
+
+    :param handler: The :class:`feldera.output_handler.OutputHandler` returned
+        by ``Pipeline.listen``.
+    :param count: Number of records to wait for. Must be positive; waiting for
+        zero records would return without observing anything.
+    :param timeout_s: Maximum wait time in seconds. ``None`` means wait forever.
+    :param poll_interval_s: Poll interval in seconds.
+
+    :raises TimeoutError: If fewer than ``count`` records arrive in time.
+    """
+    if count < 1:
+        raise ValueError(f"record count must be positive, got {count}")
+
+    wait_for_condition(
+        f"{count} record(s) on the '{handler.view_name}' listener",
+        lambda: len(handler.to_pandas(clear_buffer=False)) >= count,
+        timeout_s,
+        poll_interval_s,
+    )


### PR DESCRIPTION
This PR eliminates a bunch of races in reading HTTP output while also getting rid of most remaining occurrences of `wait_for_idle`. See individual commit messages.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
