### PR TITLE
[adapters] bump delta-rs to fix the deletion-vector scan deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,7 +4385,7 @@ checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 [[package]]
 name = "deltalake"
 version = "0.32.3"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "buoyant_kernel",
  "ctor 0.10.1",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4425,7 +4425,7 @@ dependencies = [
 [[package]]
 name = "deltalake-azure"
 version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "bytes",
  "deltalake-core",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "deltalake-catalog-unity"
 version = "0.16.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.32.3"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "deltalake-gcp"
 version = "0.16.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=4913d02fabc643bd898fcb72d5d2afb73c77ac29#4913d02fabc643bd898fcb72d5d2afb73c77ac29"
+source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,8 @@ dbsp = { path = "crates/dbsp", version = "0.337.0" }
 datafusion-functions-json = "0.53.1"
 dbsp_nexmark = { path = "crates/nexmark" }
 deadpool-postgres = "0.14.1"
-# Feldera fork of delta-rs: upstream tag `rust-v0.32.3` + 4 patches, on branch
-# `v0.32.3-feldera-unity-fix`. When bumping the pinned revision, preserve these
-# patches:
+# Feldera fork of delta-rs: upstream tag `rust-v0.32.3` + 6 patches, on branch
+# `dv-async-load`. When bumping the pinned revision, preserve these patches:
 #   - 7f8bb445 "Disable unsupported feature check." — relax the writer-side
 #     protocol-feature gate so we can write tables produced by newer clients.
 #   - 5b35c098 "delta-rs: round-robin pre-split unpartitioned scans into
@@ -147,10 +146,19 @@ deadpool-postgres = "0.14.1"
 #   - 4913d02f "catalog-unity: refresh Unity Catalog S3 credentials before they
 #     expire" — the vended temporary credentials last an hour, so a long-running
 #     `uc://` pipeline failed with `ExpiredToken` without this.
+#   - 943cf48b "delta-rs: load deletion vectors without the blocking pool":
+#     planning a scan spawned one blocking task per deletion-vector file, and
+#     each waited on a hand-off that needed a second thread from the same pool,
+#     so a table with enough vectors deadlocked Tokio's pool for good. Reported
+#     upstream with a standalone reproduction:
+#     https://github.com/ryzhyk/delta-rs-dv-deadlock
+#   - 78a5d066 "delta-rs: regression test for the deletion-vector blocking-pool
+#     deadlock": eight vectors against four blocking threads, which wedges
+#     without the patch above.
 # Diff vs. upstream:
-#   https://github.com/delta-io/delta-rs/compare/rust-v0.32.3...feldera:delta-rs:v0.32.3-feldera-unity-fix
-deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "4913d02fabc643bd898fcb72d5d2afb73c77ac29" }
-deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "4913d02fabc643bd898fcb72d5d2afb73c77ac29" }
+#   https://github.com/delta-io/delta-rs/compare/rust-v0.32.3...feldera:delta-rs:dv-async-load
+deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "78a5d066d60feffcc7dcd9bae62d1c537dd9018c" }
+deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "78a5d066d60feffcc7dcd9bae62d1c537dd9018c" }
 
 delta_kernel = { package = "buoyant_kernel", version = "0.22" }
 derive_more = { version = "1.0.0" }


### PR DESCRIPTION
A customer ran into https://github.com/delta-io/delta-rs/issues/4657.

This bumps delta-rs dependency to a version with our fix (not yet upstreamed).

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
