### PR TITLE
python: Raise test pipeline provisioning timeout to 300s

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -487,8 +487,9 @@ def build_pipeline(
         compilation_profile=CompilationProfile.OPTIMIZED,
         runtime_config=RuntimeConfig(
             # Covers node auto-provisioning: a pipeline that needs a fresh
-            # node shape waits for node boot plus image pull.
-            provisioning_timeout_secs=180,
+            # node shape waits for node boot plus image pull, and parallel
+            # test workers can request several fresh nodes at once.
+            provisioning_timeout_secs=300,
             resources=resources,
             workers=FELDERA_TEST_NUM_WORKERS,
             hosts=FELDERA_TEST_NUM_HOSTS,


### PR DESCRIPTION
Raises the shared test harness provisioning timeout in `build_pipeline()` from 180s to 300s.

Why: in ci.yml run [31395130678](https://github.com/feldera/feldera/actions/runs/31395130678) (attempt 3), three arm64 workload tests (`test_constant_table`, `test_now`, `test_aggregate_joins`) failed with "Pipeline could not be provisioned within the timeout of 180s". The job's cleanup step then found all three pipelines alive and reclaimed them: they provisioned shortly after the deadline. The workload suite launches several pipelines at once via pytest-xdist, so multiple pods race for fresh arm64 nodes and the 180s budget does not cover node boot plus the image pull.

Genuine provisioning breakage now takes 2 minutes longer to surface per test; workers run in parallel, so wall-clock cost on a green run is zero.