### PR TITLE
[adapters] fix delta filter over undeclared columns in follow mode

### DIFF
--- a/crates/adapterlib/src/utils/datafusion.rs
+++ b/crates/adapterlib/src/utils/datafusion.rs
@@ -318,9 +318,9 @@ pub fn validate_sql_order_by(order_by: &str) -> Result<(), ParserError> {
 }
 
 /// Collect into `columns` every column name an expression's AST references,
-/// walking nested sub-expressions. For a compound reference such as `t.c` only
-/// the trailing part (`c`) is taken, since that is the column; leading parts are
-/// table qualifiers.
+/// walking nested sub-expressions. Every part of a compound reference `a.b.c` is
+/// kept: the AST cannot tell a table qualifier from a column from a struct
+/// field, so any part may be the column.
 ///
 /// Over-collecting is harmless for the callers here -- it merely keeps a column
 /// from being pruned -- but under-collecting would drop a column the connector
@@ -332,9 +332,7 @@ fn collect_referenced_columns(expr: &Expr, columns: &mut BTreeSet<String>) {
                 columns.insert(ident.value.clone());
             }
             Expr::CompoundIdentifier(parts) => {
-                if let Some(column) = parts.last() {
-                    columns.insert(column.value.clone());
-                }
+                columns.extend(parts.iter().map(|part| part.value.clone()));
             }
             _ => {}
         }
@@ -924,8 +922,15 @@ mod tests {
             ),
             // Function arguments are walked; the function name is not a column.
             ("lower(status) = 'gone'", columns(&["status"])),
-            // A compound reference resolves to its trailing (column) part.
-            ("t.deleted = true", columns(&["deleted"])),
+            // A compound reference is a qualified column (`t.deleted`) or a
+            // struct field access (`info.deleted`), so both parts are kept.
+            ("info.deleted = true", columns(&["info", "deleted"])),
+            // The column is the first part under struct nesting and the second
+            // under a qualifier, so deeper nesting keeps every part.
+            (
+                "t.info.flags.deleted",
+                columns(&["t", "info", "flags", "deleted"]),
+            ),
             // A predicate over no columns yields the empty set.
             ("1 = 1", columns(&[])),
         ] {

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -327,6 +327,29 @@ fn relabel_nested_columns(
     .map_err(|e| anyhow!("relabeling column-mapped field names failed: {e}"))
 }
 
+/// Apply the connector's optional `filter` to `df`, or return `df` unchanged.
+/// The expression parses against `df`'s own schema, so `df` must still carry
+/// every column the filter names. `relation` names the frame when a caller has
+/// more than one (the two CDC sides); pass `None` when `description` already
+/// identifies it.
+pub(super) fn apply_filter(
+    df: DataFrame,
+    filter: Option<&str>,
+    description: &str,
+    relation: Option<&str>,
+) -> AnyResult<DataFrame> {
+    let Some(filter) = filter else {
+        return Ok(df);
+    };
+    let expr = df
+        .parse_sql_expr(filter)
+        .map_err(|e| anyhow!("invalid 'filter' expression '{filter}': {e}"))?;
+    let frame = relation.map_or(String::new(), |r| format!(" to '{r}'"));
+    df.filter(expr).map_err(|e| {
+        anyhow!("internal error processing {description}; {REPORT_ERROR}; error applying 'filter'{frame}: {e}")
+    })
+}
+
 /// Build the `DataFrame` that streams a CDC transaction to the circuit.
 ///
 /// Equivalent (in SQL) to:
@@ -354,12 +377,10 @@ fn relabel_nested_columns(
 /// would have been ingested anyway. This also shrinks the inputs to
 /// `EXCEPT ALL`, which sorts both relations.
 ///
-/// The filter is parsed against each `DataFrame`'s own schema, so
-/// column references resolve against the correct relation. The two
-/// sides cannot share a single parsed `Expr` because column
-/// references would otherwise point at the wrong relation after
-/// `except`. (`cdc_adds` and `cdc_removes` are labels for the two
-/// sides, not registered tables.)
+/// Each side is filtered separately (see [`apply_filter`]): the two
+/// cannot share one parsed `Expr`, because its column references
+/// would point at the wrong relation after `except`. (`cdc_adds` and
+/// `cdc_removes` are labels for the two sides, not registered tables.)
 ///
 /// Caveat: `EXCEPT ALL` relies on `arrow_row::RowConverter`, which in
 /// the currently pinned `arrow-row` does not support `Map` columns.
@@ -380,24 +401,12 @@ pub(super) fn build_cdc_dataframe(
     order_by: &str,
     description: &str,
 ) -> AnyResult<DataFrame> {
-    let apply_filter = |df: DataFrame, side: &'static str| -> AnyResult<DataFrame> {
-        let Some(filter) = filter else {
-            return Ok(df);
-        };
-        let expr = df
-            .parse_sql_expr(filter)
-            .map_err(|e| anyhow!("invalid 'filter' expression '{filter}': {e}"))?;
-        df.filter(expr).map_err(|e| {
-            anyhow!("internal error processing {description}; {REPORT_ERROR}; error applying 'filter' to '{side}': {e}")
-        })
-    };
-
-    let adds_df = apply_filter(adds_df, "cdc_adds")?;
+    let adds_df = apply_filter(adds_df, filter, description, Some("cdc_adds"))?;
 
     let result_df = match removes_df {
         None => adds_df,
         Some(removes_df) => {
-            let removes_df = apply_filter(removes_df, "cdc_removes")?;
+            let removes_df = apply_filter(removes_df, filter, description, Some("cdc_removes"))?;
             adds_df.except(removes_df).map_err(|e| {
                 anyhow!("failed to build the CDC set difference for {description}: {e}. This typically means the Delta table contains a `Map` column, which the CDC deduplication step (`EXCEPT ALL`) does not yet support.")
             })?
@@ -1096,8 +1105,9 @@ struct DeltaTableInputEndpointInner {
     catchup_follow_state: Mutex<CatchupFollowState>,
 
     /// SQL columns the connector actually reads (skippable unused columns
-    /// removed when `skip_unused_columns` is set). A delta column is kept iff it
-    /// is a member. Derived once from the immutable SQL schema.
+    /// removed when `skip_unused_columns` is set). One input to which Delta
+    /// columns are kept; see [`needs_column`](DeltaTableInputEndpointInner::needs_column).
+    /// Derived once from the immutable SQL schema.
     used_sql_columns: OnceLock<ColumnNameSet>,
 
     /// SQL columns named by the connector's own expressions -- `filter`,
@@ -1456,21 +1466,24 @@ impl DeltaTableInputEndpointInner {
                 .contains(&field.name.name())
     }
 
-    /// True if CDC keeps the column named `name`. When `skip_unused_columns`
-    /// is off, keep everything. When on, keep a column only if the circuit
-    /// reads it (`used_sql_columns`) or a connector expression names it
-    /// (`config_referenced_columns`, which also covers Delta metadata columns
-    /// like `__feldera_op` that the SQL schema omits).
+    /// True if the connector reads the column `name`: the circuit uses it, or a
+    /// connector expression names it -- including Delta columns the SQL table
+    /// never declares (`__feldera_op`, a filter-only column), which the
+    /// projection then drops.
+    fn needs_column(&self, name: &str) -> bool {
+        self.used_sql_columns().contains(name) || self.config_referenced_columns().contains(name)
+    }
+
+    /// True if CDC keeps the column named `name`: everything when
+    /// `skip_unused_columns` is off, otherwise the columns the connector needs.
     ///
     /// The plain and DV-masked CDC sides must apply this same rule, or their
-    /// columns differ and the `UNION ALL` no longer lines up by position. The
-    /// off case needs the explicit `!skip_unused_columns()`: `used_sql_columns`
-    /// holds only SQL columns, but the unprojected frame also carries Delta
-    /// physical columns the SQL table never maps.
+    /// columns differ and the `UNION ALL` no longer lines up by position. Hence
+    /// the explicit off case: [`project_cdc_columns`](Self::project_cdc_columns)
+    /// returns the plain side unprojected when the flag is off, so the masked
+    /// side must keep everything too.
     fn keeps_cdc_column(&self, name: &str) -> bool {
-        !self.skip_unused_columns()
-            || self.used_sql_columns().contains(name)
-            || self.config_referenced_columns().contains(name)
+        !self.skip_unused_columns() || self.needs_column(name)
     }
 
     /// Project `df` to the columns the connector needs when `skip_unused_columns`
@@ -3337,7 +3350,7 @@ impl DeltaTableInputEndpointInner {
     /// projection (see [`filtered_parquet_table`]). It must match the columns
     /// any file it unions with keeps, so the providers line up in one query. It
     /// is a predicate rather than a fixed list because the callers differ:
-    /// follow keeps its `used_columns`, CDC keeps `keeps_cdc_column`.
+    /// follow keeps `needs_column`, CDC keeps `keeps_cdc_column`.
     async fn file_provider(
         &self,
         table: &DeltaTable,
@@ -3542,7 +3555,7 @@ impl DeltaTableInputEndpointInner {
                 None => RoaringTreemap::new(),
             };
             self.file_provider(table, path, bitmap, ReadMode::NotInBitmap, |name| {
-                used_columns.contains(&name)
+                self.needs_column(name)
             })
             .await?
         } else {
@@ -3590,7 +3603,7 @@ impl DeltaTableInputEndpointInner {
                 let description = format!("file '{path}'");
                 let provider = self
                     .file_provider(table, path, positions.clone(), ReadMode::InBitmap, |name| {
-                        used_columns.contains(&name)
+                        self.needs_column(name)
                     })
                     .await?;
                 self.emit_provider(
@@ -3622,9 +3635,11 @@ impl DeltaTableInputEndpointInner {
         }
     }
 
-    /// Read `provider` restricted to `used_columns`, apply the connector's
-    /// optional `filter` expression (`self.config.filter`), and push the rows to
-    /// the input stream with `polarity`.
+    /// Apply the connector's optional `filter` to `provider`, project to
+    /// `used_columns`, and push the rows to the input stream with `polarity`.
+    ///
+    /// The filter runs first because it may name Delta columns `used_columns`
+    /// does not carry, the ones the SQL table never declares.
     #[allow(clippy::too_many_arguments)]
     async fn emit_provider(
         &self,
@@ -3643,20 +3658,12 @@ impl DeltaTableInputEndpointInner {
         // Translate column-mapped physical names back to logical before any
         // logical-name projection or filter.
         let df = self.project_physical_to_logical(df)?;
+
+        let df = apply_filter(df, self.config.filter.as_deref(), description, None)?;
+
         let df = df.select_columns(used_columns).map_err(|e| {
             anyhow!("internal error processing {description}; {REPORT_ERROR}; error selecting columns: {e}")
         })?;
-
-        let df = if let Some(filter) = &self.config.filter {
-            let expr = df
-                .parse_sql_expr(filter)
-                .map_err(|e| anyhow!("invalid 'filter' expression '{filter}': {e}"))?;
-            df.filter(expr).map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error applying 'filter': {e}")
-            })?
-        } else {
-            df
-        };
 
         let _record_count = self
             .execute_df(

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4161,3 +4161,243 @@ fn delta_table_unity_people_2m() {
 
     forget(json_file);
 }
+
+/// A `filter` is a `where` clause over the Delta table, so it may name a column
+/// the SQL table does not declare; follow mode used to project those away first.
+async fn run_follow_filter_undeclared_column_test(filter_expr: &str) {
+    use crate::test::TestStruct;
+    use arrow::array::{Array, BooleanArray, Int64Array, RecordBatch, StringArray, StructArray};
+    use arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
+        Schema as ArrowSchema,
+    };
+    use deltalake::kernel::{DataType as KernelDataType, PrimitiveType, StructField};
+
+    init_logging();
+
+    // `region` and `meta` exist only in the Delta table. `meta.tag` mirrors
+    // `region`, so both filter forms select the same rows.
+    let meta_fields: ArrowFields =
+        vec![Arc::new(ArrowField::new("tag", ArrowDataType::Utf8, false))].into();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, false),
+        ArrowField::new("b", ArrowDataType::Boolean, false),
+        ArrowField::new("s", ArrowDataType::Utf8, false),
+        ArrowField::new("region", ArrowDataType::Utf8, false),
+        ArrowField::new("meta", ArrowDataType::Struct(meta_fields.clone()), false),
+    ]));
+    let struct_fields = vec![
+        StructField::new("id", KernelDataType::Primitive(PrimitiveType::Long), false),
+        StructField::new(
+            "b",
+            KernelDataType::Primitive(PrimitiveType::Boolean),
+            false,
+        ),
+        StructField::new("s", KernelDataType::Primitive(PrimitiveType::String), false),
+        StructField::new(
+            "region",
+            KernelDataType::Primitive(PrimitiveType::String),
+            false,
+        ),
+        StructField::new(
+            "meta",
+            KernelDataType::try_from_arrow(&ArrowDataType::Struct(meta_fields.clone())).unwrap(),
+            false,
+        ),
+    ];
+
+    // Even ids are in region 'us' (kept), odd ids in 'eu' (filtered out).
+    let region = |id: u32| if id.is_multiple_of(2) { "us" } else { "eu" };
+    let row = |id: u32| TestStruct {
+        id,
+        b: false,
+        i: None,
+        s: format!("row-{id}"),
+    };
+    let make_batch = |ids: &[u32]| -> RecordBatch {
+        RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(
+                    ids.iter().map(|id| *id as i64),
+                )) as Arc<dyn Array>,
+                Arc::new(ids.iter().map(|_| Some(false)).collect::<BooleanArray>()),
+                Arc::new(StringArray::from_iter_values(
+                    ids.iter().map(|id| format!("row-{id}")),
+                )),
+                Arc::new(StringArray::from_iter_values(
+                    ids.iter().map(|id| region(*id)),
+                )),
+                Arc::new(StructArray::new(
+                    meta_fields.clone(),
+                    vec![Arc::new(StringArray::from_iter_values(
+                        ids.iter().map(|id| region(*id)),
+                    ))],
+                    None,
+                )),
+            ],
+        )
+        .unwrap()
+    };
+
+    async fn append(delta: DeltaTable, batch: RecordBatch) -> DeltaTable {
+        delta
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap()
+    }
+
+    let table_dir = TempDir::new().unwrap();
+    let table_uri = table_dir.path().display().to_string();
+    let mut delta = create_table(&table_uri, &HashMap::new(), &struct_fields).await;
+
+    let storage_dir = TempDir::new().unwrap();
+    // The error callback runs on a worker thread, where a panic is swallowed:
+    // record the error so the wait below can fail on it instead of timing out.
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let read_pipeline = {
+        let errors = errors.clone();
+        let table_uri = table_uri.clone();
+        let storage_dir = storage_dir.path().to_path_buf();
+        let filter_expr = filter_expr.to_string();
+        tokio::task::spawn_blocking(move || {
+            let pipeline_config: PipelineConfig = serde_json::from_value(json!({
+                "name": "test",
+                "workers": 4,
+                "storage_config": { "path": storage_dir },
+                "inputs": {
+                    "test_input1": {
+                        "stream": "test_input1",
+                        "transport": {
+                            "name": "delta_table_input",
+                            "config": {
+                                "uri": table_uri,
+                                "mode": "follow",
+                                "filter": filter_expr,
+                                "skip_unused_columns": true,
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap();
+            Controller::with_test_config(
+                move |workers| {
+                    Ok(test_circuit::<TestStruct>(
+                        workers,
+                        &TestStruct::schema(),
+                        &[Some("output")],
+                    ))
+                },
+                &pipeline_config,
+                Box::new(move |e, _| errors.lock().unwrap().push(e.to_string())),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap()
+    };
+    read_pipeline.start();
+    let output = SqlIdentifier::from("test_output1");
+
+    let batch1: Vec<u32> = (0..6).collect();
+    delta = append(delta, make_batch(&batch1)).await;
+    let mut expected: Vec<TestStruct> = batch1
+        .iter()
+        .filter(|id| region(**id) == "us")
+        .map(|id| row(*id))
+        .collect();
+    wait_or_connector_error(&read_pipeline, &output, &expected, &errors).await;
+
+    // A second commit: the filter must still resolve past the first log entry.
+    let batch2: Vec<u32> = (6..12).collect();
+    let _ = append(delta, make_batch(&batch2)).await;
+    expected.extend(
+        batch2
+            .iter()
+            .filter(|id| region(**id) == "us")
+            .map(|id| row(*id)),
+    );
+    wait_or_connector_error(&read_pipeline, &output, &expected, &errors).await;
+
+    read_pipeline.stop().unwrap();
+}
+
+/// [`wait_for_records_materialized`], but report a connector error as soon as
+/// one arrives rather than waiting out the materialization timeout.
+async fn wait_or_connector_error<T>(
+    pipeline: &Controller,
+    table: &SqlIdentifier,
+    expected_output: &[T],
+    errors: &Arc<Mutex<Vec<String>>>,
+) where
+    T: for<'a> DeserializeWithContext<'a, SqlSerdeConfig, Variant> + DBData,
+{
+    let wait = wait_for_records_materialized(pipeline, table, expected_output);
+    tokio::pin!(wait);
+    loop {
+        tokio::select! {
+            _ = &mut wait => return,
+            _ = sleep(Duration::from_millis(250)) => {
+                if let Some(error) = errors.lock().unwrap().first() {
+                    panic!("connector reported an error: {error}");
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_filter_undeclared_column_test() {
+    run_follow_filter_undeclared_column_test("region = 'us'").await;
+}
+
+/// Same, over a field of an undeclared struct column, the form reported in the
+/// issue: it parses as a compound identifier, so the read set must keep `meta`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_filter_undeclared_struct_field_test() {
+    run_follow_filter_undeclared_column_test("meta.tag = 'us'").await;
+}
+
+/// Filtering before projecting must not widen the scan: DataFusion's projection
+/// pushdown collapses the two, so columns neither step names stay pruned.
+#[tokio::test]
+async fn follow_filter_before_projection_prunes_scan() {
+    use crate::integrated::delta_table::input::apply_filter;
+    use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+
+    // `region` is filtered on but not projected; `junk` is neither.
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, false),
+        ArrowField::new("b", ArrowDataType::Boolean, false),
+        ArrowField::new("s", ArrowDataType::Utf8, false),
+        ArrowField::new("region", ArrowDataType::Utf8, false),
+        ArrowField::new("junk", ArrowDataType::Utf8, false),
+    ]));
+
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "t",
+        Arc::new(MemTable::try_new(arrow_schema.clone(), vec![vec![]]).unwrap()),
+    )
+    .unwrap();
+
+    let df = apply_filter(
+        ctx.table("t").await.unwrap(),
+        Some("region = 'us'"),
+        "unit-test",
+        None,
+    )
+    .unwrap();
+    let df = df.select_columns(&["id", "b", "s"]).unwrap();
+
+    let plan = format!("{}", df.into_optimized_plan().unwrap().display_indent());
+    assert!(
+        plan.contains("projection=") && !plan.contains("junk"),
+        "the scan must read only the projected columns plus the filter's, so \
+         'junk' must be pruned; plan was:\n{plan}"
+    );
+}

--- a/python/tests/platform/fixtures/deletion_vectors.py
+++ b/python/tests/platform/fixtures/deletion_vectors.py
@@ -15,7 +15,7 @@ invokes this file with::
 
 Without ``--cdc``, it writes a two-version table:
 
-* v0: ``total_rows`` rows (``id``, ``name``, ``value``) with DVs enabled.
+* v0: ``total_rows`` rows (``id``, ``name``, ``value``, ``meta``) with DVs enabled.
 * v1: ``DELETE`` of the even ``id`` rows, which produces deletion vectors.
 
 With ``--cdc``, it writes a four-version table shaped like a CDC event log
@@ -50,6 +50,8 @@ def _write_plain_fixture(spark, dest: str, total_rows: int) -> None:
             "cast(id as int) as id",
             "concat('user_', id) as name",
             "cast(id * 1.5 as double) as value",
+            # Mirrors `value`, so a filter can name it as a struct field.
+            "struct(cast(id * 1.5 as double) as value) as meta",
         )
         .write.format("delta")
         .option("delta.enableDeletionVectors", "true")

--- a/python/tests/platform/test_delta_input_catchup.py
+++ b/python/tests/platform/test_delta_input_catchup.py
@@ -30,19 +30,10 @@ INITIAL_VERSIONS = 10
 FOLLOW_ROUNDS = (3, 2, 4)
 
 
-def _writer_storage_options(loc: DeltaTestLocation) -> dict | None:
-    opts = loc.delta_storage_options()
-    if not opts:
-        return None
-    if loc.uri.startswith("s3://"):
-        opts.setdefault("aws_s3_allow_unsafe_rename", "true")
-    return opts
-
-
 def _delta_version(loc: DeltaTestLocation) -> int:
     from deltalake import DeltaTable
 
-    dt = DeltaTable(loc.uri, storage_options=_writer_storage_options(loc))
+    dt = DeltaTable(loc.uri, storage_options=loc.writer_storage_options())
     return dt.version()
 
 
@@ -55,7 +46,7 @@ def _append_version(loc: DeltaTestLocation, row_id: int) -> None:
         pa.Table.from_pylist([{"id": row_id}]),
         mode="append",
         schema_mode="merge",
-        storage_options=_writer_storage_options(loc),
+        storage_options=loc.writer_storage_options(),
     )
 
 
@@ -67,7 +58,7 @@ def _seed_delta_table(loc: DeltaTestLocation, num_versions: int) -> None:
         loc.uri,
         pa.Table.from_pylist([{"id": 0}]),
         mode="overwrite",
-        storage_options=_writer_storage_options(loc),
+        storage_options=loc.writer_storage_options(),
     )
     for version in range(1, num_versions):
         _append_version(loc, version * 2)
@@ -205,7 +196,7 @@ def _append_cdc_insert(
         ),
         mode=mode,
         schema_mode="merge",
-        storage_options=_writer_storage_options(loc),
+        storage_options=loc.writer_storage_options(),
     )
 
 
@@ -438,7 +429,7 @@ def test_delta_input_cdc_multi_key_order_by(pipeline_name):
             ),
             mode=mode,
             schema_mode="merge",
-            storage_options=_writer_storage_options(loc),
+            storage_options=loc.writer_storage_options(),
         )
 
     try:

--- a/python/tests/platform/test_delta_input_deletion_vectors.py
+++ b/python/tests/platform/test_delta_input_deletion_vectors.py
@@ -54,7 +54,7 @@ DV_DELETED_ROWS = TOTAL_ROWS - EXPECTED_ROWS_AFTER_DV
 FOLLOW_DV_DELETE_INPUT_RECORDS = TOTAL_ROWS + DV_DELETED_ROWS
 FOLLOW_RESTORE_INPUT_RECORDS = EXPECTED_ROWS_AFTER_DV + DV_DELETED_ROWS
 # Bump to invalidate cached MinIO copies when the fixture definition changes.
-FIXTURE_VERSION = "dv_snapshot_v1"
+FIXTURE_VERSION = "dv_snapshot_v2"
 # CDC-shaped fixture (see fixtures/deletion_vectors.py --cdc): v0 inserts
 # TOTAL_ROWS events, v1 DV-deletes the even ids, v2 restores them (shrinking
 # the DVs away), v3 appends one event.
@@ -358,3 +358,50 @@ def test_delta_input_cdc_with_deletion_vectors(pipeline_name):
         "only the single v3 insert event may arrive; a higher count "
         "means soft-deleted or restored events were re-ingested"
     )
+
+
+# `value` is `id * 1.5`, so `>= 150.0` keeps ids 100..=200; the DV commit
+# retracts the even ones, leaving the odd ids in that range.
+_FILTER_KEPT_IDS = [
+    i for i in range(1, TOTAL_ROWS + 1) if i * 1.5 >= 150.0 and i % 2 == 1
+]
+
+
+def _run_dv_follow_filter_test(pipeline_name: str, filter_expr: str) -> None:
+    """A DV-masked follow read must still read the `filter`'s columns.
+
+    Masked files bypass the listing path and are read through a provider whose
+    schema is the read set, so an undeclared filter column resolves only if the
+    read set keeps it.
+    """
+    result = _ingest_dv_fixture(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        columns="id INT NOT NULL",
+        extra_config={
+            "version": 0,
+            "end_version": 1,
+            "filter": filter_expr,
+        },
+    )
+    assert result.total == len(_FILTER_KEPT_IDS), (
+        f"filter '{filter_expr}' must keep ids 100..=200 and the DV commit "
+        f"must retract the even ones; got {result.total} rows, expected "
+        f"{len(_FILTER_KEPT_IDS)}"
+    )
+    assert result.even_id_rows == 0, (
+        "the surviving rows must be the odd ids, not the deleted even ids"
+    )
+
+
+def test_delta_input_dv_follow_filter_undeclared_col(pipeline_name):
+    _run_dv_follow_filter_test(pipeline_name, "value >= 150.0")
+
+
+def test_delta_input_dv_follow_filter_struct_field(pipeline_name):
+    """A compound identifier: the read set must keep `meta`, not just `value`.
+
+    Separate function rather than a parametrized case so each gets its own
+    pipeline name (see `test_delta_input_column_mapping.py`).
+    """
+    _run_dv_follow_filter_test(pipeline_name, "meta.value >= 150.0")

--- a/python/tests/platform/test_delta_input_filter.py
+++ b/python/tests/platform/test_delta_input_filter.py
@@ -1,0 +1,114 @@
+"""Delta input: a ``filter`` may name a column the SQL table does not declare.
+
+Follow mode used to project the frame down to the SQL columns before parsing the
+filter, failing with "No field named ..." while the snapshot path accepted it
+(https://github.com/feldera/feldera/issues/6908). The run is
+``snapshot_and_follow`` over a two-version table, so it covers both paths.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+
+from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
+from tests import TEST_CLIENT
+from tests.utils import DeltaTestLocation
+
+TABLE = "t"
+CONNECTOR = "delta_in"
+
+ROWS_PER_VERSION = 10
+# Even ids are in region 'us' and pass the filter; odd ids are in 'eu'.
+KEPT_IDS = [i for i in range(2 * ROWS_PER_VERSION) if i % 2 == 0]
+
+# `region` exists only in the Delta table; the filter below is its only reader.
+_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.int64()),
+        pa.field("region", pa.string()),
+    ]
+)
+
+
+def _rows(start: int, count: int) -> pa.Table:
+    return pa.Table.from_pylist(
+        [
+            {"id": i, "region": "us" if i % 2 == 0 else "eu"}
+            for i in range(start, start + count)
+        ],
+        schema=_SCHEMA,
+    )
+
+
+def _seed_two_versions(loc: DeltaTestLocation) -> None:
+    """v0: the first batch of rows; v1: the second, as a follow-mode commit."""
+    from deltalake import write_deltalake
+
+    storage_options = loc.writer_storage_options()
+    write_deltalake(
+        loc.uri,
+        _rows(0, ROWS_PER_VERSION),
+        mode="overwrite",
+        storage_options=storage_options,
+    )
+    write_deltalake(
+        loc.uri,
+        _rows(ROWS_PER_VERSION, ROWS_PER_VERSION),
+        mode="append",
+        storage_options=storage_options,
+    )
+
+
+def _build_sql(loc: DeltaTestLocation, *, filter_expr: str) -> str:
+    """Declare only `id`: `region` is visible to the filter alone."""
+    config = dict(loc.connector_config)
+    config.update({"filter": filter_expr, "version": 0, "end_version": 1})
+    connectors = json.dumps(
+        [
+            {
+                "name": CONNECTOR,
+                "transport": {"name": "delta_table_input", "config": config},
+            }
+        ]
+    ).replace("'", "''")
+    return (
+        f"CREATE TABLE {TABLE} (id BIGINT NOT NULL)"
+        f" WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
+    )
+
+
+def test_delta_input_filter_over_undeclared_column(pipeline_name):
+    filter_expr = "region = 'us'"
+    loc = DeltaTestLocation.create(pipeline_name, mode="snapshot_and_follow")
+    try:
+        _seed_two_versions(loc)
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=_build_sql(loc, filter_expr=filter_expr),
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
+        ).create_or_replace()
+        pipeline.start()
+        # Query before stopping: an ad-hoc query needs a live pipeline.
+        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+        ids = [
+            int(row["id"])
+            for row in pipeline.query(f"SELECT id FROM {TABLE} ORDER BY id")
+        ]
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()
+
+    # An error in either phase fails the pipeline before it completes.
+    assert ids == KEPT_IDS, (
+        f"filter '{filter_expr}' must keep exactly the 'us' rows across the "
+        "snapshot and the follow commit"
+    )

--- a/python/tests/runtime/test_checkpoint_runtime_upgrade.py
+++ b/python/tests/runtime/test_checkpoint_runtime_upgrade.py
@@ -257,23 +257,6 @@ def _row(idx: int) -> dict:
     }
 
 
-def _writer_storage_options(source: DeltaTestLocation) -> dict | None:
-    """Return ``storage_options`` for ``deltalake.write_deltalake``.
-
-    The base options come from the connector config. For S3/MinIO writes
-    we also enable ``aws_s3_allow_unsafe_rename`` because deltalake's
-    default lock provider is DynamoDB, which is not available in the
-    test environment.
-    """
-
-    opts = source.delta_storage_options()
-    if not opts:
-        return None
-    if source.uri.startswith("s3://"):
-        opts.setdefault("aws_s3_allow_unsafe_rename", "true")
-    return opts
-
-
 def _ensure_delta_source(source: DeltaTestLocation) -> None:
     """Generate the Delta source if the cache is missing or wrong-sized."""
 
@@ -300,7 +283,7 @@ def _ensure_delta_source(source: DeltaTestLocation) -> None:
         source.uri,
         table,
         mode="overwrite",
-        storage_options=_writer_storage_options(source),
+        storage_options=source.writer_storage_options(),
     )
 
 

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -142,6 +142,19 @@ class DeltaTestLocation:
             if k not in ("uri", "mode")
         }
 
+    def writer_storage_options(self) -> dict[str, str] | None:
+        """`storage_options` for `deltalake.write_deltalake`, or None for local.
+
+        S3 writes need the unsafe-rename opt-in: deltalake's default lock
+        provider is DynamoDB, which the test environment does not run.
+        """
+        opts = self.delta_storage_options()
+        if not opts:
+            return None
+        if self.uri.startswith("s3://"):
+            opts.setdefault("aws_s3_allow_unsafe_rename", "true")
+        return opts
+
     def _s3_filesystem(self):
         """Build a pyarrow ``S3FileSystem`` from the connector config.
 


### PR DESCRIPTION
A `filter` is a `where` clause over the Delta table, so it may name a column the SQL table does not declare. Snapshot mode allowed that; follow mode projected the frame down to the SQL columns before parsing the filter, and failed with "No field named ...".

Filter first, then project: the read set keeps the filter's columns so it resolves, and the projection drops them before the circuit sees them.

Fix #6908 

### Describe Manual Test Plan

relying on added tests

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

not a breaking change