### PR TITLE
[dbsp] Limit checkpoint fingerprints to the JS-safe 53-bit range

### DIFF
--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -6,7 +6,7 @@ use crate::storage::file::SerializerInner;
 use crate::{Error, NumEntries, TypedBox};
 use enum_map::{Enum, EnumMap};
 use feldera_types::checkpoint::{
-    CheckpointDependencies, CheckpointDependenciesWrite, CheckpointMetadata,
+    CheckpointDependencies, CheckpointDependenciesWrite, CheckpointMetadata, Fingerprint,
 };
 use feldera_types::constants::{
     ACTIVATION_MARKER_FILE, CHECKPOINT_DEPENDENCIES, CHECKPOINT_FILE_NAME, DATAFUSION_TEMP_DIR,
@@ -64,7 +64,7 @@ impl Checkpointer {
     }
 
     /// Verifies that existing checkpoints have the specified fingerprint.
-    pub fn verify_fingerprint(&self, fingerprint: u64) -> Result<(), Error> {
+    pub fn verify_fingerprint(&self, fingerprint: Fingerprint) -> Result<(), Error> {
         if self
             .checkpoint_list
             .iter()
@@ -348,7 +348,7 @@ impl Checkpointer {
     pub(super) fn commit(
         &mut self,
         uuid: Uuid,
-        fingerprint: u64,
+        fingerprint: Fingerprint,
         identifier: Option<String>,
         steps: Option<u64>,
         processed_records: Option<u64>,
@@ -745,6 +745,7 @@ mod test {
     use std::sync::Arc;
 
     use feldera_storage::{DirEntry, StorageBackend, StoragePath};
+    use feldera_types::checkpoint::Fingerprint;
     use feldera_types::config::{FileBackendConfig, StorageCacheConfig};
     use feldera_types::constants::CHECKPOINT_FILE_NAME;
     use itertools::Itertools;
@@ -837,7 +838,7 @@ mod test {
         std::fs::write(&state_file, b"spine state").unwrap();
 
         checkpointer
-            .commit(uuid, 0, None, Some(0), Some(0))
+            .commit(uuid, Fingerprint::default(), None, Some(0), Some(0))
             .unwrap();
         drop(checkpointer);
 
@@ -922,7 +923,7 @@ mod test {
         .unwrap();
 
         checkpointer
-            .commit(uuid, 0, None, Some(0), Some(0))
+            .commit(uuid, Fingerprint::default(), None, Some(0), Some(0))
             .unwrap();
         drop(checkpointer);
 
@@ -985,7 +986,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
         .unwrap();
 
         checkpointer
-            .commit(uuid, 0, None, Some(0), Some(0))
+            .commit(uuid, Fingerprint::default(), None, Some(0), Some(0))
             .unwrap();
         drop(checkpointer);
 
@@ -1023,7 +1024,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
             .map(|i| {
                 let uuid = uuid::Uuid::now_v7();
                 checkpointer
-                    .commit(uuid, 0, None, Some(i as u64), Some(0))
+                    .commit(uuid, Fingerprint::default(), None, Some(i as u64), Some(0))
                     .unwrap();
                 uuid
             })
@@ -1067,7 +1068,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
         for i in 0..Checkpointer::MIN_CHECKPOINT_THRESHOLD + 1 {
             let uuid = uuid::Uuid::now_v7();
             checkpointer
-                .commit(uuid, 0, None, Some(i as u64), Some(0))
+                .commit(uuid, Fingerprint::default(), None, Some(i as u64), Some(0))
                 .unwrap();
             uuids.push(uuid);
         }
@@ -1105,7 +1106,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
         let mut checkpointer = Checkpointer::new(make_backend()).unwrap();
         let uuid = uuid::Uuid::now_v7();
         checkpointer
-            .commit(uuid, 0, None, Some(0), Some(0))
+            .commit(uuid, Fingerprint::default(), None, Some(0), Some(0))
             .unwrap();
         drop(checkpointer);
 
@@ -1143,7 +1144,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
         let mut checkpointer = Checkpointer::new(backend).unwrap();
 
         let uuid = uuid::Uuid::now_v7();
-        let result = checkpointer.commit(uuid, 0, None, Some(0), Some(0));
+        let result = checkpointer.commit(uuid, Fingerprint::default(), None, Some(0), Some(0));
         assert!(
             result.is_err(),
             "commit should fail when catalog write fails"
@@ -1218,7 +1219,13 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
 
             for i in 0..Checkpointer::MIN_CHECKPOINT_THRESHOLD {
                 self.checkpointer
-                    .commit(uuid::Uuid::now_v7(), 0, None, Some(i as u64), Some(0))
+                    .commit(
+                        uuid::Uuid::now_v7(),
+                        Fingerprint::default(),
+                        None,
+                        Some(i as u64),
+                        Some(0),
+                    )
                     .unwrap();
             }
 
@@ -1245,7 +1252,7 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
 
             let uuid = uuid::Uuid::now_v7();
             self.checkpointer
-                .commit(uuid, 0, None, Some(2), Some(0))
+                .commit(uuid, Fingerprint::default(), None, Some(2), Some(0))
                 .unwrap();
 
             TestState::<ExtraCheckpoints> {
@@ -1269,7 +1276,13 @@ ERROR dbsp::circuit::checkpointer: 1 checkpoint(s) need missing file: w0-aaaaaaa
             self.precondition();
 
             self.checkpointer
-                .commit(uuid::Uuid::now_v7(), 0, None, Some(3), Some(0))
+                .commit(
+                    uuid::Uuid::now_v7(),
+                    Fingerprint::default(),
+                    None,
+                    Some(3),
+                    Some(0),
+                )
                 .unwrap();
 
             TestState::<ExtraCheckpoints> {

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -63,6 +63,7 @@ use dyn_clone::{DynClone, clone_box};
 use feldera_ir::{LirCircuit, LirNodeId};
 use feldera_samply::Span;
 use feldera_storage::{FileCommitter, StoragePath};
+use feldera_types::checkpoint::Fingerprint;
 use itertools::Itertools;
 use nix::{
     sys::time::TimeValLike,
@@ -7363,7 +7364,7 @@ where
             Ok(())
         });
 
-        (named > 0).then(|| format!("scope-{:016x}", fingerprint.finish()))
+        (named > 0).then(|| format!("scope-{:016x}", fingerprint.finish_raw()))
     }
 
     /// Absolute path of the file holding this subcircuit's clock.
@@ -8756,7 +8757,7 @@ impl CircuitHandle {
         Ok(())
     }
 
-    pub fn fingerprint(&self) -> u64 {
+    pub fn fingerprint(&self) -> Fingerprint {
         let mut fip = Fingerprinter::default();
         let _ = self.circuit.map_nodes_recursive(&mut |node: &dyn Node| {
             node.fingerprint(&mut fip);

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -16,7 +16,7 @@ use crossbeam::channel::{Receiver, Select, Sender, TryRecvError, bounded};
 use feldera_buffer_cache::ThreadType;
 use feldera_ir::LirCircuit;
 use feldera_storage::{FileCommitter, StorageBackend, StoragePath};
-use feldera_types::checkpoint::CheckpointMetadata;
+use feldera_types::checkpoint::{CheckpointMetadata, Fingerprint};
 use feldera_types::config::DevTweaks;
 use feldera_types::config::dev_tweaks::{BufferCacheAllocationStrategy, BufferCacheStrategy};
 pub use feldera_types::config::{StorageCacheConfig, StorageConfig, StorageOptions};
@@ -1371,7 +1371,7 @@ pub struct DBSPHandle {
     checkpointer: Option<Arc<Mutex<Checkpointer>>>,
 
     /// Circuit fingerprint.
-    fingerprint: u64,
+    fingerprint: Fingerprint,
 
     /// Information about operators that participate in bootstrapping the new parts of the circuit.
     bootstrap_info: Option<BootstrapInfo>,
@@ -1444,7 +1444,7 @@ impl DBSPHandle {
         runtime: RuntimeHandle,
         command_senders: Vec<Sender<Command>>,
         status_receivers: Vec<Receiver<Result<Response, DbspError>>>,
-        fingerprint: u64,
+        fingerprint: Fingerprint,
     ) -> Result<Self, DbspError> {
         // TODO: We allow the circuit to change between suspend and resume in Persistent mode;
         // we therefore only validate the fingerprint in ephemeral mode; however it can sometimes
@@ -2211,7 +2211,7 @@ impl DBSPHandle {
     }
 
     /// Fingerprint of this circuit.
-    pub fn fingerprint(&self) -> u64 {
+    pub fn fingerprint(&self) -> Fingerprint {
         self.fingerprint
     }
 
@@ -2680,7 +2680,7 @@ pub struct CheckpointCommitter {
     checkpointer: Arc<Mutex<Checkpointer>>,
     uuid: Uuid,
     readers: Vec<Vec<Arc<dyn FileCommitter>>>,
-    fingerprint: u64,
+    fingerprint: Fingerprint,
     name: Option<String>,
     steps: Option<u64>,
     processed_records: Option<u64>,

--- a/crates/dbsp/src/circuit/fingerprinter.rs
+++ b/crates/dbsp/src/circuit/fingerprinter.rs
@@ -4,6 +4,8 @@
 //! `std::hash::DefaultHasher` is not used because it is not stable beyond the
 //! current rust release.
 
+use feldera_types::checkpoint::Fingerprint;
+
 pub struct Fingerprinter {
     // The fingerprint of the circuit.
     hash: u64,
@@ -29,7 +31,15 @@ impl Fingerprinter {
         self.hash
     }
 
-    pub fn finish(self) -> u64 {
+    /// Returns the raw fingerprint for the circuit.  DBSP uses this raw value
+    /// internally for persistent IDs.
+    pub fn finish_raw(self) -> u64 {
         self.hash
+    }
+
+    /// Returns the [Fingerprint] for the circuit, which is the type exposed
+    /// externally.
+    pub fn finish(self) -> Fingerprint {
+        self.finish_raw().into()
     }
 }

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt::Display, time::Duration};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -119,13 +119,87 @@ pub struct CheckpointMetadata {
     /// An optional name for the checkpoint.
     pub identifier: Option<String>,
     /// Fingerprint of the circuit at the time of the checkpoint.
-    pub fingerprint: u64,
+    #[schema(inline)]
+    pub fingerprint: Fingerprint,
     /// Total size of the checkpoint files in bytes.
     pub size: Option<u64>,
     /// Total number of steps made.
     pub steps: Option<u64>,
     /// Total number of records processed.
     pub processed_records: Option<u64>,
+}
+
+/// Fingerprint for a checkpoint.
+///
+/// Fingerprints are intentionally limited to the range `0..2**53` to be in the
+/// safe integer range for JavaScript.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Fingerprint(u64);
+
+/// The derive can't express `maximum` for a tuple struct (utoipa only allows
+/// `Example`/`Default`/`Title`/`Format`/`ValueType`/`As`/`Deprecated` on one),
+/// so this is hand-written to advertise the `0..2**53` invariant.
+impl<'__s> utoipa::ToSchema<'__s> for Fingerprint {
+    fn schema() -> (&'__s str, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>) {
+        (
+            "Fingerprint",
+            utoipa::openapi::ObjectBuilder::new()
+                .schema_type(utoipa::openapi::SchemaType::Integer)
+                .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                    utoipa::openapi::KnownFormat::Int64,
+                )))
+                .minimum(Some(0.0))
+                .maximum(Some(9007199254740991.0)) // 2**53 - 1
+                .description(Some(
+                    "Fingerprint of the circuit at the time of the checkpoint, \
+                     limited to 0..2**53 to stay within JavaScript's safe integer range.",
+                ))
+                .into(),
+        )
+    }
+}
+
+impl Display for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<u64> for Fingerprint {
+    fn from(value: u64) -> Self {
+        Self(value & ((1 << 53) - 1))
+    }
+}
+
+impl Fingerprint {
+    /// Returns a `Fingerprint` with the given value, masking off the high bits
+    /// to put it in in the correct range.
+    pub fn new(value: u64) -> Self {
+        value.into()
+    }
+
+    /// Returns the fingerprint's value, in the range `0..2**53`.
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Serialize for Fingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Fingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::new(u64::deserialize(deserializer)?))
+    }
 }
 
 /// Identifies a host within a multihost pipeline.
@@ -326,5 +400,69 @@ mod tests {
             .prefix(),
             "host42"
         );
+    }
+
+    /// Boundary values around the 2**53 cutoff must mask exactly at the
+    /// cutoff, not one-off.
+    #[test]
+    fn fingerprint_new_masks_high_bits() {
+        assert_eq!(Fingerprint::new(0).value(), 0);
+        assert_eq!(Fingerprint::new(42).value(), 42);
+        assert_eq!(Fingerprint::new((1 << 53) - 1).value(), (1 << 53) - 1);
+        assert_eq!(Fingerprint::new(1 << 53).value(), 0);
+        assert_eq!(Fingerprint::new(u64::MAX).value(), (1 << 53) - 1);
+    }
+
+    /// Reproduces issue #6841: a fingerprint above `i64::MAX`, as found in a
+    /// checkpoint written before this masking existed (or synced from an
+    /// older host), must still deserialize into the safe range so that
+    /// re-serializing it over the REST API stays parseable by an `i64`
+    /// client such as `fda`. Loading it through `serde` (not just
+    /// `Fingerprint::new`) is the point: that's the path a stored checkpoint
+    /// list actually takes on startup.
+    #[test]
+    fn fingerprint_deserialize_masks_out_of_range_value() {
+        let raw = "14128757731148314856"; // from the issue's repro, exceeds i64::MAX
+        let fp: Fingerprint = serde_json::from_str(raw).unwrap();
+        assert_eq!(fp.value(), 5469299714439400);
+        assert!(fp.value() <= i64::MAX as u64);
+
+        // Re-serializing must not resurrect the original out-of-range value.
+        assert_eq!(serde_json::to_string(&fp).unwrap(), "5469299714439400");
+    }
+
+    /// Fingerprint serializes as a bare integer, not `{"0": ...}`, so
+    /// existing REST clients that expect a plain number keep working.
+    #[test]
+    fn fingerprint_serializes_as_plain_integer() {
+        assert_eq!(serde_json::to_string(&Fingerprint::new(123)).unwrap(), "123");
+    }
+
+    #[cfg(feature = "testing")]
+    mod fingerprint_proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// Every raw hash, however the high bits are set, must mask down
+            /// into the JS-safe range and keep its low 53 bits intact.
+            #[test]
+            fn new_stays_in_safe_range(raw in any::<u64>()) {
+                let fp = Fingerprint::new(raw);
+                prop_assert!(fp.value() < (1u64 << 53));
+                prop_assert_eq!(fp.value(), raw & ((1u64 << 53) - 1));
+            }
+
+            /// Values already inside the safe range round-trip through JSON
+            /// unchanged, which is what makes the masking a no-op for the
+            /// common case.
+            #[test]
+            fn json_round_trips_in_range(raw in 0..(1u64 << 53)) {
+                let fp = Fingerprint::new(raw);
+                let json = serde_json::to_string(&fp).unwrap();
+                let back: Fingerprint = serde_json::from_str(&json).unwrap();
+                prop_assert_eq!(back.value(), raw);
+            }
+        }
     }
 }

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -140,7 +140,10 @@ pub struct Fingerprint(u64);
 /// `Example`/`Default`/`Title`/`Format`/`ValueType`/`As`/`Deprecated` on one),
 /// so this is hand-written to advertise the `0..2**53` invariant.
 impl<'__s> utoipa::ToSchema<'__s> for Fingerprint {
-    fn schema() -> (&'__s str, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>) {
+    fn schema() -> (
+        &'__s str,
+        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    ) {
         (
             "Fingerprint",
             utoipa::openapi::ObjectBuilder::new()
@@ -435,7 +438,10 @@ mod tests {
     /// existing REST clients that expect a plain number keep working.
     #[test]
     fn fingerprint_serializes_as_plain_integer() {
-        assert_eq!(serde_json::to_string(&Fingerprint::new(123)).unwrap(), "123");
+        assert_eq!(
+            serde_json::to_string(&Fingerprint::new(123)).unwrap(),
+            "123"
+        );
     }
 
     #[cfg(feature = "testing")]

--- a/crates/pipeline-manager/migrations/V36__mask_checkpoint_fingerprints.sql
+++ b/crates/pipeline-manager/migrations/V36__mask_checkpoint_fingerprints.sql
@@ -1,0 +1,37 @@
+-- `storage_status_details` embeds each checkpoint's fingerprint as a plain
+-- JSON integer. Generated REST clients (e.g. `fda`) parse it as `i64`, so a
+-- fingerprint with the high bit set fails to parse (issue #6841). Circuit
+-- fingerprints are now masked to the range 0..2^53 when computed or loaded
+-- from a checkpoint file, but a pipeline that isn't currently running never
+-- gets a fresh status report to pick up that fix, so its last-cached
+-- `storage_status_details` can still hold an out-of-range value. Mask any
+-- checkpoint fingerprint already stored here the same way.
+UPDATE pipeline
+SET storage_status_details = fixed.details::text
+FROM (
+    SELECT
+        p.id,
+        jsonb_set(
+            p.storage_status_details::jsonb,
+            '{checkpoints}',
+            (
+                SELECT jsonb_agg(
+                    jsonb_set(
+                        checkpoint,
+                        '{fingerprint}',
+                        to_jsonb((checkpoint ->> 'fingerprint')::numeric % 9007199254740992::numeric)
+                    )
+                )
+                FROM jsonb_array_elements(p.storage_status_details::jsonb -> 'checkpoints') AS checkpoint
+            )
+        ) AS details
+    FROM pipeline AS p
+    WHERE p.storage_status_details IS NOT NULL
+      AND p.storage_status_details::jsonb ? 'checkpoints'
+      AND EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(p.storage_status_details::jsonb -> 'checkpoints') AS checkpoint
+          WHERE (checkpoint ->> 'fingerprint')::numeric >= 9007199254740992::numeric
+      )
+) AS fixed
+WHERE pipeline.id = fixed.id;

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -41,7 +41,7 @@ use crate::oidc::destination::{TenantIssuerPolicy, validate_tenant_oidc_url};
 use crate::oidc::trust_name::validate_oidc_trust_name;
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
-use feldera_types::checkpoint::CheckpointMetadata;
+use feldera_types::checkpoint::{CheckpointMetadata, Fingerprint};
 use feldera_types::config::{
     DevTweaks, FtConfig, PipelineConfig, ProgramIr, ResourceConfig, RuntimeConfig,
 };
@@ -737,7 +737,7 @@ fn limited_optional_storage_status_details() -> impl Strategy<Value = Option<ser
             let checkpoints = vec![CheckpointMetadata {
                 uuid: Default::default(),
                 identifier: None,
-                fingerprint: 0,
+                fingerprint: Fingerprint::default(),
                 size: None,
                 steps: Some(v.1),
                 processed_records: None,
@@ -3434,7 +3434,7 @@ async fn pipeline_deployment() {
             checkpoints: vec![CheckpointMetadata {
                 uuid: Default::default(),
                 identifier: None,
-                fingerprint: 456,
+                fingerprint: Fingerprint::new(456),
                 size: None,
                 steps: None,
                 processed_records: None,
@@ -3475,7 +3475,7 @@ async fn pipeline_deployment() {
             checkpoints: vec![CheckpointMetadata {
                 uuid: Default::default(),
                 identifier: None,
-                fingerprint: 123,
+                fingerprint: Fingerprint::new(123),
                 size: None,
                 steps: None,
                 processed_records: None,

--- a/openapi.json
+++ b/openapi.json
@@ -8476,7 +8476,8 @@
           "fingerprint": {
             "type": "integer",
             "format": "int64",
-            "description": "Fingerprint of the circuit at the time of the checkpoint.",
+            "description": "Fingerprint of the circuit at the time of the checkpoint, limited to 0..2**53 to stay within JavaScript's safe integer range.",
+            "maximum": 9007199254740991,
             "minimum": 0
           },
           "identifier": {


### PR DESCRIPTION
fda's REST client generates the CheckpointMetadata.fingerprint field as i64 from the OpenAPI schema, so a checkpoint whose 64-bit fingerprint has the high bit set breaks `fda pipelines`/`fda status` for the whole instance (#6841). Add a Fingerprint newtype that masks to 0..2**53 both when a circuit computes a fresh fingerprint and when one is deserialized, so checkpoints already on disk get corrected on load instead of only new ones.

Also add a migration to mask any checkpoint fingerprint already cached in a pipeline's storage_status_details: a stopped pipeline has no running worker to send a fresh status report, so its last-cached value would otherwise stay out of range indefinitely.

Fixes https://github.com/feldera/feldera/issues/6841

### Describe Manual Test Plan

Tested a sample migration

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated
