### PR TITLE
[manager] accept postgres_cdc_input as an input connector

### DIFF
--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -728,6 +728,7 @@ pub fn generate_program_info(
                 | TransportConfig::S3Input(_)
                 | TransportConfig::DeltaTableInput(_)
                 | TransportConfig::PostgresInput(_)
+                | TransportConfig::PostgresCdcInput(_)
                 | TransportConfig::IcebergInput(_)
                 | TransportConfig::Datagen(_)
                 | TransportConfig::Nexmark(_)


### PR DESCRIPTION
PR #5988 added the connector to feldera-types, to the SQL compiler's ConnectorValidator and to the adapter, but not to this allow-list, so the usage documented in
docs.feldera.com/docs/connectors/sources/postgresql-cdc.md has never compiled on main.

This is the same change as 19b8d33d8 on the unmerged pg-cdc-ft-fixes branch, split out so the fix does not wait on that branch.

Fixes #6807