### PR TITLE
[python] add a pipeline metrics accessor to the SDK; use it for test scrapes

### DIFF
--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -114,6 +114,15 @@ class Pipeline:
 
         return PipelineStatistics.from_dict(self.client.get_pipeline_stats(self.name))
 
+    def metrics(self, format: str = "prometheus"):
+        """Gets the pipeline circuit metrics.
+
+        :param format: The metrics format, "prometheus" (default) or "json".
+        :return: Prometheus exposition text as `str`, or a `dict` for "json".
+        """
+
+        return self.client.get_pipeline_metrics(self.name, format=format)
+
     def logs(self) -> Generator[str, None, None]:
         """Gets the pipeline logs."""
 

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -490,6 +490,20 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 
         return resp
 
+    def get_pipeline_metrics(self, name: str, format: str = "prometheus"):
+        """
+        Get the pipeline circuit metrics
+
+        :param name: The name of the pipeline
+        :param format: The metrics format, "prometheus" (default) or "json".
+        :return: Prometheus exposition text as `str`, or a `dict` for "json".
+        """
+
+        return self.http.get(
+            path=f"/pipelines/{name}/metrics",
+            params={"format": format},
+        )
+
     def get_pipeline_logs(self, pipeline_name: str) -> Generator[str, None, None]:
         """
         Get the pipeline logs

--- a/python/tests/platform/test_delta_input_catchup.py
+++ b/python/tests/platform/test_delta_input_catchup.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime, timezone
-from http import HTTPStatus
 
 import pyarrow as pa
 import pytest
@@ -21,7 +20,6 @@ from feldera import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
 from tests import TEST_CLIENT, enterprise_only
-from tests.platform.helper import api_url, get
 from tests.utils import DeltaTestLocation, wait_for_condition
 
 TABLE = "t"
@@ -115,10 +113,9 @@ def _build_sql(loc: DeltaTestLocation, *, mode: str, paused: bool = False) -> st
 
 
 def _delta_metric(pipeline_name: str, metric_name: str) -> float:
-    response = get(api_url(f"/pipelines/{pipeline_name}/metrics?format=prometheus"))
-    assert response.status_code == HTTPStatus.OK, response.text
+    scrape = TEST_CLIENT.get_pipeline_metrics(pipeline_name)
     pattern = rf'^{re.escape(metric_name)}\{{[^}}]*endpoint="{re.escape(ENDPOINT)}"[^}}]*\}}\s+(\S+)'
-    for line in response.text.splitlines():
+    for line in scrape.splitlines():
         match = re.match(pattern, line)
         if match:
             return float(match.group(1))

--- a/python/tests/platform/test_iceberg_input.py
+++ b/python/tests/platform/test_iceberg_input.py
@@ -34,7 +34,6 @@ import re
 import uuid as uuidlib
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
-from http import HTTPStatus
 
 import pytest
 
@@ -43,7 +42,6 @@ from feldera.enums import FaultToleranceModel
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
 from tests import TEST_CLIENT, enterprise_only
-from tests.platform.helper import api_url, get
 from tests.utils import IcebergTestLocation, wait_for_condition
 
 TABLE = "t"
@@ -309,10 +307,9 @@ def _build_pipeline(name: str, sql: str, *, fault_tolerant: bool = False):
 
 
 def _metric(pipeline_name: str, metric_name: str) -> float:
-    response = get(api_url(f"/pipelines/{pipeline_name}/metrics?format=prometheus"))
-    assert response.status_code == HTTPStatus.OK, response.text
+    scrape = TEST_CLIENT.get_pipeline_metrics(pipeline_name)
     pattern = rf'^{re.escape(metric_name)}\{{[^}}]*endpoint="{re.escape(ENDPOINT)}"[^}}]*\}}\s+(\S+)'
-    for line in response.text.splitlines():
+    for line in scrape.splitlines():
         match = re.match(pattern, line)
         if match:
             return float(match.group(1))


### PR DESCRIPTION
The iceberg and delta platform tests scrape `/metrics?format=prometheus` with the raw no-retry test helper, so a restarted pipeline pod's brief unreachable window (503 `PipelineInteractionUnreachable` while per-pod DNS and the dataplane settle) fails the suite on a single connect timeout. 

Changes:

| Piece | What |
|---|---|
| `FelderaClient.get_pipeline_metrics(name, format="prometheus")` | GET `/pipelines/{name}/metrics` through the SDK's retrying HTTP layer; returns Prometheus text as `str`, or parsed JSON for `format="json"` |
| `Pipeline.metrics(format=...)` | thin wrapper next to `stats()` |
| `test_iceberg_input.py`, `test_delta_input_catchup.py` | `_metric`/`_delta_metric` scrape via the SDK instead of the raw helper; regex parsing unchanged |

No new plumbing: `__validate` already returns `.text` for `text/plain`, the pipeline serves the scrape as exactly `text/plain`, and the manager proxy forwards headers verbatim.

An audit of the remaining raw pod-facing calls in the python tests found no other exposed site: every other one either sits behind `wait_for_pipeline_reachable` or follows an SDK call that has already proven the pod reachable.