### PR TITLE
dbsp: Give every stream in a nested circuit an id of its own

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -1864,8 +1864,8 @@ pub trait CircuitBase: 'static {
     /// since all of them maintain a shared global counter.
     fn allocate_stream_id(&self) -> StreamId;
 
-    /// Reference to the global counter shared by all circuits.
-    fn last_stream_id(&self) -> RefCell<StreamId>;
+    /// The global stream id counter, shared by every circuit in the pipeline.
+    fn last_stream_id(&self) -> Rc<RefCell<StreamId>>;
 
     /// Relative depth of `self` from the root circuit.
     ///
@@ -2942,7 +2942,9 @@ where
     circuit_event_handlers: CircuitEventHandlers,
     scheduler_event_handlers: SchedulerEventHandlers,
     store: RefCell<CircuitCache>,
-    last_stream_id: RefCell<StreamId>,
+    /// Shared with the parent and all child circuits, so that stream ids are
+    /// unique across the whole pipeline.
+    last_stream_id: Rc<RefCell<StreamId>>,
     metadata_exchange: MetadataExchange,
     balancer: Rc<Balancer>,
 }
@@ -2960,7 +2962,7 @@ where
         global_node_id: GlobalNodeId,
         circuit_event_handlers: CircuitEventHandlers,
         scheduler_event_handlers: SchedulerEventHandlers,
-        last_stream_id: RefCell<StreamId>,
+        last_stream_id: Rc<RefCell<StreamId>>,
     ) -> Self {
         let metadata_exchange = MetadataExchange::new();
 
@@ -3306,7 +3308,7 @@ impl RootCircuit {
                 GlobalNodeId::root(),
                 Rc::new(RefCell::new(HashMap::new())),
                 Rc::new(RefCell::new(HashMap::new())),
-                RefCell::new(StreamId::new(0)),
+                Rc::new(RefCell::new(StreamId::new(0))),
             )),
             time: Rc::new(RefCell::new(())),
         }
@@ -3659,7 +3661,7 @@ where
         *last_stream_id
     }
 
-    fn last_stream_id(&self) -> RefCell<StreamId> {
+    fn last_stream_id(&self) -> Rc<RefCell<StreamId>> {
         self.inner().last_stream_id.clone()
     }
 
@@ -8959,12 +8961,18 @@ mod tests {
     use super::ElapsedTime;
     use crate::{
         Circuit, Error as DbspError, RootCircuit,
-        circuit::schedule::{DynamicScheduler, Scheduler},
+        circuit::{
+            NodeId,
+            circuit_builder::{CircuitBase, StreamId},
+            schedule::{DynamicScheduler, Scheduler},
+        },
         monitor::TraceMonitor,
         operator::{Generator, Z1},
     };
     use anyhow::anyhow;
-    use std::{cell::RefCell, ops::Deref, rc::Rc, thread, time::Duration, vec::Vec};
+    use std::{
+        cell::RefCell, collections::HashMap, ops::Deref, rc::Rc, thread, time::Duration, vec::Vec,
+    };
 
     #[test]
     fn elapsed_time_record_returns_closure_result() {
@@ -9233,6 +9241,68 @@ mod tests {
         assert_eq!(monitor.count_regions_with_name(REGION), 2);
         assert_eq!(monitor.count_nodes_in_region(r1.as_ref().unwrap()), Some(1));
         assert_eq!(monitor.count_nodes_in_region(r2.as_ref().unwrap()), Some(1));
+    }
+
+    /// Every stream in a circuit must have an id of its own, including the
+    /// streams a nested circuit exports to its parent.
+    ///
+    /// Stream ids identify streams in `Edges`, so a reused id makes edge
+    /// bookkeeping ambiguous.  Deleting the replay edges of a bootstrap
+    /// (`CircuitHandle::complete_replay`) deletes edges by stream id, and used
+    /// to take the live edge carrying a recursive scope's output with them,
+    /// after which the scope's consumer ran ahead of the scope in every step
+    /// and read an empty stream.
+    #[test]
+    fn stream_ids_are_unique_across_nested_circuits() {
+        let circuit = RootCircuit::build(|circuit| {
+            let mut n: usize = 0;
+            let source = circuit.add_source(Generator::new(move || {
+                n += 1;
+                n
+            }));
+            let exported = circuit
+                .iterate_with_condition(|child| {
+                    let mut counter = 0;
+                    let countdown = source.delta0(child).apply_mut(move |parent_val| {
+                        if *parent_val > 0 {
+                            counter = *parent_val;
+                        };
+                        let res = counter;
+                        counter -= 1;
+                        res
+                    });
+                    let (z1_output, z1_feedback) = child.add_feedback_with_export(Z1::new(1));
+                    let mul = countdown.apply2(&z1_output.local, |n1: &usize, n2: &usize| n1 * n2);
+                    z1_feedback.connect(&mul);
+                    Ok((countdown.condition(|n| *n <= 1), z1_output.export))
+                })
+                .unwrap();
+
+            // Streams created in the parent after the scope.  The child handed
+            // out ids of its own, so these are where a reused id surfaces.
+            let mut stream = exported.apply(|n| *n);
+            for _ in 0..16 {
+                stream = stream.apply(|n| *n);
+            }
+            Ok(())
+        })
+        .unwrap()
+        .0;
+
+        let mut producer_of: HashMap<StreamId, NodeId> = HashMap::new();
+        for edge in circuit.circuit.edges().iter() {
+            if let Some(stream) = &edge.stream {
+                let producer: NodeId = *producer_of.entry(stream.stream_id()).or_insert(edge.from);
+                assert_eq!(
+                    producer,
+                    edge.from,
+                    "stream {} is produced by both {} and {}",
+                    stream.stream_id(),
+                    producer,
+                    edge.from
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stream ids are documented as globally unique, and `Edges` bookkeeping, the
replay machinery and several circuit caches key on them. They are not unique.

A child circuit receives a copy of the parent's counter rather than the counter:

```rust
fn last_stream_id(&self) -> RefCell<StreamId> {
    self.inner().last_stream_id.clone()   // clones the StreamId inside the cell
}
```

so the child hands out ids that the parent then hands out again. One of the ids
a child allocates belongs to a stream in the *parent*:
`FeedbackOutputNode::with_export` allocates the id of the stream a scope exports
from inside the child.

## What it broke

`CircuitHandle::complete_replay` ends a bootstrap by deleting the replay edges
**by stream id**:

```rust
self.circuit.edges_mut().delete_stream(*stream_id);
```

On 0.291.1 (the 6765 fixes backported, so operators inside recursive scopes
checkpoint), a recursive pipeline resumed from a checkpoint panicked at
`circuit_builder.rs:144`, `Option::unwrap()` on `None` in `StreamValue::peek`,
at 2, 4 and 8 workers, immediately after "Bootstrap complete".

Instrumenting the schedule showed why. Each of the program's 12 recursive scopes
exported a stream whose id had also gone to a root level stream created later,
in every case the replay stream of the accumulate trace that consumes the
export:

```
StreamId(568) produced by ['579', '621']       # 579 Subcircuit, 621 Z1 (trace)
  n579 -> n580 stream=Some(StreamId(568))      # the live export edge
  n621 -> n620 stream=Some(StreamId(568))      # the replay edge
```

Deleting the replay edges took `n579 -> n580` with them, so the scheduler
prepared `Consolidate [580]` with no predecessors:

```
 before:  n579 preds=[…] succs=["n580"]     n580 preds=["n579"] succs=[…]
 after:   n579 preds=[…] succs=[]           n580 preds=[]       succs=[…]
```

From then on the Consolidate ran in the first batch of every step, ahead of the
scope, and read an export stream that nothing had written:

```
MISSING STREAM VALUE: consumer="[580] Consolidate" tokens=0 consumers=1
 || COMPLETE_REPLAY
 || TRANSACTION
   [40] Z1 (trace)  … 6 more Z1 (trace)
   [580] Consolidate            <- no [579] Subcircuit ahead of it
```

Whether a program collides depends on how its ids fall, which is why main has
not tripped over it: the same program bootstraps cleanly here. The defect is the
same.

## The fix

Share the counter, as the comment on `last_stream_id` always claimed. Stream ids
exist only at runtime; nothing on disk changes, and no fingerprint or persistent
id derives from them.

## Testing

- New unit test asserting the invariant that broke: no two producers may share a
  stream id. It fails without the fix, on this branch and on main:
  `stream s5 is produced by both n1 and n5`.
- `cargo test -p dbsp --lib`, 435 tests including the replay tests: pass (run in
  the 0.291.1 tree where the fix originated).
- On the customer's program at 4 workers, the upgrade that panicked now
  completes: bootstrap finishes and `result` matches a reference run row for row
  after each of the following input batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
