### PR TITLE
python: add LongOperationWarning to reduce poll-loop log spam

### DIFF
--- a/python/feldera/_long_operation_warning.py
+++ b/python/feldera/_long_operation_warning.py
@@ -1,0 +1,52 @@
+import logging
+import time
+from typing import Callable, Optional
+
+
+class LongOperationWarning:
+    """
+    Suppresses per-iteration logging in polling loops.
+
+    Logging on every iteration of a wait loop floods the log when polling
+    quickly or waiting a long time. Instead, this logs only after
+    `warn_threshold_s` seconds have elapsed, then doubles the threshold
+    before warning again, so warnings become progressively less frequent the
+    longer the operation runs. If a warning was ever emitted, a later call to
+    `done()` logs that the operation finished, so a warning about a stuck
+    operation does not go unresolved in the log.
+
+    Mirrors `LongOperationWarning` in crates/adapters/src/util.rs.
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        message: Callable[[float], str],
+        done_message: Optional[Callable[[float], str]] = None,
+        warn_threshold_s: float = 5.0,
+        level: int = logging.DEBUG,
+    ):
+        self._logger = logger
+        self._message = message
+        self._done_message = done_message
+        self._warn_threshold_s = warn_threshold_s
+        self._level = level
+        self._start = time.monotonic()
+        self._warned = False
+
+    def elapsed(self) -> float:
+        """Seconds elapsed since this object was created."""
+        return time.monotonic() - self._start
+
+    def check(self) -> None:
+        """Logs a warning if the current threshold has elapsed, then doubles it."""
+        elapsed = self.elapsed()
+        if elapsed >= self._warn_threshold_s:
+            self._logger.log(self._level, self._message(elapsed))
+            self._warn_threshold_s *= 2
+            self._warned = True
+
+    def done(self) -> None:
+        """Logs completion, but only if `check()` previously logged a warning."""
+        if self._warned and self._done_message is not None:
+            self._logger.log(self._level, self._done_message(self.elapsed()))

--- a/python/feldera/_long_operation_warning.py
+++ b/python/feldera/_long_operation_warning.py
@@ -15,7 +15,11 @@ class LongOperationWarning:
     `done()` logs that the operation finished, so a warning about a stuck
     operation does not go unresolved in the log.
 
-    Mirrors `LongOperationWarning` in crates/adapters/src/util.rs.
+    Mirrors `LongOperationWarning` in crates/adapters/src/util.rs. Defaults to
+    WARNING, not DEBUG: these messages only fire rarely (thanks to the
+    backoff), so there's no spam to hide, and a DEBUG default would make them
+    invisible under most logging configurations -- including this project's
+    own test suite, which defaults to INFO.
     """
 
     def __init__(
@@ -24,7 +28,7 @@ class LongOperationWarning:
         message: Callable[[float], str],
         done_message: Optional[Callable[[float], str]] = None,
         warn_threshold_s: float = 5.0,
-        level: int = logging.DEBUG,
+        level: int = logging.WARNING,
     ):
         self._logger = logger
         self._message = message

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -20,6 +20,7 @@ import pyarrow as pa
 
 from feldera._callback_runner import CallbackRunner
 from feldera._helpers import chunk_dataframe, ensure_dataframe_has_columns
+from feldera._long_operation_warning import LongOperationWarning
 from feldera.enums import (
     BootstrapPolicy,
     CheckpointStatus,
@@ -44,6 +45,8 @@ from feldera.rest.sql_view import SQLView
 from feldera.runtime_config import RuntimeConfig
 from feldera.stats import InputEndpointStatus, OutputEndpointStatus, PipelineStatistics
 from feldera.types import CheckpointMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class Pipeline:
@@ -384,6 +387,12 @@ class Pipeline:
             raise RuntimeError("Pipeline must be running to wait for completion")
 
         start_time = time.monotonic()
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still waiting for pipeline {self.name} to complete, "
+            f"waited {elapsed:.1f} seconds",
+            lambda elapsed: f"pipeline {self.name} completed after {elapsed:.1f} seconds",
+        )
 
         while True:
             if timeout_s is not None:
@@ -393,10 +402,6 @@ class Pipeline:
                         f"timeout ({timeout_s}s) reached while waiting for"
                         f" pipeline '{self.name}' to complete"
                     )
-                logging.debug(
-                    f"waiting for pipeline {self.name} to complete: elapsed"
-                    f" time {elapsed}s, timeout: {timeout_s}s"
-                )
 
             pipeline_complete: bool = self.is_complete()
             if pipeline_complete is None:
@@ -404,8 +409,10 @@ class Pipeline:
                     "received unknown metrics from the pipeline, pipeline_complete is None"
                 )
             elif pipeline_complete:
+                long_op.done()
                 break
 
+            long_op.check()
             time.sleep(1)
 
         if force_stop:

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 import pyarrow.ipc
 import requests
 
+from feldera._long_operation_warning import LongOperationWarning
 from feldera.enums import BootstrapPolicy, PipelineFieldSelector, PipelineStatus
 from feldera.rest._helpers import determine_client_version
 from feldera.rest._httprequests import HttpRequests
@@ -175,6 +176,11 @@ class FelderaClient:
         """Wait for pipeline compilation -- internal use only."""
         wait = ["Pending", "CompilingSql", "SqlCompiled", "CompilingRust"]
         start_time = time.monotonic()
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still compiling {name}, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"{name} finished compiling after {elapsed:.1f} seconds",
+        )
         while True:
             elapsed = time.monotonic() - start_time
             if timeout_s is not None and elapsed > timeout_s:
@@ -187,6 +193,7 @@ class FelderaClient:
             status = p.program_status
 
             if status == "Success":
+                long_op.done()
                 if expected_program_version is None:
                     return self.get_pipeline(name, PipelineFieldSelector.ALL)
 
@@ -224,11 +231,7 @@ class FelderaClient:
 
                 raise RuntimeError(error_message)
 
-            logger.debug(
-                "still compiling %s, waiting for %.1f more seconds",
-                name,
-                poll_interval_s,
-            )
+            long_op.check()
             time.sleep(poll_interval_s)
 
     def __wait_for_pipeline_state(
@@ -240,6 +243,13 @@ class FelderaClient:
         poll_interval_s: float = 0.5,
     ):
         start_time = time.monotonic()
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still waiting for {pipeline_name} to transition to "
+            f"'{state}', waited {elapsed:.1f} seconds",
+            lambda elapsed: f"{pipeline_name} transitioned to '{state}' after "
+            f"{elapsed:.1f} seconds",
+        )
 
         while True:
             if timeout_s is not None:
@@ -254,6 +264,7 @@ class FelderaClient:
             status = resp.deployment_status
 
             if status.lower() == state.lower():
+                long_op.done()
                 break
             elif (
                 status == "Stopped"
@@ -267,11 +278,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 {resp.deployment_error.get("message", "")}"""
                 )
 
-            logger.debug(
-                "still starting %s, waiting for %.1f more seconds",
-                pipeline_name,
-                poll_interval_s,
-            )
+            long_op.check()
             time.sleep(poll_interval_s)
 
     def __wait_for_pipeline_state_one_of(
@@ -284,6 +291,12 @@ Reason: The pipeline is in a STOPPED state due to the following error:
     ) -> PipelineStatus:
         start_time = time.monotonic()
         states = [state.lower() for state in states]
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still waiting for {pipeline_name} to transition to "
+            f"one of {states}, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"{pipeline_name} transitioned after {elapsed:.1f} seconds",
+        )
 
         while True:
             if timeout_s is not None:
@@ -298,6 +311,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             status = resp.deployment_status
 
             if status.lower() in states:
+                long_op.done()
                 return PipelineStatus.from_str(status)
             elif (
                 status == "Stopped"
@@ -310,11 +324,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 Reason: The pipeline is in a STOPPED state due to the following error:
 {resp.deployment_error.get("message", "")}"""
                 )
-            logger.debug(
-                "still starting %s, waiting for %.1f more seconds",
-                pipeline_name,
-                poll_interval_s,
-            )
+            long_op.check()
             time.sleep(poll_interval_s)
 
     def create_pipeline(self, pipeline: Pipeline, wait: bool = True) -> Pipeline:
@@ -752,6 +762,11 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             return
 
         start = time.monotonic()
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still stopping {pipeline_name}, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"{pipeline_name} stopped after {elapsed:.1f} seconds",
+        )
 
         while True:
             if timeout_s is not None and time.monotonic() - start > timeout_s:
@@ -764,12 +779,10 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             ).deployment_status
 
             if status == "Stopped":
+                long_op.done()
                 return
 
-            logger.debug(
-                "still stopping %s, waiting for 100 more milliseconds",
-                pipeline_name,
-            )
+            long_op.check()
             time.sleep(0.1)
 
     def dismiss_error_pipeline(
@@ -810,6 +823,11 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             return
 
         start = time.monotonic()
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still clearing {pipeline_name}, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"{pipeline_name} storage cleared after {elapsed:.1f} seconds",
+        )
         while True:
             if timeout_s is not None and time.monotonic() - start > timeout_s:
                 raise FelderaTimeoutError(
@@ -820,13 +838,10 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             ).storage_status
 
             if status == "Cleared":
+                long_op.done()
                 return
 
-            logger.debug(
-                "still clearing %s, waiting for %.1f more seconds",
-                pipeline_name,
-                poll_interval_s,
-            )
+            long_op.check()
             time.sleep(poll_interval_s)
 
     def start_transaction(self, pipeline_name: str) -> int:
@@ -1022,6 +1037,13 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         if not wait:
             return
 
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"transaction {transaction_id} on {pipeline_name} "
+            f"hasn't committed, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"transaction {transaction_id} on {pipeline_name} "
+            f"committed after {elapsed:.1f} seconds",
+        )
         while True:
             if timeout_s is not None:
                 elapsed = time.monotonic() - start_time
@@ -1030,12 +1052,10 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 
             stats = self.get_pipeline_stats(pipeline_name)
             if stats["global_metrics"]["transaction_id"] != transaction_id:
+                long_op.done()
                 return
 
-            logging.debug(
-                "commit hasn't completed, waiting for %.1f more seconds",
-                poll_interval_s,
-            )
+            long_op.check()
             time.sleep(poll_interval_s)
 
     def checkpoint_pipeline(self, pipeline_name: str) -> int:
@@ -1248,6 +1268,13 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         max_backoff = 5
         exponent = 1.2
         retries = 0
+        long_op = LongOperationWarning(
+            logger,
+            lambda elapsed: f"still waiting for inputs represented by {token} "
+            f"to be processed, waited {elapsed:.1f} seconds",
+            lambda elapsed: f"inputs represented by {token} processed after "
+            f"{elapsed:.1f} seconds",
+        )
 
         while True:
             if end:
@@ -1259,12 +1286,10 @@ Reason: The pipeline is in a STOPPED state due to the following error:
                     )
 
             if self.completion_token_processed(pipeline_name, token):
+                long_op.done()
                 break
 
-            elapsed = time.monotonic() - start
-            logger.debug(
-                f"still waiting for inputs represented by {token} to be processed; elapsed: {elapsed}s"
-            )
+            long_op.check()
 
             retries += 1
             backoff = min(max_backoff, initial_backoff * (exponent**retries))

--- a/python/tests/unit/test_long_operation_warning.py
+++ b/python/tests/unit/test_long_operation_warning.py
@@ -1,0 +1,91 @@
+"""Tests for LongOperationWarning, which suppresses spam in polling loops."""
+
+import logging
+from unittest import mock
+
+from feldera._long_operation_warning import LongOperationWarning
+
+
+def _make(monotonic, **kwargs):
+    """Build a LongOperationWarning with `time.monotonic` patched to `monotonic`."""
+    with mock.patch(
+        "feldera._long_operation_warning.time.monotonic", side_effect=monotonic
+    ):
+        return LongOperationWarning(
+            logging.getLogger("test"),
+            lambda elapsed: f"waiting, elapsed={elapsed}",
+            lambda elapsed: f"done, elapsed={elapsed}",
+            **kwargs,
+        )
+
+
+def _check_at(long_op, t):
+    with mock.patch("feldera._long_operation_warning.time.monotonic", return_value=t):
+        long_op.check()
+
+
+def _done_at(long_op, t):
+    with mock.patch("feldera._long_operation_warning.time.monotonic", return_value=t):
+        long_op.done()
+
+
+class TestLongOperationWarning:
+    def test_no_warning_before_threshold(self, caplog):
+        long_op = _make([0.0], warn_threshold_s=5.0, level=logging.WARNING)
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 4.9)
+        assert caplog.records == []
+
+    def test_warning_after_threshold(self, caplog):
+        long_op = _make([0.0], warn_threshold_s=5.0, level=logging.WARNING)
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 5.0)
+        assert len(caplog.records) == 1
+        assert "waiting, elapsed=5.0" in caplog.records[0].message
+
+    def test_threshold_doubles_after_each_warning(self, caplog):
+        # Without doubling, every one-second tick after 5s would log again;
+        # this is exactly the spam LongOperationWarning exists to prevent.
+        long_op = _make([0.0], warn_threshold_s=5.0, level=logging.WARNING)
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 5.0)  # 1st warning, threshold -> 10
+            _check_at(long_op, 9.0)  # below new threshold, no warning
+            _check_at(long_op, 10.0)  # 2nd warning, threshold -> 20
+        assert len(caplog.records) == 2
+
+    def test_done_is_noop_if_never_warned(self, caplog):
+        long_op = _make([0.0], warn_threshold_s=5.0, level=logging.WARNING)
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 1.0)  # below threshold, no warning
+            _done_at(long_op, 1.5)
+        assert caplog.records == []
+
+    def test_done_logs_if_previously_warned(self, caplog):
+        long_op = _make([0.0], warn_threshold_s=5.0, level=logging.WARNING)
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 5.0)
+            _done_at(long_op, 7.0)
+        assert len(caplog.records) == 2
+        assert "done, elapsed=7.0" in caplog.records[1].message
+
+    def test_done_without_done_message_is_silent(self, caplog):
+        with mock.patch(
+            "feldera._long_operation_warning.time.monotonic", return_value=0.0
+        ):
+            long_op = LongOperationWarning(
+                logging.getLogger("test"),
+                lambda elapsed: f"waiting, elapsed={elapsed}",
+                warn_threshold_s=5.0,
+                level=logging.WARNING,
+            )
+        with caplog.at_level(logging.WARNING):
+            _check_at(long_op, 5.0)
+            _done_at(long_op, 7.0)
+        assert len(caplog.records) == 1
+
+    def test_uses_configured_level(self, caplog):
+        long_op = _make([0.0], warn_threshold_s=1.0, level=logging.DEBUG)
+        with caplog.at_level(logging.DEBUG):
+            _check_at(long_op, 1.0)
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.DEBUG

--- a/python/tests/unit/test_long_operation_warning.py
+++ b/python/tests/unit/test_long_operation_warning.py
@@ -89,3 +89,15 @@ class TestLongOperationWarning:
             _check_at(long_op, 1.0)
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.DEBUG
+
+    def test_default_level_is_visible_at_info(self, caplog):
+        # tests/__init__.py configures this project's test suite at INFO by
+        # default. A DEBUG default here would silently drop every warning
+        # under that configuration -- which is exactly what happened in CI
+        # (https://github.com/feldera/feldera/actions/runs/30584868028): a
+        # pipeline stuck provisioning for 180s never logged a single "still
+        # waiting" line because the messages were below the configured level.
+        long_op = _make([0.0], warn_threshold_s=5.0)  # no explicit level
+        with caplog.at_level(logging.INFO):
+            _check_at(long_op, 5.0)
+        assert len(caplog.records) == 1


### PR DESCRIPTION
The Python client logged a debug line on every iteration of its wait loops (compile, start/stop, clear storage, commit transaction, wait for token/completion), flooding logs on fast or long polls. Port the Rust LongOperationWarning (crates/adapters/src/util.rs) to back off the warning threshold exponentially, and log once when a previously-warned wait finally completes.
