### PR TITLE
api: report the real unchanged_since in cluster_healthz; add fda cluster health/config

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -510,7 +510,8 @@ pub enum ClusterAction {
 
     /// Check the health of the cluster services.
     ///
-    /// Exits with code 0 if all services are healthy, and 1 otherwise.
+    /// Exits with code 0 if all services are healthy, 1 if the health cannot be
+    /// retrieved, and 2 if any service is unhealthy.
     Health,
 
     /// Retrieve the platform configuration (edition, version, license, build information).

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -507,6 +507,14 @@ pub enum ClusterAction {
         #[arg(default_value = "status")]
         selector: ClusterMonitorEventFieldSelector,
     },
+
+    /// Check the health of the cluster services.
+    ///
+    /// Exits with code 0 if all services are healthy, and 1 otherwise.
+    Health,
+
+    /// Retrieve the platform configuration (edition, version, license, build information).
+    Config,
 }
 
 #[derive(Subcommand)]

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -3741,6 +3741,7 @@ async fn cluster(format: OutputFormat, action: ClusterAction, client: Client) {
             };
             match format {
                 OutputFormat::Text => {
+                    let now = Utc::now();
                     let mut rows = vec![];
                     rows.push([
                         "service".to_string(),
@@ -3760,12 +3761,12 @@ async fn cluster(format: OutputFormat, action: ClusterAction, client: Client) {
                             format!(
                                 "{} ({:.0}s ago)",
                                 status.unchanged_since,
-                                (Utc::now() - status.unchanged_since).as_seconds_f64()
+                                (now - status.unchanged_since).as_seconds_f64()
                             ),
                             format!(
                                 "{} ({:.0}s ago)",
                                 status.checked_at,
-                                (Utc::now() - status.checked_at).as_seconds_f64()
+                                (now - status.checked_at).as_seconds_f64()
                             ),
                             status.message.clone(),
                         ]);
@@ -3788,7 +3789,8 @@ async fn cluster(format: OutputFormat, action: ClusterAction, client: Client) {
                 }
             }
             if !health.all_healthy {
-                std::process::exit(1);
+                // Exit 1 means the health could not be retrieved; 2 means unhealthy.
+                std::process::exit(2);
             }
         }
         ClusterAction::Config => {

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -3725,6 +3725,117 @@ async fn cluster(format: OutputFormat, action: ClusterAction, client: Client) {
                 }
             }
         }
+        ClusterAction::Health => {
+            // Both 200 (all healthy) and 503 (some service unhealthy) carry a
+            // `HealthStatus` body.
+            let health = match client.get_cluster_health().send().await {
+                Ok(response) => response.into_inner(),
+                Err(Error::ErrorResponse(response)) => response.into_inner(),
+                Err(e) => {
+                    eprintln!(
+                        "Unable to retrieve cluster health from {}: {e}",
+                        client.baseurl()
+                    );
+                    std::process::exit(1);
+                }
+            };
+            match format {
+                OutputFormat::Text => {
+                    let mut rows = vec![];
+                    rows.push([
+                        "service".to_string(),
+                        "healthy".to_string(),
+                        "unchanged_since".to_string(),
+                        "checked_at".to_string(),
+                        "message".to_string(),
+                    ]);
+                    for (service, status) in [
+                        ("api", &health.api),
+                        ("compiler", &health.compiler),
+                        ("runner", &health.runner),
+                    ] {
+                        rows.push([
+                            service.to_string(),
+                            status.healthy.to_string(),
+                            format!(
+                                "{} ({:.0}s ago)",
+                                status.unchanged_since,
+                                (Utc::now() - status.unchanged_since).as_seconds_f64()
+                            ),
+                            format!(
+                                "{} ({:.0}s ago)",
+                                status.checked_at,
+                                (Utc::now() - status.checked_at).as_seconds_f64()
+                            ),
+                            status.message.clone(),
+                        ]);
+                    }
+                    println!(
+                        "{}",
+                        Builder::from_iter(rows).build().with(Style::rounded())
+                    );
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&health)
+                            .expect("Failed to serialize cluster health")
+                    );
+                }
+                _ => {
+                    eprintln!("Unsupported output format: {}", format);
+                    std::process::exit(1);
+                }
+            }
+            if !health.all_healthy {
+                std::process::exit(1);
+            }
+        }
+        ClusterAction::Config => {
+            let response = client
+                .get_config()
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().to_string(),
+                    "Unable to retrieve platform configuration",
+                    1,
+                ))
+                .unwrap();
+            match format {
+                OutputFormat::Text => {
+                    // A summary without `build_info.cargo_dependencies`, which lists
+                    // every crate and dwarfs the table. JSON output has all fields.
+                    let value = json!({
+                        "edition": response.edition,
+                        "version": response.version,
+                        "revision": response.revision,
+                        "runtime_revision": response.runtime_revision,
+                        "build_source": response.build_source,
+                        "build_timestamp": response.build_info.build_timestamp,
+                        "rustc_version": response.build_info.rustc_version,
+                        "cargo_target_triple": response.build_info.cargo_target_triple,
+                        "license_validity": response.license_validity,
+                        "update_info": response.update_info,
+                        "unstable_features": response.unstable_features,
+                        "changelog_url": response.changelog_url,
+                    });
+                    let table = json_to_table(&value).collapse().to_string();
+                    println!("{}", table);
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&response.into_inner())
+                            .expect("Failed to serialize platform configuration")
+                    );
+                }
+                _ => {
+                    eprintln!("Unsupported output format: {}", format);
+                    std::process::exit(1);
+                }
+            }
+        }
     }
 }
 

--- a/crates/pipeline-manager/src/api/endpoints/cluster.rs
+++ b/crates/pipeline-manager/src/api/endpoints/cluster.rs
@@ -230,25 +230,77 @@ pub(crate) async fn get_cluster_event(
         .json(&event))
 }
 
+/// Health of the cluster as a whole and of each of its services.
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct HealthStatus {
+    /// Whether every service is healthy.
     pub all_healthy: bool,
+    /// Health of the API server(s).
     pub api: ServiceStatus,
+    /// Health of the compiler server(s).
     pub compiler: ServiceStatus,
+    /// Health of the runner(s).
     pub runner: ServiceStatus,
 }
 
+/// Health of a single service derived from the retained cluster monitor events.
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct ServiceStatus {
+    /// Whether the service passed its most recent health check.
     pub healthy: bool,
+    /// Human-readable report from the most recent health check.
     pub message: String,
+    /// Approximate time the service last transitioned between healthy and unhealthy:
+    /// the timestamp of the oldest retained consecutive cluster monitor event with the
+    /// same `healthy` conclusion. Bounded by event retention (at most 72h / 1000 events).
     pub unchanged_since: DateTime<Utc>,
+    /// Timestamp of the most recent cluster monitor event.
     pub checked_at: DateTime<Utc>,
+}
+
+/// Timestamp of the oldest event in the run of consecutive events (newest first) that
+/// share the health conclusion that `service_status` extracts from the event with
+/// `latest_event_id`. The run is bounded by event retention. Returns `None` if that
+/// event is not in the list.
+///
+/// # Example
+///
+/// ```ignore
+/// // Newest first:      e1         e2         e3
+/// // recorded_at:       100        90         80
+/// // api_status:        Unhealthy  Unhealthy  Healthy
+/// let events = [e1, e2, e3];
+///
+/// // Anchored at e1, the unhealthy run spans e1..=e2: the api service
+/// // became unhealthy at t=90.
+/// let since = service_unchanged_since(&events, e1.id, |event| event.api_status);
+/// assert_eq!(since, Some(e2.recorded_at));
+/// ```
+fn service_unchanged_since(
+    events_newest_first: &[ClusterMonitorEvent],
+    latest_event_id: ClusterMonitorEventId,
+    service_status: fn(&ClusterMonitorEvent) -> MonitorStatus,
+) -> Option<DateTime<Utc>> {
+    let mut run = events_newest_first
+        .iter()
+        .skip_while(|event| event.id != latest_event_id);
+    let latest_event = run.next()?;
+    let latest_healthy = service_status(latest_event) == MonitorStatus::Healthy;
+    let mut unchanged_since = latest_event.recorded_at;
+    for event in run {
+        if (service_status(event) == MonitorStatus::Healthy) != latest_healthy {
+            break;
+        }
+        unchanged_since = event.recorded_at;
+    }
+    Some(unchanged_since)
 }
 
 /// Check Cluster Health
 ///
 /// Determine the latest cluster health via the latest cluster monitor event.
+/// Each service's `unchanged_since` reports the approximate time it last transitioned
+/// between healthy and unhealthy, bounded by event retention (at most 72h / 1000 events).
 #[utoipa::path(
     context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
@@ -262,12 +314,18 @@ pub struct ServiceStatus {
 pub(crate) async fn get_cluster_health(
     state: WebData<ServerState>,
 ) -> Result<HttpResponse, ManagerError> {
-    let latest_event = state
-        .db
-        .lock()
-        .await
-        .get_latest_cluster_monitor_event_extended()
-        .await?;
+    let db = state.db.lock().await;
+    let latest_event = db.get_latest_cluster_monitor_event_extended().await?;
+    let events = db.list_cluster_monitor_events().await?;
+    drop(db);
+    let unchanged_since = |service_status| {
+        service_unchanged_since(&events, latest_event.id, service_status)
+            .unwrap_or(latest_event.recorded_at)
+    };
+    let api_unchanged_since = unchanged_since(|event: &ClusterMonitorEvent| event.api_status);
+    let compiler_unchanged_since =
+        unchanged_since(|event: &ClusterMonitorEvent| event.compiler_status);
+    let runner_unchanged_since = unchanged_since(|event: &ClusterMonitorEvent| event.runner_status);
     let health_status = HealthStatus {
         all_healthy: latest_event.api_status == MonitorStatus::Healthy
             && latest_event.compiler_status == MonitorStatus::Healthy
@@ -275,25 +333,84 @@ pub(crate) async fn get_cluster_health(
         api: ServiceStatus {
             healthy: latest_event.api_status == MonitorStatus::Healthy,
             message: latest_event.api_self_info,
-            unchanged_since: latest_event.recorded_at,
+            unchanged_since: api_unchanged_since,
             checked_at: latest_event.recorded_at,
         },
         compiler: ServiceStatus {
             healthy: latest_event.compiler_status == MonitorStatus::Healthy,
             message: latest_event.compiler_self_info,
-            unchanged_since: latest_event.recorded_at,
+            unchanged_since: compiler_unchanged_since,
             checked_at: latest_event.recorded_at,
         },
         runner: ServiceStatus {
             healthy: latest_event.runner_status == MonitorStatus::Healthy,
             message: latest_event.runner_self_info,
-            unchanged_since: latest_event.recorded_at,
+            unchanged_since: runner_unchanged_since,
             checked_at: latest_event.recorded_at,
         },
     };
-    if health_status.api.healthy && health_status.compiler.healthy && health_status.runner.healthy {
+    if health_status.all_healthy {
         Ok(HttpResponse::Ok().json(health_status))
     } else {
         Ok(HttpResponse::ServiceUnavailable().json(health_status))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(id: u128, seconds: i64, api_status: MonitorStatus) -> ClusterMonitorEvent {
+        ClusterMonitorEvent {
+            id: ClusterMonitorEventId(Uuid::from_u128(id)),
+            recorded_at: DateTime::from_timestamp(seconds, 0).unwrap(),
+            api_status,
+            compiler_status: MonitorStatus::Healthy,
+            runner_status: MonitorStatus::Healthy,
+        }
+    }
+
+    /// `service_unchanged_since` returns the start of the health run anchored at the
+    /// given latest event.
+    #[test]
+    fn unchanged_since_finds_run_start() {
+        let events = vec![
+            event(1, 100, MonitorStatus::Unhealthy),
+            event(2, 90, MonitorStatus::Unhealthy),
+            event(3, 80, MonitorStatus::InitialUnhealthy),
+            event(4, 70, MonitorStatus::Healthy),
+        ];
+        let at = |seconds| DateTime::from_timestamp(seconds, 0).unwrap();
+        let api_status = |event: &ClusterMonitorEvent| event.api_status;
+        let compiler_status = |event: &ClusterMonitorEvent| event.compiler_status;
+
+        // The unhealthy run spans events 1..=3 (`InitialUnhealthy` counts as unhealthy).
+        let since = service_unchanged_since(
+            &events,
+            ClusterMonitorEventId(Uuid::from_u128(1)),
+            api_status,
+        );
+        assert_eq!(since, Some(at(80)));
+        // Anchoring mid-list skips newer events; a single-element run yields its own timestamp.
+        let since = service_unchanged_since(
+            &events,
+            ClusterMonitorEventId(Uuid::from_u128(4)),
+            api_status,
+        );
+        assert_eq!(since, Some(at(70)));
+        // A run with no transition extends to the oldest retained event.
+        let since = service_unchanged_since(
+            &events,
+            ClusterMonitorEventId(Uuid::from_u128(1)),
+            compiler_status,
+        );
+        assert_eq!(since, Some(at(70)));
+        // An anchor absent from the list yields `None`.
+        let since = service_unchanged_since(
+            &events,
+            ClusterMonitorEventId(Uuid::from_u128(99)),
+            api_status,
+        );
+        assert_eq!(since, None);
     }
 }

--- a/crates/pipeline-manager/src/api/endpoints/cluster.rs
+++ b/crates/pipeline-manager/src/api/endpoints/cluster.rs
@@ -252,7 +252,7 @@ pub struct ServiceStatus {
     pub message: String,
     /// Approximate time the service last transitioned between healthy and unhealthy:
     /// the timestamp of the oldest retained consecutive cluster monitor event with the
-    /// same `healthy` conclusion. Bounded by event retention (at most 72h / 1000 events).
+    /// same `healthy` conclusion. Bounded by event retention.
     pub unchanged_since: DateTime<Utc>,
     /// Timestamp of the most recent cluster monitor event.
     pub checked_at: DateTime<Utc>,
@@ -300,7 +300,7 @@ fn service_unchanged_since(
 ///
 /// Determine the latest cluster health via the latest cluster monitor event.
 /// Each service's `unchanged_since` reports the approximate time it last transitioned
-/// between healthy and unhealthy, bounded by event retention (at most 72h / 1000 events).
+/// between healthy and unhealthy, bounded by event retention.
 #[utoipa::path(
     context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),

--- a/openapi.json
+++ b/openapi.json
@@ -373,7 +373,7 @@
           "Platform"
         ],
         "summary": "Check Cluster Health",
-        "description": "Required role: `read` or higher.\n\nDetermine the latest cluster health via the latest cluster monitor event.\nEach service's `unchanged_since` reports the approximate time it last transitioned\nbetween healthy and unhealthy, bounded by event retention (at most 72h / 1000 events).",
+        "description": "Required role: `read` or higher.\n\nDetermine the latest cluster health via the latest cluster monitor event.\nEach service's `unchanged_since` reports the approximate time it last transitioned\nbetween healthy and unhealthy, bounded by event retention.",
         "operationId": "get_cluster_health",
         "responses": {
           "200": {
@@ -14855,7 +14855,7 @@
           "unchanged_since": {
             "type": "string",
             "format": "date-time",
-            "description": "Approximate time the service last transitioned between healthy and unhealthy:\nthe timestamp of the oldest retained consecutive cluster monitor event with the\nsame `healthy` conclusion. Bounded by event retention (at most 72h / 1000 events)."
+            "description": "Approximate time the service last transitioned between healthy and unhealthy:\nthe timestamp of the oldest retained consecutive cluster monitor event with the\nsame `healthy` conclusion. Bounded by event retention."
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -373,7 +373,7 @@
           "Platform"
         ],
         "summary": "Check Cluster Health",
-        "description": "Required role: `read` or higher.\n\nDetermine the latest cluster health via the latest cluster monitor event.",
+        "description": "Required role: `read` or higher.\n\nDetermine the latest cluster health via the latest cluster monitor event.\nEach service's `unchanged_since` reports the approximate time it last transitioned\nbetween healthy and unhealthy, bounded by event retention (at most 72h / 1000 events).",
         "operationId": "get_cluster_health",
         "responses": {
           "200": {
@@ -10936,6 +10936,7 @@
       },
       "HealthStatus": {
         "type": "object",
+        "description": "Health of the cluster as a whole and of each of its services.",
         "required": [
           "all_healthy",
           "api",
@@ -10944,7 +10945,8 @@
         ],
         "properties": {
           "all_healthy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether every service is healthy."
           },
           "api": {
             "$ref": "#/components/schemas/ServiceStatus"
@@ -14829,6 +14831,7 @@
       },
       "ServiceStatus": {
         "type": "object",
+        "description": "Health of a single service derived from the retained cluster monitor events.",
         "required": [
           "healthy",
           "message",
@@ -14838,17 +14841,21 @@
         "properties": {
           "checked_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the most recent cluster monitor event."
           },
           "healthy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the service passed its most recent health check."
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable report from the most recent health check."
           },
           "unchanged_since": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Approximate time the service last transitioned between healthy and unhealthy:\nthe timestamp of the oldest retained consecutive cluster monitor event with the\nsame `healthy` conclusion. Bounded by event retention (at most 72h / 1000 events)."
           }
         }
       },


### PR DESCRIPTION
## What

- `GET /v0/cluster_healthz`: each service's `unchanged_since` now reports the approximate time the service last transitioned between healthy and unhealthy. It is derived from the retained cluster monitor events (the timestamp of the oldest consecutive event that shares the latest event's healthy conclusion) and is bounded by event retention (72h / 1000 events). It previously echoed `checked_at`.
- `fda cluster health`: prints per-service health and exits 0 only when all services are healthy. Both the 200 and 503 responses carry the `HealthStatus` body, so an unhealthy cluster still prints the full table.
- `fda cluster config`: prints the platform configuration from `/v0/config`. Text output summarizes (drops the huge `build_info.cargo_dependencies` list); JSON output has all fields.

```
$ fda cluster health
╭──────────┬─────────┬─────────────────────────────────┬─────────────────────────────────┬───────────────────────────────────────────────╮
│ service  │ healthy │ unchanged_since                 │ checked_at                      │ message                                       │
├──────────┼─────────┼─────────────────────────────────┼─────────────────────────────────┼───────────────────────────────────────────────┤
│ api      │ true    │ 2026-08-20 04:17:28 UTC (146s…) │ 2026-08-20 04:17:28 UTC (146s…) │ Healthy: The api service responded success…   │
│ compiler │ true    │ …                               │ …                               │ …                                             │
│ runner   │ true    │ …                               │ …                               │ …                                             │
╰──────────┴─────────┴─────────────────────────────────┴─────────────────────────────────┴───────────────────────────────────────────────╯
```

## Testing

- Unit test for the run-scan helper (`service_unchanged_since`), covering the transition case, mid-list anchoring, a run that reaches retention, and a missing anchor. Verified the test fails against the previous behavior.
- Smoke-tested `fda cluster health` and `fda cluster config` against the staging EKS instance.
