### PR TITLE
Revert "Disable aws-lc-sys jitter entropy to avoid startup SIGABRT"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,12 +6,3 @@
 # - Also note that we can't change the major version without making sure
 #   the database directories in ~/.feldera for users get upgraded too.
 POSTGRESQL_VERSION = "=15.13.0"
-
-# aws-lc-sys's CPU Jitter Entropy source can fail its startup health check on
-# freshly-started VMs/containers (timing jitter too regular in the first
-# seconds of process life), which aws-lc treats as fatal and aborts with no
-# stderr output. This disables jitter entropy at build time, leaving
-# getrandom(2) as the sole (and still sound) entropy source.
-# See https://github.com/feldera/cloud/issues/1845 and
-# https://github.com/aws/aws-lc-rs/issues/1072
-AWS_LC_SYS_NO_JITTER_ENTROPY = "1"

--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -1590,12 +1590,6 @@ async fn call_compiler(
         // Set compiler stack size to 20MB (10x the default) to prevent
         // SIGSEGV when the compiler runs out of stack on large programs.
         .env("RUST_MIN_STACK", "20971520")
-        // aws-lc-sys's CPU Jitter Entropy source can fail its startup health
-        // check on freshly-started VMs/containers and aborts the whole
-        // process with no stderr output (see feldera/cloud#1845). This env
-        // var must be set for this build too, since it links the pipeline
-        // binary that hits the abort, not just the pipeline-manager binary.
-        .env("AWS_LC_SYS_NO_JITTER_ENTROPY", "1")
         .current_dir(&workspace_dir)
         .arg("build")
         .arg("--workspace")


### PR DESCRIPTION
Reverts the `AWS_LC_SYS_NO_JITTER_ENTROPY=1` build setting. The diagnosis behind
it was most likely wrong, and it does not prevent the crash it targeted.

## What actually aborts

The silent `SIGABRT` during the first TLS handshake is aws-lc's entropy source
aborting when the arm64 `RNDR` instruction fails, not the CPU jitter entropy
health check.

Some Google Cloud arm64 hosts advertise `FEAT_RNG` via `ID_AA64ISAR0_EL1.RNDR`
but the instruction never returns entropy. Measured in-process on a GKE
`n4a-highcpu-8` (Axion) node:

| probe | result |
|---|---|
| `/proc/cpuinfo` Features | includes `rng` |
| `OPENSSL_armcap_P` | `0x3887d`, so `ARMV8_RNG` (bit 17) is set |
| `rndr_multiple8(buf, 8)` | 0, on three consecutive calls |
| `CRYPTO_rndr_multiple8(buf, 48)` | 0 |

aws-lc selects the hardware RNG because capability detection says it exists, then
`abort()`s when it fails, with no fallback and nothing written to stderr. Located
by breakpointing every branch feeding the tail-merged `bl abort` in
`rand_bytes_impl` on a live crashing process.

This is per-instance rather than per-machine-type: a sibling node of the same
type ran the same binary and workload fine, and its `rndr_multiple8` returns 1.

## Why disabling jitter entropy does not help

`RNDR` is fatal in both entropy source configurations. The flag only changes
which callback the hardware RNG backs, and therefore which abort fires:

| configuration | `get_extra_entropy` | `get_prediction_resistance` | aborts at |
|---|---|---|---|
| default, CPU jitter on | `entropy_os_get_extra_entropy` | `entropy_cpu_get_prediction_resistance` (RNDR) | `rand.c:259` |
| `NO_JITTER_ENTROPY=1` | `entropy_cpu_get_extra_entropy` (RNDR) | `NULL` | `rand.c:294` |

Both branch on the same `have_hw_rng_aarch64()`. Consistent with this, the
crashes continued after the reverted commit landed.

The upstream issue the original commit matched against (aws/aws-lc-rs#1072) is a
different failure: it aborts in `tree_jitter_initialize_once` on Windows, whereas
these backtraces are in `rand_bytes_impl`.

## Mitigation

`OPENSSL_armcap=~0x20000` clears `ARMV8_RNG` at runtime, after which both
configurations route around `RNDR`. Verified against the pipeline binary:

| | `OPENSSL_armcap_P` | bit 17 | `RAND_bytes` |
|---|---|---|---|
| baseline | `0x3887d` | set | 1 |
| `OPENSSL_armcap=~0x20000` | `0x1887d` | clear | 1 |

That is a runtime setting and belongs in the deployment rather than the build, so
it is applied there instead of in this repo.

A bug report is going upstream to aws-lc asking it to fall back rather than abort
when a probed hardware RNG fails, and to retry `RNDR` the way the x86 path already
retries `RDRAND` (`rdrand_multiple8` retries 10 times; `rndr_multiple8` does not
retry at all, though Arm documents `RNDR` as permitted to fail transiently).
