### PR TITLE
[profiler] Add a button to export profile diagram as an .svg image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
       "version": "0.0.1",
       "devDependencies": {
         "@types/cytoscape": "^3.21.9",
+        "happy-dom": "^20.9.0",
         "typescript": "^5.9.2",
         "vitest": "^4.1.8",
       },
@@ -143,6 +144,7 @@
         "cytoscape": "^3.33.1",
         "cytoscape-dblclick": "^0.3.1",
         "cytoscape-elk": "^2.3.0",
+        "cytoscape-svg": "^0.4.0",
         "elkjs": "^0.11.0",
       },
     },
@@ -1243,6 +1245,8 @@
     "cytoscape-dblclick": ["cytoscape-dblclick@0.3.1", "", { "peerDependencies": { "cytoscape": "^3.4.2" } }, "sha512-xeL6lP2Td0RIvVSTxsBDY94KM0JfDsi9X6BPr6Y7PQGi5CP2RXx+1fNEtageXpk+gDkKFylW0pjoGbk2uc1J7Q=="],
 
     "cytoscape-elk": ["cytoscape-elk@2.3.0", "", { "dependencies": { "elkjs": "^0.9.3" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-1h2ZmPOy5HD2+mrfF3P2ICxfnDyPCWg/xLVs7fIjTOzdQu51ydrMtm6Sb7KnhFwLBzhGIVYI2Gbns0njggBarQ=="],
+
+    "cytoscape-svg": ["cytoscape-svg@0.4.0", "", { "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-omqIzfPd1Vy9mk6lHTiR2wTbjxELxb9GXSQ2pE6W+GwAe/6/yvOUQ2h5ApFf2QhCBnpMwLkCTq5DZXxBCgUpDw=="],
 
     "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
 

--- a/js-packages/profiler-layout/src/lib/components/DiagramFileMenu.svelte
+++ b/js-packages/profiler-layout/src/lib/components/DiagramFileMenu.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  // "File" dropdown menu for the graph-panel header. Owns its open/close state
+  // and the "Export as .svg" action.
+  import { downloadFile } from '../functions/download'
+  import { profileImageFileName } from '../functions/fileName'
+
+  let {
+    exportSvg,
+    onError,
+    pipelineName,
+    snapshotDate
+  }: {
+    /** Serialize the current diagram to an SVG document, or null if nothing is rendered yet. */
+    exportSvg: () => Promise<string | null>
+    /** Report a user-facing error (nothing to export, serialization failed). */
+    onError: (message: string) => void
+    /** Pipeline name, used in the exported file name. */
+    pipelineName?: string
+    /** Profile snapshot date, used in the exported file name (falls back to today). */
+    snapshotDate?: Date | null
+  } = $props()
+
+  let open = $state(false)
+  let menuEl: HTMLDivElement | undefined = $state()
+
+  async function exportImage() {
+    open = false
+    try {
+      const svg = await exportSvg()
+      if (!svg) {
+        onError('No diagram to export yet.')
+        return
+      }
+      downloadFile(svg, profileImageFileName(pipelineName, snapshotDate ?? new Date()), 'image/svg+xml')
+    } catch (e) {
+      onError(`Failed to export image: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+</script>
+
+<!-- Close the menu on an outside click or Escape. -->
+<svelte:window
+  onclick={(e) => {
+    if (open && menuEl && !menuEl.contains(e.target as Node)) {
+      open = false
+    }
+  }}
+  onkeydown={(e) => {
+    if (e.key === 'Escape') {
+      open = false
+    }
+  }}
+/>
+
+<div class="relative" bind:this={menuEl}>
+  <button
+    class="btn h-6 !bg-surface-100-900 px-3 text-sm outline-none"
+    onclick={() => (open = !open)}
+    aria-haspopup="menu"
+    aria-expanded={open}
+  >
+    File
+  </button>
+  {#if open}
+    <div class="absolute top-8 left-0 z-30 w-max min-w-[180px]" role="menu">
+      <div class="bg-white-dark flex flex-col overflow-hidden rounded shadow-md">
+        <button
+          class="px-4 py-2 text-left text-sm hover:preset-tonal-surface"
+          role="menuitem"
+          onclick={exportImage}
+        >
+          Export as .svg
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/js-packages/profiler-layout/src/lib/components/DiagramFileMenu.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/DiagramFileMenu.svelte.spec.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+
+// downloadFile is a side-effecting DOM helper; stub it so the test asserts wiring, not a real
+// browser download. vi.mock is hoisted, so the factory creates the spy inline.
+vi.mock('../functions/download', () => ({ downloadFile: vi.fn() }))
+
+import { downloadFile } from '../functions/download'
+import DiagramFileMenu from './DiagramFileMenu.svelte'
+
+const findButton = (container: HTMLElement, text: string) =>
+  Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.trim() === text)
+
+const openExportItem = async (container: HTMLElement) => {
+  findButton(container, 'File')?.click()
+  await expect.poll(() => findButton(container, 'Export as .svg') !== undefined).toBe(true)
+  findButton(container, 'Export as .svg')?.click()
+}
+
+describe('DiagramFileMenu', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('downloads the exported SVG, naming the file from the pipeline and snapshot date', async () => {
+    const exportSvg = vi.fn(async () => '<svg></svg>')
+    const onError = vi.fn()
+    const { container } = render(DiagramFileMenu, {
+      exportSvg,
+      onError,
+      pipelineName: 'my-pipeline',
+      snapshotDate: new Date(2024, 2, 9)
+    })
+
+    await openExportItem(container)
+
+    await expect.poll(() => exportSvg.mock.calls.length).toBe(1)
+    await expect.poll(() => vi.mocked(downloadFile).mock.calls.length).toBe(1)
+    const [content, filename, mimeType] = vi.mocked(downloadFile).mock.calls[0]!
+    expect(content).toBe('<svg></svg>')
+    expect(filename).toBe('my-pipeline-2024.03.09.svg')
+    expect(mimeType).toBe('image/svg+xml')
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('reports an error and skips the download when nothing is rendered yet', async () => {
+    const exportSvg = vi.fn(async () => null)
+    const onError = vi.fn()
+    const { container } = render(DiagramFileMenu, { exportSvg, onError })
+
+    await openExportItem(container)
+
+    await expect.poll(() => onError.mock.calls.length).toBe(1)
+    expect(downloadFile).not.toHaveBeenCalled()
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ProfilerDiagram.svelte
@@ -4,6 +4,7 @@
     type Dataflow,
     type JsonProfiles,
     type ProfilerCallbacks,
+    type SvgExportOptions,
     Visualizer,
     type VisualizerConfig
   } from 'profiler-lib'
@@ -107,6 +108,11 @@
 
   export function showTopNodes(isSticky?: boolean) {
     return instance?.visualizer.showTopNodes(isSticky)
+  }
+
+  /** Serialize the rendered diagram to an SVG document string, or null if not yet rendered. */
+  export async function exportSvg(options?: SvgExportOptions): Promise<string | null> {
+    return (await instance?.visualizer.exportSvg(options)) ?? null
   }
 
   // Cleanup on component destruction

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -26,6 +26,7 @@
   import { type AnalysisView, isNodeView, metricsModeOf } from '../functions/metricsMode'
   import { severityLabel, uniqueCategories, uniqueSeverities } from '../functions/triage'
   import type { MetricsMode } from './MetricsView.svelte'
+  import DiagramFileMenu from './DiagramFileMenu.svelte'
   import ProfilerDiagram from './ProfilerDiagram.svelte'
   import type { TooltipData } from './ProfilerTooltip.svelte'
   import ProfileTimestampSelector from './ProfileTimestampSelector.svelte'
@@ -50,6 +51,8 @@
      *  tab. Absent when the bundle carried no config. */
     runtimeConfig?: unknown
     triageResults: TriageResults
+    /** Pipeline name, used in the exported diagram's file name. */
+    pipelineName?: string
     profileFiles: [Date, ZipItem[]][]
     selectedTimestamp: Date | null
     onSelectTimestamp: (timestamp: Date) => void
@@ -72,6 +75,7 @@
     globalMetrics,
     runtimeConfig,
     triageResults,
+    pipelineName,
     profileFiles,
     selectedTimestamp,
     onSelectTimestamp,
@@ -329,8 +333,14 @@
     <!-- Header -->
     <div class="flex flex-shrink-0 flex-wrap items-center gap-2 p-4">
       {@render loadProfileControl?.()}
-      <ProfileTimestampSelector {profileFiles} {selectedTimestamp} {onSelectTimestamp} />
       {#if hasProfile}
+        <DiagramFileMenu
+          exportSvg={() => profilerDiagram?.exportSvg() ?? Promise.resolve(null)}
+          onError={(message) => (error = message)}
+          {pipelineName}
+          snapshotDate={selectedTimestamp}
+        />
+        <ProfileTimestampSelector {profileFiles} {selectedTimestamp} {onSelectTimestamp} />
         <div class="ml-auto">
           <input
             bind:value={nodeSearchQuery}

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte.spec.ts
@@ -100,6 +100,32 @@ const expectDividerDownGrowsTopPane = async (container: HTMLElement) => {
   await expect.poll(topPaneSize).toBeGreaterThan(sizeBefore)
 }
 
+describe('SupportBundleViewerLayout File menu', () => {
+  const findButtonByText = (container: HTMLElement, text: string) =>
+    Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.trim() === text)
+
+  it('shows the File menu only once a profile is present', async () => {
+    const { container, rerender } = render(SupportBundleViewerLayout, baseProps())
+    // Exporting needs a rendered diagram, so the menu is gated on the profile.
+    expect(findButtonByText(container, 'File')).toBeUndefined()
+    await rerender({ profileData: someProfile })
+    expect(findButtonByText(container, 'File')).toBeDefined()
+  })
+
+  it('reveals "Export as .svg" when the File menu is opened', async () => {
+    const { container } = render(SupportBundleViewerLayout, {
+      ...baseProps(),
+      profileData: someProfile
+    })
+    const fileButton = findButtonByText(container, 'File')
+    expect(fileButton).toBeDefined()
+    expect(findButtonByText(container, 'Export as .svg')).toBeUndefined()
+
+    fileButton?.click()
+    await expect.poll(() => findButtonByText(container, 'Export as .svg') !== undefined).toBe(true)
+  })
+})
+
 describe('SupportBundleViewerLayout vertical pane order', () => {
   it('grows the graph pane when the divider moves down after a profile loads late', async () => {
     const { container, rerender } = render(SupportBundleViewerLayout, baseProps())

--- a/js-packages/profiler-layout/src/lib/functions/download.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/download.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { downloadFile } from './download'
+
+describe('downloadFile', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('downloads the content as a named blob of the given type', async () => {
+    let capturedBlob: Blob | undefined
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation((source: Blob | MediaSource) => {
+        capturedBlob = source as Blob
+        return 'blob:mock-url'
+      })
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    // Capture the transient anchor and suppress the real navigation/download.
+    let anchor: HTMLAnchorElement | undefined
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      anchor = this
+    })
+
+    downloadFile('<svg></svg>', 'diagram.svg', 'image/svg+xml')
+
+    // Synchronous assertions first: the deferred revoke must not have run yet, and any `await`
+    // below would let its macrotask fire.
+    expect(createObjectURL).toHaveBeenCalledOnce()
+    expect(capturedBlob?.type).toBe('image/svg+xml')
+    expect(anchor?.download).toBe('diagram.svg')
+    expect(anchor?.getAttribute('href')).toBe('blob:mock-url')
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    expect(await capturedBlob?.text()).toBe('<svg></svg>')
+
+    // Revocation is deferred so the browser can read the blob before the URL is released.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/download.ts
+++ b/js-packages/profiler-layout/src/lib/functions/download.ts
@@ -1,0 +1,14 @@
+/** Trigger a browser download of `content` as a file named `filename`.
+ *
+ *  Wraps the content in a Blob and clicks a transient anchor. Revocation of the object URL is
+ *  deferred so the browser can start reading the blob before the URL is released.
+ */
+export function downloadFile(content: BlobPart, filename: string, mimeType: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: mimeType }))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = 'noopener'
+  anchor.click()
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}

--- a/js-packages/profiler-layout/src/lib/functions/fileName.spec.ts
+++ b/js-packages/profiler-layout/src/lib/functions/fileName.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { profileImageFileName } from './fileName'
+
+describe('profileImageFileName', () => {
+  it('combines the pipeline name and the snapshot date as YYYY.MM.DD', () => {
+    // Month is 0-based: 2 -> March.
+    expect(profileImageFileName('my-pipeline', new Date(2024, 2, 9))).toBe(
+      'my-pipeline-2024.03.09.svg'
+    )
+  })
+
+  it('zero-pads the month and day', () => {
+    // Without padding this would be "2025.1.5"; the assertion pins the padding.
+    expect(profileImageFileName('p', new Date(2025, 0, 5))).toBe('p-2025.01.05.svg')
+  })
+
+  it('sanitizes characters that are unsafe in file names', () => {
+    expect(profileImageFileName('My Pipeline!/v2', new Date(2024, 2, 9))).toBe(
+      'My-Pipeline-v2-2024.03.09.svg'
+    )
+  })
+
+  it('collapses runs of separators', () => {
+    expect(profileImageFileName('a  -  b', new Date(2024, 2, 9))).toBe('a-b-2024.03.09.svg')
+  })
+
+  it('falls back to "dataflow-diagram" when the name is missing or empty', () => {
+    expect(profileImageFileName(undefined, new Date(2024, 2, 9))).toBe(
+      'dataflow-diagram-2024.03.09.svg'
+    )
+    expect(profileImageFileName('   ', new Date(2024, 2, 9))).toBe('dataflow-diagram-2024.03.09.svg')
+  })
+})

--- a/js-packages/profiler-layout/src/lib/functions/fileName.ts
+++ b/js-packages/profiler-layout/src/lib/functions/fileName.ts
@@ -1,0 +1,26 @@
+/** Build the download file name for an exported profile diagram: the pipeline name followed by
+ *  the snapshot date as YYYY.MM.DD, e.g. "my-pipeline-2024.03.09.svg". Falls back to
+ *  "dataflow-diagram" when no pipeline name is known.
+ */
+export function profileImageFileName(pipelineName: string | undefined, date: Date): string {
+  const base = sanitizeFileNamePart(pipelineName ?? '') || 'dataflow-diagram'
+  return `${base}-${formatDateYYYYMMDD(date)}.svg`
+}
+
+/** Format a date as zero-padded YYYY.MM.DD in local time. */
+function formatDateYYYYMMDD(date: Date): string {
+  const yyyy = String(date.getFullYear()).padStart(4, '0')
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yyyy}.${mm}.${dd}`
+}
+
+/** Replace characters that are unsafe or awkward in file names with '-', collapse repeats, and
+ *  trim leading/trailing separators. */
+function sanitizeFileNamePart(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+}

--- a/js-packages/profiler-lib/package.json
+++ b/js-packages/profiler-lib/package.json
@@ -26,10 +26,12 @@
     "cytoscape": "^3.33.1",
     "cytoscape-dblclick": "^0.3.1",
     "cytoscape-elk": "^2.3.0",
+    "cytoscape-svg": "^0.4.0",
     "elkjs": "^0.11.0"
   },
   "devDependencies": {
     "@types/cytoscape": "^3.21.9",
+    "happy-dom": "^20.9.0",
     "typescript": "^5.9.2",
     "vitest": "^4.1.8"
   }

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -12,6 +12,7 @@ import { ViewNavigator } from './navigator.js';
 import { ZSet } from "./zset.js";
 import { MetadataSelection } from './metadataSelection.js';
 import { type NodeAttributes, type TooltipCell, type ProfilerCallbacks } from './profiler.js';
+import { exportGraphSvg, type SvgExportOptions } from './svgExport.js';
 
 /** A measurement together with a normalized [0, 100] percentile for color scaling. The original
  * `PropertyValue` is preserved so consumers can format on demand (via `.toString()`) or compute
@@ -1106,6 +1107,14 @@ export class CytographRendering {
         let reachable = this.cy.edges();
         reachable.removeClass('highlight-forward');
         reachable.removeClass('highlight-backward');
+    }
+
+    /**
+     * Serialize the current graph to a standalone SVG document string.
+     * Exports the whole graph with a solid background.
+     */
+    async exportSvg(options?: SvgExportOptions): Promise<string> {
+        return exportGraphSvg(this.cy, options);
     }
 
     /**

--- a/js-packages/profiler-lib/src/cytoscape-svg.d.ts
+++ b/js-packages/profiler-lib/src/cytoscape-svg.d.ts
@@ -1,0 +1,6 @@
+// Ambient types for `cytoscape-svg`, which ships no declarations. The extension is a
+// registration function passed to `cytoscape.use`, matching cytoscape's `Ext` shape.
+declare module 'cytoscape-svg' {
+    const register: import('cytoscape').Ext
+    export default register
+}

--- a/js-packages/profiler-lib/src/index.ts
+++ b/js-packages/profiler-lib/src/index.ts
@@ -9,6 +9,7 @@ export {
     type NodeAttributes,
     type TooltipRow,
     type TooltipCell,
+    type SvgExportOptions,
     NodeAndMetric,
     shadeOfRed
 } from './profiler.js';

--- a/js-packages/profiler-lib/src/profiler.ts
+++ b/js-packages/profiler-lib/src/profiler.ts
@@ -3,11 +3,13 @@
 
 import { CircuitProfile, NodeAndMetric, PropertyValue } from "./profile.js";
 import { Cytograph, CytographRendering } from "./cytograph.js";
+import { type SvgExportOptions } from "./svgExport.js";
 import { CircuitSelector } from "./selection.js";
 import { MetadataSelector } from './metadataSelection.js';
 import { Option, shadeOfRed } from "./util.js";
 
 export { NodeAndMetric, shadeOfRed };
+export type { SvgExportOptions };
 
 /** Represents a selectable metric option */
 export interface MetricOption {
@@ -346,6 +348,17 @@ export class Visualizer {
                 }
             }
         }
+    }
+
+    /**
+     * Export the currently rendered diagram as a standalone SVG document string.
+     * Returns null when no profile has been rendered yet.
+     */
+    async exportSvg(options?: SvgExportOptions): Promise<string | null> {
+        if (!this.rendering) {
+            return null;
+        }
+        return this.rendering.exportSvg(options);
     }
 
     /**

--- a/js-packages/profiler-lib/src/svgExport.test.ts
+++ b/js-packages/profiler-lib/src/svgExport.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+// A DOM environment is required only so the static cytoscape / cytoscape-dblclick imports (which
+// reference `window` at load time) resolve; this test itself renders nothing.
+import { describe, expect, it } from 'vitest'
+import { frameSvg } from './svgExport.js'
+import { type ProfilerCallbacks, Visualizer, type VisualizerConfig } from './profiler.js'
+
+const noopCallbacks: ProfilerCallbacks = {
+    displayNodeAttributes: () => {},
+    displayTopNodes: () => {},
+    onMetricsChanged: () => {},
+    displayMessage: () => {},
+    onError: () => {}
+}
+
+describe('Visualizer.exportSvg', () => {
+    it('returns null before any profile is rendered', async () => {
+        // This environment has no DOM. The constructor only stores its config (it never touches
+        // the containers), so dummy elements are enough to exercise the pre-render guard. Dropping
+        // that guard would dereference a null `rendering` here and throw instead of returning null.
+        const config = {
+            graphContainer: {} as HTMLElement,
+            navigatorContainer: {} as HTMLElement,
+            callbacks: noopCallbacks
+        } satisfies VisualizerConfig
+        const visualizer = new Visualizer(config)
+        expect(await visualizer.exportSvg()).toBeNull()
+    })
+})
+
+describe('frameSvg', () => {
+    const svg = (attrs: string, body = '<circle cx="10" cy="10" r="5"/>') =>
+        `<svg xmlns="http://www.w3.org/2000/svg" ${attrs}>${body}</svg>`
+
+    it('grows the canvas by padding on every edge and adds a matching viewBox', () => {
+        const framed = frameSvg(svg('width="100" height="60"'), 20, '#ffffff')
+        const root = new DOMParser().parseFromString(framed, 'image/svg+xml').documentElement
+        // 100 + 2*20 wide, 60 + 2*20 tall.
+        expect(root.getAttribute('width')).toBe('140')
+        expect(root.getAttribute('height')).toBe('100')
+        expect(root.getAttribute('viewBox')).toBe('0 0 140 100')
+    })
+
+    it('offsets the original content by the padding and keeps it', () => {
+        const framed = frameSvg(svg('width="100" height="60"'), 20, '#ffffff')
+        const root = new DOMParser().parseFromString(framed, 'image/svg+xml').documentElement
+        const group = root.querySelector('g[transform]')
+        expect(group?.getAttribute('transform')).toBe('translate(20,20)')
+        expect(group?.querySelector('circle')).not.toBeNull()
+    })
+
+    it('paints a background rect that covers the whole framed canvas', () => {
+        const framed = frameSvg(svg('width="100" height="60"'), 20, '#123456')
+        const root = new DOMParser().parseFromString(framed, 'image/svg+xml').documentElement
+        const rect = root.querySelector('rect')
+        expect(rect?.getAttribute('fill')).toBe('#123456')
+        expect(rect?.getAttribute('width')).toBe('140')
+        expect(rect?.getAttribute('height')).toBe('100')
+    })
+
+    it('returns the input unchanged when the size is unknown', () => {
+        // No width/height to frame around; framing would produce a zero-size canvas, so leave it.
+        const input = svg('', '<g/>')
+        expect(frameSvg(input, 20, '#ffffff')).toBe(input)
+    })
+})

--- a/js-packages/profiler-lib/src/svgExport.ts
+++ b/js-packages/profiler-lib/src/svgExport.ts
@@ -1,0 +1,109 @@
+// SVG export for the profiler diagram: lazily loads the cytoscape-svg extension, exports the
+// whole graph, and frames it with padding and a solid background.
+
+import cytoscape from 'cytoscape';
+
+/** Options for exporting the diagram as SVG. */
+export interface SvgExportOptions {
+    /** Uniform padding (in diagram units) added around the graph's bounding box. Default 20. */
+    padding?: number;
+    /** Background color filling the whole image, padding included. Default white ('#ffffff'). */
+    background?: string;
+}
+
+/** Default padding framed around an exported diagram. */
+const DEFAULT_SVG_PADDING = 20;
+const DEFAULT_SVG_BACKGROUND = '#ffffff';
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/** Options accepted by the `svg()` method the `cytoscape-svg` extension adds to the core. */
+interface CytoscapeSvgOptions {
+    /** Export the whole graph rather than only the current viewport. */
+    full?: boolean;
+    /** Scale factor applied to the exported drawing. */
+    scale?: number;
+    /** Background color painted behind the graph (transparent when omitted). */
+    bg?: string;
+}
+
+/** The cytoscape core once the `cytoscape-svg` extension is registered. */
+interface SvgCapableCore {
+    svg(options?: CytoscapeSvgOptions): string;
+}
+
+// The extension registers a global `svg` core method; register it once per page. Loaded lazily
+// because its UMD bundle touches `window` at import time, which would break Node environments
+// (e.g. unit tests) that never render.
+let svgExtensionRegistered = false;
+async function ensureSvgExtension(): Promise<void> {
+    if (svgExtensionRegistered) {
+        return;
+    }
+    const { default: cytoscapeSvg } = await import('cytoscape-svg');
+    cytoscape.use(cytoscapeSvg);
+    svgExtensionRegistered = true;
+}
+
+/**
+ * Export a cytoscape graph to a standalone SVG document string. Exports the whole graph (not just
+ * the viewport), framed with padding and a solid background.
+ */
+export async function exportGraphSvg(
+    cy: cytoscape.Core,
+    options?: SvgExportOptions
+): Promise<string> {
+    await ensureSvgExtension();
+    const padding = options?.padding ?? DEFAULT_SVG_PADDING;
+    const background = options?.background ?? DEFAULT_SVG_BACKGROUND;
+    // Export the tight bounding box transparently, then frame it so the background covers the
+    // padding too (cytoscape-svg fills its background only behind the content box).
+    const svg = (cy as unknown as SvgCapableCore).svg({ full: true });
+    return frameSvg(svg, padding, background);
+}
+
+/**
+ * Frame a `cytoscape-svg` document: add uniform padding around the graph and a solid background
+ * that also covers the padding. `cytoscape-svg` exports a tight bounding box and paints its
+ * background only behind the content, so padding and background are added here instead.
+ *
+ * Exported for testing. Returns the input unchanged when it cannot be parsed or has no size.
+ */
+export function frameSvg(svg: string, padding: number, background: string): string {
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    const root = doc.documentElement;
+    if (root.localName !== 'svg' || root.getElementsByTagName('parsererror').length > 0) {
+        return svg;
+    }
+    const width = Number.parseFloat(root.getAttribute('width') ?? '');
+    const height = Number.parseFloat(root.getAttribute('height') ?? '');
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+        return svg;
+    }
+
+    const pad = Math.max(0, padding);
+    const framedWidth = width + 2 * pad;
+    const framedHeight = height + 2 * pad;
+
+    // Move the existing content into a group offset by the padding.
+    const content = doc.createElementNS(SVG_NAMESPACE, 'g');
+    content.setAttribute('transform', `translate(${pad},${pad})`);
+    while (root.firstChild) {
+        content.appendChild(root.firstChild);
+    }
+
+    // Background rect first (behind the content), sized to the full framed canvas.
+    const backgroundRect = doc.createElementNS(SVG_NAMESPACE, 'rect');
+    backgroundRect.setAttribute('x', '0');
+    backgroundRect.setAttribute('y', '0');
+    backgroundRect.setAttribute('width', String(framedWidth));
+    backgroundRect.setAttribute('height', String(framedHeight));
+    backgroundRect.setAttribute('fill', background);
+    root.appendChild(backgroundRect);
+    root.appendChild(content);
+
+    root.setAttribute('width', String(framedWidth));
+    root.setAttribute('height', String(framedHeight));
+    root.setAttribute('viewBox', `0 0 ${framedWidth} ${framedHeight}`);
+
+    return new XMLSerializer().serializeToString(root);
+}

--- a/js-packages/profiler-lib/tsconfig.json
+++ b/js-packages/profiler-lib/tsconfig.json
@@ -4,7 +4,9 @@
         "rootDir": "./src",
         "outDir": "./dist",
         // Environment Settings
-        "module": "es6",
+        // es2020 (over es6) enables dynamic import(), used to lazily load the browser-only
+        // cytoscape-svg extension so Node consumers (e.g. unit tests) never evaluate it.
+        "module": "es2020",
         "target": "esnext",
         "moduleResolution": "node",
         "types": [],

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/profile-viewer/+page.svelte
@@ -296,6 +296,7 @@
         {globalMetrics}
         {runtimeConfig}
         {triageResults}
+        pipelineName={displayPipelineName}
         profileFiles={getProfileFiles()}
         selectedTimestamp={selectedProfile}
         onSelectTimestamp={handleSelectTimestamp}


### PR DESCRIPTION

<img width="806" height="419" alt="image" src="https://github.com/user-attachments/assets/db5cb698-94ed-4e65-bb34-502722b077f4" />

The collapsed nodes and node colors are rendered as-is.

<img width="2465" height="4149" alt="fraud-detection-2026 07 30" src="https://github.com/user-attachments/assets/c18fd531-ee18-467d-b4ee-ed53fc7b4273" />

Testing: manual, added unit tests