### PR TITLE
Disable aws-lc-sys jitter entropy to avoid startup SIGABRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,12 @@
 # - Also note that we can't change the major version without making sure
 #   the database directories in ~/.feldera for users get upgraded too.
 POSTGRESQL_VERSION = "=15.13.0"
+
+# aws-lc-sys's CPU Jitter Entropy source can fail its startup health check on
+# freshly-started VMs/containers (timing jitter too regular in the first
+# seconds of process life), which aws-lc treats as fatal and aborts with no
+# stderr output. This disables jitter entropy at build time, leaving
+# getrandom(2) as the sole (and still sound) entropy source.
+# See https://github.com/feldera/cloud/issues/1845 and
+# https://github.com/aws/aws-lc-rs/issues/1072
+AWS_LC_SYS_NO_JITTER_ENTROPY = "1"

--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -1590,6 +1590,12 @@ async fn call_compiler(
         // Set compiler stack size to 20MB (10x the default) to prevent
         // SIGSEGV when the compiler runs out of stack on large programs.
         .env("RUST_MIN_STACK", "20971520")
+        // aws-lc-sys's CPU Jitter Entropy source can fail its startup health
+        // check on freshly-started VMs/containers and aborts the whole
+        // process with no stderr output (see feldera/cloud#1845). This env
+        // var must be set for this build too, since it links the pipeline
+        // binary that hits the abort, not just the pipeline-manager binary.
+        .env("AWS_LC_SYS_NO_JITTER_ENTROPY", "1")
         .current_dir(&workspace_dir)
         .arg("build")
         .arg("--workspace")


### PR DESCRIPTION
CPU Jitter Entropy's health check can fail on freshly-started VMs/containers (timing signal too regular in the first seconds of process life), which aws-lc treats as fatal and abort()s with no stderr output. This has been crashing pipelines and coordinators seconds after startup during the first TLS handshake, matching aws-lc-rs#1072.

Set AWS_LC_SYS_NO_JITTER_ENTROPY=1 in .cargo/config.toml for CI/local builds, and explicitly in the pipeline compiler's cargo invocation, which env_clear()s and needs it forwarded separately since it builds the pipeline binary that actually hits the abort.

Fixes: https://github.com/feldera/cloud/issues/1845