### PR TITLE
[adapters] Fix the tick-accounting race in test_clock

### DIFF
--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -440,6 +440,26 @@ mod test {
         }
     }
 
+    /// Waits for the circuit to process `expected` ticks, then returns the
+    /// tick count once it has settled.
+    ///
+    /// Waiting beats a fixed sleep for the lower bound: a loaded machine can
+    /// take longer to replay than any sleep the test would pick.  The settle
+    /// period then gives a tick beyond `expected` time to arrive, so the
+    /// caller checks its upper bound against the final count rather than a
+    /// snapshot taken mid-replay.
+    fn settled_ticks(stats: &ClockStats, expected: usize) -> usize {
+        const TIMEOUT: Duration = Duration::from_secs(30);
+        const SETTLE: Duration = Duration::from_secs(2);
+
+        let deadline = std::time::Instant::now() + TIMEOUT;
+        while stats.ticks() < expected && std::time::Instant::now() < deadline {
+            sleep(Duration::from_millis(10));
+        }
+        sleep(SETTLE);
+        stats.ticks()
+    }
+
     /// Create a simple test circuit that passes each of a number of streams right
     /// through to the corresponding output.  The number of streams is the length of
     /// `persistent_output_ids`, which also specifies optional persistent output ids.
@@ -573,26 +593,41 @@ mod test {
 
         sleep(Duration::from_secs(5));
 
-        // Pause the controller first to prevent more ticks from being generated
-        // before we count them and stop the pipeline
+        // Stop the tick stream, so that Run 1 ends with a bounded number of
+        // post-checkpoint ticks.
         controller.pause();
 
-        let old_ticks = ticks;
-        let ticks_after_checkpoint = test_stats.ticks() - old_ticks;
+        println!("Stopping the pipeline");
+        controller.stop().unwrap();
+
+        // Count Run 1's post-checkpoint ticks only once the pipeline has
+        // stopped, which `stop` guarantees by joining the circuit thread.
+        // `pause` is asynchronous, and a step that races it is still journaled
+        // and hence still replayed, so a count taken before the stop can be
+        // one short of what Run 2 replays.
+        let ticks_after_checkpoint = test_stats.ticks() - ticks;
 
         println!("{ticks_after_checkpoint} additional ticks after the checkpoint");
 
-        // Capture the last `NOW()` emitted in Run 1.  Used below to verify
-        // the no-catchup contract across the restart.
+        // The replay assertion below tolerates one live tick, so a baseline of
+        // one is indistinguishable from a replay that emits nothing, and a
+        // baseline of zero asserts nothing at all.  Two journaled ticks is the
+        // smallest baseline that makes the assertion detect a broken replay.
+        assert!(
+            ticks_after_checkpoint >= 2,
+            "only {ticks_after_checkpoint} ticks were journaled between the \
+             checkpoint and the stop; the replay assertion needs at least two \
+             to tell a real replay from the live tick that follows it"
+        );
+
+        // The last `NOW()` emitted in Run 1.  Used below to verify the
+        // no-catchup contract across the restart.
         let last_v_run1 = test_stats.last_value();
         println!("Run 1 last emitted NOW(): {last_v_run1} ms (anchor {anchor_ms})");
         assert!(
             last_v_run1 > anchor_ms,
             "Run 1 should have emitted at least one tick past the anchor"
         );
-
-        println!("Stopping the pipeline");
-        controller.stop().unwrap();
 
         test_stats.clear();
 
@@ -608,12 +643,19 @@ mod test {
         )
         .unwrap();
 
-        sleep(Duration::from_secs(5));
-
-        let ticks = test_stats.ticks();
+        // Replay runs without `start`, and the pipeline stays paused once it
+        // completes, so the tick count settles as soon as replay is done.
+        let ticks = settled_ticks(&test_stats, ticks_after_checkpoint);
         println!("{ticks} ticks replayed after restart");
-        // Allow at most one extra tick after pause.
-        assert!(ticks >= ticks_after_checkpoint && ticks <= ticks_after_checkpoint + 1);
+        // One extra tick is allowed: the first step after replay commits the
+        // last replayed transaction, and the controller queries every
+        // connector for input on that step, so the clock connector answers it
+        // with a live tick even though the pipeline is paused.
+        assert!(
+            ticks >= ticks_after_checkpoint && ticks <= ticks_after_checkpoint + 1,
+            "replayed {ticks} ticks, expected the {ticks_after_checkpoint} \
+             journaled after the checkpoint, plus at most one live tick"
+        );
 
         // No-catchup contract: post-replay emissions continue from
         // `last_v_run1` rather than jumping back to the anchor.


### PR DESCRIPTION
Makes `transport::clock::test::test_clock` count replayed clock ticks against a baseline that cannot race the pipeline, which is what [failed in the merge queue](https://github.com/feldera/feldera/actions/runs/30334386760/job/90198147938) (`assertion failed: ticks >= ticks_after_checkpoint && ticks <= ticks_after_checkpoint + 1`). The failure cancelled every other job in that run; nothing was wrong with the change under test (#6718).

## Why it failed

Both sides of the assertion were off by one, in opposite directions. The job's own replay log names the journaled steps (7 through 12, so six of them):

| Term | Reported in CI | Ground truth | Cause |
|---|---|---|---|
| `ticks_after_checkpoint` | 5 | 6 journaled steps | Sampled right after `controller.pause()`. Pause is asynchronous, so a step that races it is still journaled, and hence still replayed, while its tick goes uncounted. |
| replayed `ticks` | 7 | 6 replayed + 1 live | Once replay ends, the first step commits the last replayed transaction, and `input_step` queues every connector on that step regardless of the paused state, so the clock connector answers with a live tick. |

The second row is systematic: locally the test reports 6 journaled and 7 replayed on every run, landing exactly on the assertion's upper bound. The `+ 1` allowance is therefore already spent, and a single miscounted tick in Run 1 fails the test. That is why the tolerance has been retuned four times (`± 2`, then exact, then `+ 1`) and why #4516 came back.

## The change

- Take Run 1's post-checkpoint baseline after `stop`, which joins the circuit thread and so counts every journaled step.
- Wait for the replayed ticks (`settled_ticks`) instead of sleeping a fixed five seconds, then read the count after a short settle, so neither a slow replay nor an overshoot can hide.
- Record why one extra tick is legitimate, and report both counts when the assertion fires.

## Validation

| Scenario | Before | After |
|---|---|---|
| Normal run | passes with zero margin (6 → 7) | passes (6 → 7), 22.2s instead of 25.2s |
| One extra post-checkpoint step journaled after the old sampling point, which is the CI condition | fails with the same assertion (6 → 9) | passes (7 → 8) |
| `Replay` stops flushing its record | not run | fails (1 → 6), so the test still catches a broken replay |
| Whole `transport::clock` module | | 7 passed |

A duplicate replay push stays invisible here because same-value records coalesce in the zset. That is harmless in production: the compiler consumes `now` as `map_index -> chain_aggregate(max) -> deindex`, so a repeated timestamp is idempotent.

## Note on the live tick after replay

A pipeline resumed from a checkpoint and left paused still runs one step and advances `NOW()` by up to one clock resolution. `NOW()` only moves forward and the aggregate is idempotent, so there is no data impact, and this PR leaves the behaviour alone rather than changing the controller's step logic to fix a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
