### PR TITLE
[adapters] count the input of a removed input endpoint

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3641,6 +3641,11 @@ impl CircuitThread {
             None => return Ok(false),
         };
 
+        // Input whose endpoint was removed before `input_step` could collect
+        // its result reached the circuit all the same, so this step processes
+        // it. See `ControllerStatus::orphaned_input`.
+        let total_consumed = total_consumed + self.controller.status.take_orphaned_input();
+
         self.step += 1;
 
         // Wake up the backpressure thread to unpause endpoints blocked due to
@@ -4374,7 +4379,9 @@ impl CircuitThread {
             let mut failed = Vec::new();
             waiting.retain(|&endpoint_id, _| {
                 let Some(status) = statuses.get(&endpoint_id) else {
-                    // Input adapter was deleted without yielding any input.
+                    // Input adapter was deleted. Input that it had already
+                    // yielded is accounted for by
+                    // `ControllerStatus::orphaned_input`.
                     return false;
                 };
                 let Some(results) = mem::take(&mut *status.progress.lock().unwrap()) else {
@@ -7286,7 +7293,10 @@ impl ControllerInner {
     pub fn disconnect_input(self: &Arc<Self>, endpoint_id: &EndpointId) {
         debug!("Disconnecting input endpoint {endpoint_id}");
 
-        if let Some(ep) = self.status.remove_input(endpoint_id) {
+        if let Some(ep) = self
+            .status
+            .remove_input(endpoint_id, &self.circuit_thread_unparker)
+        {
             if let Some(reader) = ep.reader.as_ref() {
                 reader.disconnect()
             }
@@ -8946,6 +8956,7 @@ impl InputConsumer for InputProbe {
                 }),
             },
             vec![],
+            &self.controller.circuit_thread_unparker,
             &self.controller.backpressure_thread_unparker,
         );
         self.controller.unpark_circuit();
@@ -8966,6 +8977,7 @@ impl InputConsumer for InputProbe {
             self.endpoint_id,
             StepResults { amt, resume },
             watermarks,
+            &self.controller.circuit_thread_unparker,
             &self.controller.backpressure_thread_unparker,
         );
         self.controller.unpark_circuit();

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -546,6 +546,20 @@ pub struct ControllerStatus {
 
     /// Output endpoint configs and metrics.
     outputs: OutputsStatus,
+
+    /// Input that reached the circuit but has no endpoint left to report it.
+    ///
+    /// An endpoint hands records to the circuit with [`Self::extended`], which
+    /// parks their size in the endpoint's own status entry for the circuit
+    /// thread to pick up and count as processed. Removing the endpoint takes
+    /// that entry with it, and an endpoint can be removed at any point: an ad
+    /// hoc `INSERT` disconnects its endpoint as soon as the queue drains. The
+    /// records are in the circuit either way, so their size is stashed here
+    /// instead and credited by the next step. Otherwise
+    /// `total_processed_records` would stay permanently below
+    /// `total_input_records`, and a client waiting for the pipeline to catch up
+    /// with an ad hoc write would wait forever.
+    orphaned_input: Mutex<BufferSize>,
 }
 
 /// Context needed by [`ControllerStatus::to_api_type`] to build the public
@@ -587,6 +601,7 @@ impl ControllerStatus {
             checkpoint_notifier,
             inputs: RwLock::new(BTreeMap::new()),
             outputs: RwLock::new(BTreeMap::new()),
+            orphaned_input: Mutex::new(BufferSize::empty()),
         }
     }
 
@@ -718,8 +733,39 @@ impl ControllerStatus {
         }
     }
 
-    pub fn remove_input(&self, endpoint_id: &EndpointId) -> Option<InputEndpointStatus> {
-        self.inputs.write().remove(endpoint_id)
+    pub fn remove_input(
+        &self,
+        endpoint_id: &EndpointId,
+        circuit_thread_unparker: &Unparker,
+    ) -> Option<InputEndpointStatus> {
+        let endpoint = self.inputs.write().remove(endpoint_id)?;
+
+        // The endpoint may have handed records to the circuit that the circuit
+        // thread has not counted yet. That result dies with the endpoint, so
+        // keep its size and request the step that credits it; see
+        // `orphaned_input`.
+        if let Some(results) = endpoint.progress.lock().unwrap().take() {
+            self.orphan_input(results.amt, circuit_thread_unparker);
+        }
+
+        Some(endpoint)
+    }
+
+    /// Stashes input that the circuit received from an endpoint that is no
+    /// longer registered, and requests the step that credits it; see
+    /// [`Self::orphaned_input`].
+    fn orphan_input(&self, amt: BufferSize, circuit_thread_unparker: &Unparker) {
+        if amt.is_empty() {
+            return;
+        }
+        *self.orphaned_input.lock().unwrap() += amt;
+        self.request_step(circuit_thread_unparker);
+    }
+
+    /// Takes the input stashed by [`Self::orphan_input`], for the caller to
+    /// count as processed by the step it is about to run.
+    pub(super) fn take_orphaned_input(&self) -> BufferSize {
+        std::mem::take(&mut *self.orphaned_input.lock().unwrap())
     }
 
     pub fn remove_output(&self, endpoint_id: &EndpointId) {
@@ -1216,11 +1262,12 @@ impl ControllerStatus {
         endpoint_id: EndpointId,
         step_results: StepResults,
         watermarks: Vec<Watermark>,
+        circuit_thread_unparker: &Unparker,
         backpressure_thread_unparker: &Unparker,
     ) {
         let inputs = self.input_status();
-        self.global_metrics
-            .consume_buffered_inputs(step_results.amt);
+        let amt = step_results.amt;
+        self.global_metrics.consume_buffered_inputs(amt);
 
         let mut finished = false;
 
@@ -1233,7 +1280,11 @@ impl ControllerStatus {
                 self.global_metrics.total_completed_steps(),
             );
             finished = endpoint_stats.finished();
-        };
+        } else {
+            // The endpoint was removed before it reported this input: the step
+            // that would have counted these records has already moved on.
+            self.orphan_input(amt, circuit_thread_unparker);
+        }
 
         drop(inputs);
 

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -1,21 +1,26 @@
 use super::{OutputEndpointControl, stats::BufferedInput};
 use crate::{
-    Controller, PipelineConfig,
+    Controller, InputConsumer, InputEndpoint, PipelineConfig, TransportInputEndpoint,
     controller::{ControllerStatusContext, TransactionInfo},
     preprocess::{DecryptionPreprocessorFactory, PassthroughPreprocessorFactory},
     test::{
         DEFAULT_TIMEOUT_MS, TestStruct, generate_test_batch, init_test_logger, test_circuit, wait,
     },
-    transport::{input_transport_config_to_endpoint, set_barrier},
+    transport::{
+        InputQueue, InputReader, InputReaderCommand, input_transport_config_to_endpoint,
+        set_barrier,
+    },
 };
 use anyhow::anyhow;
+use chrono::Utc;
 use crossbeam::sync::Parker;
 use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
-use feldera_adapterlib::format::BufferSize;
+use feldera_adapterlib::format::{BufferSize, Parser};
 use feldera_types::{
-    config::{InputEndpointConfig, OutputEndpointConfig},
+    config::{FtModel, InputEndpointConfig, OutputEndpointConfig},
     constants::STATE_FILE,
     memory_pressure::MemoryPressure,
+    program_schema::Relation,
 };
 use serde_json::json;
 use std::{
@@ -27,7 +32,7 @@ use std::{
     iter::repeat_n,
     ops::Range,
     path::{Path, PathBuf},
-    sync::{atomic::Ordering, mpsc},
+    sync::{Arc, Mutex, atomic::Ordering, mpsc},
     thread::sleep,
     time::Duration,
 };
@@ -1041,6 +1046,182 @@ fn fault_tolerance_mismatch_unregisters_the_endpoint() {
         "the rejected endpoint stayed registered"
     );
     assert!(controller.status().input_status().is_empty());
+
+    controller.stop().unwrap();
+}
+
+/// An input endpoint that hands its input to the circuit when the test says so,
+/// rather than in reply to a `Queue` command.
+///
+/// The controller collects an endpoint's input in two steps: the endpoint
+/// reports it with [`InputConsumer::extended`], which parks the result in the
+/// endpoint's status entry, and the circuit thread then picks the result up and
+/// counts the records as processed.  Releasing the input outside a `Queue`
+/// command puts the endpoint between those two steps for as long as the test
+/// needs, which is the window that a removed endpoint has to lose input in.
+#[derive(Clone)]
+struct ManualInputEndpoint {
+    details: Arc<Mutex<Option<ManualInputEndpointDetails>>>,
+}
+
+struct ManualInputEndpointDetails {
+    parser: Box<dyn Parser>,
+    queue: InputQueue,
+}
+
+impl ManualInputEndpoint {
+    fn new() -> Self {
+        Self {
+            details: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Parses `data` and queues it, reporting the records as buffered.
+    fn push(&self, data: &str) {
+        let mut guard = self.details.lock().unwrap();
+        let details = guard.as_mut().unwrap();
+        let parsed = details.parser.parse(data.as_bytes(), None);
+        details.queue.push(parsed, Utc::now());
+    }
+
+    /// Flushes the queued records to the circuit and reports them to the
+    /// controller.
+    fn release(&self) {
+        self.details.lock().unwrap().as_ref().unwrap().queue.queue();
+    }
+}
+
+impl InputEndpoint for ManualInputEndpoint {
+    fn fault_tolerance(&self) -> Option<FtModel> {
+        None
+    }
+}
+
+impl TransportInputEndpoint for ManualInputEndpoint {
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        _schema: Relation,
+        _resume_info: Option<serde_json::Value>,
+    ) -> anyhow::Result<Box<dyn InputReader>> {
+        *self.details.lock().unwrap() = Some(ManualInputEndpointDetails {
+            parser,
+            queue: InputQueue::new(consumer),
+        });
+        Ok(Box::new(self.clone()))
+    }
+}
+
+impl InputReader for ManualInputEndpoint {
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+        self
+    }
+
+    fn request(&self, command: InputReaderCommand) {
+        match command {
+            // Report no input: the test releases it with
+            // `ManualInputEndpoint::release`.
+            InputReaderCommand::Queue { .. } => self
+                .details
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .queue
+                .consumer
+                .extended(BufferSize::empty(), None, Vec::new()),
+            InputReaderCommand::Extend
+            | InputReaderCommand::Pause
+            | InputReaderCommand::Disconnect => (),
+            InputReaderCommand::Replay { .. } => {
+                unreachable!("this endpoint is not fault tolerant")
+            }
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        false
+    }
+}
+
+/// Removing an input endpoint must not take the count of the input it already
+/// handed to the circuit with it.
+///
+/// The endpoint reports its input with `extended`, which stores the result in
+/// the endpoint's status entry for the circuit thread to count as processed.
+/// A `disconnect_input` removes the endpoint, losing this count.  The records
+/// reach the circuit either way, so losing their count would leave
+/// `total_processed_records` permanently below `total_input_records`.
+#[test]
+fn removed_input_endpoint_input_is_still_counted() {
+    init_test_logger();
+
+    // Buffer enough that the trigger runs no step on its own: the test decides
+    // when the circuit sees the input.
+    let config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 4,
+        "min_batch_size_records": 1_000_000,
+        "max_buffering_delay_usecs": 1_000_000_000,
+        "clock_resolution_usecs": null,
+    }))
+    .unwrap();
+
+    let controller = Controller::with_test_config(
+        |circuit_config| {
+            Ok(test_circuit::<TestStruct>(
+                circuit_config,
+                &TestStruct::schema(),
+                &[None],
+            ))
+        },
+        &config,
+        Box::new(|e, _| panic!("error: {e}")),
+    )
+    .unwrap();
+    controller.start();
+
+    let endpoint = ManualInputEndpoint::new();
+    let endpoint_config: InputEndpointConfig = serde_json::from_value(json!({
+        "stream": "test_input1",
+        "transport": {
+            "name": "file_input",
+            "config": { "path": "unused" }
+        },
+        "format": { "name": "csv" }
+    }))
+    .unwrap();
+    let endpoint_id = controller
+        .add_input_endpoint("manual", endpoint_config, Box::new(endpoint.clone()), None)
+        .unwrap();
+
+    // The endpoint hands three records to the circuit and is removed before the
+    // circuit thread collects the result.
+    endpoint.push("1,true,,foo\n2,true,,foo\n3,true,,foo\n");
+    endpoint.release();
+    let status = controller.status();
+    assert_eq!(status.num_total_input_records(), 3);
+    assert_eq!(status.num_buffered_input_records(), 0);
+    assert_eq!(
+        status.num_total_processed_records(),
+        0,
+        "the test needs the result to still be uncollected here"
+    );
+
+    controller.disconnect_input(&endpoint_id);
+    wait(|| controller.pipeline_complete(), 10_000)
+        .expect("the input of a removed endpoint was never counted as processed");
+    assert_eq!(controller.status().num_total_processed_records(), 3);
+
+    // Same again, except that the endpoint reports the input only after it has
+    // been removed, which is the window an endpoint that replies on its own
+    // thread has between `remove_input` and losing its reader.
+    endpoint.push("4,true,,foo\n5,true,,foo\n6,true,,foo\n");
+    endpoint.release();
+    wait(|| controller.pipeline_complete(), 10_000)
+        .expect("input reported after the endpoint was removed was never counted as processed");
+    assert_eq!(controller.status().num_total_processed_records(), 6);
 
     controller.stop().unwrap();
 }


### PR DESCRIPTION
Removing an input endpoint threw away the count of input it had already handed to the circuit, so `total_processed_records` -- and with it `total_completed_records` -- stayed permanently below `total_input_records` and the pipeline never reported completion.

`ControllerStatus::extended` decrements the global `buffered_input_records` and bumps `total_circuit_input_records` unconditionally, but stores the endpoint's `StepResults` in that endpoint's status entry, and that parked result is what `input_step` sums into the amount a step credits as processed.  `remove_input` dropped the entry. An ad hoc `INSERT` disconnects its endpoint as soon as its queue drains, which is inside the very `input_step` that collected the records, so losing the race for the status map between `queue()` and the collection loop lost the count of records the circuit had already processed.  An endpoint that replies on its own thread, such as `/ingress`, has a far wider window: it can report input after `disconnect_input` has unregistered it.

Salvage the count in both places into `ControllerStatus::orphaned_input` and credit it to the next step, which is the step that processes those records.  Stashing also requests a step, since an idle pipeline runs none on its own.  The credit is applied where the per-endpoint results were already summed, before `step_circuit`, so ad hoc queries still observe the data before the pipeline reports it processed.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
