### PR TITLE
[adapters] pg-out: keep the backtrace out of the connector's error message

### DIFF
--- a/crates/adapters/src/integrated/postgres/error.rs
+++ b/crates/adapters/src/integrated/postgres/error.rs
@@ -46,11 +46,17 @@ impl BackoffError {
         }
     }
 
+    /// Flattens the error and everything it is chained to into one message.
+    ///
+    /// `{:#}` walks the chain, so the server's message and its DETAIL survive,
+    /// which is the whole reason the postgres error is chained rather than
+    /// interpolated. `{:?}` walks it too, but also prints the backtrace anyhow
+    /// captured, which runs to kilobytes whenever `RUST_BACKTRACE` is set and
+    /// leaves no room under the cap the endpoint status applies.
     pub fn inner(self) -> anyhow::Error {
         match self {
             BackoffError::Permanent(error) | BackoffError::Temporary(error) => {
-                // include the context info
-                anyhow!("{error:?}")
+                anyhow!("{error:#}")
             }
         }
     }


### PR DESCRIPTION
`test_pg_error_message_is_bounded` fails whenever `RUST_BACKTRACE` is set, which is how CI runs the adapter tests.

`BackoffError::inner` formats with `{:?}`, which prints the error chain and the backtrace anyhow captured with it. The backtrace came to 3816 of the message's 8612 bytes, so the message no longer fitted the 8 KiB the endpoint status allows, and the status layer elided its middle. The test asserts that it never has to, since a connector is expected to bound what it quotes.

Format with `{:#}` instead. It walks the chain the same way, so the server's message and its DETAIL still reach the report, which is why the postgres error is chained rather than interpolated in the first place. What it leaves out is the backtrace, whose size depends on the toolchain and the architecture rather than on anything the connector did. The same message is now 4796 bytes.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
