### PR TITLE
[adapters] delta: don't open a catchup window while the endpoint is paused

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1993,6 +1993,10 @@ impl DeltaTableInputEndpointInner {
                             }
                             DeltaTableTransactionMode::Catchup => {
                                 if self.catchup_target().is_none() {
+                                    // A catchup window batches every commit up to the table's latest version into a transaction, so open
+                                    // it only while the connector is running; otherwise it can latch the table version from before it was paused.
+                                    wait_running(&mut receiver).await;
+
                                     let target =
                                         match self.catchup_target_version(Arc::clone(&table)).await
                                         {

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -364,7 +364,7 @@ async fn run_catchup_lag_experiment(
     );
     input_config.insert(
         "transaction_mode".into(),
-        serde_json::to_value(transaction_mode).unwrap(),
+        serde_json::to_value(transaction_mode.clone()).unwrap(),
     );
     input_config.insert("filter".into(), "bigint % 2 = 0".into());
     if let Some(end_version) = end_version {
@@ -482,6 +482,14 @@ async fn run_catchup_lag_experiment(
              (completed version: {:?}, table version: {version_after_burst})",
             pipeline_completed_version(&pipeline),
         );
+
+        if transaction_mode == DeltaTableTransactionMode::Catchup {
+            assert_eq!(
+                delta_catchup_target_version(&pipeline),
+                None,
+                "round {round}: no catchup window may be open while the endpoint is paused"
+            );
+        }
 
         let inject_read_failure = inject_read_failure_before_resume_round == Some(round);
         #[cfg(unix)]


### PR DESCRIPTION
Catchup mode batches every Delta commit up to the table's latest version into one Feldera transaction. It picks that version when it opens the window, and the follow loop could open one with a pause already pending: the loop waits for `Running` at the top of each iteration, then reads a log entry and opens the window further down, and the endpoint can pause in between. The window then targets a version from before the pause, so the commits written during the pause -- the backlog catchup mode exists to batch -- are split across later windows.

Wait for `Running` again before choosing the target. The window then spans everything the table has accumulated by the time the connector resumes.

This is the flake behind `delta_table_snapshot_and_follow_catchup_snapshot_transaction_test` failing with `catchup_target_version` one version short of the burst: the test builds its backlog while paused, so it depends on this window never opening early. The new test parks the follow loop between the two points with a read failure and reproduces it deterministically; the shared experiment now also asserts that no window survives a pause.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
