### PR TITLE
ci: update feldera-dev image tooling

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -23,7 +23,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -23,7 +23,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,7 +35,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,7 +35,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -24,7 +24,7 @@ jobs:
       AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
       AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,7 +78,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -24,7 +24,7 @@ jobs:
       AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
       AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,7 +78,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -170,7 +170,7 @@ jobs:
   adjust-versions:
     runs-on: [gke-runners-amd64]
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
           cache-dependency-glob: "python/uv.lock"
       - name: "Set up Python"
@@ -90,7 +90,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -139,7 +139,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -170,7 +170,7 @@ jobs:
   adjust-versions:
     runs-on: [gke-runners-amd64]
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -20,7 +20,7 @@ jobs:
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   main:
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     runs-on: [gke-runners-amd64]
     steps:
       # Compute the internal-PR boolean once so individual steps can reference

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -20,7 +20,7 @@ jobs:
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   main:
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     runs-on: [gke-runners-amd64]
     steps:
       # Compute the internal-PR boolean once so individual steps can reference

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -39,7 +39,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'release' }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -39,7 +39,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'release' }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
           cache-dependency-glob: "python/uv.lock"
       - name: "Set up Python"
@@ -70,7 +70,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -105,7 +105,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
         with:
-          version: "0.11.3"
+          version: "0.12.5"
           enable-cache: true
       - name: "Set up Python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -32,7 +32,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     services:
       postgres:
         image: debezium/postgres:15
@@ -149,7 +149,7 @@ jobs:
     # it. Pulled from ghcr.io directly: this runner lacks the GCP registry
     # identity the gke runners use for the ghcr-remote mirror.
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: ghcr.io/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     services:
       pubsub:
         image: ghcr.io/feldera/gcloud-pubsub-emulator:e852273e07

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -32,7 +32,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     services:
       postgres:
         image: debezium/postgres:15
@@ -149,7 +149,7 @@ jobs:
     # it. Pulled from ghcr.io directly: this runner lacks the GCP registry
     # identity the gke runners use for the ghcr-remote mirror.
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: ghcr.io/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     services:
       pubsub:
         image: ghcr.io/feldera/gcloud-pubsub-emulator:e852273e07

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -211,7 +211,7 @@ jobs:
       FELDERA_HOST: https://pipeline-manager:8080
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     services:
       pipeline-manager:
         image: ${{ vars.FELDERA_IMAGE_NAME }}:${{ inputs.image_tag || format('sha-{0}', github.sha) }}

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -211,7 +211,7 @@ jobs:
       FELDERA_HOST: https://pipeline-manager:8080
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     services:
       pipeline-manager:
         image: ${{ vars.FELDERA_IMAGE_NAME }}:${{ inputs.image_tag || format('sha-{0}', github.sha) }}

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -42,7 +42,7 @@ jobs:
       AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
       AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -42,7 +42,7 @@ jobs:
       AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
       AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-e9e4499d6414ba10311bd7ef7cd20816e1d9f5c7
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336
+      image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
 
     steps:
       - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,17 +1856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.16",
- "instant",
- "rand 0.8.6",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4109,7 +4098,6 @@ dependencies = [
  "feldera-size-of",
  "feldera-storage",
  "feldera-types",
- "flate2",
  "futures",
  "futures-util",
  "hashbrown 0.14.5",
@@ -4149,16 +4137,13 @@ dependencies = [
  "seq-macro",
  "serde",
  "serde_json",
- "serde_json_path_to_error",
  "smallvec",
  "snap",
- "static_assertions",
  "tar",
  "tarpc",
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
- "thread-id",
  "time",
  "tokio",
  "tokio-util",
@@ -4192,19 +4177,16 @@ dependencies = [
  "atomic",
  "awc",
  "aws-config",
- "aws-credential-types",
  "aws-lc-rs",
  "aws-msk-iam-sasl-signer",
  "aws-sdk-dynamodb",
  "aws-sdk-s3",
  "aws-sigv4",
  "aws-types",
- "backoff",
  "backtrace",
  "base64 0.22.1",
  "bstr",
  "buoyant_kernel",
- "bytemuck",
  "bytes",
  "bytestring",
  "chrono",
@@ -4227,8 +4209,6 @@ dependencies = [
  "enum-map",
  "erased-serde 0.3.31",
  "etl",
- "etl-config",
- "etl-postgres",
  "feldera-adapterlib",
  "feldera-datagen",
  "feldera-iceberg",
@@ -4241,7 +4221,6 @@ dependencies = [
  "feldera-storage",
  "feldera-types",
  "feldera_rust_decimal",
- "flate2",
  "form_urlencoded",
  "futures",
  "futures-timer",
@@ -4261,10 +4240,7 @@ dependencies = [
  "nix 0.29.0",
  "nonzero_ext",
  "num-bigint",
- "num-derive",
- "num-traits",
  "once_cell",
- "ordered-float 4.6.0",
  "parking_lot 0.12.4",
  "parquet",
  "postgres",
@@ -4296,11 +4272,9 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2 0.10.9",
- "smallstr",
  "smallvec",
  "tempfile",
  "test_bin",
- "thread-id",
  "threadpool",
  "tokio",
  "tokio-postgres 0.7.18",
@@ -4314,7 +4288,6 @@ dependencies = [
  "uuid",
  "vergen-gitcl",
  "xxhash-rust",
- "zip",
 ]
 
 [[package]]
@@ -4343,7 +4316,6 @@ dependencies = [
  "serde",
  "serde_with",
  "time",
- "tracing",
  "tracing-log",
  "tracing-subscriber",
 ]
@@ -5381,11 +5353,8 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_arrow",
- "serde_dynamo",
  "serde_json",
  "serde_json_path_to_error",
- "serde_yaml",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "xxhash-rust",
@@ -5395,7 +5364,6 @@ dependencies = [
 name = "feldera-buffer-cache"
 version = "0.336.0"
 dependencies = [
- "crossbeam-utils",
  "enum-map",
  "feldera-types",
  "proptest",
@@ -5437,7 +5405,6 @@ dependencies = [
  "rand 0.8.6",
  "rand_distr",
  "range-set",
- "rmpv",
  "serde",
  "serde_json",
  "tokio",
@@ -5449,7 +5416,6 @@ dependencies = [
 name = "feldera-fxp"
 version = "0.336.0"
 dependencies = [
- "bytecheck",
  "dbsp",
  "feldera-size-of",
  "feldera-types",
@@ -5457,7 +5423,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.6",
- "rand_distr",
  "rkyv",
  "serde",
  "serde_json",
@@ -5517,11 +5482,8 @@ dependencies = [
 name = "feldera-observability"
 version = "0.336.0"
 dependencies = [
- "actix-http",
- "awc",
  "chrono",
  "colored",
- "reqwest 0.12.24",
  "serde_json",
  "sysinfo 0.38.4",
  "tracing",
@@ -5558,7 +5520,6 @@ dependencies = [
  "feldera-size-of",
  "flate2",
  "itertools 0.14.0",
- "libc",
  "mach2 0.6.0",
  "memory-stats",
  "nix 0.29.0",

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -15,7 +15,7 @@ publish = true
 
 [features]
 with-avro = ["apache-avro"]
-with-dynamodb = ["aws-sdk-dynamodb", "serde_dynamo"]
+with-dynamodb = ["aws-sdk-dynamodb"]
 
 [dependencies]
 feldera-types = { workspace = true }
@@ -24,7 +24,6 @@ feldera-storage = { workspace = true }
 dbsp = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
 aws-sdk-dynamodb = { workspace = true, optional = true }
-serde_yaml = { workspace = true }
 actix-web = { workspace = true, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
 erased-serde = { workspace = true }
 dyn-clone = { workspace = true }
@@ -32,7 +31,6 @@ arrow = { workspace = true, features = ["chrono-tz"] }
 apache-avro = { workspace = true, optional = true }
 serde_arrow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_dynamo = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true, features = ["with-serde"] }
@@ -43,7 +41,6 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 datafusion = { workspace = true }
 datafusion-functions-json = { workspace = true }
-thiserror = { workspace = true }
 serde_json_path_to_error = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -72,7 +72,7 @@ iceberg-tests-s3tables = []
 iceberg-tests-follow = []
 fips = ["rustls/fips", "aws-lc-rs/fips"]
 bench-mode = []
-with-postgres-cdc = ["etl", "etl-config", "etl-postgres"]
+with-postgres-cdc = ["etl"]
 # jemalloc heap-profiling endpoint (/heap_profile). Linux-only dep; on other
 # targets the feature is a no-op.
 with-heap-profiling = ["dep:jemalloc_pprof"]
@@ -161,7 +161,10 @@ deltalake = { workspace = true, features = [
     "azure",
     "unity-experimental",
 ], optional = true }
-deltalake-catalog-unity = { workspace = true, features = ["aws", "azure", "gcp"], optional = true}
+# No code here calls it; deltalake re-exports the crate. The direct declaration
+# enables its aws/azure/gcp features, which provide cloud credentials for the
+# unity catalog.
+deltalake-catalog-unity = { workspace = true, features = ["aws", "azure", "gcp"], optional = true }
 apache-avro = { workspace = true, optional = true }
 schema_registry_converter = { workspace = true, features = [
     "avro",
@@ -173,7 +176,6 @@ rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1",
     "tokio-pg",
 ] }
 url = { workspace = true }
-ordered-float = { workspace = true }
 atomic = { workspace = true }
 once_cell = { workspace = true }
 dbsp_nexmark = { workspace = true, features = [], optional = true }
@@ -205,9 +207,6 @@ redis = { workspace = true, features = ["r2d2"], optional = true }
 r2d2 = { workspace = true, optional = true }
 async-channel = { workspace = true }
 threadpool = { workspace = true }
-bytemuck = { workspace = true }
-num-derive = { workspace = true }
-num-traits = { workspace = true } # Used by num-derive derive macro, which cargo-machete can't see
 postgres = { workspace = true }
 dyn-clone = { workspace = true }
 cpu-time = "1.0.0"
@@ -217,7 +216,6 @@ tokio-postgres-rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 base64 = { workspace = true }
 aws-msk-iam-sasl-signer = "1.0.1"
-aws-credential-types = "1.2.3"
 # No code here calls it; the AWS SDK pulls it transitively. The declaration
 # floors the version at 1.4.5, where SigV4a signing stopped using ring. A
 # lockfile regenerated during a rebase resolved it back below that twice; a
@@ -230,22 +228,15 @@ itertools = { workspace = true }
 metrics-process = { version = "2.4.0", default-features = false }
 rustls = { workspace = true }
 serde_json_path_to_error = { workspace = true }
-smallstr = { workspace = true }
 dashmap = { workspace = true }
-thread-id = { workspace = true }
 parking_lot = { workspace = true }
-backoff = { workspace = true }
-zip = { workspace = true }
 smallvec = { workspace = true }
 delta_kernel = { workspace = true }
 roaring = { workspace = true, optional = true }
-flate2 = { workspace = true }
 etl = { workspace = true, optional = true }
-etl-config = { workspace = true, optional = true }
-etl-postgres = { workspace = true, optional = true }
 
 [package.metadata.cargo-machete]
-ignored = ["num-traits", "aws-sigv4"]
+ignored = ["aws-sigv4", "deltalake-catalog-unity"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Optional so the SQL test fixture (sql-to-dbsp-compiler/temp), which builds

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -179,9 +179,8 @@ use feldera_types::constants::{STATE_FILE, STEPS_FILE};
 use feldera_types::format::json::{JsonFlavor, JsonParserConfig, JsonUpdateFormat};
 pub use feldera_types::pipeline_diff::compute_pipeline_diff;
 use feldera_types::program_schema::{SqlIdentifier, canonical_identifier};
-// Connector tests assert that a connector's own error messages stay under the
-// bound the endpoint status enforces.
-#[cfg(test)]
+// Connectors size the payloads they embed in error messages against the bound
+// the endpoint status enforces, and their tests assert they stay under it.
 pub(crate) use stats::MAX_CONNECTOR_ERROR_LEN;
 pub use stats::{CompletionToken, ControllerStatus, ControllerStatusContext, InputEndpointStatus};
 

--- a/crates/adapters/src/integrated/postgres/error.rs
+++ b/crates/adapters/src/integrated/postgres/error.rs
@@ -55,6 +55,16 @@ impl BackoffError {
         }
     }
 
+    /// Byte length of the formatted error chain, so a caller embedding a
+    /// payload in its context can size it to what [`Self::inner`] leaves over.
+    pub fn message_len(&self) -> usize {
+        match self {
+            BackoffError::Permanent(error) | BackoffError::Temporary(error) => {
+                format!("{error:?}").len()
+            }
+        }
+    }
+
     pub fn context(self, context: String) -> Self {
         match self {
             BackoffError::Temporary(error) => BackoffError::Temporary(error.context(context)),

--- a/crates/adapters/src/integrated/postgres/output.rs
+++ b/crates/adapters/src/integrated/postgres/output.rs
@@ -10,7 +10,7 @@ use crate::{ControllerError, PipelineState, util::indexed_operation_type};
 use crate::{
     buffer_op,
     catalog::{RecordFormat, SerBatchReader, SerCursor},
-    controller::{ControllerInner, EndpointId},
+    controller::{ControllerInner, EndpointId, MAX_CONNECTOR_ERROR_LEN},
     flush_op,
     format::{Encoder, OutputConsumer},
     transport::OutputEndpoint,
@@ -297,11 +297,19 @@ impl PostgresWorker {
         if let Err(e) = result {
             // Report only a prefix of the payload: it holds a whole batch of
             // records, up to `max_buffer_size_bytes`, which is far too large
-            // to keep in the error list served by `/stats`.
-            let error = BackoffError::from(e).context(format!(
+            // to keep in the error list served by `/stats`. The postgres error
+            // below the context embeds the failing row, so a fixed prefix
+            // bound can push the whole message past MAX_CONNECTOR_ERROR_LEN;
+            // give the prefix only the room the error chain leaves over.
+            const ERRMSG_HEADROOM_BYTES: usize = 512;
+            let error = BackoffError::from(e);
+            let payload_prefix_budget = MAX_CONNECTOR_ERROR_LEN
+                .saturating_sub(error.message_len() + ERRMSG_HEADROOM_BYTES)
+                .min(MAX_RECORD_LEN_IN_ERRMSG);
+            let error = error.context(format!(
                 "while executing {name} statement for {num_records} record(s) ({} bytes), which start with: {}",
                 v.len(),
-                truncate_ellipse(v, MAX_RECORD_LEN_IN_ERRMSG, "...")
+                truncate_ellipse(v, payload_prefix_budget, "...")
             ));
 
             // Transaction state is decided by whether the error is retry-able.

--- a/crates/buffer-cache/Cargo.toml
+++ b/crates/buffer-cache/Cargo.toml
@@ -11,7 +11,6 @@ publish = true
 description = "Weighted in-memory buffer caches with LRU and S3-FIFO eviction"
 
 [dependencies]
-crossbeam-utils = { workspace = true }
 enum-map = { workspace = true }
 feldera-types = { workspace = true }
 quick_cache = { workspace = true }

--- a/crates/datagen/Cargo.toml
+++ b/crates/datagen/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 governor = { workspace = true }
 fake = { workspace = true, features = ["http"] }
-rmpv = { workspace = true, features = ["with-serde"] }
 serde = { workspace = true, features = ["derive"] }
 async-channel = { workspace = true }
 range-set = { workspace = true }

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -73,7 +73,6 @@ feldera-samply = { workspace = true }
 feldera-types = { workspace = true }
 feldera-macros = { workspace = true }
 libc = { workspace = true }
-static_assertions = { workspace = true }
 zip = { workspace = true }
 ouroboros = { workspace = true }
 tracing = { workspace = true }
@@ -97,10 +96,7 @@ async-stream = { workspace = true }
 futures-util = { workspace = true }
 feldera-buffer-cache = { workspace = true }
 memory-stats = { workspace = true }
-serde_json_path_to_error = { workspace = true }
-flate2 = { workspace = true }
 nix = { workspace = true, features = ["process", "time"] }
-thread-id = { workspace = true }
 pin-project-lite = { workspace = true }
 
 [dev-dependencies]

--- a/crates/feldera-observability/Cargo.toml
+++ b/crates/feldera-observability/Cargo.toml
@@ -11,9 +11,6 @@ authors = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-awc = { workspace = true }
-actix-http = { workspace = true }
-reqwest = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fxp/Cargo.toml
+++ b/crates/fxp/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 dbsp = ["serde", "rkyv", "size_of", "dep:dbsp", "dep:feldera-types"]
 serde = ["dep:serde"]
 rkyv = ["dep:rkyv"]
-validation = ["rkyv", "dep:bytecheck", "rkyv/validation"]
+validation = ["rkyv", "rkyv/validation"]
 size_of = ["dep:size-of"]
 
 [dependencies]
@@ -26,11 +26,9 @@ smallstr = { workspace = true }
 smallvec = { workspace = true }
 size-of = { workspace = true, optional = true }
 rkyv = { workspace = true, features = ["size_64"], optional = true }
-bytecheck = { version = "0.6.12", optional = true }
 dbsp = { workspace = true, optional = true }
 feldera-types = { workspace = true, optional = true }
 rand = { workspace = true, features = ["small_rng"] }
-rand_distr = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/ir/Cargo.toml
+++ b/crates/ir/Cargo.toml
@@ -22,3 +22,7 @@ zip = { workspace = true }
 utoipa = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+
+[package.metadata.cargo-machete]
+# proptest-derive generated code references proptest.
+ignored = ["proptest"]

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -27,7 +27,6 @@ release = false
 dbsp = { workspace = true }
 anyhow = { workspace = true }
 csv = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-log = { workspace = true }
 rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1", features = ["rkyv", "rkyv-64"] }

--- a/crates/rest-api/Cargo.toml
+++ b/crates/rest-api/Cargo.toml
@@ -38,4 +38,5 @@ serde_json = { workspace = true }
 syn = { workspace = true }
 
 [package.metadata.cargo-machete]
-ignored = ["progenitor-client", "chrono", "prettytable-rs", "serde", "serde_json", "uuid"]
+# The build.rs-generated client code references these.
+ignored = ["progenitor-client", "chrono", "serde", "uuid", "reqwest", "feldera-types", "rustversion"]

--- a/crates/samply/Cargo.toml
+++ b/crates/samply/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2024"
 crossbeam = { workspace = true }
 flate2 = { workspace = true }
 itertools = { workspace = true }
-libc = { workspace = true }
 memory-stats = { workspace = true }
 nix = { workspace = true, features = ["process", "time"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/sqllib/Cargo.toml
+++ b/crates/sqllib/Cargo.toml
@@ -63,3 +63,7 @@ size-of = { workspace = true }
 [[bench]]
 name = "flat_variant_serialize"
 harness = false
+
+[package.metadata.cargo-machete]
+# The md-5 package's library is named md5, which cargo-machete cannot match.
+ignored = ["md-5"]

--- a/crates/storage-test-compat/Cargo.toml
+++ b/crates/storage-test-compat/Cargo.toml
@@ -24,3 +24,7 @@ feldera-types = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+
+[package.metadata.cargo-machete]
+# The feldera-macros declare_tuple expansion references these.
+ignored = ["serde", "size-of", "rkyv", "derive_more"]

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update --fix-missing && apt-get install -y \
     nats-server
 
 # Install trufflehog
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin v3.90.1
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin v3.97.0
 
 # Install docker cli tool
 RUN  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
@@ -73,16 +73,42 @@ RUN apt-get update --fix-missing && apt-get install -y nodejs
 
 # Install helm cli tool
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod +x get_helm.sh \
-    && ./get_helm.sh --version v3.17.1 \
+    && ./get_helm.sh --version v3.21.4 \
     && rm ./get_helm.sh
 
-# Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/v1.33.0/bin/linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/kubectl" \
+# Install kubectl. Stay within one minor version of the EKS clusters (1.34),
+# per the kubectl version-skew policy.
+RUN curl -LO "https://dl.k8s.io/release/v1.34.10/bin/linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/kubectl" \
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/
 
 # Install k3d
-RUN curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.3 bash
+RUN curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.9.0 bash
+
+# Install the GitHub CLI
+RUN arch=`dpkg --print-architecture`; \
+    curl -LO https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_$arch.tar.gz \
+    && tar -xzf gh_2.97.0_linux_$arch.tar.gz \
+    && mv gh_2.97.0_linux_$arch/bin/gh /usr/local/bin/ \
+    && rm -rf gh_2.97.0_linux_$arch gh_2.97.0_linux_$arch.tar.gz
+
+# Install actionlint (GitHub Actions workflow linter)
+RUN arch=`dpkg --print-architecture`; \
+    curl -LO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_$arch.tar.gz \
+    && tar -xzf actionlint_1.7.12_linux_$arch.tar.gz actionlint \
+    && mv actionlint /usr/local/bin/ \
+    && rm actionlint_1.7.12_linux_$arch.tar.gz
+
+# terraform, tflint, and trivy for pre-commit hooks
+RUN arch=`dpkg --print-architecture`; \
+    curl -LO https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_linux_$arch.zip \
+    && unzip terraform_1.15.8_linux_$arch.zip terraform -d /usr/local/bin/ \
+    && rm terraform_1.15.8_linux_$arch.zip
+RUN arch=`dpkg --print-architecture`; \
+    curl -LO https://github.com/terraform-linters/tflint/releases/download/v0.64.0/tflint_linux_$arch.zip \
+    && unzip tflint_linux_$arch.zip -d /usr/local/bin/ \
+    && rm tflint_linux_$arch.zip
+RUN curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.74.0
 
 FROM install-pkgs AS base
 
@@ -127,15 +153,15 @@ ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.bun/bin:/home/ubuntu/.cargo/bin:
 ENV RUSTUP_HOME=/home/ubuntu/.rustup
 ENV CARGO_HOME=/home/ubuntu/.cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile default --default-toolchain 1.93.1
-RUN cargo install --locked cargo-machete@0.7.0 cargo-edit@0.13.1 just@1.40.0
+RUN cargo install --locked cargo-machete@0.9.2 cargo-edit@0.13.13 just@1.58.0
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/0.11.3/install.sh | sh
+RUN curl -LsSf https://astral.sh/uv/0.12.5/install.sh | sh
 RUN uv python install 3.10
 RUN uv tool install pre-commit --with pre-commit-uv --force-reinstall
 
 # Install Bun.js
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
 
 # Install gradle, the version needs to match the version that calcite uses which avoid reinstalling this every time we run build.sh
 RUN cd /home/ubuntu \
@@ -145,16 +171,16 @@ RUN cd /home/ubuntu \
 
 # The download URL for mold uses x86_64/aarch64 whereas dpkg --print-architecture says amd64/arm64
 RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
-    cd /home/ubuntu && curl -LO https://github.com/rui314/mold/releases/download/v2.40.1/mold-2.40.1-$arch-linux.tar.gz \
-    && tar -xzvf mold-2.40.1-$arch-linux.tar.gz \
-    && mv mold-2.40.1-$arch-linux /home/ubuntu/mold \
-    && rm mold-2.40.1-$arch-linux.tar.gz
+    cd /home/ubuntu && curl -LO https://github.com/rui314/mold/releases/download/v2.42.0/mold-2.42.0-$arch-linux.tar.gz \
+    && tar -xzvf mold-2.42.0-$arch-linux.tar.gz \
+    && mv mold-2.42.0-$arch-linux /home/ubuntu/mold \
+    && rm mold-2.42.0-$arch-linux.tar.gz
 
 # Install sccache
 RUN  arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
-    cd /home/ubuntu && curl -LO https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-$arch-unknown-linux-musl.tar.gz \
-    && tar zxvf sccache-v0.15.0-$arch-unknown-linux-musl.tar.gz \
-    && cp sccache-v0.15.0-$arch-unknown-linux-musl/sccache /home/ubuntu/.cargo/bin \
+    cd /home/ubuntu && curl -LO https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-$arch-unknown-linux-musl.tar.gz \
+    && tar zxvf sccache-v0.17.0-$arch-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.17.0-$arch-unknown-linux-musl/sccache /home/ubuntu/.cargo/bin \
     && chmod +x /home/ubuntu/.cargo/bin/sccache
 
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold -C link-arg=-Wl,--compress-debug-sections=zlib"
@@ -172,4 +198,3 @@ COPY Cargo.lock /tmp/Cargo.lock
 RUN CARGO_LOCK=/tmp/Cargo.lock PREFIX=/usr/local bash /tmp/install-librdkafka.sh \
     && rm -f /tmp/install-librdkafka.sh /tmp/Cargo.lock
 USER ubuntu
-

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -110,6 +110,13 @@ RUN arch=`dpkg --print-architecture`; \
     && rm tflint_linux_$arch.zip
 RUN curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.74.0
 
+# dnscontrol deploys DNS in the infrastructure repo
+RUN arch=`dpkg --print-architecture`; \
+    curl -LO https://github.com/StackExchange/dnscontrol/releases/download/v4.46.0/dnscontrol_4.46.0_linux_$arch.tar.gz \
+    && tar -xzf dnscontrol_4.46.0_linux_$arch.tar.gz dnscontrol \
+    && mv dnscontrol /usr/local/bin/ \
+    && rm dnscontrol_4.46.0_linux_$arch.tar.gz
+
 FROM install-pkgs AS base
 
 # Modify ubuntu user UID/GID to 1001 and create docker group with GID 123


### PR DESCRIPTION
Updates the feldera-dev CI image and switches all jobs to it.

Version bumps (rust stays at 1.93.1): sccache 0.17.0, cargo-machete 0.9.2, cargo-edit 0.13.13, just 1.58.0, uv 0.12.5, bun 1.3.14, mold 2.42.0, helm 3.21.4 (stays on v3; v4 is a breaking major), kubectl 1.34.10 (EKS runs 1.34, skew policy allows one minor), k3d 5.9.0, trufflehog 3.97.0.

New tools: gh 2.97.0, actionlint 1.7.12, tflint 0.64.0, terraform 1.15.8, trivy 0.74.0.

cargo-machete 0.9.2 detects more unused dependencies: 29 dropped, false positives restored with ignore entries (md-5, generated-code deps in rest-api/fda/ir/storage-test-compat, deltalake-catalog-unity for feature unification).

Verified: image builds locally on arm64 with all tools at the expected versions; cargo check --workspace --all-targets and pre-commit --all-files pass.

Image: ghcr.io/feldera/feldera-dev:sha-caf7c73bda49a3f8c078b55164bec0537f3d6336 (built from this branch by run 32184156228).