### PR TITLE
[python] test_events: ignore Unavailable status events

### DIFF
--- a/python/tests/platform/test_pipeline_events.py
+++ b/python/tests/platform/test_pipeline_events.py
@@ -181,6 +181,8 @@ def test_events(pipeline_name):
 
     # Map events such that evolution test can be written cleanly
     # Consecutive events are removed because it is possible for events to be repeated if a status takes a longer time
+    # `Unavailable` events are removed because the runner reports them whenever it momentarily
+    # cannot reach the pipeline, which depends on the environment rather than on the lifecycle
     events_status_limited = list(
         map(
             lambda e1: (
@@ -192,7 +194,10 @@ def test_events(pipeline_name):
                 e1["program_status"],
                 e1["storage_status"],
             ),
-            events_status,
+            filter(
+                lambda e1: e1["deployment_runtime_status"] != "Unavailable",
+                events_status,
+            ),
         )
     )
 


### PR DESCRIPTION
`test_events` asserts an exact status-event sequence, so it fails whenever the runner
happens to record `Unavailable`. That status means the runner momentarily could not reach
the pipeline, which reflects the cluster rather than the lifecycle under test.

### Describe Manual Test Plan

Seen in CI  a compiler-server outage crash-looped the pipeline container, the pod left service, its DNS
record was withdrawn, and the runner recorded one `Unavailable` event between `Initializing`
and `Running`:

```
At index 5 diff: ('Provisioned', 'Provisioned', 'Unavailable', 'Unavailable', False, 'Success', 'InUse')
             != ('Provisioned', 'Provisioned', 'Initializing', 'Running', False, 'Success', 'InUse')
```

Replayed the 47 events that run recorded (from its support bundle) through the test's
mapping code:

| | Result |
| --- | --- |
| Before this change | FAIL, reproducing the CI failure exactly |
| After this change | PASS |
| After this change, with a genuine `Paused` transition deleted | still FAIL |

The last row matters: the filter drops only `Unavailable`, and the test still catches a
lifecycle transition that goes missing.

## Checklist

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

None.
