### PR TITLE
Test checkpoint sync diagnostics

### DIFF
--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -336,29 +336,51 @@ class TestCheckpointSync(SharedTestPipeline):
         )
 
     def _wait_for_automated_sync(self, chk_uuid=None, chk_steps=None):
-        """Poll until the periodic sync has uploaded a checkpoint at least as recent as *chk_uuid*."""
+        """Poll until the periodic sync has uploaded a checkpoint at least as recent as *chk_uuid*.
+
+        Reads the raw sync status rather than
+        `Pipeline.last_successful_checkpoint_sync`, which raises the same
+        `RuntimeError` whether the sync failed, was never attempted, or is still
+        in flight.  A timeout here reports the last status and the checkpoints
+        that were available, since the interesting failures are a `failure` the
+        sync kept retrying and a status that reports nothing at all.
+        """
+        last_status = None
 
         def checkpoint_sync_completed() -> bool:
-            try:
-                synced = self.pipeline.last_successful_checkpoint_sync()
-                print("Automatically synced checkpoint UUID:", synced, file=sys.stderr)
-                if synced is None:
-                    return False
-                if chk_uuid is None:
-                    return True
-                s_steps = self._checkpoint_steps(synced)
-                if chk_steps is not None and s_steps is not None:
-                    return s_steps >= chk_steps
-                return UUID(str(synced)) >= UUID(str(chk_uuid))
-            except RuntimeError:
+            nonlocal last_status
+            last_status = self.pipeline.client.sync_checkpoint_status(
+                self.pipeline.name
+            )
+            print(f"Automated sync status: {last_status}", file=sys.stderr)
+            uuids = [
+                UUID(u)
+                for u in (last_status.get("success"), last_status.get("periodic"))
+                if u is not None
+            ]
+            if not uuids:
                 return False
+            synced = max(uuids)
+            if chk_uuid is None:
+                return True
+            s_steps = self._checkpoint_steps(synced)
+            if chk_steps is not None and s_steps is not None:
+                return s_steps >= chk_steps
+            return synced >= UUID(str(chk_uuid))
 
-        wait_for_condition(
-            "automated checkpoint sync completes",
-            checkpoint_sync_completed,
-            timeout_s=30.0,
-            poll_interval_s=0.5,
-        )
+        try:
+            wait_for_condition(
+                "automated checkpoint sync completes",
+                checkpoint_sync_completed,
+                timeout_s=30.0,
+                poll_interval_s=0.5,
+            )
+        except TimeoutError as e:
+            chks = [chk.to_dict() for chk in self.pipeline.checkpoints()]
+            raise TimeoutError(
+                f"{e}; waited for {chk_uuid} (steps {chk_steps}),"
+                f" last sync status {last_status}, checkpoints {chks}"
+            ) from e
 
     def _sync_and_verify(self, chk_uuid=None, chk_steps=None):
         """Trigger a manual sync and assert it covers *chk_uuid*. Returns the synced UUID."""

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -128,25 +128,36 @@ def storage_cfg(
     }
 
 
-def build_runtime_config(*args, **kwargs):
-    """Build a `RuntimeConfig`, with h2 frame-level tracing on by default.
+# Logging filter that turns on h2 frame-level tracing, for the tests chasing the
+# multihost completion hang.
+#
+# test_owner_lock_allows_renamed_pipeline and other tests in this file, plus
+# test_iceberg_ordered_resume_skips_ingested, have hung in CI waiting for
+# /completion_status or /checkpoint_status to report done on a multihost pipeline
+# that had, per /stats, already finished (feldera/cloud#1897 is the same shape).
+# The completion/checkpoint counters are updated correctly and published to the
+# coordinator's watch channel, but the coordinator's cached view of them can go
+# stale if the underlying h2 stream stalls without erroring.  Frame-level tracing
+# on both the pipeline (h2 0.3.x via actix-http) and the coordinator (h2 0.4.x
+# via reqwest/hyper) shows the window updates, send capacity and wakers for
+# whichever stream gets stuck.
+#
+# The trace outruns the pipeline log buffer within seconds -- a 35-minute CI run
+# discarded 559,942 lines and left 1.4s of history, which is not enough to
+# diagnose anything else that goes wrong -- so tests opt in individually rather
+# than all of them paying for it.  Remove once the hang is understood and fixed.
+H2_TRACE_LOGGING = (
+    "object_store=warn,buoyant_kernel=warn,info,h2=trace,actix_http::h2=trace"
+)
 
-    This test has twice hung in CI waiting for /completion_status or
-    /checkpoint_status to report done on a multihost pipeline that
-    had, per /stats, already finished (feldera/cloud#1897 is the same
-    shape). h2 frame-level tracing on both the pipeline (h2 0.3.x via
-    actix-http) and the coordinator (h2 0.4.x via reqwest/hyper)
-    should show whether a stream's send capacity/window update is
-    being lost.
 
-    The additional logging can be removed once the hang is understood
-    and fixed.
+def build_runtime_config(*args, h2_trace: bool = False, **kwargs):
+    """Build a `RuntimeConfig`, with h2 frame-level tracing if *h2_trace*.
 
+    See `H2_TRACE_LOGGING` for what the tracing is for and what it costs.
     """
-    kwargs.setdefault(
-        "logging",
-        "object_store=warn,buoyant_kernel=warn,info,h2=trace,actix_http::h2=trace",
-    )
+    if h2_trace:
+        kwargs.setdefault("logging", H2_TRACE_LOGGING)
     return RuntimeConfig(*args, **kwargs)
 
 
@@ -175,6 +186,7 @@ class TestCheckpointSync(SharedTestPipeline):
         ft_interval: int = 60,
         push_interval: Optional[int] = None,
         retention_min_age: int = 0,
+        h2_trace: bool = False,
     ):
         """Configure the pipeline with AtLeastOnce FT and start it."""
         storage_config = storage_cfg(
@@ -190,6 +202,7 @@ class TestCheckpointSync(SharedTestPipeline):
                 fault_tolerance_model=FaultToleranceModel.AtLeastOnce,
                 storage=Storage(config=storage_config),
                 checkpoint_interval_secs=ft_interval,
+                h2_trace=h2_trace,
             )
         )
         self.pipeline.start()
@@ -625,6 +638,7 @@ class TestCheckpointSync(SharedTestPipeline):
                 storage=Storage(
                     config=storage_cfg(bucket_name, start_from_checkpoint="latest")
                 ),
+                h2_trace=True,
             )
         )
         self.pipeline.start()


### PR DESCRIPTION
These commits should make future CI failures in TestCheckpointSync easier to interpret.

These are test-only changes.