### PR TITLE
[docs] Fix broken vldb23.pdf link

### DIFF
--- a/docs.feldera.com/docs/literature/papers.md
+++ b/docs.feldera.com/docs/literature/papers.md
@@ -20,7 +20,7 @@ The following publications and awards describe Feldera's theoretical foundation,
   A shorter and simpler version of the VLDB 2023 DBSP paper.
 
 * [DBSP: Automatic Incremental View Maintenance for Rich Query
-  Languages](/vldb23.pdf)
+  Languages](pathname:///vldb23.pdf)
   *Mihai Budiu, Tej Chajed, Frank McSherry, Leonid Ryzhyk, and Val
   Tannen*, Proceedings of the VLDB Endowment (VLDB), Vancouver,
   Canada, August, 2023, pages 1601-1614.

--- a/docs.feldera.com/docs/tutorials/basics/part2.md
+++ b/docs.feldera.com/docs/tutorials/basics/part2.md
@@ -209,7 +209,7 @@ try!).
 This reflects the internal workings of Feldera: instead of reevaluating the
 query from scratch on every new input, it only updates affected outputs by
 propagating input changes through the query execution plan.  We refer to this as
-**incremental query evaluation**.  See our [paper](/vldb23.pdf) for a rigorous
+**incremental query evaluation**.  See our [paper](pathname:///vldb23.pdf) for a rigorous
 description of this technique.
 
 ## Takeaways


### PR DESCRIPTION
Docusaurus rewrites root-absolute links to static files into content-hashed asset paths, and trailingSlash:true then appends a trailing slash after the .pdf extension, producing a 404 (/assets/files/vldb23-<hash>.pdf/). Use the pathname: protocol, the convention already used elsewhere in these docs for raw file links, so Docusaurus leaves the URL untouched.

Found via the docs-linkcheck CI job.
