### PR TITLE
adapters: pg-out: restore the {:#} error formatting from #6889

### DIFF
--- a/crates/adapters/src/integrated/postgres/error.rs
+++ b/crates/adapters/src/integrated/postgres/error.rs
@@ -63,10 +63,11 @@ impl BackoffError {
 
     /// Byte length of the formatted error chain, so a caller embedding a
     /// payload in its context can size it to what [`Self::inner`] leaves over.
+    /// Formats with `{:#}` for the same reason [`Self::inner`] does.
     pub fn message_len(&self) -> usize {
         match self {
             BackoffError::Permanent(error) | BackoffError::Temporary(error) => {
-                format!("{error:?}").len()
+                format!("{error:#}").len()
             }
         }
     }


### PR DESCRIPTION
The rebase of #6884 resolved crates/adapters/src/integrated/postgres/error.rs by keeping its branch side, which reverted 2ba7f442c (pg-out: keep the backtrace out of the connector's error message). Restore it, and format message_len with {:#} so the payload prefix budget from #6884 measures what inner() actually emits instead of the backtrace-inflated chain.