### PR TITLE
[SQL] Inline user-defined functions when they call NOW() directly or indirectly

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/IRTransform.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/IRTransform.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.util.ICastable;
@@ -8,6 +9,8 @@ import java.util.function.Function;
 
 /** A function that transforms an InnerNode into another one. */
 public interface IRTransform extends Function<IDBSPInnerNode, IDBSPInnerNode>, ICastable {
+    /** The circuit currently being analyzed */
+    void setCircuitContext(DBSPCircuit circuit);
     /** The operator containing the inner node that is being transformed */
     void setOperatorContext(DBSPOperator operator);
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -166,7 +166,8 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.operatorContext = operatorContext;
     }
 
-    public void setCircuitContext(@Nullable DBSPCircuit circuit) {
+    @Override
+    public void setCircuitContext(DBSPCircuit circuit) {
         this.circuitContext = circuit;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/SimplifyConditionals.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/SimplifyConditionals.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
@@ -53,6 +54,13 @@ public class SimplifyConditionals implements IRTransform {
         this.containsIf.setOperatorContext(operator);
         this.findConstants.setOperatorContext(operator);
         this.replaceConstants.setOperatorContext(operator);
+    }
+
+    @Override
+    public void setCircuitContext(DBSPCircuit circuit) {
+        this.containsIf.setCircuitContext(circuit);
+        this.findConstants.setCircuitContext(circuit);
+        this.replaceConstants.setCircuitContext(circuit);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -75,6 +75,7 @@ public class CircuitOptimizer extends Passes {
         // Example dumping circuit to a png file
         // this.dump(3);
         // First part of optimizations may still synthesize some circuit components
+        this.add(new UDFInliner(compiler).getCircuitRewriter(false));
         // Runs before ImplementNow so temporal filters compare fields instead of
         // expensive computations, which makes them implementable as windows
         this.add(new DecomposeExpensiveFilters(compiler));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApply2Operator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyNOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyOperator;
@@ -75,6 +76,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.IRTransform;
+import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 import org.dbsp.sqlCompiler.ir.aggregate.DBSPAggregateList;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.aggregate.DBSPAggregator;
@@ -975,6 +977,13 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 toAdd = new DBSPDeclaration(item);
         }
         this.getUnderConstructionCircuit().addDeclaration(toAdd);
+    }
+
+    @Override
+    public Token startVisit(IDBSPOuterNode circuit) {
+        if (circuit.is(DBSPCircuit.class))
+            this.transform.setCircuitContext(circuit.to(DBSPCircuit.class));
+        return super.startVisit(circuit);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/InnerCSE.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/InnerCSE.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
@@ -56,6 +57,12 @@ public class InnerCSE implements IRTransform {
     @Override
     public String toString() {
         return "InnerCSE";
+    }
+
+    @Override
+    public void setCircuitContext(DBSPCircuit circuit) {
+        this.numbering.setCircuitContext(circuit);
+        this.cse.setCircuitContext(circuit);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/UDFInliner.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/UDFInliner.java
@@ -1,0 +1,67 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.Expensive;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpressionTranslator;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.ContainsNow;
+import org.dbsp.sqlCompiler.ir.DBSPFunction;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Utilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Inline SQL UDF functions when
+ * - they are simple
+ * - have NOW() as an argument */
+public class UDFInliner extends ExpressionTranslator {
+    public final Map<String, DBSPFunction> udfMap = new HashMap<>();
+    final ContainsNow cn;
+
+    public UDFInliner(DBSPCompiler compiler) {
+        super(compiler);
+        this.cn = new ContainsNow(compiler, true);
+    }
+
+    @Override
+    public void setCircuitContext(DBSPCircuit circuit) {
+        for (var entry: circuit.declarationMap.entrySet()) {
+            if (entry.getValue().item.is(DBSPFunctionItem.class)) {
+                DBSPFunctionItem func = entry.getValue().item.to(DBSPFunctionItem.class);
+                if (func.function.body != null) {
+                    Utilities.putNew(this.udfMap, entry.getKey(), func.function);
+                }
+            }
+        }
+        super.setCircuitContext(circuit);
+    }
+
+    @Override
+    public void postorder(DBSPApplyExpression expression) {
+        DBSPExpression[] args = Linq.map(expression.arguments, this::getE, DBSPExpression.class);
+        String function = expression.getFunctionName();
+        boolean hasNow = false;
+        for (var arg: args) {
+            cn.apply(arg);
+            if (cn.found()) {
+                hasNow = true;
+                break;
+            }
+        }
+        if (function != null && this.udfMap.containsKey(function)) {
+            DBSPClosureExpression func = this.udfMap.get(function).asClosure();
+            boolean expensive = Expensive.isExpensive(this.compiler, func);
+            if (!expensive || hasNow) {
+                DBSPExpression inlined = func.call(args).reduce(this.compiler);
+                this.map(expression, inlined);
+                return;
+            }
+        }
+        super.postorder(expression);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
@@ -97,6 +97,9 @@ public class MonotoneAnalyzer implements CircuitTransform, IWritesLogs {
             public void setOperatorContext(DBSPOperator operator) {}
 
             @Override
+            public void setCircuitContext(DBSPCircuit circuit) {}
+
+            @Override
             public IDBSPInnerNode apply(IDBSPInnerNode e) {
                 if (e.isExpression()) {
                     return e.to(DBSPExpression.class).ensureTree(compiler);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
@@ -1,9 +1,12 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPHopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.TestUtil;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
@@ -860,5 +863,43 @@ public class Regression3Tests extends SqlIoTest {
                 Assert.assertTrue(this.filterFound);
             }
         });
+    }
+
+    @Test
+    public void issue5940() {
+        // Without inlining CRT_DATE this generates a very inefficient implementation using JOIN
+        // With inlining this generates a Window operator
+        var ccs = this.getCCS("""
+                CREATE FUNCTION CRT_DATE(T TIMESTAMP) RETURNS DATE AS CAST(T AS DATE);
+                CREATE TABLE T(D DATE, X INT);
+                CREATE VIEW V AS SELECT * FROM T WHERE T.D < CRT_DATE(NOW())""");
+        var visitor = new CircuitVisitor(ccs.compiler) {
+            boolean windowFound = false;
+
+            @Override
+            public void postorder(DBSPStreamJoinOperator node) {
+                Assert.fail("JOIN should not be present");
+            }
+
+            @Override
+            public void postorder(DBSPWindowOperator node) {
+                this.windowFound = true;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertTrue(this.windowFound);
+                super.endVisit();
+            }
+        };
+        ccs.visit(visitor);
+
+        /// inline multiple nested functions
+        ccs = this.getCCS("""
+                CREATE FUNCTION CRT_DATE(T TIMESTAMP) RETURNS DATE AS CAST(T AS DATE);
+                CREATE FUNCTION YR(D DATE) RETURNS BIGINT AS EXTRACT(YEAR FROM D);
+                CREATE TABLE T(X BIGINT);
+                CREATE VIEW V AS SELECT * FROM T WHERE T.X < YR(CRT_DATE(NOW()));""");
+        ccs.visit(visitor);
     }
 }


### PR DESCRIPTION
Fixes #5940 

The infra in this PR introduces a pass which can perform inlining of user-defined functions written in SQL. This can generate better code, but, crucially, it is very important for functions invoked with NOW() as arguments: this enables the compiler to detect whether these calls can be compiled into efficient temporal filters. In the absence of inlining these functions are opaque calls and the generated code uses the worst-case implementation using expensive JOINs.

## Checklist

- [x] Unit tests added/updated
