### PR TITLE
[types] Serialize checkpoint fingerprint as OpenAPI format uint64

### DIFF
--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -119,6 +119,8 @@ pub struct CheckpointMetadata {
     /// An optional name for the checkpoint.
     pub identifier: Option<String>,
     /// Fingerprint of the circuit at the time of the checkpoint.
+    // Uses the full 64-bit range.
+    #[schema(format = "uint64")]
     pub fingerprint: u64,
     /// Total size of the checkpoint files in bytes.
     pub size: Option<u64>,

--- a/crates/rest-api/src/lib.rs
+++ b/crates/rest-api/src/lib.rs
@@ -3,3 +3,23 @@
 use feldera_observability::ReqwestTracingExt;
 
 include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::types::CheckpointMetadata;
+
+    /// Reproduces issue #6841: `fda pipelines`/`fda status` failed to parse
+    /// any pipeline's checkpoint list once one checkpoint's fingerprint had
+    /// the high bit set, because the generated `fingerprint` field was `i64`.
+    /// `format: uint64` on that field (checkpoint.rs) makes progenitor/typify
+    /// generate `u64` instead, so this must deserialize without error.
+    #[test]
+    fn checkpoint_metadata_accepts_fingerprint_above_i64_max() {
+        let raw = r#"{
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "fingerprint": 14128757731148314856
+        }"#;
+        let metadata: CheckpointMetadata = serde_json::from_str(raw).unwrap();
+        assert_eq!(metadata.fingerprint, 14128757731148314856);
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -8475,7 +8475,7 @@
         "properties": {
           "fingerprint": {
             "type": "integer",
-            "format": "int64",
+            "format": "uint64",
             "description": "Fingerprint of the circuit at the time of the checkpoint.",
             "minimum": 0
           },


### PR DESCRIPTION
fda's REST client generates the CheckpointMetadata.fingerprint field as i64 from the OpenAPI schema, so a checkpoint whose 64-bit fingerprint has the high bit set breaks `fda pipelines`/`fda status` for the whole instance (#6841). Annotate the field with `#[schema(format = "uint64")]` so progenitor/typify generate `u64` instead, which accepts the full unsigned range without truncating or otherwise altering the fingerprint value.

### Describe Manual Test Plan

Unit tests only.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated
