### PR TITLE
ci: pull the job image through the Artifact Registry mirror

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -23,7 +23,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,7 +35,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -24,7 +24,7 @@ jobs:
       AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
       AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,7 +78,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -170,7 +170,7 @@ jobs:
   adjust-versions:
     runs-on: [gke-runners-amd64]
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -20,7 +20,7 @@ jobs:
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   main:
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     runs-on: [gke-runners-amd64]
     steps:
       # Compute the internal-PR boolean once so individual steps can reference

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -39,7 +39,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'release' }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -32,7 +32,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     services:
       postgres:
         image: debezium/postgres:15

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -215,7 +215,7 @@ jobs:
       FELDERA_HOST: https://pipeline-manager:8080
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     services:
       pipeline-manager:
         image: ${{ vars.FELDERA_IMAGE_NAME }}:${{ inputs.image_tag || format('sha-{0}', github.sha) }}

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -42,7 +42,7 @@ jobs:
       AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
       AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-a5ab793b8d261068867b9fdfad3f04157b2536fc
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Points the `container:` job image at the Artifact Registry pull-through mirror instead of ghcr.io.

## Why

Cloud NAT never processes traffic to Google APIs: Private Google Access always wins, so Artifact Registry pulls cost nothing in NAT data processing. Pulls from ghcr.io and docker.io are billed at $0.045/GiB

## Verification

A `test-web-console-unit` run on `main` after the cluster rollout confirmed the new pod spec works: the runner image pulled from `us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/actions/actions-runner`, dind pulled from `mirror.gcr.io/library/docker`, no direct `ghcr.io/actions` pulls remained, and the job passed. CI on this PR is what exercises the `feldera-dev` path.