### PR TITLE
[python] Drop unoptimized profile from platform config tests

### DIFF
--- a/python/tests/platform/test_pipeline_configs.py
+++ b/python/tests/platform/test_pipeline_configs.py
@@ -5,10 +5,8 @@ from feldera.rest.errors import FelderaAPIError
 from tests import TEST_CLIENT
 from .helper import (
     API_PREFIX,
-    cleanup_pipeline,
     gen_pipeline_name,
     patch_json,
-    post_json,
     put_json,
 )
 
@@ -93,20 +91,6 @@ def test_pipeline_runtime_config(pipeline_name):
         # Rust test checks error_code == InvalidRuntimeConfig
         assert err.get("error_code") == "InvalidRuntimeConfig", err
 
-    # Patching original (create with explicit rich config)
-    pipeline_name_2 = pipeline_name + "-2"
-    cleanup_pipeline(pipeline_name_2)
-    original_body = {
-        "name": pipeline_name_2,
-        "program_code": "-- patch original",
-        "program_config": {
-            "profile": "unoptimized",
-            "cache": False,
-        },
-    }
-    resp_orig = post_json(f"{API_PREFIX}/pipelines", original_body)
-    assert resp_orig.status_code in (HTTPStatus.CREATED, HTTPStatus.OK), resp_orig.text
-
     # Patch modifying some nested fields
     patch_body = {
         "runtime_config": {
@@ -177,14 +161,14 @@ def test_pipeline_program_config(pipeline_name):
         "name": pipeline_name,
         "program_code": "sql-2",
         "program_config": {
-            "profile": "unoptimized",
+            "profile": "dev",
             "cache": False,
         },
     }
     resp = put_json(_pipeline_url(pipeline_name), original_body)
     assert resp.status_code in (HTTPStatus.CREATED, HTTPStatus.OK), resp.text
     pc_original = resp.json()["program_config"]
-    assert pc_original.get("profile") == "unoptimized"
+    assert pc_original.get("profile") == "dev"
     assert not pc_original.get("cache")
 
     # Patch no changes


### PR DESCRIPTION
CI compilers precompile dependencies only for the default `optimized` profile. A platform test pipeline requesting `profile: unoptimized` with `cache: false` forced a cold build of the full dependency tree (~4 minutes) that serially blocked every other queued Rust build on its compiler replica. Under parallel test load that backlog consumed the start timeout of unrelated tests and made them flake.

Changes in `python/tests/platform/test_pipeline_configs.py`:

- `test_pipeline_runtime_config`: delete the second pipeline creation. It carried the `unoptimized` + `cache: false` config, its SQL compiled (comment-only program), and nothing ever read it back: the subsequent PATCH and all assertions target the first pipeline. Dead code whose only observable effect was the queue-hogging build.
- `test_pipeline_program_config`: assert the profile round-trip with `dev` instead of `unoptimized`. The test's SQL intentionally fails to compile, so no Rust build runs either way; `dev` still exercises a non-default profile through PUT/PATCH.

No test under `tests/platform` sets `unoptimized` anymore.
