### PR TITLE
[adapters] Fix delta S3 tests.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -3461,18 +3461,22 @@ async fn delta_table_cdc_s3_test_suspend() {
     let object_store_config = [
         (
             "aws_access_key_id".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap(),
+            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID")
+                .unwrap()
+                .into(),
         ),
         (
             "aws_secret_access_key".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap(),
+            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY")
+                .unwrap()
+                .into(),
         ),
         // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
-        ("aws_region".to_string(), "us-east-2".to_string()),
-        ("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".to_string()),
+        ("aws_region".to_string(), "us-east-2".into()),
+        ("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".into()),
     ]
     .into_iter()
-    .collect::<HashMap<_, _>>();
+    .collect::<HashMap<String, Value>>();
 
     let input_table_uri = format!("s3://feldera-delta-table-test/{input_uuid}/");
 


### PR DESCRIPTION
These tests don't run by default and we periodically break them.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
