### PR TITLE
[dbsp] Include `Builder::done` in time to complete a merge in the spine.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -8859,6 +8859,24 @@ pub struct ElapsedTime {
     pub cpu: Duration,
 }
 
+impl ElapsedTime {
+    /// Calls `f()` and adds the real time and CPU that the call takes to this
+    /// `ElapsedTime`.
+    pub fn record<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let start = Instant::now();
+        let start_cpu = ThreadCpuTime::now();
+        let result = f();
+        *self += ElapsedTime {
+            real: start.elapsed(),
+            cpu: start_cpu.elapsed(),
+        };
+        result
+    }
+}
+
 impl AddAssign for ElapsedTime {
     fn add_assign(&mut self, rhs: Self) {
         self.real += rhs.real;
@@ -8929,11 +8947,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let start = Instant::now();
-        let start_cputime = ThreadCpuTime::now();
-        let ret = this.task.poll(cx);
-        this.elapsed.real += start.elapsed();
-        this.elapsed.cpu += start_cputime.elapsed();
+        let ret = this.elapsed.record(|| this.task.poll(cx));
         ret.map(|value| (value, take(&mut *this.elapsed)))
     }
 }
@@ -8946,8 +8960,39 @@ mod tests {
         monitor::TraceMonitor,
         operator::{Generator, Z1},
     };
+    use super::ElapsedTime;
     use anyhow::anyhow;
-    use std::{cell::RefCell, ops::Deref, rc::Rc, vec::Vec};
+    use std::{cell::RefCell, ops::Deref, rc::Rc, thread, time::Duration, vec::Vec};
+
+    #[test]
+    fn elapsed_time_record_returns_closure_result() {
+        let mut elapsed = ElapsedTime::default();
+        let result = elapsed.record(|| 1 + 1);
+        assert_eq!(result, 2);
+    }
+
+    #[test]
+    fn elapsed_time_record_accumulates_across_calls() {
+        let mut elapsed = ElapsedTime::default();
+        elapsed.record(|| thread::sleep(Duration::from_millis(20)));
+        elapsed.record(|| thread::sleep(Duration::from_millis(20)));
+
+        // Each call's real time adds to the total instead of overwriting it.
+        assert!(elapsed.real >= Duration::from_millis(35));
+    }
+
+    #[test]
+    fn elapsed_time_record_detects_blocking() {
+        // A closure that only sleeps blocks the thread without spending any
+        // CPU time, which is the same signature a stalled synchronous I/O
+        // call (e.g. a slow `fsync`) leaves behind. This is what lets
+        // `real` much greater than `cpu` flag a stall in the merge stats.
+        let mut elapsed = ElapsedTime::default();
+        elapsed.record(|| thread::sleep(Duration::from_millis(50)));
+
+        assert!(elapsed.real >= Duration::from_millis(45));
+        assert!(elapsed.cpu < elapsed.real / 4);
+    }
 
     #[test]
     fn sum_circuit_dynamic() {

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -8954,13 +8954,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::ElapsedTime;
     use crate::{
         Circuit, Error as DbspError, RootCircuit,
         circuit::schedule::{DynamicScheduler, Scheduler},
         monitor::TraceMonitor,
         operator::{Generator, Z1},
     };
-    use super::ElapsedTime;
     use anyhow::anyhow;
     use std::{cell::RefCell, ops::Deref, rc::Rc, thread, time::Duration, vec::Vec};
 

--- a/crates/dbsp/src/trace/spine_async.rs
+++ b/crates/dbsp/src/trace/spine_async.rs
@@ -9,7 +9,7 @@
 use crate::{
     Error, NumEntries, Runtime,
     circuit::{
-        ElapsedTime, ThreadCpuTime, max_level0_batch_size_records,
+        ElapsedTime, max_level0_batch_size_records,
         metadata::{
             BLOOM_FILTER_BITS_PER_KEY, BLOOM_FILTER_HIT_RATE_PERCENT, BLOOM_FILTER_HITS_COUNT,
             BLOOM_FILTER_MISSES_COUNT, BLOOM_FILTER_SIZE_BYTES, COMPACTION_STATE, COMPLETED_MERGES,
@@ -1324,8 +1324,8 @@ where
             if level == 0 {
                 self.worker_state.report_slot0_merge(merger.fuel);
             }
-            let merger = opt_merger.take().unwrap();
-            let new_batch = Arc::new(merger.builder.done());
+            let mut merger = opt_merger.take().unwrap();
+            let new_batch = merger.elapsed.record(|| Arc::new(merger.builder.done()));
             let new_level =
                 Spine::<B>::size_to_level(&new_batch, self.max_level0_batch_size_records, true);
             self.state.lock().unwrap().merge_complete(
@@ -1454,9 +1454,7 @@ where
     fn merge(&mut self, mut fuel: isize) -> isize {
         debug_assert!(fuel > 0);
         let supplied_fuel = fuel;
-        let start = Instant::now();
-        let start_cpu = ThreadCpuTime::now();
-        match &mut self.inner {
+        self.elapsed.record(|| match &mut self.inner {
             MergeInner::ListMerger(merger) => {
                 merger.work(&mut self.builder, &self.frontier, &mut fuel);
                 self.done = fuel > 0;
@@ -1470,11 +1468,7 @@ where
                     merger.run();
                 }
             }
-        };
-        self.elapsed += ElapsedTime {
-            real: start.elapsed(),
-            cpu: start_cpu.elapsed(),
-        };
+        });
         self.n_steps += 1;
         let consumed_fuel = supplied_fuel - fuel;
         self.fuel += consumed_fuel;


### PR DESCRIPTION
Finishing a merge can do a lot of I/O due to fsync(), but that cost wasn't being included.  This fixes the problem.  It also factors out the code for measuring elapsed time into a new helper ElapsedTime::record().

### Describe Manual Test Plan

Ran the unit tests with and without temporary changes that break them.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated
