### PR TITLE
issues/6124: feat(postgres-cdc): configurable batch + memory_backpressure

### DIFF
--- a/crates/adapters/src/integrated/postgres/cdc_input.rs
+++ b/crates/adapters/src/integrated/postgres/cdc_input.rs
@@ -29,7 +29,10 @@ use feldera_adapterlib::transport::{Resume, Watermark};
 use feldera_types::config::FtModel;
 use feldera_types::coordination::Completion;
 use feldera_types::format::json::JsonFlavor;
-use feldera_types::transport::postgres::{PostgresCdcReaderConfig, PostgresTlsConfig};
+use feldera_types::transport::postgres::{
+    PostgresCdcBatchConfig, PostgresCdcMemoryBackpressureConfig, PostgresCdcReaderConfig,
+    PostgresTlsConfig,
+};
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
@@ -346,13 +349,15 @@ impl PostgresCdcInputInner {
             // etl stores its replication state in the source database itself, so
             // the state store reuses the source connection.
             store_pg_connection: None,
-            batch: BatchConfig::default(),
+            batch: batch_config_from(&self.config.batch),
             table_error_retry_delay_ms: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_DELAY_MS,
             table_error_retry_max_attempts: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS,
             max_table_sync_workers: PipelineConfig::DEFAULT_MAX_TABLE_SYNC_WORKERS,
             max_copy_connections_per_table: PipelineConfig::DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE,
             memory_refresh_interval_ms: PipelineConfig::DEFAULT_MEMORY_REFRESH_INTERVAL_MS,
-            memory_backpressure: Some(MemoryBackpressureConfig::default()),
+            memory_backpressure: Some(memory_backpressure_config_from(
+                &self.config.memory_backpressure,
+            )),
             table_sync_copy: TableSyncCopyConfig::IncludeAllTables,
             invalidated_slot_behavior: InvalidatedSlotBehavior::default(),
         };
@@ -1240,6 +1245,26 @@ fn parse_pg_uri(
     })
 }
 
+/// Convert the connector's batch configuration into etl's `BatchConfig`.
+fn batch_config_from(config: &PostgresCdcBatchConfig) -> BatchConfig {
+    BatchConfig {
+        max_fill_ms: config.max_fill_ms,
+        memory_budget_ratio: config.memory_budget_ratio,
+        max_bytes: config.max_bytes,
+    }
+}
+
+/// Convert the connector's memory backpressure configuration into etl's
+/// `MemoryBackpressureConfig`.
+fn memory_backpressure_config_from(
+    config: &PostgresCdcMemoryBackpressureConfig,
+) -> MemoryBackpressureConfig {
+    MemoryBackpressureConfig {
+        activate_threshold: config.activate_threshold,
+        resume_threshold: config.resume_threshold,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1774,6 +1799,61 @@ mod tests {
         assert_eq!(
             missing_required(&["id", "name"], &["c0", "c1"]),
             vec!["c0", "c1"]
+        );
+    }
+
+    #[test]
+    fn test_batch_config_from_maps_all_fields() {
+        let config = PostgresCdcBatchConfig {
+            max_fill_ms: 5_000,
+            memory_budget_ratio: 0.3,
+            max_bytes: 1024,
+        };
+
+        let etl_config = batch_config_from(&config);
+
+        assert_eq!(etl_config.max_fill_ms, 5_000);
+        assert_eq!(etl_config.memory_budget_ratio, 0.3);
+        assert_eq!(etl_config.max_bytes, 1024);
+    }
+
+    #[test]
+    fn test_batch_config_from_default_matches_connector_default() {
+        let etl_config = batch_config_from(&PostgresCdcBatchConfig::default());
+
+        assert_eq!(etl_config.max_fill_ms, BatchConfig::default().max_fill_ms);
+        assert_eq!(
+            etl_config.memory_budget_ratio,
+            BatchConfig::default().memory_budget_ratio
+        );
+        assert_eq!(etl_config.max_bytes, BatchConfig::default().max_bytes);
+    }
+
+    #[test]
+    fn test_memory_backpressure_config_from_maps_all_fields() {
+        let config = PostgresCdcMemoryBackpressureConfig {
+            activate_threshold: 0.6,
+            resume_threshold: 0.4,
+        };
+
+        let etl_config = memory_backpressure_config_from(&config);
+
+        assert_eq!(etl_config.activate_threshold, 0.6);
+        assert_eq!(etl_config.resume_threshold, 0.4);
+    }
+
+    #[test]
+    fn test_memory_backpressure_config_from_default_matches_connector_default() {
+        let etl_config =
+            memory_backpressure_config_from(&PostgresCdcMemoryBackpressureConfig::default());
+
+        assert_eq!(
+            etl_config.activate_threshold,
+            MemoryBackpressureConfig::default().activate_threshold
+        );
+        assert_eq!(
+            etl_config.resume_threshold,
+            MemoryBackpressureConfig::default().resume_threshold
         );
     }
 }

--- a/crates/feldera-types/src/transport/postgres.rs
+++ b/crates/feldera-types/src/transport/postgres.rs
@@ -67,6 +67,159 @@ impl PostgresTlsConfig {
     }
 }
 
+/// Batch processing configuration for the Postgres CDC connector.
+///
+/// Controls how replication events are buffered into a batch before being
+/// flushed to Feldera. Mirrors the batch configuration of the underlying
+/// `etl` replication library; fields omitted from the configuration fall
+/// back to `etl`'s own defaults.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct PostgresCdcBatchConfig {
+    /// Maximum time, in milliseconds, to wait before flushing a partially
+    /// filled batch. This is the latency bound for batching: once the first
+    /// event enters a batch, the batch is flushed when this timer elapses,
+    /// even if `max_bytes` was not reached.
+    ///
+    /// Default: 10000 (10 seconds).
+    #[serde(default = "default_batch_max_fill_ms")]
+    #[schema(default = default_batch_max_fill_ms)]
+    pub max_fill_ms: u64,
+
+    /// Ratio of process memory reserved for incoming replication batch
+    /// bytes, in the `(0.0, 1.0]` interval. The configured memory is divided
+    /// by the number of active streams at runtime, so each stream gets only
+    /// a per-stream share of the global memory budget.
+    ///
+    /// Default: 0.2.
+    #[serde(default = "default_batch_memory_budget_ratio")]
+    #[schema(default = default_batch_memory_budget_ratio)]
+    pub memory_budget_ratio: f32,
+
+    /// Maximum preferred byte size for one batch per active stream. This is
+    /// a ceiling, not a target: the runtime still chooses the smaller value
+    /// between this limit and the memory-ratio budget computed from
+    /// `memory_budget_ratio`.
+    ///
+    /// Default: 8388608 (8 MiB).
+    #[serde(default = "default_batch_max_bytes")]
+    #[schema(default = default_batch_max_bytes)]
+    pub max_bytes: usize,
+}
+
+impl Default for PostgresCdcBatchConfig {
+    fn default() -> Self {
+        Self {
+            max_fill_ms: default_batch_max_fill_ms(),
+            memory_budget_ratio: default_batch_memory_budget_ratio(),
+            max_bytes: default_batch_max_bytes(),
+        }
+    }
+}
+
+// `f32` doesn't implement `Eq` because of NaN, so it can't be derived here.
+// `validate()` rejects NaN/out-of-range ratios, so equality is reflexive for
+// any value that passes validation; this lets `PostgresCdcReaderConfig` (and
+// its containing `TransportConfig` enum) keep deriving `Eq`.
+impl Eq for PostgresCdcBatchConfig {}
+
+impl PostgresCdcBatchConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0.0..=1.0).contains(&self.memory_budget_ratio) || self.memory_budget_ratio == 0.0 {
+            return Err("batch.memory_budget_ratio must be in the (0.0, 1.0] interval".to_string());
+        }
+
+        if self.max_bytes == 0 {
+            return Err("batch.max_bytes must be greater than 0".to_string());
+        }
+
+        Ok(())
+    }
+}
+
+fn default_batch_max_fill_ms() -> u64 {
+    10_000
+}
+
+fn default_batch_memory_budget_ratio() -> f32 {
+    0.2
+}
+
+fn default_batch_max_bytes() -> usize {
+    8 * 1024 * 1024
+}
+
+/// Memory-based backpressure configuration for the Postgres CDC connector.
+///
+/// When the connector's memory usage rises above `activate_threshold`, it
+/// pauses reading further replication events until usage drops back below
+/// `resume_threshold`. Mirrors the memory backpressure configuration of the
+/// underlying `etl` replication library.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct PostgresCdcMemoryBackpressureConfig {
+    /// Memory usage ratio above which backpressure is activated, in the
+    /// `(0.0, 1.0]` interval.
+    ///
+    /// Default: 0.85.
+    #[serde(default = "default_memory_backpressure_activate_threshold")]
+    #[schema(default = default_memory_backpressure_activate_threshold)]
+    pub activate_threshold: f32,
+
+    /// Memory usage ratio below which backpressure is released, in the
+    /// `[0.0, 1.0)` interval. Must be lower than `activate_threshold`.
+    ///
+    /// Default: 0.75.
+    #[serde(default = "default_memory_backpressure_resume_threshold")]
+    #[schema(default = default_memory_backpressure_resume_threshold)]
+    pub resume_threshold: f32,
+}
+
+impl Default for PostgresCdcMemoryBackpressureConfig {
+    fn default() -> Self {
+        Self {
+            activate_threshold: default_memory_backpressure_activate_threshold(),
+            resume_threshold: default_memory_backpressure_resume_threshold(),
+        }
+    }
+}
+
+// See the corresponding `impl Eq for PostgresCdcBatchConfig` above for why
+// this is sound despite the `f32` fields.
+impl Eq for PostgresCdcMemoryBackpressureConfig {}
+
+impl PostgresCdcMemoryBackpressureConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0.0..=1.0).contains(&self.activate_threshold) || self.activate_threshold == 0.0 {
+            return Err(
+                "memory_backpressure.activate_threshold must be in the (0.0, 1.0] interval"
+                    .to_string(),
+            );
+        }
+
+        if !(0.0..=1.0).contains(&self.resume_threshold) || self.resume_threshold == 1.0 {
+            return Err(
+                "memory_backpressure.resume_threshold must be in the [0.0, 1.0) interval"
+                    .to_string(),
+            );
+        }
+
+        if self.resume_threshold >= self.activate_threshold {
+            return Err("memory_backpressure.resume_threshold must be lower than \
+                 memory_backpressure.activate_threshold"
+                .to_string());
+        }
+
+        Ok(())
+    }
+}
+
+fn default_memory_backpressure_activate_threshold() -> f32 {
+    0.85
+}
+
+fn default_memory_backpressure_resume_threshold() -> f32 {
+    0.75
+}
+
 /// Postgres CDC input connector configuration.
 ///
 /// Uses logical replication to capture ongoing changes from a Postgres database.
@@ -90,6 +243,21 @@ pub struct PostgresCdcReaderConfig {
     #[serde(flatten)]
     #[schema(inline)]
     pub tls: PostgresTlsConfig,
+
+    /// Batch processing configuration.
+    ///
+    /// Controls how replication events are buffered before being flushed to
+    /// Feldera. When omitted, uses the underlying `etl` library's defaults.
+    #[serde(default)]
+    pub batch: PostgresCdcBatchConfig,
+
+    /// Memory-based backpressure configuration.
+    ///
+    /// Controls when the connector pauses reading further replication
+    /// events to avoid exceeding available memory. When omitted, uses the
+    /// underlying `etl` library's defaults.
+    #[serde(default)]
+    pub memory_backpressure: PostgresCdcMemoryBackpressureConfig,
 }
 
 impl PostgresCdcReaderConfig {
@@ -101,6 +269,9 @@ impl PostgresCdcReaderConfig {
         if self.source_table.trim().is_empty() {
             return Err("source_table cannot be empty".to_string());
         }
+
+        self.batch.validate()?;
+        self.memory_backpressure.validate()?;
 
         if self.tls.ssl_client_pem.is_some()
             || self.tls.ssl_client_location.is_some()
@@ -311,6 +482,8 @@ mod tests {
             publication: "publication".to_string(),
             source_table: "public.table".to_string(),
             tls,
+            batch: PostgresCdcBatchConfig::default(),
+            memory_backpressure: PostgresCdcMemoryBackpressureConfig::default(),
         }
     }
 
@@ -361,5 +534,120 @@ mod tests {
 
         let err = config.validate().unwrap_err();
         assert!(err.contains("source_table cannot be empty"));
+    }
+
+    #[test]
+    fn postgres_cdc_config_deserializes_without_batch_or_memory_backpressure() {
+        let json = r#"{
+            "uri": "postgres://user:password@localhost:5432/database",
+            "publication": "publication",
+            "source_table": "public.table"
+        }"#;
+        let config: PostgresCdcReaderConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.batch, PostgresCdcBatchConfig::default());
+        assert_eq!(
+            config.memory_backpressure,
+            PostgresCdcMemoryBackpressureConfig::default()
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn postgres_cdc_batch_config_deserializes_with_partial_fields() {
+        let json = r#"{"max_bytes": 4194304}"#;
+        let config: PostgresCdcBatchConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.max_bytes, 4 * 1024 * 1024);
+        assert_eq!(config.max_fill_ms, default_batch_max_fill_ms());
+        assert_eq!(
+            config.memory_budget_ratio,
+            default_batch_memory_budget_ratio()
+        );
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn postgres_cdc_batch_config_rejects_zero_memory_budget_ratio() {
+        let config = PostgresCdcBatchConfig {
+            memory_budget_ratio: 0.0,
+            ..Default::default()
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("batch.memory_budget_ratio"));
+    }
+
+    #[test]
+    fn postgres_cdc_batch_config_rejects_out_of_range_memory_budget_ratio() {
+        let config = PostgresCdcBatchConfig {
+            memory_budget_ratio: 1.5,
+            ..Default::default()
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("batch.memory_budget_ratio"));
+    }
+
+    #[test]
+    fn postgres_cdc_batch_config_rejects_zero_max_bytes() {
+        let config = PostgresCdcBatchConfig {
+            max_bytes: 0,
+            ..Default::default()
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("batch.max_bytes"));
+    }
+
+    #[test]
+    fn postgres_cdc_memory_backpressure_config_rejects_zero_activate_threshold() {
+        let config = PostgresCdcMemoryBackpressureConfig {
+            activate_threshold: 0.0,
+            ..Default::default()
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("memory_backpressure.activate_threshold"));
+    }
+
+    #[test]
+    fn postgres_cdc_memory_backpressure_config_rejects_resume_threshold_of_one() {
+        let config = PostgresCdcMemoryBackpressureConfig {
+            resume_threshold: 1.0,
+            ..Default::default()
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("memory_backpressure.resume_threshold"));
+    }
+
+    #[test]
+    fn postgres_cdc_memory_backpressure_config_rejects_resume_gte_activate() {
+        let config = PostgresCdcMemoryBackpressureConfig {
+            activate_threshold: 0.5,
+            resume_threshold: 0.5,
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("must be lower than"));
+    }
+
+    #[test]
+    fn postgres_cdc_config_rejects_invalid_batch_config() {
+        let mut config = postgres_cdc_config(PostgresTlsConfig::default());
+        config.batch.max_bytes = 0;
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("batch.max_bytes"));
+    }
+
+    #[test]
+    fn postgres_cdc_config_rejects_invalid_memory_backpressure_config() {
+        let mut config = postgres_cdc_config(PostgresTlsConfig::default());
+        config.memory_backpressure.activate_threshold = 0.0;
+
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("memory_backpressure.activate_threshold"));
     }
 }

--- a/docs.feldera.com/docs/connectors/sources/postgresql-cdc.md
+++ b/docs.feldera.com/docs/connectors/sources/postgresql-cdc.md
@@ -24,19 +24,42 @@ privileges.
 
 Use transport name `postgres_cdc_input`.
 
-| Property          | Type   | Default | Description                                                                                                                                                                                     |
-| ----------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `uri`\*           | string |         | PostgreSQL connection URL, e.g. `"postgres://postgres:password@localhost:5432/postgres"`. The URL must include a username, host, and database name. The user must have `REPLICATION` privilege. |
-| `publication`\*   | string |         | Name of an existing PostgreSQL publication. The publication must include `source_table`.                                                                                                        |
-| `source_table`\*  | string |         | PostgreSQL table to replicate, usually schema-qualified, e.g. `"public.orders"`.                                                                                                                |
-| `ssl_ca_pem`      | string |         | CA certificates in PEM format. Setting this enables TLS and takes precedence over `ssl_ca_location`.                                                                                            |
-| `ssl_ca_location` | string |         | Path to a PEM file containing CA certificates. Used when `ssl_ca_pem` is not set.                                                                                                               |
+| Property              | Type   | Default | Description                                                                                                                                                                                     |
+|-----------------------|--------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `uri`\*               | string |         | PostgreSQL connection URL, e.g. `"postgres://postgres:password@localhost:5432/postgres"`. The URL must include a username, host, and database name. The user must have `REPLICATION` privilege. |
+| `publication`\*       | string |         | Name of an existing PostgreSQL publication. The publication must include `source_table`.                                                                                                        |
+| `source_table`\*      | string |         | PostgreSQL table to replicate, usually schema-qualified, e.g. `"public.orders"`.                                                                                                                |
+| `ssl_ca_pem`          | string |         | CA certificates in PEM format. Setting this enables TLS and takes precedence over `ssl_ca_location`.                                                                                            |
+| `ssl_ca_location`     | string |         | Path to a PEM file containing CA certificates. Used when `ssl_ca_pem` is not set.                                                                                                               |
+| `batch`               | object |         | Batch processing configuration. See [Batch configuration](#batch-configuration) below. When omitted, uses the underlying `etl` library's defaults.                                              |
+| `memory_backpressure` | object |         | Memory-based backpressure configuration. See [Memory backpressure configuration](#memory-backpressure-configuration) below. When omitted, uses the underlying `etl` library's defaults.         |
 
 [*]: Required fields
 
 The CDC connector does not support client-certificate TLS options
 (`ssl_client_pem`, `ssl_client_location`, `ssl_client_key`,
 `ssl_client_key_location`, or `ssl_certificate_chain_location`).
+
+### Batch configuration
+
+Controls how replication events are buffered into a batch before being
+flushed to Feldera.
+
+| Property              | Type    | Default | Description                                                                                                                                            |
+|-----------------------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_fill_ms`         | integer | 10000   | Maximum time, in milliseconds, to wait before flushing a partially filled batch.                                                                       |
+| `memory_budget_ratio` | float   | 0.2     | Ratio, in `(0.0, 1.0]`, of process memory reserved for incoming replication batch bytes, divided across active streams.                                |
+| `max_bytes`           | integer | 8388608 | Maximum preferred byte size for one batch per active stream (8 MiB). A ceiling, not a target: the smaller of this and the memory-ratio budget applies. |
+
+### Memory backpressure configuration
+
+Controls when the connector pauses reading further replication events to
+avoid exceeding available memory.
+
+| Property             | Type  | Default | Description                                                                                                         |
+|----------------------|-------|---------|---------------------------------------------------------------------------------------------------------------------|
+| `activate_threshold` | float | 0.85    | Memory usage ratio, in `(0.0, 1.0]`, above which backpressure is activated.                                         |
+| `resume_threshold`   | float | 0.75    | Memory usage ratio, in `[0.0, 1.0)`, below which backpressure is released. Must be lower than `activate_threshold`. |
 
 ## PostgreSQL setup
 
@@ -160,6 +183,42 @@ CREATE TABLE orders (
                 "publication": "feldera_orders",
                 "source_table": "public.orders",
                 "ssl_ca_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+            }
+        }
+    }]'
+);
+```
+
+## Memory vs. throughput tuning example
+
+For a high-throughput table, you may want larger batches (fewer, bigger
+flushes) and a memory backpressure window tuned for the worker's available
+memory:
+
+```sql
+CREATE TABLE orders (
+    id BIGINT NOT NULL,
+    customer TEXT NOT NULL,
+    amount DECIMAL(10, 2),
+    status TEXT NOT NULL
+) WITH (
+    'materialized' = 'true',
+    'connectors' = '[{
+        "transport": {
+            "name": "postgres_cdc_input",
+            "config": {
+                "uri": "postgres://feldera:password@localhost:5432/postgres",
+                "publication": "feldera_orders",
+                "source_table": "public.orders",
+                "batch": {
+                    "max_fill_ms": 2000,
+                    "memory_budget_ratio": 0.3,
+                    "max_bytes": 16777216
+                },
+                "memory_backpressure": {
+                    "activate_threshold": 0.9,
+                    "resume_threshold": 0.7
+                }
             }
         }
     }]'

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcBatchConfig.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcBatchConfig.java
@@ -1,0 +1,16 @@
+package org.dbsp.sqlCompiler.compiler.frontend.connectors.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Batch processing configuration for the Postgres CDC input connector. */
+@SuppressWarnings("unused")
+public class PostgresCdcBatchConfig {
+    @JsonProperty("max_fill_ms")
+    public long maxFillMs = 10_000;
+
+    @JsonProperty("memory_budget_ratio")
+    public double memoryBudgetRatio = 0.2;
+
+    @JsonProperty("max_bytes")
+    public long maxBytes = 8L * 1024 * 1024;
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcMemoryBackpressureConfig.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcMemoryBackpressureConfig.java
@@ -1,0 +1,13 @@
+package org.dbsp.sqlCompiler.compiler.frontend.connectors.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Memory-based backpressure configuration for the Postgres CDC input connector. */
+@SuppressWarnings("unused")
+public class PostgresCdcMemoryBackpressureConfig {
+    @JsonProperty("activate_threshold")
+    public double activateThreshold = 0.85;
+
+    @JsonProperty("resume_threshold")
+    public double resumeThreshold = 0.75;
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcReaderConfig.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/PostgresCdcReaderConfig.java
@@ -29,12 +29,45 @@ public class PostgresCdcReaderConfig implements IValidateConfig {
     @Nullable @JsonProperty("ssl_certificate_chain_location") public String sslCertificateChainLocation = null;
     @Nullable @JsonProperty("verify_hostname")               public Boolean verifyHostname = null;
 
+    @JsonProperty("batch")
+    public PostgresCdcBatchConfig batch = new PostgresCdcBatchConfig();
+
+    @JsonProperty("memory_backpressure")
+    public PostgresCdcMemoryBackpressureConfig memoryBackpressure = new PostgresCdcMemoryBackpressureConfig();
+
     @Override
     public boolean validate(ConfigReporter reporter) {
         boolean ok = true;
         ok = ok && this.checkNonEmpty(reporter, uri, "uri");
         ok = ok && this.checkNonEmpty(reporter, publication, "publication");
         ok = ok && this.checkNonEmpty(reporter, sourceTable, "source_table");
+
+        if (batch.memoryBudgetRatio <= 0.0 || batch.memoryBudgetRatio > 1.0) {
+            reporter.warnPath("batch/memory_budget_ratio", "Invalid configuration",
+                    "\"batch.memory_budget_ratio\" must be in the (0.0, 1.0] interval");
+            ok = false;
+        }
+        if (batch.maxBytes <= 0) {
+            reporter.warnPath("batch/max_bytes", "Invalid configuration",
+                    "\"batch.max_bytes\" must be greater than 0");
+            ok = false;
+        }
+
+        if (memoryBackpressure.activateThreshold <= 0.0 || memoryBackpressure.activateThreshold > 1.0) {
+            reporter.warnPath("memory_backpressure/activate_threshold", "Invalid configuration",
+                    "\"memory_backpressure.activate_threshold\" must be in the (0.0, 1.0] interval");
+            ok = false;
+        }
+        if (memoryBackpressure.resumeThreshold < 0.0 || memoryBackpressure.resumeThreshold >= 1.0) {
+            reporter.warnPath("memory_backpressure/resume_threshold", "Invalid configuration",
+                    "\"memory_backpressure.resume_threshold\" must be in the [0.0, 1.0) interval");
+            ok = false;
+        }
+        if (memoryBackpressure.resumeThreshold >= memoryBackpressure.activateThreshold) {
+            reporter.warnPath("memory_backpressure/resume_threshold", "Invalid configuration",
+                    "\"memory_backpressure.resume_threshold\" must be lower than \"memory_backpressure.activate_threshold\"");
+            ok = false;
+        }
         return ok;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
@@ -786,6 +786,131 @@ public class ConnectorTests extends BaseSQLTests {
     }
 
     @Test
+    public void postgresCdcReaderValidBatchAndMemoryBackpressure() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "batch": {
+                      "max_fill_ms": 5000,
+                      "memory_budget_ratio": 0.3,
+                      "max_bytes": 4194304
+                    },
+                    "memory_backpressure": {
+                      "activate_threshold": 0.9,
+                      "resume_threshold": 0.6
+                    }
+                  }
+                }""");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsZeroBatchMemoryBudgetRatio() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "batch": {
+                      "memory_budget_ratio": 0.0
+                    }
+                  }
+                }""",
+                "\"batch.memory_budget_ratio\" must be in the (0.0, 1.0] interval");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsOutOfRangeBatchMemoryBudgetRatio() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "batch": {
+                      "memory_budget_ratio": 1.5
+                    }
+                  }
+                }""",
+                "\"batch.memory_budget_ratio\" must be in the (0.0, 1.0] interval");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsZeroBatchMaxBytes() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "batch": {
+                      "max_bytes": 0
+                    }
+                  }
+                }""",
+                "\"batch.max_bytes\" must be greater than 0");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsZeroActivateThreshold() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "memory_backpressure": {
+                      "activate_threshold": 0.0
+                    }
+                  }
+                }""",
+                "\"memory_backpressure.activate_threshold\" must be in the (0.0, 1.0] interval");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsResumeThresholdOfOne() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "memory_backpressure": {
+                      "resume_threshold": 1.0
+                    }
+                  }
+                }""",
+                "\"memory_backpressure.resume_threshold\" must be in the [0.0, 1.0) interval");
+    }
+
+    @Test
+    public void postgresCdcReaderRejectsResumeGteActivateThreshold() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "postgres_cdc_input",
+                  "config": {
+                    "uri": "postgres://localhost/db",
+                    "publication": "my_pub",
+                    "source_table": "public.orders",
+                    "memory_backpressure": {
+                      "activate_threshold": 0.5,
+                      "resume_threshold": 0.5
+                    }
+                  }
+                }""",
+                "must be lower than");
+    }
+
+    @Test
     public void postgresWriterCdcMissingOpColumn() {
         viewConnectorTest("""
                 "transport": {


### PR DESCRIPTION
This PR is only about offering a configuration option on batch & memory backpressure, since they relate to the same tradeoff.

crates/feldera-types/src/transport/postgres.rs — added PostgresCdcBatchConfig (max_fill_ms, memory_budget_ratio, max_bytes) and PostgresCdcMemoryBackpressureConfig (activate_threshold, resume_threshold), each mirroring etl's own field shapes/defaults, with their own validate(). Wired into PostgresCdcReaderConfig as two new #[serde(default)] fields, so both are fully optional and back-compatible. 15 tests (up from 5).

crates/adapters/src/integrated/postgres/cdc_input.rs — replaced the hardcoded BatchConfig::default() / MemoryBackpressureConfig::default() in PipelineConfig construction with values derived from the connector config, via two small conversion functions. 4 new tests (55 total, up from 51).

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
