### PR TITLE
[docs] Update Delta input docs to with correct config param

### DIFF
--- a/docs.feldera.com/docs/connectors/sources/delta.md
+++ b/docs.feldera.com/docs/connectors/sources/delta.md
@@ -150,7 +150,7 @@ along with the following configuration options
     </TabItem>
 </Tabs>
 
-A typical connector config includes `unity_client_id`, `unity_client_secret`,  and `unity_host` options.
+A typical connector config includes `unity_client_id`, `unity_client_secret`,  and `databricks_host` options.
 You may need to configure additional object store-specific properties,
 e.g., you may need to configure `aws_region` when opening a Delta table in S3.
 
@@ -472,7 +472,7 @@ Read table snapshot via Unity catalog.
   "mode": "snapshot",
   "unity_client_id": "<CLIENT_ID>",
   "unity_client_secret": "<CLIENT_SECRET>",
-  "unity_host": "https://dbc-XXX-XXX.cloud.databricks.com",
+  "databricks_host": "https://dbc-XXX-XXX.cloud.databricks.com",
   "aws_region": "us-west-1"
 }
 ```


### PR DESCRIPTION
Docs had invalid unity_host param stil listed in the example and config description. Removed outdated/invalid references

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
