### PR TITLE
deps: bump roaring to 0.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10872,9 +10872,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ rmp-serde = "1.3.0"
 rmpv = "1.3.0"
 # Pin `roaring` exactly because the crate only supports the current stable
 # Rust and may start requiring newer compiler features in patch releases.
-roaring = "=0.11.3"
+roaring = "=0.11.4"
 rstest = "0.15"
 # Make sure this is the same rustls version used by the `tonic` crate.
 # See the `ensure_default_crypto_provider` function.


### PR DESCRIPTION
Bumps the workspace `roaring` pin from `=0.11.3` to `=0.11.4`.

0.11.3 dropped the `Eq` impl on `RoaringBitmap`/`RoaringTreemap`; 0.11.4 restored it ([roaring-rs#341](https://github.com/RoaringBitmap/roaring-rs/pull/341)). Because the pin is exact, that propagates: lance >= 8.0.0 requires `roaring ^0.11.4`, so lance and dbsp currently cannot resolve into the same build.

Keeping the pin exact — 0.11.4's MSRV is 1.90.0, below this workspace's `rust-version` of 1.93.1.

### Describe Manual Test Plan

`cargo test -p dbsp --lib`: 575/576 pass. The failure, `recursive::test::issue4168`, is its own 200s watchdog tripping under parallel load — alone it passes in 22.7s.

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

None.
