### PR TITLE
[adapters] Fix disconnect race in NATS mock test framework.

### DIFF
--- a/crates/adapters/src/transport/nats/input/test/mock_framework.rs
+++ b/crates/adapters/src/transport/nats/input/test/mock_framework.rs
@@ -170,6 +170,23 @@ impl NatsMockRunner {
         }
     }
 
+    /// Waits for the worker task to fully exit after `disconnect()`.
+    ///
+    /// `disconnect()` only enqueues a command; the background reader task
+    /// keeps pulling and queuing messages until the worker task processes it
+    /// and cancels the reader. Without waiting here, a caller that publishes
+    /// more records right after `disconnect()` races the background reader,
+    /// which can still pick them up and have a stale, already-queued `Queue`
+    /// command flush them. `is_closed()` only goes true once the worker task
+    /// has returned and dropped the command channel, so waiting for it here
+    /// proves the reader is gone before the caller does anything else.
+    fn wait_for_disconnect(&self) -> AnyResult<()> {
+        let endpoint = self.endpoint();
+        wait(|| endpoint.is_closed(), DEFAULT_TIMEOUT_MS)
+            .map_err(|()| anyhow::anyhow!("Timed out waiting for endpoint to disconnect"))?;
+        Ok(())
+    }
+
     fn zset(&self) -> &MockDeZSet<NatsTestRecord, NatsTestRecord> {
         if let Some(zset) = self.zset.as_ref() {
             zset
@@ -342,6 +359,7 @@ impl NatsMockRunner {
                     );
                 }
                 self.endpoint().disconnect();
+                self.wait_for_disconnect()?;
             }
 
             NatsMockAction::DisconnectAllowNonFatal => {
@@ -350,6 +368,7 @@ impl NatsMockRunner {
                     "Streaming NATS connector should never signal end-of-input"
                 );
                 self.endpoint().disconnect();
+                self.wait_for_disconnect()?;
             }
 
             NatsMockAction::Sleep(dur) => {


### PR DESCRIPTION
disconnect() only enqueues a command; the background reader task keeps pulling and queuing JetStream messages until the worker task processes it and cancels the reader. A caller that publishes more records right after disconnect() races that reader, and a stale, already-queued Queue command can flush the new records into the zset. Waiting for is_closed() proves the worker task has fully torn down the reader before the test does anything else, closing the race behind test_nats_disconnect_stops_delivery.

Fixes: https://github.com/feldera/feldera/issues/6363

### Describe Manual Test Plan

Tested that it works even with the race exaggerated.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated
