### PR TITLE
[demos] Serve the batch-analytics TPC-H data from a live bucket

### DIFF
--- a/crates/ir/test/sample_c.sql
+++ b/crates/ir/test/sample_c.sql
@@ -47,9 +47,9 @@ CREATE TABLE LINEITEM (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/lineitem",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/lineitem",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -72,9 +72,9 @@ CREATE TABLE ORDERS  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/orders",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/orders",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -97,9 +97,9 @@ CREATE TABLE PART (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/part",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/part",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -121,9 +121,9 @@ CREATE TABLE CUSTOMER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/customer",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/customer",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -144,9 +144,9 @@ CREATE TABLE SUPPLIER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/supplier",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/supplier",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -165,9 +165,9 @@ CREATE TABLE PARTSUPP (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/partsupp",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/partsupp",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -185,9 +185,9 @@ CREATE TABLE NATION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/nation",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/nation",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -204,9 +204,9 @@ CREATE TABLE REGION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/region",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/region",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }

--- a/crates/pipeline-manager/demos/README.md
+++ b/crates/pipeline-manager/demos/README.md
@@ -22,6 +22,17 @@ All the SQL files in `sql/` are packaged demos with every Feldera release.
   uv run run.py --api-url http://localhost:8080
   ```
 
+## Demo data
+
+`00-accelerating-batch-analytics.sql` reads TPC-H Delta tables from
+`s3://feldera-demo-datasets/tpch/sf0.1` (`us-west-1`). The bucket allows anonymous
+reads, so the demo needs no credentials.
+
+To regenerate the data with the official TPC-H `dbgen`, run
+[`scripts/tpch_demo_data.py`](../../../scripts/tpch_demo_data.py) with write
+credentials for the bucket. Pass `--scale-factor 0.1` to republish the set the
+demo reads.
+
 ## Specification
 
 The format is as follows:

--- a/crates/pipeline-manager/demos/sql/00-accelerating-batch-analytics.sql
+++ b/crates/pipeline-manager/demos/sql/00-accelerating-batch-analytics.sql
@@ -51,9 +51,9 @@ CREATE TABLE LINEITEM (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/lineitem",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/lineitem",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -77,9 +77,9 @@ CREATE TABLE ORDERS  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/orders",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/orders",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -103,9 +103,9 @@ CREATE TABLE PART (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/part",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/part",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -128,9 +128,9 @@ CREATE TABLE CUSTOMER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/customer",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/customer",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -152,9 +152,9 @@ CREATE TABLE SUPPLIER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/supplier",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/supplier",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -174,9 +174,9 @@ CREATE TABLE PARTSUPP (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/partsupp",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/partsupp",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -195,9 +195,9 @@ CREATE TABLE NATION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/nation",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/nation",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -215,9 +215,9 @@ CREATE TABLE REGION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/region",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/region",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }

--- a/docs.feldera.com/docs/use_cases/batch/part1.md
+++ b/docs.feldera.com/docs/use_cases/batch/part1.md
@@ -16,7 +16,8 @@ large volumes of data, execute queries with a high degree of complexity, and
 give answers to critical business questions.
 
 The raw data, stored in Delta Lake format, is publicly available in a S3 bucket
-at `s3://batchtofeldera`.
+at `s3://feldera-demo-datasets/tpch/sf0.1` in region `us-west-1`, readable without
+credentials.
 
 ## TPC-H Schema
 
@@ -38,14 +39,14 @@ Create a new SQL notebook with the following table definitions:
 
 ```sql
 -- Spark SQL
-CREATE TABLE IF NOT EXISTS lineitem LOCATION 's3://batchtofeldera/lineitem';
-CREATE TABLE IF NOT EXISTS orders LOCATION 's3://batchtofeldera/orders';
-CREATE TABLE IF NOT EXISTS part LOCATION 's3://batchtofeldera/part';
-CREATE TABLE IF NOT EXISTS customer LOCATION 's3://batchtofeldera/customer';
-CREATE TABLE IF NOT EXISTS supplier LOCATION 's3://batchtofeldera/supplier';
-CREATE TABLE IF NOT EXISTS nation LOCATION 's3://batchtofeldera/nation';
-CREATE TABLE IF NOT EXISTS region LOCATION 's3://batchtofeldera/region';
-CREATE TABLE IF NOT EXISTS partsupp LOCATION 's3://batchtofeldera/partsupp';
+CREATE TABLE IF NOT EXISTS lineitem LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/lineitem';
+CREATE TABLE IF NOT EXISTS orders LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/orders';
+CREATE TABLE IF NOT EXISTS part LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/part';
+CREATE TABLE IF NOT EXISTS customer LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/customer';
+CREATE TABLE IF NOT EXISTS supplier LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/supplier';
+CREATE TABLE IF NOT EXISTS nation LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/nation';
+CREATE TABLE IF NOT EXISTS region LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/region';
+CREATE TABLE IF NOT EXISTS partsupp LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/partsupp';
 ```
 
 The tables in our S3 bucket have the following sizes:
@@ -99,14 +100,14 @@ Similarly, we define the remaining queries up to TPC-H Q10.
 
 ```sql
 -- Spark SQL
-CREATE TABLE IF NOT EXISTS lineitem LOCATION 's3://batchtofeldera/lineitem';
-CREATE TABLE IF NOT EXISTS orders LOCATION 's3://batchtofeldera/orders';
-CREATE TABLE IF NOT EXISTS part LOCATION 's3://batchtofeldera/part';
-CREATE TABLE IF NOT EXISTS customer LOCATION 's3://batchtofeldera/customer';
-CREATE TABLE IF NOT EXISTS supplier LOCATION 's3://batchtofeldera/supplier';
-CREATE TABLE IF NOT EXISTS nation LOCATION 's3://batchtofeldera/nation';
-CREATE TABLE IF NOT EXISTS region LOCATION 's3://batchtofeldera/region';
-CREATE TABLE IF NOT EXISTS partsupp LOCATION 's3://batchtofeldera/partsupp';
+CREATE TABLE IF NOT EXISTS lineitem LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/lineitem';
+CREATE TABLE IF NOT EXISTS orders LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/orders';
+CREATE TABLE IF NOT EXISTS part LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/part';
+CREATE TABLE IF NOT EXISTS customer LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/customer';
+CREATE TABLE IF NOT EXISTS supplier LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/supplier';
+CREATE TABLE IF NOT EXISTS nation LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/nation';
+CREATE TABLE IF NOT EXISTS region LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/region';
+CREATE TABLE IF NOT EXISTS partsupp LOCATION 's3://feldera-demo-datasets/tpch/sf0.1/partsupp';
 
 create view q1
 as select

--- a/docs.feldera.com/docs/use_cases/batch/part2.md
+++ b/docs.feldera.com/docs/use_cases/batch/part2.md
@@ -43,9 +43,9 @@ CREATE TABLE LINEITEM (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/lineitem",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/lineitem",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -67,9 +67,9 @@ CREATE TABLE ORDERS  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/orders",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/orders",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -91,9 +91,9 @@ CREATE TABLE PART (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/part",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/part",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -114,9 +114,9 @@ CREATE TABLE CUSTOMER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/customer",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/customer",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -136,9 +136,9 @@ CREATE TABLE SUPPLIER (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/supplier",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/supplier",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -156,9 +156,9 @@ CREATE TABLE PARTSUPP (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/partsupp",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/partsupp",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -175,9 +175,9 @@ CREATE TABLE NATION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/nation",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/nation",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -193,9 +193,9 @@ CREATE TABLE REGION  (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/region",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/region",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }
@@ -538,9 +538,9 @@ CREATE TABLE LINEITEM (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/lineitem",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/lineitem",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot_and_follow"
       }
     }

--- a/docs.feldera.com/docs/use_cases/batch/part3.md
+++ b/docs.feldera.com/docs/use_cases/batch/part3.md
@@ -69,9 +69,9 @@ CREATE TABLE LINEITEM (
     "transport": {
       "name": "delta_table_input",
       "config": {
-        "uri": "s3://batchtofeldera/lineitem",
+        "uri": "s3://feldera-demo-datasets/tpch/sf0.1/lineitem",
         "aws_skip_signature": "true",
-        "aws_region": "ap-southeast-2",
+        "aws_region": "us-west-1",
         "mode": "snapshot"
       }
     }

--- a/python/tests/workloads/test_tpch.py
+++ b/python/tests/workloads/test_tpch.py
@@ -195,8 +195,8 @@ def run_cli():
         s3_region = args.s3_region
     else:
         input_mode = "delta"
-        s3_path = "s3://batchtofeldera"
-        s3_region = "ap-southeast-2"
+        s3_path = "s3://feldera-demo-datasets/tpch/sf0.1"
+        s3_region = "us-west-1"
 
     mode = args.mode
 
@@ -1643,8 +1643,8 @@ class TestTPCH(unittest.TestCase):
         config = TPCHTestConfig(
             "transaction",
             "delta",
-            s3_path="s3://batchtofeldera",
-            s3_region="ap-southeast-2",
+            s3_path="s3://feldera-demo-datasets/tpch/sf0.1",
+            s3_region="us-west-1",
             s3_skip_signature=True,
         )
         tpch_test(config)
@@ -1653,8 +1653,8 @@ class TestTPCH(unittest.TestCase):
         config = TPCHTestConfig(
             "stream",
             "delta",
-            s3_path="s3://batchtofeldera",
-            s3_region="ap-southeast-2",
+            s3_path="s3://feldera-demo-datasets/tpch/sf0.1",
+            s3_region="us-west-1",
             s3_skip_signature=True,
         )
         tpch_test(config)

--- a/scripts/tpch_demo_data.py
+++ b/scripts/tpch_demo_data.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "deltalake>=0.20",
+#     "pyarrow>=15",
+# ]
+# ///
+"""Publish TPC-H Delta tables to the public demo-data bucket.
+
+The accelerating-batch-analytics demo and python/tests/workloads/test_tpch.py read
+these tables anonymously. Regenerate them with:
+
+    ./scripts/tpch_demo_data.py --scale-factor 0.01 --scale-factor 0.1 --scale-factor 1
+
+Data comes from the official TPC-H dbgen (via the tpch-kit packaging, which adds a
+macOS build and drops dbgen's trailing row delimiter but leaves the generator
+untouched). Uploading needs write credentials for the bucket; readers need none.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.csv as pacsv
+from deltalake import write_deltalake
+
+TPCH_KIT_REPO = "https://github.com/gregrahn/tpch-kit.git"
+
+DECIMAL = pa.decimal128(15, 2)
+
+
+def column(name: str, arrow_type: pa.DataType, nullable: bool = False) -> pa.Field:
+    return pa.field(name, arrow_type, nullable=nullable)
+
+
+# Column order must match dbgen's output, which follows the TPC-H spec. Only
+# n_comment and r_comment are nullable, mirroring the demo's CREATE TABLE.
+SCHEMAS: dict[str, pa.Schema] = {
+    "lineitem": pa.schema(
+        [
+            column("l_orderkey", pa.int32()),
+            column("l_partkey", pa.int32()),
+            column("l_suppkey", pa.int32()),
+            column("l_linenumber", pa.int32()),
+            column("l_quantity", DECIMAL),
+            column("l_extendedprice", DECIMAL),
+            column("l_discount", DECIMAL),
+            column("l_tax", DECIMAL),
+            column("l_returnflag", pa.string()),
+            column("l_linestatus", pa.string()),
+            column("l_shipdate", pa.date32()),
+            column("l_commitdate", pa.date32()),
+            column("l_receiptdate", pa.date32()),
+            column("l_shipinstruct", pa.string()),
+            column("l_shipmode", pa.string()),
+            column("l_comment", pa.string()),
+        ]
+    ),
+    "orders": pa.schema(
+        [
+            column("o_orderkey", pa.int32()),
+            column("o_custkey", pa.int32()),
+            column("o_orderstatus", pa.string()),
+            column("o_totalprice", DECIMAL),
+            column("o_orderdate", pa.date32()),
+            column("o_orderpriority", pa.string()),
+            column("o_clerk", pa.string()),
+            column("o_shippriority", pa.int32()),
+            column("o_comment", pa.string()),
+        ]
+    ),
+    "part": pa.schema(
+        [
+            column("p_partkey", pa.int32()),
+            column("p_name", pa.string()),
+            column("p_mfgr", pa.string()),
+            column("p_brand", pa.string()),
+            column("p_type", pa.string()),
+            column("p_size", pa.int32()),
+            column("p_container", pa.string()),
+            column("p_retailprice", DECIMAL),
+            column("p_comment", pa.string()),
+        ]
+    ),
+    "customer": pa.schema(
+        [
+            column("c_custkey", pa.int32()),
+            column("c_name", pa.string()),
+            column("c_address", pa.string()),
+            column("c_nationkey", pa.int32()),
+            column("c_phone", pa.string()),
+            column("c_acctbal", DECIMAL),
+            column("c_mktsegment", pa.string()),
+            column("c_comment", pa.string()),
+        ]
+    ),
+    "supplier": pa.schema(
+        [
+            column("s_suppkey", pa.int32()),
+            column("s_name", pa.string()),
+            column("s_address", pa.string()),
+            column("s_nationkey", pa.int32()),
+            column("s_phone", pa.string()),
+            column("s_acctbal", DECIMAL),
+            column("s_comment", pa.string()),
+        ]
+    ),
+    "partsupp": pa.schema(
+        [
+            column("ps_partkey", pa.int32()),
+            column("ps_suppkey", pa.int32()),
+            column("ps_availqty", pa.int32()),
+            column("ps_supplycost", DECIMAL),
+            column("ps_comment", pa.string()),
+        ]
+    ),
+    "nation": pa.schema(
+        [
+            column("n_nationkey", pa.int32()),
+            column("n_name", pa.string()),
+            column("n_regionkey", pa.int32()),
+            column("n_comment", pa.string(), nullable=True),
+        ]
+    ),
+    "region": pa.schema(
+        [
+            column("r_regionkey", pa.int32()),
+            column("r_name", pa.string()),
+            column("r_comment", pa.string(), nullable=True),
+        ]
+    ),
+}
+
+# Canonical row counts at scale factor 1, straight from the TPC-H spec. Every
+# other scale factor scales linearly except nation and region, which are fixed.
+SF1_ROW_COUNTS = {
+    "lineitem": 6001215,
+    "orders": 1500000,
+    "partsupp": 800000,
+    "part": 200000,
+    "customer": 150000,
+    "supplier": 10000,
+    "nation": 25,
+    "region": 5,
+}
+
+
+def build_dbgen(work_dir: Path) -> Path:
+    """Clone and build the official dbgen, returning the directory holding it."""
+    dbgen_dir = work_dir / "tpch-kit" / "dbgen"
+    if (dbgen_dir / "dbgen").exists():
+        return dbgen_dir
+
+    print(f"Cloning {TPCH_KIT_REPO}")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", TPCH_KIT_REPO, str(work_dir / "tpch-kit")],
+        check=True,
+    )
+
+    machine = "MACOS" if sys.platform == "darwin" else "LINUX"
+    print(f"Building dbgen for {machine}")
+    subprocess.run(
+        ["make", f"MACHINE={machine}", "DATABASE=POSTGRESQL"],
+        cwd=dbgen_dir,
+        check=True,
+    )
+    return dbgen_dir
+
+
+def generate_tables(dbgen_dir: Path, scale_factor: float, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Generating scale factor {scale_factor} into {out_dir}")
+    subprocess.run(
+        [str(dbgen_dir / "dbgen"), "-s", str(scale_factor), "-f", "-q"],
+        cwd=dbgen_dir,
+        env={**os.environ, "DSS_PATH": str(out_dir)},
+        check=True,
+    )
+
+
+def read_table(tbl_path: Path, schema: pa.Schema) -> pa.Table:
+    """Parse a dbgen .tbl file into an Arrow table with the TPC-H schema."""
+    return pacsv.read_csv(
+        tbl_path,
+        read_options=pacsv.ReadOptions(column_names=schema.names),
+        parse_options=pacsv.ParseOptions(delimiter="|", quote_char=False),
+        convert_options=pacsv.ConvertOptions(
+            column_types={f.name: f.type for f in schema},
+            # dbgen never emits an empty field, so an empty string is data, not a
+            # null. Passing no null strings keeps it that way.
+            null_values=[],
+            strings_can_be_null=False,
+        ),
+    ).cast(schema)
+
+
+def check_row_count(table: str, scale_factor: float, actual: int) -> None:
+    """Reject a truncated generate or a parse that split rows."""
+    if table in ("nation", "region"):
+        expected = SF1_ROW_COUNTS[table]
+    else:
+        expected = round(SF1_ROW_COUNTS[table] * scale_factor)
+
+    # lineitem carries 1-7 rows per order, so its total drifts a little with the
+    # generator's random draw. Every other table scales exactly.
+    tolerance = max(10, round(expected * 0.05)) if table == "lineitem" else 0
+
+    if abs(actual - expected) > tolerance:
+        raise SystemExit(
+            f"{table} at sf{scale_factor:g}: parsed {actual} rows, expected "
+            f"{expected}" + (f" +/- {tolerance}" if tolerance else "")
+        )
+
+
+def publish(
+    tbl_dir: Path, target_root: str, scale_factor: float, storage_options: dict
+) -> None:
+    for table, schema in SCHEMAS.items():
+        arrow_table = read_table(tbl_dir / f"{table}.tbl", schema)
+        check_row_count(table, scale_factor, arrow_table.num_rows)
+
+        uri = f"{target_root}/{table}"
+        print(f"  {table}: {arrow_table.num_rows} rows -> {uri}")
+        write_deltalake(
+            uri,
+            arrow_table,
+            mode="overwrite",
+            schema_mode="overwrite",
+            storage_options=storage_options,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scale-factor",
+        type=float,
+        action="append",
+        dest="scale_factors",
+        help="TPC-H scale factor; repeat to publish several (default: 0.01, 0.1, 1)",
+    )
+    parser.add_argument(
+        "--bucket",
+        default="feldera-demo-datasets",
+        help="Destination S3 bucket (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="tpch",
+        help="Key prefix under the bucket (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-west-1",
+        help="Bucket region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Write Delta tables here instead of S3, for a local dry run",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        help="Keep dbgen and the .tbl files here instead of a temporary directory",
+    )
+    args = parser.parse_args()
+
+    scale_factors = args.scale_factors or [0.01, 0.1, 1]
+
+    work_dir = args.work_dir or Path(tempfile.mkdtemp(prefix="tpch-"))
+    work_dir.mkdir(parents=True, exist_ok=True)
+    keep_work_dir = args.work_dir is not None
+
+    try:
+        dbgen_dir = build_dbgen(work_dir)
+
+        for scale_factor in scale_factors:
+            label = f"sf{scale_factor:g}"
+            tbl_dir = work_dir / f"tbl-{label}"
+            generate_tables(dbgen_dir, scale_factor, tbl_dir)
+
+            if args.output_dir:
+                target_root = str((args.output_dir / label).resolve())
+                storage_options = {}
+            else:
+                target_root = f"s3://{args.bucket}/{args.prefix}/{label}"
+                storage_options = {"AWS_REGION": args.region}
+
+            print(f"Publishing {label} to {target_root}")
+            publish(tbl_dir, target_root, scale_factor, storage_options)
+    finally:
+        if not keep_work_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
AWS disabled `s3://batchtofeldera` along with the account that owned it, so every
read answers `403 AllAccessDisabled`. That breaks the `accelerating-batch-analytics`
packaged demo for anyone who opens it in the Web Console, and fails the
"Validate and run packaged demos" step in CI.

This points the demo, the TPC-H workload tests, and the batch use-case docs at
`s3://feldera-demo-datasets/tpch/sf0.1` in `us-west-1`.

The bucket is provisioned as code with anonymous `GetObject` and `ListBucket`, so
readers still need no credentials and `aws_skip_signature` keeps working.

The replacement carries the same scale factor as the old bucket, so the record
counts in the tutorial are unchanged (lineitem 601k, customer 15.0k, ...).

`scripts/tpch_demo_data.py` regenerates the data from the official TPC-H `dbgen`
(v2.17.3). Scale factors 0.01, 0.1 and 1 are published under `tpch/sf<N>/`.

### Describe Manual Test Plan

- Generated all three scale factors with the official `dbgen` and confirmed the
  canonical TPC-H cardinalities (sf1: lineitem 6,001,215, orders 1,500,000;
  sf0.1: lineitem 600,572, customer 15,000).
- Confirmed the Delta schema matches the demo's `CREATE TABLE`: `integer`,
  `decimal(15,2)`, `date`, `string`, with only `n_comment` and `r_comment`
  nullable.
- Read all 8 tables from S3 with every AWS credential stripped from the
  environment, mirroring how the connector reads them.
- Verified anonymous `LIST` and `GET` over plain HTTPS return `200`.

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

- [ ] OpenAPI / REST HTTP API / feldera-types / manager
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib
- [ ] Python SDK
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

None. The demo's SQL schema and the tutorial's record counts are unchanged; only
the bucket the data is served from differs.
