### PR TITLE
[web-console] Fix content in Change Stream tab resets when opening Interaction panel

### DIFF
--- a/js-packages/common-ui/src/lib/TabsPanel.svelte
+++ b/js-packages/common-ui/src/lib/TabsPanel.svelte
@@ -77,7 +77,7 @@
        (without `min-h-0` flex children refuse to shrink below their content size, so
        any inner overflow would push the panel taller than the Pane). -->
   <div class="relative min-h-0 flex-1">
-    {#each tabs as { id, panel: TabComponent, keepAlive }}
+    {#each tabs as { id, panel: TabComponent, keepAlive } (id)}
       {#snippet tab()}
         <TabComponent {...tabProps}></TabComponent>
       {/snippet}

--- a/js-packages/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
+++ b/js-packages/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
@@ -19,18 +19,20 @@ export const useTryPipeline = () => {
       already_created,
       trigger_location
     })
-    try {
-      const newPipeline = await api.postPipeline({
-        name: pipeline.name,
-        description: pipeline.description,
-        program_code: pipeline.program_code,
-        program_config: {},
-        runtime_config: {},
-        udf_rust: pipeline.udf_rust,
-        udf_toml: pipeline.udf_toml
-      })
-      updatePipelines((pipelines) => (pipelines.push(newPipeline), pipelines))
-    } catch {}
+    if (!already_created) {
+      try {
+        const newPipeline = await api.postPipeline({
+          name: pipeline.name,
+          description: pipeline.description,
+          program_code: pipeline.program_code,
+          program_config: {},
+          runtime_config: {},
+          udf_rust: pipeline.udf_rust,
+          udf_toml: pipeline.udf_toml
+        })
+        updatePipelines((pipelines) => (pipelines.push(newPipeline), pipelines))
+      } catch {}
+    }
     goto(resolve(`/pipelines/${encodeURIComponent(pipeline.name)}/`))
   }
 }


### PR DESCRIPTION
Prevent an error toast when clicking on an already existing demo

Testing: -manual:
First issue - start a demo, subscribe and receive any rows in Change Stream, then open or close the Interaction panel.
Second issue - click on any demo that has already been created, observe that there is no error toast notification on bottom right