### PR TITLE
python: retry ingress POST past transient pipeline unreachability

### DIFF
--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 import unittest
 from http import HTTPStatus
 from typing import Any, Dict, Iterable
@@ -223,6 +224,56 @@ def pipeline_stats(pipeline: str):
     r = get(api_url(f"/pipelines/{pipeline}/stats"))
     assert r.status_code == HTTPStatus.OK, (r.status_code, r.text)
     return r.json()
+
+
+def wait_for_pipeline_reachable(pipeline_name: str, timeout_s: float = 30.0) -> None:
+    """
+    Poll the pipeline's `/stats` endpoint until it responds.
+
+    `start_pipeline()`/`resume_pipeline()`/`start_pipeline_as_paused()` (`wait=True`)
+    only wait for the control plane's deployment_status to report "running";
+    the pod itself can still be briefly unreachable through its k8s service
+    afterward. Call this before the *first* raw (no-retry) helper call that
+    talks to the pod directly -- ingress, egress, stats, metrics, logs,
+    checkpoint, clear, circuit profiles, etc. -- to absorb that startup race
+    instead of flaking on it.
+
+    Most tests don't need this call at all:
+
+    - Calls made through the `feldera.Pipeline`/`FelderaClient` SDK (e.g.
+      `pipeline.input_json`, `pipeline.query`) already retry transient 503s
+      themselves, so the race resolves on its own.
+    - Once any pod-facing call -- raw or SDK -- has already succeeded for a
+      given pipeline incarnation, the pod is proven reachable and later raw
+      calls in the same test don't need to wait again.
+
+    It's only the *first* raw pod-facing call after a start/resume, with
+    nothing preceding it to have already warmed the connection, that's
+    exposed to this race.
+
+    :raises RuntimeError: If an error other than transient unreachability is
+        returned.
+    :raises TimeoutError: If the pod is still unreachable after `timeout_s`.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        response = get(api_url(f"/pipelines/{pipeline_name}/stats"))
+        if response.status_code == HTTPStatus.OK:
+            return
+        if (
+            response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+            and response.json().get("error_code") == "PipelineInteractionUnreachable"
+        ):
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"pipeline '{pipeline_name}' still unreachable after {timeout_s:.0f}s"
+                )
+            time.sleep(0.5)
+            continue
+        raise RuntimeError(
+            f"unexpected response waiting for pipeline '{pipeline_name}' to "
+            f"become reachable: {response.status_code} {response.text}"
+        )
 
 
 def connector_stats(pipeline: str, table: str, connector: str):

--- a/python/tests/platform/test_checkpoint_suspend.py
+++ b/python/tests/platform/test_checkpoint_suspend.py
@@ -20,6 +20,7 @@ from .helper import (
     wait_for_condition,
     gen_pipeline_name,
     patch_json,
+    wait_for_pipeline_reachable,
 )
 
 
@@ -76,6 +77,7 @@ def test_checkpoint_enterprise(pipeline_name):
     sql = "CREATE TABLE t1(x int) WITH ('materialized'='true');"
     create_pipeline(pipeline_name, sql)
     start_pipeline_as_paused(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     for _ in range(5):
         resp = post_no_body(api_url(f"/pipelines/{pipeline_name}/checkpoint"))
@@ -205,6 +207,7 @@ def test_suspend_enterprise(pipeline_name):
 
     # Start pipeline (all connectors remain paused)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     assert _max_rss_bytes_metric(pipeline_name) == before_max_rss_mb * 1_000_000
     assert connector_paused(pipeline_name, "t1", "c1")
     assert connector_paused(pipeline_name, "t1", "c2")
@@ -230,6 +233,7 @@ def test_suspend_enterprise(pipeline_name):
     )
     assert resp.status_code == HTTPStatus.OK, resp.text
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     assert _max_rss_bytes_metric(pipeline_name) == after_max_rss_mb * 1_000_000
     # After resume: c1 running (EOI), c2,c3 still paused
     assert not connector_paused(pipeline_name, "t1", "c1")
@@ -249,6 +253,7 @@ def test_suspend_enterprise(pipeline_name):
     # Suspend/resume again
     stop_pipeline(pipeline_name, force=False)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # All connectors should now be running (EOI)
     assert not connector_paused(pipeline_name, "t1", "c1")

--- a/python/tests/platform/test_completion_tokens.py
+++ b/python/tests/platform/test_completion_tokens.py
@@ -16,6 +16,7 @@ from .helper import (
     gen_pipeline_name,
     adhoc_query_json,
     wait_for_condition,
+    wait_for_pipeline_reachable,
 )
 from tests import TEST_CLIENT
 
@@ -68,6 +69,7 @@ CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1;
 """
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     for i in range(0, 200):
         token = _ingress_with_token(
@@ -152,6 +154,7 @@ WITH (
     assert r.status_code == HTTPStatus.CREATED, r.text
     wait_for_program_success(pipeline_name, 1)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Ingest a number of rows; track expected counts
     for i in range(0, 50):

--- a/python/tests/platform/test_ingress_formats.py
+++ b/python/tests/platform/test_ingress_formats.py
@@ -14,6 +14,7 @@ from .helper import (
     create_pipeline,
     get,
     wait_for_condition,
+    wait_for_pipeline_reachable,
 )
 from tests import TEST_CLIENT
 
@@ -199,6 +200,7 @@ def test_json_ingress(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Raw format (missing some fields)
     _ingress_and_wait_token(
@@ -366,6 +368,7 @@ def test_variant_column_json_and_csv(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Subscribe to the csv change stream before ingesting.
     egress = http_request(
@@ -441,6 +444,7 @@ def test_map_column(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     _ingress_and_wait_token(
         pipeline_name,
@@ -461,6 +465,7 @@ def test_parse_datetime(pipeline_name):
     sql = "CREATE TABLE t1(t TIME, ts TIMESTAMP, d DATE) WITH ('materialized'='true');"
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     _ingress_and_wait_token(
         pipeline_name,
@@ -485,6 +490,7 @@ def test_quoted_columns(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     _ingress_and_wait_token(
         pipeline_name,
         "T1",
@@ -506,6 +512,7 @@ def test_primary_keys(pipeline_name):
     sql = "CREATE TABLE t1(id bigint not null, s varchar not null, primary key(id)) "
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Insert two rows
     _ingress_and_wait_token(
@@ -557,6 +564,7 @@ def _test_case_sensitive_tables(pipeline_name: str, use_new_api: bool):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     stream_v1 = _change_stream_start(pipeline_name, '"V1"', use_new_api)
     stream_v1_lower = _change_stream_start(pipeline_name, '"v1"', use_new_api)
@@ -611,6 +619,7 @@ def test_duplicate_outputs(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     stream = _change_stream_start(pipeline_name, "V1", False)
     reader = JsonLineReader(stream)
@@ -669,6 +678,7 @@ def test_upsert(pipeline_name):
     )
     create_pipeline(pipeline_name, sql)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     stream = _change_stream_start(pipeline_name, "T1", True)
     reader = JsonLineReader(stream)

--- a/python/tests/platform/test_metrics_logs.py
+++ b/python/tests/platform/test_metrics_logs.py
@@ -15,6 +15,7 @@ from .helper import (
     clear_pipeline,
     gen_pipeline_name,
     wait_for_condition,
+    wait_for_pipeline_reachable,
 )
 
 from feldera.testutils import FELDERA_TEST_NUM_HOSTS
@@ -57,6 +58,7 @@ def test_pipeline_metrics(pipeline_name):
     """
     create_pipeline(pipeline_name, "")
     start_pipeline_as_paused(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Default
     r_default = get(api_url(f"/pipelines/{pipeline_name}/metrics"))
@@ -104,6 +106,7 @@ def test_pipeline_stats(pipeline_name):
 
     create_pipeline(pipeline_name, sql)
     start_pipeline_as_paused(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # Create output connector on v1 (egress)
     r_out = post_no_body(api_url(f"/pipelines/{pipeline_name}/egress/v1"), stream=True)
@@ -225,6 +228,7 @@ def test_pipeline_logs(pipeline_name):
 
     # Pause pipeline
     start_pipeline_as_paused(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     assert (
         get(api_url(f"/pipelines/{pipeline_name}/logs"), stream=True).status_code
         == HTTPStatus.OK
@@ -232,6 +236,7 @@ def test_pipeline_logs(pipeline_name):
 
     # Start pipeline
     resume_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     assert (
         get(api_url(f"/pipelines/{pipeline_name}/logs"), stream=True).status_code
         == HTTPStatus.OK

--- a/python/tests/platform/test_orchestration.py
+++ b/python/tests/platform/test_orchestration.py
@@ -17,6 +17,7 @@ from .helper import (
     pipeline_stats,
     connector_paused,
     wait_for_condition,
+    wait_for_pipeline_reachable,
     get,
 )
 from feldera.testutils import FELDERA_TEST_NUM_HOSTS
@@ -70,6 +71,7 @@ def test_pipeline_orchestration_basic(pipeline_name):
 
         create_pipeline(cur_pipeline_name, sql)
         start_pipeline_as_paused(cur_pipeline_name)
+        wait_for_pipeline_reachable(cur_pipeline_name)
 
         if FELDERA_TEST_NUM_HOSTS > 1:
             # The multihost coordinator can report that it is ready
@@ -117,6 +119,7 @@ def test_pipeline_orchestration_basic(pipeline_name):
 
         # Start pipeline
         resume_pipeline(cur_pipeline_name)
+        wait_for_pipeline_reachable(cur_pipeline_name)
         p_paused, c_paused, processed = _basic_orchestration_info(
             cur_pipeline_name, table_name, connector_name
         )
@@ -168,6 +171,7 @@ def test_pipeline_orchestration_errors(pipeline_name):
 
     create_pipeline(pipeline_name, sql)
     start_pipeline_as_paused(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
 
     # ACCEPTED endpoints
     for endpoint in [
@@ -309,8 +313,10 @@ def test_pipeline_orchestration_scenarios(pipeline_name):
     def apply_step(step: str):
         if step == Step.START_PIPELINE:
             start_pipeline(pipeline_name)
+            wait_for_pipeline_reachable(pipeline_name)
         elif step == Step.START_PIPELINE_AS_PAUSED:
             start_pipeline_as_paused(pipeline_name)
+            wait_for_pipeline_reachable(pipeline_name)
         elif step == Step.PAUSE_PIPELINE:
             pause_pipeline(pipeline_name)
         elif step == Step.START_CONNECTOR_1:

--- a/python/tests/platform/test_pipeline_error.py
+++ b/python/tests/platform/test_pipeline_error.py
@@ -6,6 +6,7 @@ from .helper import (
     gen_pipeline_name,
     post_json,
     api_url,
+    wait_for_pipeline_reachable,
 )
 from tests import TEST_CLIENT
 
@@ -78,6 +79,11 @@ def test_pipeline_error_dismissal(pipeline_name):
 
 
 def cause_error_and_wait_for_stopped(pipeline):
+    # `post_json` uses the no-retry `http_request` helper (other tests rely on
+    # that to see raw status codes), so absorb the post-start pod-reachability
+    # race before using it, rather than failing the test on infra flakiness.
+    wait_for_pipeline_reachable(pipeline.name)
+
     # This data causes the pipeline to panic
     response = post_json(
         api_url(

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -26,6 +26,7 @@ from .helper import (
     api_url,
     adhoc_query_json,
     post_no_body,
+    wait_for_pipeline_reachable,
 )
 from tests import enterprise_only
 from feldera.testutils import (
@@ -71,6 +72,7 @@ def test_deploy_pipeline(pipeline_name):
     create_pipeline(pipeline_name, sql)
 
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     assert _ingress(pipeline_name, "t1", "1\n2\n3\n").status_code == HTTPStatus.OK
     assert _ingress(pipeline_name, "t1", "4\r\n5\r\n6").status_code == HTTPStatus.OK
 
@@ -79,6 +81,7 @@ def test_deploy_pipeline(pipeline_name):
     assert got == [{"c1": i} for i in range(1, 7)]
 
     resume_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     got = adhoc_query_json(pipeline_name, "select * from t1 order by c1")
     assert got == [{"c1": i} for i in range(1, 7)]
 
@@ -98,6 +101,7 @@ def test_pipeline_panic(pipeline_name):
     create_pipeline(pipeline_name, sql)
 
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     _ingress(pipeline_name, "t1", "1\n2\n3\n")
 
     err = _wait_for_stopped_with_error(pipeline_name)
@@ -310,6 +314,7 @@ def test_pipeline_clear(pipeline_name):
 
     # Start (becomes InUse)
     start_pipeline(pipeline_name)
+    wait_for_pipeline_reachable(pipeline_name)
     obj = get_pipeline(pipeline_name, "status").json()
     assert StorageStatus.from_str(obj.get("storage_status")) == StorageStatus.INUSE
 
@@ -861,6 +866,7 @@ def test_connector_stats_errors_count(pipeline_name):
         TEST_CLIENT, pipeline_name, "CREATE TABLE t1 (v1 INT);"
     ).create_or_replace()
     pipeline.start()
+    wait_for_pipeline_reachable(pipeline_name)
     assert _ingress(pipeline_name, "t1", "1\n2\n3\n").status_code == HTTPStatus.OK
     assert (
         _ingress(pipeline_name, "t1", "a\nb\nc\nd\n").status_code

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -21,7 +21,11 @@ from feldera.testutils import (
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
-from .helper import wait_for_condition, wait_for_records
+from .helper import (
+    wait_for_condition,
+    wait_for_records,
+    wait_for_pipeline_reachable,
+)
 
 
 class TestPipeline(SharedTestPipeline):
@@ -998,6 +1002,7 @@ class TestPipeline(SharedTestPipeline):
     # is already compressed).
     def test_circuit_profile_streaming(self):
         self.pipeline.start()
+        wait_for_pipeline_reachable(self.pipeline.name)
 
         resp = http_request(
             "GET",
@@ -1032,6 +1037,7 @@ class TestPipeline(SharedTestPipeline):
     # is transparent (compressed and uncompressed responses yield the same data).
     def test_circuit_json_profile_streaming(self):
         self.pipeline.start()
+        wait_for_pipeline_reachable(self.pipeline.name)
 
         # Request with gzip — the pipeline compresses and the streaming
         # proxy passes the compressed bytes through.  `requests`


### PR DESCRIPTION
Right after start() reports "running", the pipeline pod can briefly be unreachable through the k8s service (control plane confirms readiness once, but nothing re-checks it before the SDK's next request). This raced with cause_error_and_wait_for_stopped's initial ingest POST, which uses the no-retry http_request test helper, and flaked test_pipeline_error_dismissal in CI with a 503 PipelineInteractionUnreachable.

This failure was observed in the CI run
https://github.com/feldera/cloud/actions/runs/31617894273/job/94194277123
