### PR TITLE
docs: document sccache S3 SSE-KMS settings

### DIFF
--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -188,7 +188,8 @@ RUN  arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x8
     cd /home/ubuntu && curl -LO https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-$arch-unknown-linux-musl.tar.gz \
     && tar zxvf sccache-v0.17.0-$arch-unknown-linux-musl.tar.gz \
     && cp sccache-v0.17.0-$arch-unknown-linux-musl/sccache /home/ubuntu/.cargo/bin \
-    && chmod +x /home/ubuntu/.cargo/bin/sccache
+    && chmod +x /home/ubuntu/.cargo/bin/sccache \
+    && rm -rf sccache-v0.17.0-$arch-unknown-linux-musl.tar.gz sccache-v0.17.0-$arch-unknown-linux-musl
 
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold -C link-arg=-Wl,--compress-debug-sections=zlib"
 

--- a/docs.feldera.com/docs/get-started/enterprise/helm-chart-reference.md
+++ b/docs.feldera.com/docs/get-started/enterprise/helm-chart-reference.md
@@ -132,6 +132,8 @@ When running multiple compiler replicas, sccache allows them to share compiled a
 | `parallelCompilation.sccache.s3.endpoint` | *(unset)* | Custom S3-compatible server endpoint (e.g., `minio.svc.cluster.local:9000`). Omit for AWS S3. |
 | `parallelCompilation.sccache.s3.existingSecret` | *(unset)* | Name of a Kubernetes secret with `access_key_id` and `secret_access_key` keys. Omit if using IRSA. |
 | `parallelCompilation.sccache.s3.serverSideEncryption` | *(unset)* | Enable server-side encryption with S3-managed keys (SSE-S3). |
+| `parallelCompilation.sccache.s3.serverSideEncryptionAwsKms` | *(unset)* | Enable SSE-KMS with the AWS-managed key (`aws/s3`). Requires sccache 0.17 or newer. |
+| `parallelCompilation.sccache.s3.serverSideEncryptionKmsKeyId` | *(unset)* | Enable SSE-KMS with a customer-managed KMS key, given as its ARN. Takes precedence over the two settings above. Requires sccache 0.17 or newer, and `kms:GenerateDataKey` plus `kms:Decrypt` on the key. |
 
 ---
 

--- a/docs.feldera.com/docs/get-started/enterprise/parallel-compilation.md
+++ b/docs.feldera.com/docs/get-started/enterprise/parallel-compilation.md
@@ -93,6 +93,16 @@ Use either IRSA (IAM Roles for Service Accounts) or a Kubernetes secret with S3 
   ```
 The secret must define keys `access_key_id` and `secret_access_key`. You can configure the secret name in `values.yaml`.
 
+If you encrypt the cache bucket with KMS (`serverSideEncryptionAwsKms` or
+`serverSideEncryptionKmsKeyId`), the principal above also needs
+`kms:GenerateDataKey` and `kms:Decrypt` on the key. Without them the bucket
+permissions look correct but every cache write fails.
+
+Both KMS settings require a Feldera release that ships sccache 0.17 or newer.
+Setting them on an older release makes sccache reject its entire configuration,
+not just the unknown keys, which disables the cache rather than only the
+encryption.
+
 
 **2. Configure sccache in `values.yaml`**
 
@@ -121,6 +131,14 @@ parallelCompilation:
       #
       # Server-side encryption (optional)
       # serverSideEncryption: false
+      #
+      # Server-side encryption with KMS (optional). Encrypt with the
+      # AWS-managed key (aws/s3):
+      # serverSideEncryptionAwsKms: true
+      #
+      # ... or with a customer-managed KMS key, which takes precedence over
+      # both settings above:
+      # serverSideEncryptionKmsKeyId: "arn:aws:kms:us-east-1:111122223333:key/<key-id>"
       #
       # Existing secret containing S3 credentials
       # The secret must have keys: access_key_id and secret_access_key
@@ -302,6 +320,8 @@ Comman causes can be misconfigured S3 bucket / endpoint / credentials.
 |-----|-------------|---------|
 | `parallelCompilation.sccache.s3.existingSecret` | Secret for S3 credentials (omit if using IRSA) | `sccache-s3-secret` |
 | `parallelCompilation.sccache.s3.serverSideEncryption` | Enable server-side encryption with s3 managed key (SSE-S3) | `false` |
+| `parallelCompilation.sccache.s3.serverSideEncryptionAwsKms` | Enable SSE-KMS with the AWS-managed key (`aws/s3`). Requires sccache 0.17 or newer | `true` |
+| `parallelCompilation.sccache.s3.serverSideEncryptionKmsKeyId` | Enable SSE-KMS with a customer-managed KMS key. Takes precedence over the two settings above. Requires sccache 0.17 or newer | `arn:aws:kms:us-east-1:111122223333:key/<key-id>` |
 | `parallelCompilation.sccache.s3.endpoint` | Custom endpoint (e.g. MinIO) | `minio.mydomain.com:9000` |
 
 **Autoscaling (experimental)**


### PR DESCRIPTION
Note the sccache 0.17 requirement and the kms:GenerateDataKey and
kms:Decrypt grants the compiler server needs on the key.

also remove the sccache tarball from the build image
The neighbouring gh and aws installs already clean up after
themselves; this block shipped its tarball and unpacked tree.

tried locally with docker, but didn't try SSE-KMS against real AWS S3 + KMS.
