### PR TITLE
deploy: drop the Go toolchain from the runtime image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To run Feldera from sources, ensure at least 6 GB of free space in the sources d
 - cmake
 - libssl-dev
 - libsasl2-dev
-- golang-go (required to build aws-lc-fips-sys when using rustls FIPS)
+- golang-go (only to build with `--features fips`, which compiles aws-lc-fips-sys from source; a default build does not need it)
 - pkg-config
 - libzstd-dev
 - clang

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -77,17 +77,6 @@ RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86
 ENV PATH="$PATH:/home/ubuntu/.cargo/bin:/home/ubuntu/mold/bin"
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold -C link-arg=-Wl,--compress-debug-sections=zlib"
 
-# Go is required to build aws-lc-fips-sys when rustls is built with FIPS.
-# Installed from upstream rather than Ubuntu's golang-go package because the
-# 24.04 package is stuck at 1.22.2 and ships many unfixed CVEs that fail our
-# image scan. Revert to apt's golang-go once Ubuntu ships a patched version.
-RUN arch=`dpkg --print-architecture`; \
-  curl -LO https://go.dev/dl/go1.26.5.linux-$arch.tar.gz \
-  && tar -xzf go1.26.5.linux-$arch.tar.gz \
-  && mv go goroot \
-  && rm go1.26.5.linux-$arch.tar.gz
-ENV PATH="$PATH:/home/ubuntu/goroot/bin"
-
 # Install Samply for profiling
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/feldera/samply/releases/download/v0.13.2/samply-installer.sh | sh
 


### PR DESCRIPTION
Remove the Go toolchain from the runtime image. Nothing the image builds has needed it since January.

## Why

Go is a build dependency of `aws-lc-fips-sys`, which only enters the dependency graph behind the `fips` cargo feature. The runtime image compiles pipelines, and the workspace `MultiCratesWriter` generates never enables that feature, so pipelines link the default provider and Go sits unused.

FIPS was on by default for nine days in January; #5488 reverted it to opt-in because the AWS-LC source build fails on GCC >= 14, which breaks recent Fedora. The toolchain has been carried ever since: 258 MB extracted, installed from an upstream tarball rather than apt because Ubuntu's `golang-go` ships CVEs that fail our image scan, and bumped three times (May, June, August) to chase scanner findings.

`deploy/build.Dockerfile` keeps `golang-go`: CI still builds the binaries with `--features fips`, which compiles `aws-lc-fips-sys` from source. That is unchanged.

## Describe Manual Test Plan

- Built `--target base` and confirmed `command -v go` finds nothing.
- Inside that image, `cargo build -p dbsp_adapters` succeeds (4m04s), which is the path a runtime pipeline compile takes.
- `cargo tree -i aws-lc-fips-sys` reports the package is absent from the default graph; it appears only with `--features fips`.
- Confirmed against the `aws-lc-sys` README that the non-FIPS provider needs no Go: "Go and Perl aren't absolutely necessary for `aws-lc-sys`, as AWS-LC provides generated build files."
- The image build itself is the regression guard: the release stage runs `--precompile`, which compiles a pipeline inside the image and fails the build if a toolchain is missing.

## Checklist

- [ ] Unit tests added/updated
- [x] Documentation updated
- [ ] Integration tests added/updated
- [ ] Changelog updated

No unit test applies to a Dockerfile; the precompile step in the image build covers it.

## Breaking Changes?

- [ ] OpenAPI / REST HTTP API / feldera-types / manager
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib
- [ ] Python SDK
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

No behavior change. Pipelines already compiled without FIPS; this only stops shipping a toolchain none of them invoked.

## Follow-up

Making the data plane actually FIPS-compliant is a separate piece of work, because Kafka (`rdkafka-sys` -> librdkafka), Postgres TLS (`postgres-openssl`), and our own 33 `openssl::` call sites all use OpenSSL, outside any validated boundary. Routing those through AWS-LC-FIPS is supported upstream (`openssl-sys` and `openssl` both expose an `aws-lc-fips` feature, and `rdkafka-sys` picks up `DEP_OPENSSL_ROOT`), and it leaves a single crypto library in the binary. That is being developed separately.
