### PR TITLE
[web-console] Fix transient test failure due to reverse scroll mechanism not aborting

### DIFF
--- a/js-packages/common-ui/src/lib/LogList.svelte
+++ b/js-packages/common-ui/src/lib/LogList.svelte
@@ -155,8 +155,9 @@
       if (idx < 0) {
         return
       }
-      // Drop stick-to-bottom so a streaming log doesn't scroll away from the match the user
-      // jumped to. They regain auto-scroll by scrolling back to the bottom themselves.
+      // Drop stick-to-bottom so a streaming log doesn't scroll away from the match
+      // we programmatically scrolled (jumped) to.
+      // Releasing stick-to-bottom before the jump also cancels any auto-scroll already in flight.
       reverseScroll.stickToBottom = false
       virtualizer?.scrollToIndex(idx, { align: 'center' })
       let attempts = 0

--- a/js-packages/common-ui/src/lib/useReverseScrollContainer.svelte.ts
+++ b/js-packages/common-ui/src/lib/useReverseScrollContainer.svelte.ts
@@ -34,16 +34,35 @@ export const useReverseScrollContainer = (
     })
   }
 
+  // Scrolling to the bottom is not finished in one go: it is executed in two animation frames
+  // (see `scrollToBottom` below). This counter is how a scheduled scroll learns that it is no
+  // longer wanted. It goes up whenever a caller sets `stickToBottom` to false, which means the
+  // scroll was set programmatically. A waiting scroll remembers the count it was scheduled with,
+  // and does nothing if that count has changed by the time it runs.
+  let unstickCount = 0
+
+  // Run `scroll` on the next animation frame, unless the caller moves the view away in between.
+  const queueScrollPass = (scroll: () => void) => {
+    const unstickCountWhenQueued = unstickCount
+    requestAnimationFrame(() => {
+      if (unstickCountWhenQueued === unstickCount) {
+        scroll()
+      }
+    })
+  }
+
+  // Scroll down twice, one frame apart. Rows are measured only once they are on the page, so the
+  // first scroll usually brings more of them into view and pushes the real bottom further down.
   const scrollToBottom = () => {
     scrollToBottomImpl()
-    requestAnimationFrame(scrollToBottomImpl)
+    queueScrollPass(scrollToBottomImpl)
   }
 
   let lastSize: number = 0
 
   const onResize = (change: 'expanded' | 'contracted') => {
     if (stickToBottom) {
-      requestAnimationFrame(scrollToBottom)
+      queueScrollPass(scrollToBottom)
     }
   }
 
@@ -143,6 +162,11 @@ export const useReverseScrollContainer = (
       return debouncedStickToBottom.current
     },
     set stickToBottom(value: boolean) {
+      if (!value) {
+        // The caller is taking the view somewhere else, so drop any scroll to the bottom that is
+        // still waiting for its animation frame. See `unstickCount` above.
+        unstickCount++
+      }
       stickToBottom = value
     }
   }

--- a/js-packages/web-console/src/lib/components/common/ReverseScrollFixture.svelte
+++ b/js-packages/web-console/src/lib/components/common/ReverseScrollFixture.svelte
@@ -1,0 +1,30 @@
+<!--
+  Harness for common-ui's `useReverseScrollContainer`: a scroll container whose content height the
+  test sets directly. A virtualiser would keep resizing the content on its own as it measures rows,
+  which is exactly what makes the timing under test hard to pin down; a single div resizes only when
+  the test says so.
+-->
+<script lang="ts">
+  import { useReverseScrollContainer } from 'common-ui'
+
+  let contentHeight = $state(1000)
+
+  const reverseScroll = useReverseScrollContainer({
+    observeContentElement: (node) => node.firstElementChild!
+  })
+
+  // Instance exports: the test drives the resize and the jump away from the bottom itself, so it
+  // owns the order of the two.
+  export const scroll = reverseScroll
+  export function setContentHeight(px: number) {
+    contentHeight = px
+  }
+</script>
+
+<div
+  data-testid="reverse-scroll-container"
+  style="height: 200px; overflow-y: auto;"
+  use:reverseScroll.action
+>
+  <div style="height: {contentHeight}px;"></div>
+</div>

--- a/js-packages/web-console/src/lib/components/common/useReverseScrollContainer.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/common/useReverseScrollContainer.svelte.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for the stick-to-bottom scroll container behind the Logs tab, the change stream
+ * and the ad-hoc query results (common-ui's `useReverseScrollContainer`).
+ *
+ * A scroll-to-bottom is queued a frame ahead by the resize observer and runs a second pass a frame
+ * after that, so growing content is re-anchored once the virtualiser has measured what it mounted.
+ * Both deferred passes run after whatever else happened in between, which is what these two tests
+ * pull apart: content that grows before the previous scroll event was delivered still has to
+ * re-anchor, while a deliberate jump away from the bottom (LogList scrolling to a search match) has
+ * to survive.
+ */
+
+import { flushSync } from 'svelte'
+import { afterEach, describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import ReverseScrollFixture from './ReverseScrollFixture.svelte'
+
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+let mounted: { unmount: () => Promise<void> } | undefined
+let mountTarget: HTMLDivElement | undefined
+
+const mountFixture = () => {
+  mountTarget = document.createElement('div')
+  document.body.appendChild(mountTarget)
+  const result = render(ReverseScrollFixture, { target: mountTarget } as any)
+  mounted = result
+  return {
+    component: result.component,
+    container: mountTarget.querySelector<HTMLDivElement>('[data-testid=reverse-scroll-container]')!
+  }
+}
+
+describe('useReverseScrollContainer', () => {
+  afterEach(async () => {
+    await mounted?.unmount()
+    mounted = undefined
+    mountTarget?.remove()
+    mountTarget = undefined
+  })
+
+  it('still scrolls down when the content grew before the last scroll was reported', async () => {
+    const { component, container } = mountFixture()
+    // Mounting sticks to the bottom of 1000px of content in a 200px box, synchronously.
+    expect(container.scrollTop).toBe(800)
+
+    // No wait here on purpose: the scroll event for the mount scroll is still undelivered, so
+    // `onscroll` reads 800 against the grown content and reports "not the bottom". A live feed
+    // outruns its own scroll events the same way, and the view still has to follow it down.
+    component.setContentHeight(4000)
+    flushSync()
+    await expect.poll(() => container.scrollTop).toBe(3800)
+  })
+
+  it('does not scroll down after the caller unstuck the view and scrolled elsewhere', async () => {
+    const { component, container } = mountFixture()
+    // Settle first: the scroll event for the mount scroll has to be delivered while the content is
+    // still 1000px tall, or `onscroll` reports "not the bottom" and the resize below queues no
+    // scroll pass at all - leaving nothing for this test to race.
+    await nextFrame()
+    await nextFrame()
+    expect(container.scrollTop).toBe(800)
+
+    component.setContentHeight(4000)
+    flushSync()
+    // The resize observer is delivered at the end of a frame, after that frame's animation-frame
+    // callbacks, so its scroll pass is queued for the next frame. Two frames land us in that next
+    // frame with the pass still pending: this callback was registered a frame earlier than the
+    // observer's, and a microtask checkpoint runs between the two.
+    await nextFrame()
+    await nextFrame()
+
+    // What LogList does when a search hits a match: give up the bottom, then scroll to the row.
+    component.scroll.stickToBottom = false
+    container.scrollTop = 500
+
+    await nextFrame()
+    await nextFrame()
+    await nextFrame()
+    expect(container.scrollTop).toBe(500)
+  })
+})


### PR DESCRIPTION
Fixes this CI failure:
https://github.com/feldera/feldera/pull/6727

The issue was the test scenario uncovers an issue in implementation where opening the log panel (which automatically sticks the viewport to bottom of the log) and then immediately programmatically scrolling to a search result makes the viewport scroll back to bottom when it shouldn't.

Testing: tested log behavior remains as expected