### PR TITLE
[adapters] Detect a pipeline restart during (sync-)checkpoint wait.

### DIFF
--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -60,7 +60,8 @@ use feldera_types::adapter_stats::{
 };
 use feldera_types::checkpoint::{
     CheckpointFailure, CheckpointPullStatus, CheckpointResponse, CheckpointStatus,
-    CheckpointSyncFailure, CheckpointSyncResponse, CheckpointSyncStatus, HostInfo,
+    CheckpointStatusQuery, CheckpointSyncFailure, CheckpointSyncResponse, CheckpointSyncStatus,
+    HostInfo,
 };
 use feldera_types::completion_token::{
     CompletionStatusArgs, CompletionStatusResponse, CompletionTokenResponse,
@@ -2252,6 +2253,7 @@ async fn checkpoint_sync(state: WebData<ServerState>) -> Result<HttpResponse, Pi
         }));
     };
 
+    let incarnation_uuid = state.incarnation_uuid;
     spawn(async move {
         let result = controller.async_sync_checkpoint(last_checkpoint).await;
         state
@@ -2261,7 +2263,10 @@ async fn checkpoint_sync(state: WebData<ServerState>) -> Result<HttpResponse, Pi
             .completed(last_checkpoint, result);
     });
 
-    Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(last_checkpoint)))
+    Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(
+        last_checkpoint,
+        incarnation_uuid,
+    )))
 }
 
 /// Request body for `POST /coordination/checkpoint/push`.
@@ -2293,6 +2298,7 @@ async fn coordination_checkpoint_push(
         }));
     }
 
+    let incarnation_uuid = state.incarnation_uuid;
     spawn(async move {
         let result = controller.async_sync_checkpoint(uuid).await;
         state
@@ -2302,7 +2308,25 @@ async fn coordination_checkpoint_push(
             .completed(uuid, result);
     });
 
-    Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(uuid)))
+    Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(uuid, incarnation_uuid)))
+}
+
+/// Checks a client-supplied incarnation UUID (from `CheckpointStatusQuery`).
+///
+/// `requested` is `None` for old clients that don't supply an UUID.
+fn check_incarnation_uuid(
+    state: &ServerState,
+    requested: Option<Uuid>,
+) -> Result<(), PipelineError> {
+    if let Some(requested) = requested
+        && requested != state.incarnation_uuid
+    {
+        return Err(PipelineError::IncarnationUuidMismatch {
+            requested,
+            expected: state.incarnation_uuid,
+        });
+    }
+    Ok(())
 }
 
 /// Initiates a checkpoint and returns its sequence number.  The caller may poll
@@ -2311,6 +2335,7 @@ async fn coordination_checkpoint_push(
 async fn checkpoint(state: WebData<ServerState>) -> Result<HttpResponse, PipelineError> {
     let controller = state.controller()?;
     let seq = state.checkpoint_state.lock().unwrap().next_seq();
+    let incarnation_uuid = state.incarnation_uuid;
     spawn(async move {
         let result = controller.async_checkpoint().await;
         state
@@ -2319,13 +2344,17 @@ async fn checkpoint(state: WebData<ServerState>) -> Result<HttpResponse, Pipelin
             .unwrap()
             .completed(seq, result.map(|c| c.circuit));
     });
-    Ok(HttpResponse::Ok().json(CheckpointResponse::new(seq)))
+    Ok(HttpResponse::Ok().json(CheckpointResponse::new(seq, incarnation_uuid)))
 }
 
 #[get("/checkpoint_status")]
-async fn checkpoint_status(state: WebData<ServerState>) -> impl Responder {
+async fn checkpoint_status(
+    state: WebData<ServerState>,
+    params: web::Query<CheckpointStatusQuery>,
+) -> Result<HttpResponse, PipelineError> {
+    check_incarnation_uuid(&state, params.incarnation_uuid)?;
     let status = state.checkpoint_state.lock().unwrap().status.clone();
-    HttpResponse::Ok().json(status)
+    Ok(HttpResponse::Ok().json(status))
 }
 
 #[get("/checkpoints")]
@@ -2358,7 +2387,10 @@ async fn remote_checkpoints(state: WebData<ServerState>) -> Result<HttpResponse,
 #[get("/checkpoint/sync_status")]
 async fn sync_checkpoint_status(
     state: WebData<ServerState>,
+    params: web::Query<CheckpointStatusQuery>,
 ) -> Result<HttpResponse, PipelineError> {
+    check_incarnation_uuid(&state, params.incarnation_uuid)?;
+
     let mut sync_state = state.sync_checkpoint_state.lock().unwrap();
 
     let controller = state.controller()?;
@@ -4329,8 +4361,10 @@ mod test_http {
             http::{TestHttpReceiver, TestHttpSender},
         },
     };
+    use actix_web::http::StatusCode;
     use feldera_types::{
         adapter_stats::TransactionStatus,
+        checkpoint::{CheckpointResponse, CheckpointStatus},
         completion_token::{CompletionStatus, CompletionStatusResponse, CompletionTokenResponse},
         runtime_status::{BootstrapConfig, BootstrapPolicy},
     };
@@ -5012,6 +5046,120 @@ outputs:
             count, 10,
             "ad-hoc query observed a stale snapshot after fault-tolerant replay"
         );
+
+        suspend_pipeline(&server, Some(&storage_dir)).await;
+    }
+
+    /// Reproduces feldera/cloud#1927: a checkpoint that spans a pipeline
+    /// process restart must not be mistaken for one still in progress.
+    /// `success: None` looks identical whether a process is still working
+    /// on the checkpoint or has simply never heard of it; `/checkpoint`
+    /// hands back an `incarnation_uuid` alongside the sequence number so
+    /// `/checkpoint_status` can tell the two apart.
+    #[actix_web::test]
+    async fn test_checkpoint_status_detects_restart() {
+        ensure_default_crypto_provider();
+
+        let tempdir = TempDir::new().unwrap();
+        let storage_dir = tempdir.path().join("storage");
+        std::fs::create_dir(&storage_dir).unwrap();
+
+        let config_str = format!(
+            r#"
+name: test
+workers: 1
+storage_config:
+    path: "{}"
+storage: true
+fault_tolerance: latest_checkpoint
+clock_resolution_usecs:
+inputs:
+outputs:
+"#,
+            storage_dir.display()
+        );
+
+        let (server, state) = start_test_server_with_state(
+            &config_str,
+            Uuid::new_v4(),
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            &[Some("v0")],
+            Some(test_program_ir("v0")),
+        )
+        .await;
+        start_pipeline(&server).await;
+
+        let resp = server
+            .post("/checkpoint")
+            .send()
+            .await
+            .unwrap()
+            .json::<CheckpointResponse>()
+            .await
+            .unwrap();
+        let seq = resp.checkpoint_sequence_number;
+        let stale_incarnation_uuid = resp
+            .incarnation_uuid
+            .expect("a current-version server always stamps a real incarnation on /checkpoint");
+
+        // Wait for the checkpoint to actually complete before crashing, so
+        // the crash below can't race the in-flight checkpoint write.
+        let start = Instant::now();
+        loop {
+            let status = server
+                .get("/checkpoint_status")
+                .send()
+                .await
+                .unwrap()
+                .json::<CheckpointStatus>()
+                .await
+                .unwrap();
+            if status.success == Some(seq) {
+                break;
+            }
+            assert!(start.elapsed() < Duration::from_secs(20));
+            sleep(Duration::from_millis(50));
+        }
+
+        // Simulate the pipeline process dying and a new one starting in its
+        // place, e.g. a pod eviction -- the new process gets a fresh
+        // incarnation UUID.
+        crash_pipeline(&state, &storage_dir).await;
+        drop(server);
+
+        let (server, _state) = start_test_server_with_state(
+            &config_str,
+            Uuid::new_v4(),
+            BootstrapConfig::from(BootstrapPolicy::Allow),
+            &[Some("v0")],
+            Some(test_program_ir("v0")),
+        )
+        .await;
+        start_pipeline(&server).await;
+
+        // A status check carrying the OLD incarnation UUID must be
+        // rejected outright, not answered with an ambiguous status that
+        // reads identically to "still in progress".
+        let resp = server
+            .get(format!(
+                "/checkpoint_status?incarnation_uuid={stale_incarnation_uuid}"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // Omitting the incarnation UUID preserves the old, ambiguous but
+        // backward-compatible behavior for clients that don't send it.
+        let status = server
+            .get("/checkpoint_status")
+            .send()
+            .await
+            .unwrap()
+            .json::<CheckpointStatus>()
+            .await
+            .unwrap();
+        assert_eq!(status.success, None);
 
         suspend_pipeline(&server, Some(&storage_dir)).await;
     }

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -5,6 +5,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use feldera_rest_api::types::*;
 use feldera_rest_api::*;
+use feldera_types::checkpoint::CheckpointResponse;
 use feldera_types::config::{FtModel, RuntimeConfig, StorageOptions};
 use feldera_types::error::ErrorResponse;
 use feldera_types::transport::clock::ClockAdvanceRequest;
@@ -1226,31 +1227,66 @@ async fn wait_for_storage_status(
     }
 }
 
-async fn wait_for_checkpoint(client: &Client, name: String, seq_number: u64, waiting_text: &str) {
+/// Waits for `checkpoint` to complete, returning the checkpoint that actually
+/// completed. That is not necessarily the one passed in: if the pipeline
+/// restarts while we wait, the original request dies with it and this
+/// triggers a fresh checkpoint, which gets its own sequence number.
+async fn wait_for_checkpoint(
+    client: &Client,
+    name: String,
+    mut checkpoint: CheckpointResponse,
+    waiting_text: &str,
+) -> CheckpointResponse {
     let mut print_every_30_seconds = Instant::now();
     let mut is_waiting_for_checkpoint = true;
     while is_waiting_for_checkpoint {
-        let cs = client
-            .get_checkpoint_status()
-            .pipeline_name(name.clone())
-            .send()
-            .await
-            .map_err(handle_errors_fatal(
-                client.baseurl().to_string(),
-                "Failed to get pipeline checkpoint status",
-                1,
-            ))
-            .unwrap();
+        let mut request = client.get_checkpoint_status().pipeline_name(name.clone());
+        if let Some(uuid) = checkpoint.incarnation_uuid {
+            request = request.incarnation_uuid(uuid);
+        }
+        let cs = match request.send().await {
+            Ok(cs) => cs,
+            Err(Error::ErrorResponse(e)) if e.error_code == "IncarnationUuidMismatch" => {
+                // The pipeline restarted since the checkpoint was requested;
+                // that request is gone, so start over. Sleep first so a
+                // crash-looping pipeline doesn't turn this into a tight
+                // retry loop.
+                sleep(Duration::from_millis(100)).await;
+                checkpoint = client
+                    .checkpoint_pipeline()
+                    .pipeline_name(name.clone())
+                    .send()
+                    .await
+                    .map_err(handle_errors_fatal(
+                        client.baseurl().to_string(),
+                        "Failed to initiate pipeline checkpoint",
+                        1,
+                    ))
+                    .unwrap()
+                    .into_inner();
+                continue;
+            }
+            Err(err) => Err(err)
+                .map_err(handle_errors_fatal(
+                    client.baseurl().to_string(),
+                    "Failed to get pipeline checkpoint status",
+                    1,
+                ))
+                .unwrap(),
+        };
         debug!("Checkpoint status {:?}", cs);
 
-        is_waiting_for_checkpoint = cs.success.map(|c| c < seq_number).unwrap_or(true);
+        is_waiting_for_checkpoint = cs
+            .success
+            .map(|c| c < checkpoint.checkpoint_sequence_number)
+            .unwrap_or(true);
         if !is_waiting_for_checkpoint {
             // We have a checkpoint at least as recent as the requested sequence number
             break;
         }
 
         if let Some(failure) = &cs.failure {
-            if failure.sequence_number < seq_number {
+            if failure.sequence_number < checkpoint.checkpoint_sequence_number {
                 continue;
             }
             eprintln!(
@@ -1269,6 +1305,7 @@ async fn wait_for_checkpoint(client: &Client, name: String, seq_number: u64, wai
 
         sleep(Duration::from_millis(500)).await;
     }
+    checkpoint
 }
 
 /// Fetch a pipeline's current tags.
@@ -1726,18 +1763,19 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 ))
                 .unwrap();
             trace!("{:#?}", response);
-            let checkpoint_sequence_number = response.into_inner().checkpoint_sequence_number;
             if !no_wait {
-                wait_for_checkpoint(
+                // Report the checkpoint that completed, which differs from the
+                // one requested above if the pipeline restarted while waiting.
+                let completed = wait_for_checkpoint(
                     &client,
                     name.clone(),
-                    checkpoint_sequence_number,
+                    response.into_inner(),
                     "Taking a checkpoint...",
                 )
                 .await;
                 println!(
                     "Pipeline checkpoint (#{}) taken successfully.",
-                    checkpoint_sequence_number
+                    completed.checkpoint_sequence_number
                 );
             }
         }

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -63,12 +63,18 @@ pub struct CheckpointFailure {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
 pub struct CheckpointResponse {
     pub checkpoint_sequence_number: u64,
+
+    /// Pass back to `/checkpoint_status` to detect pipeline restarts.
+    ///
+    /// Only `None` if sent by an older pipeline.
+    pub incarnation_uuid: Option<Uuid>,
 }
 
 impl CheckpointResponse {
-    pub fn new(checkpoint_sequence_number: u64) -> Self {
+    pub fn new(checkpoint_sequence_number: u64, incarnation_uuid: Uuid) -> Self {
         Self {
             checkpoint_sequence_number,
+            incarnation_uuid: Some(incarnation_uuid),
         }
     }
 }
@@ -77,12 +83,29 @@ impl CheckpointResponse {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
 pub struct CheckpointSyncResponse {
     pub checkpoint_uuid: Uuid,
+
+    /// Pass back to `/checkpoint/sync_status` to detect pipeline restarts.
+    ///
+    /// Only `None` if sent by an older pipeline.
+    pub incarnation_uuid: Option<Uuid>,
 }
 
 impl CheckpointSyncResponse {
-    pub fn new(checkpoint_uuid: Uuid) -> Self {
-        Self { checkpoint_uuid }
+    pub fn new(checkpoint_uuid: Uuid, incarnation_uuid: Uuid) -> Self {
+        Self {
+            checkpoint_uuid,
+            incarnation_uuid: Some(incarnation_uuid),
+        }
     }
+}
+
+/// Query parameters for `/checkpoint_status` and `/checkpoint/sync_status`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct CheckpointStatusQuery {
+    /// Pass the value from the initial response, to detect pipeline restarts.
+    ///
+    /// Optional to allow older clients to continue working.
+    pub incarnation_uuid: Option<Uuid>,
 }
 
 /// Checkpoint status returned by the `/checkpoint/sync_status` endpoint.
@@ -254,6 +277,23 @@ pub enum CheckpointPullStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A newer client's `CheckpointResponse`/`CheckpointSyncResponse` must
+    /// still parse a response from an older pipeline that predates the
+    /// `incarnation_uuid` field, yielding `None` rather than a
+    /// deserialization error.
+    #[test]
+    fn deserialize_response_missing_incarnation_uuid() {
+        let resp: CheckpointResponse =
+            serde_json::from_str(r#"{"checkpoint_sequence_number": 3}"#).unwrap();
+        assert_eq!(resp.checkpoint_sequence_number, 3);
+        assert_eq!(resp.incarnation_uuid, None);
+
+        let sync_resp: CheckpointSyncResponse =
+            serde_json::from_str(r#"{"checkpoint_uuid": "00000000-0000-0000-0000-000000000001"}"#)
+                .unwrap();
+        assert_eq!(sync_resp.incarnation_uuid, None);
+    }
 
     /// Legacy bare-array dependencies.json from older checkpoints must still
     /// parse, yielding an empty state-file list (no manifest verification).

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -1203,12 +1203,19 @@ pub(crate) async fn checkpoint_pipeline(
     security(("JSON web token (JWT) or API key" = [])),
     params(
         ("pipeline_name" = String, Path, description = "Unique pipeline name"),
+        ("incarnation_uuid" = Option<Uuid>, Query, description = "Incarnation UUID returned by the `POST checkpoint` request this status check is for. If given and it does not match the pipeline's current incarnation, the pipeline process has restarted since the checkpoint was requested and the response is a 400 error rather than a status."),
     ),
     responses(
         (status = OK
          , description = "Checkpoint status retrieved successfully"
          , content_type = "application/json"
          , body = CheckpointStatus),
+        (status = BAD_REQUEST
+            , description = "The given `incarnation_uuid` does not match the pipeline's \
+                              current incarnation (error code `IncarnationUuidMismatch`): \
+                              the pipeline process has restarted since the checkpoint was \
+                              requested"
+            , body = ErrorResponse),
         (status = NOT_FOUND
             , description = "Pipeline with that name does not exist"
             , body = ErrorResponse
@@ -1265,12 +1272,18 @@ pub(crate) async fn get_checkpoint_status(
     security(("JSON web token (JWT) or API key" = [])),
     params(
         ("pipeline_name" = String, Path, description = "Unique pipeline name"),
+        ("incarnation_uuid" = Option<Uuid>, Query, description = "Incarnation UUID returned by the `POST checkpoint/sync` request this status check is for. If given and it does not match the pipeline's current incarnation, the pipeline process has restarted since the sync was requested and the response is a 400 error rather than a status."),
     ),
     responses(
         (status = OK
          , description = "Checkpoint sync status retrieved successfully"
          , content_type = "application/json"
          , body = CheckpointSyncStatus),
+        (status = BAD_REQUEST
+            , description = "The given `incarnation_uuid` does not match the pipeline's \
+                              current incarnation (error code `IncarnationUuidMismatch`): \
+                              the pipeline process has restarted since the sync was requested"
+            , body = ErrorResponse),
         (status = NOT_FOUND
             , description = "Pipeline with that name does not exist"
             , body = ErrorResponse

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -55,6 +55,11 @@ import TabItem from '@theme/TabItem';
           now requires exactly 16 bytes; a longer value used to be truncated.  See
           [UUID operations](https://docs.feldera.com/sql/uuid).
 
+        - `/checkpoint` and `/checkpoint/sync` now return an `incarnation_uuid`
+          that can be used with their corresponding status calls to detect if
+          the pipeline restarts.  If it does, the operation itself must be restarted
+          (the most common use of the Python API does this automatically).
+
         ## v0.330.0
 
         - Feldera's membership table now authorizes every login: a user acts

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -269,11 +269,18 @@ A sync operation can be triggered by making a `POST` request to:
 curl -X POST 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync'
 ```
 
-This initiates the sync and returns the UUID of the checkpoint being synced:
+This initiates the sync and returns the UUID of the checkpoint being synced,
+along with the UUID of the pipeline process that accepted the request:
 
 ```json
-{ "checkpoint_uuid": "019779b4-8760-75f2-bdf0-71b825e63610" }
+{
+    "checkpoint_uuid": "019779b4-8760-75f2-bdf0-71b825e63610",
+    "incarnation_uuid": "019779b4-8760-75f2-bdf0-71b825e63611"
+}
 ```
+
+Pass `incarnation_uuid` to `sync_status` while waiting for the sync, as described
+under [detecting a pipeline restart](#detecting-a-pipeline-restart).
 
 ## Checking sync status
 
@@ -346,6 +353,48 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
     "periodic": "019779c1-8317-7a71-bd78-7b971f4a3c43"
 }
 ```
+
+### Detecting a pipeline restart
+
+If a pipeline restarts while a sync is in flight (e.g. because its pod
+was evicted), the request dies with it.  The client can detect this by
+passing the `incarnation_uuid` returned by `POST /checkpoint/sync`
+back to `sync_status`:
+
+```bash
+curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status?incarnation_uuid=019779b4-8760-75f2-bdf0-71b825e63611'
+```
+
+If the pipeline has restarted since the sync was requested, the incarnation
+no longer matches and the request fails with HTTP 400 and error code
+`IncarnationUuidMismatch` instead of returning an ambiguous status:
+
+```json
+{
+    "message": "Incarnation UUID mismatch (019779b4-8760-75f2-bdf0-71b825e63611 in request, expected 019779c1-8317-7a71-bd78-7b971f4a3c99)",
+    "error_code": "IncarnationUuidMismatch",
+    "details": {
+        "requested": "019779b4-8760-75f2-bdf0-71b825e63611",
+        "expected": "019779c1-8317-7a71-bd78-7b971f4a3c99"
+    }
+}
+```
+
+Trigger a new sync in response; the old one no longer exists. The parameter
+is optional, so a client that omits it keeps the previous behavior and cannot
+tell a restart apart from a sync in progress.
+
+The same parameter and error apply to `POST /checkpoint` and
+`GET /checkpoint_status`, which track local checkpoints the same way.
+
+`Pipeline.sync_checkpoint(wait=True)` in the Python SDK does this for you: it
+detects the restart and retries with a fresh sync. `Pipeline.checkpoint(wait=True)`
+and `fda pipeline checkpoint` do the same for local checkpoints.
+
+To poll status yourself instead, use `sync_checkpoint_response()`, or
+`checkpoint_response()` for a local checkpoint. Only these return the
+`incarnation_uuid` that the later status check needs; `sync_checkpoint()` and
+`checkpoint()` return just the UUID or sequence number.
 
 ## Multihost pipelines
 

--- a/openapi.json
+++ b/openapi.json
@@ -2681,6 +2681,17 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "incarnation_uuid",
+            "in": "query",
+            "description": "Incarnation UUID returned by the `POST checkpoint/sync` request this status check is for. If given and it does not match the pipeline's current incarnation, the pipeline process has restarted since the sync was requested and the response is a 400 error rather than a status.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            }
           }
         ],
         "responses": {
@@ -2690,6 +2701,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CheckpointSyncStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The given `incarnation_uuid` does not match the pipeline's current incarnation (error code `IncarnationUuidMismatch`): the pipeline process has restarted since the sync was requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2802,6 +2823,17 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "incarnation_uuid",
+            "in": "query",
+            "description": "Incarnation UUID returned by the `POST checkpoint` request this status check is for. If given and it does not match the pipeline's current incarnation, the pipeline process has restarted since the checkpoint was requested and the response is a 400 error rather than a status.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            }
           }
         ],
         "responses": {
@@ -2811,6 +2843,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CheckpointStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The given `incarnation_uuid` does not match the pipeline's current incarnation (error code `IncarnationUuidMismatch`): the pipeline process has restarted since the checkpoint was requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -8523,6 +8565,12 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "incarnation_uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Pass back to `/checkpoint_status` to detect pipeline restarts.\n\nOnly `None` if sent by an older pipeline.",
+            "nullable": true
           }
         }
       },
@@ -8576,6 +8624,12 @@
           "checkpoint_uuid": {
             "type": "string",
             "format": "uuid"
+          },
+          "incarnation_uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Pass back to `/checkpoint/sync_status` to detect pipeline restarts.\n\nOnly `None` if sent by an older pipeline.",
+            "nullable": true
           }
         }
       },

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1054,7 +1054,7 @@ metrics"""
         if not wait:
             return resp
 
-        start = time.time()
+        start = time.monotonic()
 
         while True:
             elapsed = time.monotonic() - start
@@ -1164,7 +1164,7 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
         if not wait:
             return resp
 
-        start = time.time()
+        start = time.monotonic()
 
         while True:
             elapsed = time.monotonic() - start

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1005,7 +1005,14 @@ metrics"""
 
     def checkpoint(self, wait: bool = False, timeout_s: Optional[float] = None) -> int:
         """
-        Checkpoints this pipeline.
+        Checkpoints this pipeline, returning just the checkpoint sequence
+        number.
+
+        This is for backward compatibility: `checkpoint_response` is a
+        better choice for a caller that plans to check the checkpoint's
+        status itself later (e.g. after this call returns with
+        `wait=False`), since it also returns the `incarnation_uuid` needed
+        for that later check to detect a pipeline restart in between.
 
         :param wait: If true, will block until the checkpoint completes.
         :param timeout_s: The maximum time (in seconds) to wait for the
@@ -1016,10 +1023,36 @@ metrics"""
         :raises FelderaAPIError: If enterprise features are not enabled.
         """
 
-        seq = self.client.checkpoint_pipeline(self.name)
+        return int(
+            self.checkpoint_response(wait=wait, timeout_s=timeout_s)[
+                "checkpoint_sequence_number"
+            ]
+        )
+
+    def checkpoint_response(
+        self, wait: bool = False, timeout_s: Optional[float] = None
+    ) -> dict:
+        """
+        Checkpoints this pipeline, returning the full response.
+
+        :param wait: If true, will block until the checkpoint completes.
+        :param timeout_s: The maximum time (in seconds) to wait for the
+            checkpoint to complete (defaults to `None` = no timeout is enforced).
+
+        :return: dict with `checkpoint_sequence_number` and
+            `incarnation_uuid`; pass the latter to `checkpoint_status` to
+            detect a pipeline restart between this call and a later status
+            check.
+
+        :raises FelderaAPIError: If enterprise features are not enabled.
+        """
+
+        resp = self.client.checkpoint_pipeline_response(self.name)
+        seq = int(resp["checkpoint_sequence_number"])
+        incarnation_uuid = resp.get("incarnation_uuid")
 
         if not wait:
-            return seq
+            return resp
 
         start = time.time()
 
@@ -1030,21 +1063,39 @@ metrics"""
                     f"""timeout ({timeout_s}s) reached while waiting for \
 pipeline '{self.name}' to make checkpoint '{seq}'"""
                 )
-            status = self.checkpoint_status(seq)
+            try:
+                status = self.checkpoint_status(seq, incarnation_uuid)
+            except FelderaAPIError as e:
+                if e.error_code == "IncarnationUuidMismatch":
+                    # The pipeline restarted since the checkpoint was
+                    # requested; that request is gone, so start over. Sleep
+                    # first so a crash-looping pipeline doesn't turn this
+                    # into a tight retry loop.
+                    time.sleep(0.1)
+                    resp = self.client.checkpoint_pipeline_response(self.name)
+                    seq = int(resp["checkpoint_sequence_number"])
+                    incarnation_uuid = resp.get("incarnation_uuid")
+                    continue
+                raise
             if status == CheckpointStatus.InProgress:
                 time.sleep(0.1)
                 continue
 
-            return seq
+            return resp
 
-    def checkpoint_status(self, seq: int) -> CheckpointStatus:
+    def checkpoint_status(
+        self, seq: int, incarnation_uuid: Optional[str] = None
+    ) -> CheckpointStatus:
         """
         Checks the status of the given checkpoint.
 
         :param seq: The checkpoint sequence number.
+        :param incarnation_uuid: The `incarnation_uuid` returned alongside
+            `seq` by `checkpoint`, if known, to allow pipeline restarts
+            to be clearly reported as `IncarnationUuidMismatch`.
         """
 
-        resp = self.client.checkpoint_pipeline_status(self.name)
+        resp = self.client.checkpoint_pipeline_status(self.name, incarnation_uuid)
         success = resp.get("success")
         if seq == success:
             return CheckpointStatus.Success
@@ -1065,7 +1116,14 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
         self, wait: bool = False, timeout_s: Optional[float] = None
     ) -> str:
         """
-        Syncs this checkpoint to object store.
+        Syncs this checkpoint to object store, returning just the
+        checkpoint uuid.
+
+        This is for backward compatibility: `sync_checkpoint_response` is
+        a better choice for a caller that plans to check the sync's status
+        itself later (e.g. after this call returns with `wait=False`),
+        since it also returns the `incarnation_uuid` needed for that later
+        check to detect a pipeline restart in between.
 
         :param wait: If true, will block until the checkpoint sync operation
             completes.
@@ -1076,10 +1134,35 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
         :raises RuntimeError: If syncing the checkpoint fails.
         """
 
-        uuid = self.client.sync_checkpoint(self.name)
+        return self.sync_checkpoint_response(wait=wait, timeout_s=timeout_s)[
+            "checkpoint_uuid"
+        ]
+
+    def sync_checkpoint_response(
+        self, wait: bool = False, timeout_s: Optional[float] = None
+    ) -> dict:
+        """
+        Syncs this checkpoint to object store, returning the full response.
+
+        :param wait: If true, will block until the checkpoint sync operation
+            completes.
+        :param timeout_s: The maximum time (in seconds) to wait for the
+            checkpoint to complete syncing.
+
+        :return: dict with `checkpoint_uuid` and `incarnation_uuid`; pass
+            the latter to `sync_checkpoint_status` to detect a pipeline
+            restart between this call and a later status check.
+
+        :raises FelderaAPIError: If no checkpoints have been made.
+        :raises RuntimeError: If syncing the checkpoint fails.
+        """
+
+        resp = self.client.sync_checkpoint_response(self.name)
+        uuid = resp["checkpoint_uuid"]
+        incarnation_uuid = resp.get("incarnation_uuid")
 
         if not wait:
-            return uuid
+            return resp
 
         start = time.time()
 
@@ -1090,7 +1173,20 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
                     f"""timeout ({timeout_s}s) reached while waiting for \
 pipeline '{self.name}' to sync checkpoint '{uuid}'"""
                 )
-            status = self.sync_checkpoint_status(uuid)
+            try:
+                status = self.sync_checkpoint_status(uuid, incarnation_uuid)
+            except FelderaAPIError as e:
+                if e.error_code == "IncarnationUuidMismatch":
+                    # The pipeline restarted since the sync was requested;
+                    # that request is gone, so start over. Sleep first so a
+                    # crash-looping pipeline doesn't turn this into a tight
+                    # retry loop.
+                    time.sleep(0.1)
+                    resp = self.client.sync_checkpoint_response(self.name)
+                    uuid = resp["checkpoint_uuid"]
+                    incarnation_uuid = resp.get("incarnation_uuid")
+                    continue
+                raise
             if status == CheckpointStatus.Failure:
                 raise RuntimeError(
                     f"failed to sync checkpoint '{uuid}': ", status.get_error()
@@ -1102,7 +1198,7 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
 
             break
 
-        return uuid
+        return resp
 
     def remote_checkpoints(self) -> list[dict]:
         """
@@ -1116,7 +1212,9 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         """
         return self.client.get_remote_checkpoints(self.name)
 
-    def sync_checkpoint_status(self, uuid: str) -> CheckpointStatus:
+    def sync_checkpoint_status(
+        self, uuid: str, incarnation_uuid: Optional[str] = None
+    ) -> CheckpointStatus:
         """
         Checks the status of the given checkpoint sync operation.
         If the checkpoint is currently being synchronized, returns
@@ -1126,9 +1224,12 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         checked.
 
         :param uuid: The checkpoint uuid.
+        :param incarnation_uuid: The `incarnation_uuid` returned alongside
+            `uuid` by `sync_checkpoint`, if known, to allow pipeline restarts
+            to be clearly reported as `IncarnationUuidMismatch`.
         """
 
-        resp = self.client.sync_checkpoint_status(self.name)
+        resp = self.client.sync_checkpoint_status(self.name, incarnation_uuid)
         success = resp.get("success")
         periodic = resp.get("periodic")
 

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -1119,49 +1119,99 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 
     def checkpoint_pipeline(self, pipeline_name: str) -> int:
         """
-        Checkpoint a pipeline.
+        Triggers checkpointing a pipeline and returns just the
+        checkpoint sequence number.
 
-        :param pipeline_name: The name of the pipeline to checkpoint
+        This is for backward compatibility:
+        `checkpoint_pipeline_response` is a better choice because it
+        allows the caller to detect that the pipeline has restarted
+        (and that therefore the checkpoint needs to be triggered
+        again).
         """
 
-        resp = self.http.post(
+        return int(
+            self.checkpoint_pipeline_response(pipeline_name)[
+                "checkpoint_sequence_number"
+            ]
+        )
+
+    def checkpoint_pipeline_response(self, pipeline_name: str) -> dict:
+        """
+        Triggers checkpointing a pipeline, returning the full response.
+
+        :param pipeline_name: The name of the pipeline to checkpoint
+        :return: dict with `checkpoint_sequence_number` and `incarnation_uuid`,
+            the latter identifying the pipeline process instance that
+            accepted the request; pass it to `checkpoint_pipeline_status` to
+            detect a pipeline restart between the request and the status
+            check.
+        """
+
+        return self.http.post(
             path=f"/pipelines/{pipeline_name}/checkpoint",
         )
 
-        return int(resp.get("checkpoint_sequence_number"))
-
-    def checkpoint_pipeline_status(self, pipeline_name: str) -> dict:
+    def checkpoint_pipeline_status(
+        self, pipeline_name: str, incarnation_uuid: Optional[str] = None
+    ) -> dict:
         """
         Gets the checkpoint status
 
         :param pipeline_name: The name of the pipeline to check the checkpoint status of.
+        :param incarnation_uuid: The `incarnation_uuid` returned by the
+            `checkpoint_pipeline_response` call, to allow pipeline restarts
+            to be clearly reported as `IncarnationUuidMismatch`.
         """
 
-        return self.http.get(path=f"/pipelines/{pipeline_name}/checkpoint_status")
+        return self.http.get(
+            path=f"/pipelines/{pipeline_name}/checkpoint_status",
+            params={"incarnation_uuid": incarnation_uuid},
+        )
 
     def sync_checkpoint(self, pipeline_name: str) -> str:
         """
-        Triggers a checkpoint synchronization for the specified pipeline.
-        Check the status by calling `pipeline_sync_checkpoint_status`.
+        Triggers a checkpoint synchronization and returns just the
+        checkpoint UUID.
 
-        :param pipeline_name: Name of the pipeline whose checkpoint should be synchronized.
+        This is for backward compatibility: `sync_checkpoint_response`
+        is a better choice because it allows the caller to detect that
+        the pipeline has restarted (and that therefore the checkpoint
+        synchronization needs to be triggered again).
         """
 
-        resp = self.http.post(
+        return self.sync_checkpoint_response(pipeline_name)["checkpoint_uuid"]
+
+    def sync_checkpoint_response(self, pipeline_name: str) -> dict:
+        """
+        Triggers a checkpoint synchronization, returning the full response.
+
+        :param pipeline_name: Name of the pipeline whose checkpoint should be synchronized.
+        :return: dict with `checkpoint_uuid` and `incarnation_uuid`, the
+            latter identifying the pipeline process instance that accepted
+            the request; pass it to `sync_checkpoint_status` to detect a
+            pipeline restart between the request and the status check.
+        """
+
+        return self.http.post(
             path=f"/pipelines/{pipeline_name}/checkpoint/sync",
         )
 
-        return resp.get("checkpoint_uuid")
-
-    def sync_checkpoint_status(self, pipeline_name: str) -> dict:
+    def sync_checkpoint_status(
+        self, pipeline_name: str, incarnation_uuid: Optional[str] = None
+    ) -> dict:
         """
         Gets the checkpoint sync status of the pipeline
 
         :param pipeline_name: The name of the pipeline to check the checkpoint synchronization status of.
+        :param incarnation_uuid: The `incarnation_uuid` returned by the
+            `sync_checkpoint_response` call this status check is for, to
+            allow pipeline restarts to be clearly reported as
+            `IncarnationUuidMismatch`.
         """
 
         return self.http.get(
             path=f"/pipelines/{pipeline_name}/checkpoint/sync_status",
+            params={"incarnation_uuid": incarnation_uuid},
         )
 
     def push_to_pipeline(

--- a/python/tests/unit/test_checkpoint_incarnation_restart.py
+++ b/python/tests/unit/test_checkpoint_incarnation_restart.py
@@ -1,0 +1,283 @@
+"""Tests for checkpoint/sync_checkpoint recovery from a pipeline restart.
+
+Covers feldera/cloud#1927: `checkpoint(wait=True)`/`sync_checkpoint(wait=True)`
+must not hang forever if the pipeline process restarts between the request
+and a status poll. These mock the `FelderaClient` so they exercise the
+`Pipeline` retry logic directly, without a running pipeline.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import requests
+
+from feldera.pipeline import Pipeline
+from feldera.rest.errors import FelderaAPIError
+
+INCARNATION_A = "aaaaaaaa-0000-0000-0000-000000000000"
+INCARNATION_B = "bbbbbbbb-0000-0000-0000-000000000000"
+
+
+def _pipeline(client) -> Pipeline:
+    pipeline = Pipeline(client)
+    pipeline._inner = SimpleNamespace(name="test_pipeline")
+    return pipeline
+
+
+def _incarnation_mismatch_error() -> FelderaAPIError:
+    resp = requests.Response()
+    resp.status_code = 400
+    resp._content = b'{"error_code": "IncarnationUuidMismatch", "message": "restarted"}'
+    resp.headers["content-type"] = "application/json"
+    prepared = requests.PreparedRequest()
+    prepared.prepare(method="GET", url="http://example.test/v0/x")
+    resp.request = prepared
+    return FelderaAPIError("mismatch", resp)
+
+
+class TestCheckpointRestartRecovery:
+    def test_retries_transparently_on_incarnation_mismatch(self):
+        client = mock.Mock()
+        client.checkpoint_pipeline_response.side_effect = [
+            {"checkpoint_sequence_number": 1, "incarnation_uuid": INCARNATION_A},
+            {"checkpoint_sequence_number": 2, "incarnation_uuid": INCARNATION_B},
+        ]
+        client.checkpoint_pipeline_status.side_effect = [
+            _incarnation_mismatch_error(),
+            {"success": 2, "failure": None},
+        ]
+
+        with mock.patch("feldera.pipeline.time.sleep"):
+            seq = _pipeline(client).checkpoint(wait=True)
+
+        assert seq == 2
+        assert client.checkpoint_pipeline_response.call_count == 2
+        client.checkpoint_pipeline_status.assert_has_calls(
+            [
+                mock.call("test_pipeline", INCARNATION_A),
+                mock.call("test_pipeline", INCARNATION_B),
+            ]
+        )
+
+    def test_handles_missing_incarnation_uuid_from_older_pipeline(self):
+        """A pipeline predating this field omits `incarnation_uuid`; the SDK
+        must fall back to the old polling behavior instead of raising."""
+        client = mock.Mock()
+        client.checkpoint_pipeline_response.return_value = {
+            "checkpoint_sequence_number": 5
+        }
+        client.checkpoint_pipeline_status.return_value = {
+            "success": 5,
+            "failure": None,
+        }
+
+        seq = _pipeline(client).checkpoint(wait=True)
+
+        assert seq == 5
+        client.checkpoint_pipeline_status.assert_called_once_with("test_pipeline", None)
+
+    def test_non_mismatch_api_error_still_propagates(self):
+        client = mock.Mock()
+        client.checkpoint_pipeline_response.return_value = {
+            "checkpoint_sequence_number": 1,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        resp = requests.Response()
+        resp.status_code = 500
+        resp._content = b'{"error_code": "SomeOtherError", "message": "boom"}'
+        resp.headers["content-type"] = "application/json"
+        prepared = requests.PreparedRequest()
+        prepared.prepare(method="GET", url="http://example.test/v0/x")
+        resp.request = prepared
+        client.checkpoint_pipeline_status.side_effect = FelderaAPIError("boom", resp)
+
+        try:
+            _pipeline(client).checkpoint(wait=True)
+            raise AssertionError("expected FelderaAPIError to propagate")
+        except FelderaAPIError as e:
+            assert e.error_code == "SomeOtherError"
+
+
+class TestSyncCheckpointRestartRecovery:
+    def test_retries_transparently_on_incarnation_mismatch(self):
+        client = mock.Mock()
+        client.sync_checkpoint_response.side_effect = [
+            {
+                "checkpoint_uuid": "11111111-0000-0000-0000-000000000000",
+                "incarnation_uuid": INCARNATION_A,
+            },
+            {
+                "checkpoint_uuid": "22222222-0000-0000-0000-000000000000",
+                "incarnation_uuid": INCARNATION_B,
+            },
+        ]
+        client.sync_checkpoint_status.side_effect = [
+            _incarnation_mismatch_error(),
+            {
+                "success": "22222222-0000-0000-0000-000000000000",
+                "periodic": None,
+                "failure": None,
+            },
+        ]
+
+        with mock.patch("feldera.pipeline.time.sleep"):
+            uuid = _pipeline(client).sync_checkpoint(wait=True)
+
+        assert uuid == "22222222-0000-0000-0000-000000000000"
+        assert client.sync_checkpoint_response.call_count == 2
+        client.sync_checkpoint_status.assert_has_calls(
+            [
+                mock.call("test_pipeline", INCARNATION_A),
+                mock.call("test_pipeline", INCARNATION_B),
+            ]
+        )
+
+    def test_handles_missing_incarnation_uuid_from_older_pipeline(self):
+        client = mock.Mock()
+        client.sync_checkpoint_response.return_value = {
+            "checkpoint_uuid": "33333333-0000-0000-0000-000000000000"
+        }
+        client.sync_checkpoint_status.return_value = {
+            "success": "33333333-0000-0000-0000-000000000000",
+            "periodic": None,
+            "failure": None,
+        }
+
+        uuid = _pipeline(client).sync_checkpoint(wait=True)
+
+        assert uuid == "33333333-0000-0000-0000-000000000000"
+        client.sync_checkpoint_status.assert_called_once_with("test_pipeline", None)
+
+
+class TestPipelineCheckpointResponse:
+    """`Pipeline.checkpoint`/`sync_checkpoint` return a bare seq/uuid, same
+    as always; `checkpoint_response`/`sync_checkpoint_response` return the
+    full dict (with `incarnation_uuid`) for a caller that plans to poll
+    status itself later, e.g. after calling with `wait=False`."""
+
+    def test_checkpoint_response_returns_full_dict_without_wait(self):
+        client = mock.Mock()
+        client.checkpoint_pipeline_response.return_value = {
+            "checkpoint_sequence_number": 1,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        resp = _pipeline(client).checkpoint_response()
+
+        assert resp == {
+            "checkpoint_sequence_number": 1,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+    def test_checkpoint_still_returns_bare_seq(self):
+        client = mock.Mock()
+        client.checkpoint_pipeline_response.return_value = {
+            "checkpoint_sequence_number": 1,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        seq = _pipeline(client).checkpoint()
+
+        assert seq == 1
+        assert isinstance(seq, int)
+
+    def test_sync_checkpoint_response_returns_full_dict_without_wait(self):
+        client = mock.Mock()
+        client.sync_checkpoint_response.return_value = {
+            "checkpoint_uuid": "66666666-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        resp = _pipeline(client).sync_checkpoint_response()
+
+        assert resp == {
+            "checkpoint_uuid": "66666666-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+    def test_sync_checkpoint_still_returns_bare_uuid(self):
+        client = mock.Mock()
+        client.sync_checkpoint_response.return_value = {
+            "checkpoint_uuid": "66666666-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        uuid = _pipeline(client).sync_checkpoint()
+
+        assert uuid == "66666666-0000-0000-0000-000000000000"
+        assert isinstance(uuid, str)
+
+
+class TestClientCheckpointBackwardCompat:
+    """https://github.com/feldera/feldera/pull/6904#discussion_r3820573531
+
+    `FelderaClient.checkpoint_pipeline`/`sync_checkpoint` must keep
+    returning a bare `int`/`str` as they did before `incarnation_uuid`
+    was introduced, so existing callers don't break. The `_response`
+    variants carry the full dict, including `incarnation_uuid`, for
+    callers (like `Pipeline`) that need it.
+    """
+
+    @staticmethod
+    def _client_with_mock_http():
+        from feldera.rest.feldera_client import FelderaClient
+
+        with mock.patch.object(
+            FelderaClient, "get_config", return_value=mock.Mock(version="x")
+        ):
+            client = FelderaClient(url="http://example.test")
+        client.http = mock.Mock()
+        return client
+
+    def test_checkpoint_pipeline_returns_bare_int(self):
+        client = self._client_with_mock_http()
+        client.http.post.return_value = {
+            "checkpoint_sequence_number": 7,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        seq = client.checkpoint_pipeline("p")
+
+        assert seq == 7
+        assert isinstance(seq, int)
+
+    def test_checkpoint_pipeline_response_returns_full_dict(self):
+        client = self._client_with_mock_http()
+        client.http.post.return_value = {
+            "checkpoint_sequence_number": 7,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        resp = client.checkpoint_pipeline_response("p")
+
+        assert resp == {
+            "checkpoint_sequence_number": 7,
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+    def test_sync_checkpoint_returns_bare_str(self):
+        client = self._client_with_mock_http()
+        client.http.post.return_value = {
+            "checkpoint_uuid": "55555555-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        uuid = client.sync_checkpoint("p")
+
+        assert uuid == "55555555-0000-0000-0000-000000000000"
+        assert isinstance(uuid, str)
+
+    def test_sync_checkpoint_response_returns_full_dict(self):
+        client = self._client_with_mock_http()
+        client.http.post.return_value = {
+            "checkpoint_uuid": "55555555-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }
+
+        resp = client.sync_checkpoint_response("p")
+
+        assert resp == {
+            "checkpoint_uuid": "55555555-0000-0000-0000-000000000000",
+            "incarnation_uuid": INCARNATION_A,
+        }


### PR DESCRIPTION
sync_checkpoint(wait=True) and checkpoint(wait=True) could hang forever if the pipeline process restarted between the request and a status poll.  This fixes the problem by introducing incarnation_uuid checking.

Fixes: https://github.com/feldera/cloud/issues/1927