### PR TITLE
[adapters] delta: fix follow and CDC reads of partitioned tables

### DIFF
--- a/crates/adapters/src/integrated/delta_table/deletion_vector.rs
+++ b/crates/adapters/src/integrated/delta_table/deletion_vector.rs
@@ -282,8 +282,8 @@ fn realign_array(
 /// columns the file lacks. Field-id matching handles `columnMapping.mode=id`
 /// tables, whose files name columns logically rather than by physical `col-<id>`.
 ///
-/// Partition columns come out NULL (Delta stores them in `partitionValues`, not
-/// in the file), a pre-existing limitation of the connector's Parquet reader.
+/// Partition columns are absent here (Delta stores them in `partitionValues`,
+/// not in the file); the caller adds them back as constants.
 fn project_to_logical(
     batch: &RecordBatch,
     logical_schema: &SchemaRef,

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -13,8 +13,8 @@ use arrow::datatypes::{
 };
 use chrono::{DateTime, Utc};
 use datafusion::catalog::TableProvider;
-use datafusion::common::DataFusionError;
 use datafusion::common::arrow::array::RecordBatch;
+use datafusion::common::{DFSchema, DataFusionError, ScalarValue};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
@@ -26,8 +26,8 @@ use dbsp::circuit::tokio::TOKIO;
 use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
 use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::execution::context::SQLOptions;
-use deltalake::datafusion::logical_expr::SortExpr;
-use deltalake::datafusion::prelude::{Expr, SessionContext, col};
+use deltalake::datafusion::logical_expr::{ExprSchemable, SortExpr};
+use deltalake::datafusion::prelude::{Expr, SessionContext, col, lit};
 use deltalake::datafusion::sql::sqlparser::dialect::GenericDialect;
 use deltalake::datafusion::sql::sqlparser::parser::Parser;
 use deltalake::datafusion::sql::sqlparser::tokenizer::Token;
@@ -164,17 +164,21 @@ fn requires_direct_object_store_read(table: &DeltaTable) -> bool {
     table.log_store().root_url().scheme() == "uc"
 }
 
-/// The table root as a base URL guaranteed to end in `/`, so string-joining a
-/// relative `Add.path` yields a well-formed URL. delta-rs normalizes the location
-/// to a trailing slash only when it has a path, so a root with none (`uc://cat.db.tbl`,
-/// or a table at a bucket root) would otherwise collapse into the joined file name.
-fn table_root_base(table: &DeltaTable) -> String {
-    let root = table.log_store().root_url().to_string();
-    if root.ends_with('/') {
-        root
-    } else {
-        format!("{root}/")
-    }
+/// A [`ListingTableUrl`] for one data file of `table`.
+///
+/// delta-rs percent-decodes an action's path when it reads the log, so `path` is
+/// already the object-store key. Appending it as URL segments re-encodes it, which
+/// [`ListingTableUrl::try_new`] then undoes exactly once; string-joining it and
+/// calling [`ListingTableUrl::parse`] instead would decode a second time (and read
+/// a `*` or `[` in a partition value as a glob), silently listing no file at all.
+fn file_listing_url(table: &DeltaTable, path: &str) -> AnyResult<ListingTableUrl> {
+    let mut url = table.log_store().root_url().clone();
+    url.path_segments_mut()
+        .map_err(|_| anyhow!("Delta table root cannot be extended with a file path"))?
+        .pop_if_empty()
+        .extend(path.split('/'));
+    ListingTableUrl::try_new(url, None)
+        .map_err(|e| anyhow!("invalid file path '{path}' in Delta log action: {e}"))
 }
 
 /// A field's physical (on-disk) name under column mapping, or its logical name
@@ -1078,6 +1082,43 @@ struct CatchupFollowState {
     transaction: Option<Option<String>>,
 }
 
+/// One data file of a CDC transaction, as the log describes it.
+struct CdcFile<'a> {
+    path: &'a str,
+    partition_values: Option<&'a HashMap<String, Option<String>>>,
+    deletion_vector: Option<&'a DeletionVectorDescriptor>,
+}
+
+/// Evaluate a compiled `cdc_delete_filter` against `batch`; returns one polarity
+/// per row.
+fn eval_delete_filter(expr: &dyn PhysicalExpr, batch: &RecordBatch) -> AnyResult<Vec<bool>> {
+    let deletions = expr.evaluate(batch).map_err(|e| {
+        anyhow!("internal error evaluating the delete filter expression; {REPORT_ERROR}: {e}")
+    })?;
+
+    let array = deletions
+        .into_array(batch.num_rows())
+        .map_err(|e| {
+            anyhow!(
+                "internal error converting the result of the delete filter expressions to array; {REPORT_ERROR}: {e}"
+            )
+        })?;
+    let bitmask = array
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| {
+            anyhow!(
+                "internal error converting the result of the delete filter expression to BooleanArray; {REPORT_ERROR}: expected Boolean, found {:?}", array.data_type()
+            )
+        })?;
+
+    Ok(bitmask
+        .into_iter()
+        // treat NULLs as inserts.
+        .map(|b| !b.unwrap_or(false))
+        .collect())
+}
+
 struct DeltaTableInputEndpointInner {
     endpoint_name: String,
     schema: Relation,
@@ -1433,9 +1474,8 @@ impl DeltaTableInputEndpointInner {
     /// `snapshot_filter`, `cdc_delete_filter`, `cdc_order_by`), case-folded for
     /// matching. Derived once and cached.
     ///
-    /// These strings are validated during configuration, so they parse here; a
-    /// parse error is therefore unreachable and contributes no columns rather
-    /// than failing the connector a second time.
+    /// Endpoint initialization parses these strings first, in every mode, so a
+    /// parse error is unreachable here.
     fn config_referenced_columns(&self) -> &ColumnNameSet {
         self.config_referenced_columns.get_or_init(|| {
             let mut columns = BTreeSet::new();
@@ -1454,6 +1494,15 @@ impl DeltaTableInputEndpointInner {
             }
             ColumnNameSet::from_names(columns)
         })
+    }
+
+    /// Validate the filter expressions that apply in every mode: 'filter' and
+    /// 'snapshot_filter'. The CDC expressions are validated by
+    /// [`validate_cdc_config`](Self::validate_cdc_config) and
+    /// [`validate_cdc_delete_filter`](Self::validate_cdc_delete_filter).
+    fn validate_config_expressions(&self) -> Result<(), ControllerError> {
+        self.validate_snapshot_filter()?;
+        self.validate_filter()
     }
 
     /// True if a column may actually be skipped: its shape permits omitting it
@@ -1508,11 +1557,8 @@ impl DeltaTableInputEndpointInner {
 
         // Filter `df`'s own field list (not the SQL schema) so the projection
         // tracks the read schema if column mapping ever varies it across
-        // versions, and preserves on-disk column order: the order the
-        // `cdc_delete_filter` `PhysicalExpr` binds by index in
-        // `extract_delete_filter_expr`. Own the kept names before consuming `df`;
-        // `select_columns` takes `df` by value, so the `df.schema()` borrow must
-        // end first.
+        // versions. Own the kept names before consuming `df`; `select_columns`
+        // takes `df` by value, so the `df.schema()` borrow must end first.
         let kept: Vec<String> = df
             .schema()
             .fields()
@@ -1844,6 +1890,14 @@ impl DeltaTableInputEndpointInner {
         mut receiver: Receiver<PipelineState>,
         init_status_sender: mpsc::Sender<Result<(), ControllerError>>,
     ) {
+        // Validate before opening the table: 'filter' applies to follow reads
+        // too, so an invalid expression must fail startup rather than the first
+        // commit.
+        if let Err(e) = self.validate_config_expressions() {
+            let _ = init_status_sender.send(Err(e)).await;
+            return;
+        }
+
         let table = match self.open_table().await {
             Err(e) => {
                 let _ = init_status_sender.send(Err(e)).await;
@@ -1863,13 +1917,10 @@ impl DeltaTableInputEndpointInner {
             return;
         };
 
-        let cdc_delete_filter = match self.prepare_cdc().await {
-            Err(e) => {
-                let _ = init_status_sender.send(Err(e)).await;
-                return;
-            }
-            Ok(cdc_delete_filter) => cdc_delete_filter,
-        };
+        if let Err(e) = self.prepare_cdc().await {
+            let _ = init_status_sender.send(Err(e)).await;
+            return;
+        }
 
         // Code before this point is part of endpoint initialization.
         // After this point, the thread should continue running until it receives a
@@ -2060,7 +2111,6 @@ impl DeltaTableInputEndpointInner {
                                 new_version,
                                 &actions,
                                 &table,
-                                cdc_delete_filter.clone(),
                                 input_stream.as_mut(),
                                 &mut receiver,
                                 start_transaction,
@@ -2386,115 +2436,64 @@ impl DeltaTableInputEndpointInner {
 
     /// Convert the delete filter SQL expression into a Datafusion PhysicalExpr.
     ///
-    /// Parses `cdc_delete_filter` directly against the snapshot schema and
-    /// lowers the resulting logical expression to a physical expression.
-    async fn extract_delete_filter_expr(
-        &self,
-    ) -> Result<Option<Arc<dyn PhysicalExpr>>, ControllerError> {
-        let Some(delete_filter) = &self.config.cdc_delete_filter else {
+    /// Compile `cdc_delete_filter`, if configured, against `schema`: the schema of
+    /// the frame the filter will evaluate.
+    fn compile_delete_filter(&self, schema: &DFSchema) -> AnyResult<Option<Arc<dyn PhysicalExpr>>> {
+        let Some(delete_filter) = self.config.cdc_delete_filter.as_deref() else {
             return Ok(None);
         };
 
-        let snapshot_df = self
-            .datafusion
-            .table("snapshot")
-            .await
-            .map_err(|_e| {
-                ControllerError::invalid_transport_configuration(
-                    &self.endpoint_name,
-                    &format!(
-                        "internal error compiling 'cdc_delete_filter' expression '{delete_filter}'; {REPORT_ERROR}: table 'snapshot' not found"
-                    ),
-                )
-            })?;
-
-        // The compiled `PhysicalExpr` binds columns by index, so it must see the
-        // same schema as the batches it will evaluate. When `skip_unused_columns`
-        // is set, `process_cdc_transaction` projects those batches to the CDC
-        // read set via `project_cdc_columns`, so project here through the same
-        // helper. Both derive the read set from the same Delta snapshot (this
-        // `snapshot` table is registered from it), so the column order matches.
-        let snapshot_df = self.project_cdc_columns(snapshot_df).map_err(|e| {
-            ControllerError::invalid_transport_configuration(
-                &self.endpoint_name,
-                &format!(
-                    "internal error compiling 'cdc_delete_filter' expression '{delete_filter}'; {REPORT_ERROR}: {e}"
-                ),
-            )
-        })?;
-
-        let schema = snapshot_df.schema().clone();
-
         let filter_expr = self
             .datafusion
-            .parse_sql_expr(delete_filter, &schema)
+            .parse_sql_expr(delete_filter, schema)
             .map_err(|e| {
-                ControllerError::invalid_transport_configuration(
-                    &self.endpoint_name,
-                    &format!("invalid 'cdc_delete_filter' expression '{delete_filter}': {e}"),
-                )
+                anyhow!("invalid 'cdc_delete_filter' expression '{delete_filter}': {e}")
             })?;
 
         let physical_expr = DefaultPhysicalPlanner::default()
-            .create_physical_expr(&filter_expr, &schema, &self.datafusion.state())
+            .create_physical_expr(&filter_expr, schema, &self.datafusion.state())
             .map_err(|e| {
-                ControllerError::invalid_transport_configuration(
-                    &self.endpoint_name,
-                    &format!(
-                        "internal error compiling 'cdc_delete_filter' expression '{delete_filter}'; {REPORT_ERROR}: {e}"
-                    ),
-                )
+                anyhow!("cannot compile 'cdc_delete_filter' expression '{delete_filter}': {e}")
             })?;
 
         Ok(Some(physical_expr))
     }
 
-    /// Evaluate delete filter expression against a batch of updates; returns a vector of polarities.
-    async fn eval_delete_filter(
-        delete_filter: &dyn PhysicalExpr,
-        batch: &RecordBatch,
-    ) -> AnyResult<Vec<bool>> {
-        let deletions = delete_filter.evaluate(batch).map_err(|e| {
-            anyhow!("internal error evaluating the delete filter expression; {REPORT_ERROR}: {e}")
+    /// Validate the filter expression specified in the 'cdc_delete_filter'
+    /// parameter by compiling it against the snapshot schema. Each transaction
+    /// compiles the expression again, against the frame it reads.
+    async fn validate_cdc_delete_filter(&self) -> Result<(), ControllerError> {
+        if self.config.cdc_delete_filter.is_none() {
+            return Ok(());
+        }
+
+        let invalid_config =
+            |e: String| ControllerError::invalid_transport_configuration(&self.endpoint_name, &e);
+
+        let snapshot_df = self.datafusion.table("snapshot").await.map_err(|_e| {
+            invalid_config(format!(
+                "internal error validating 'cdc_delete_filter'; {REPORT_ERROR}: table 'snapshot' not found"
+            ))
         })?;
+        let snapshot_df = self
+            .project_cdc_columns(snapshot_df)
+            .map_err(|e| invalid_config(e.to_string()))?;
 
-        let array = deletions
-            .into_array(batch.num_rows())
-            .map_err(|e| {
-                anyhow!(
-                    "internal error converting the result of the delete filter expressions to array; {REPORT_ERROR}: {e}"
-                )
-            })?;
-        let bitmask = array
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .ok_or_else(|| {
-                anyhow!(
-                    "internal error converting the result of the delete filter expression to BooleanArray; {REPORT_ERROR}: expected Boolean, found {:?}", array.data_type()
-                )
-            })?;
-
-        let polarities = bitmask
-            .into_iter()
-            // treat NULLs as inserts.
-            .map(|b| !b.unwrap_or(false))
-            .collect::<Vec<bool>>();
-
-        Ok(polarities)
+        self.compile_delete_filter(snapshot_df.schema())
+            .map(|_| ())
+            .map_err(|e| invalid_config(e.to_string()))
     }
 
     /// Prepare to read initial snapshot, if required by endpoint configuration.
     ///
     /// * register snapshot as a datafusion table
-    /// * validate snapshot config: filter condition and timestamp column
+    /// * validate the timestamp column against the registered snapshot
     async fn prepare_snapshot_query(&self, table: &Arc<DeltaTable>) -> Result<(), ControllerError> {
         if !self.config.snapshot() && !self.config.is_cdc() {
             return Ok(());
         }
 
         self.register_snapshot_table(table).await?;
-        self.validate_snapshot_filter()?;
-        self.validate_filter()?;
 
         if let Some(timestamp_column) = &self.config.timestamp_column {
             validate_timestamp_column(
@@ -2511,11 +2510,10 @@ impl DeltaTableInputEndpointInner {
     }
 
     /// Prepare to process CDC stream.
-    async fn prepare_cdc(&self) -> Result<Option<Arc<dyn PhysicalExpr>>, ControllerError> {
+    async fn prepare_cdc(&self) -> Result<(), ControllerError> {
         self.validate_cdc_config()?;
 
-        let delete_expr = self.extract_delete_filter_expr().await?;
-        Ok(delete_expr)
+        self.validate_cdc_delete_filter().await
     }
 
     /// Execute a SQL query to load a complete or partial snapshot of the DeltaTable.
@@ -2826,16 +2824,15 @@ impl DeltaTableInputEndpointInner {
     ) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
         let result = if polarity {
             if let Some(delete_filter_expr) = cdc_delete_filter {
-                let polarities =
-                    match Self::eval_delete_filter(delete_filter_expr.as_ref(), &batch).await {
-                        Ok(polarities) => polarities,
-                        Err(e) => {
-                            return (
-                                None,
-                                vec![ParseError::bin_envelope_error(e.to_string(), &[], None)],
-                            );
-                        }
-                    };
+                let polarities = match eval_delete_filter(delete_filter_expr.as_ref(), &batch) {
+                    Ok(polarities) => polarities,
+                    Err(e) => {
+                        return (
+                            None,
+                            vec![ParseError::bin_envelope_error(e.to_string(), &[], None)],
+                        );
+                    }
+                };
                 // println!(
                 //     "insert_with_polarities: {} updates, {} insertions",
                 //     polarities.len(),
@@ -2881,7 +2878,6 @@ impl DeltaTableInputEndpointInner {
         new_version: i64,
         actions: &[Action],
         table: &DeltaTable,
-        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
@@ -2920,15 +2916,8 @@ impl DeltaTableInputEndpointInner {
         let timestamp = Utc::now();
 
         if self.config.is_cdc() {
-            self.process_cdc_transaction(
-                actions,
-                table,
-                cdc_delete_filter,
-                input_stream,
-                receiver,
-                start_transaction,
-            )
-            .await?;
+            self.process_cdc_transaction(actions, table, input_stream, receiver, start_transaction)
+                .await?;
         } else {
             // Compute the projected read set once for the whole transaction; each
             // `process_action` borrows the `&str` view rather than re-collecting it
@@ -2999,6 +2988,7 @@ impl DeltaTableInputEndpointInner {
                     self.process_follow_action(
                         action,
                         &remove.path,
+                        remove.partition_values.as_ref(),
                         newly_deleted,
                         false,
                         table,
@@ -3019,6 +3009,7 @@ impl DeltaTableInputEndpointInner {
                     self.process_follow_action(
                         action,
                         &add.path,
+                        Some(&add.partition_values),
                         restored,
                         true,
                         table,
@@ -3063,7 +3054,6 @@ impl DeltaTableInputEndpointInner {
         &self,
         actions: &[Action],
         table: &DeltaTable,
-        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
@@ -3115,12 +3105,16 @@ impl DeltaTableInputEndpointInner {
         // This loop must run before the removes side is built below: it
         // drains `removes_by_path` of every matched path, leaving only the
         // unpaired removes there.
-        let mut add_files: Vec<(&str, Option<&DeletionVectorDescriptor>)> = Vec::new();
+        let mut add_files: Vec<CdcFile<'_>> = Vec::new();
         for add in &adds {
             if removes_by_path.remove(add.path.as_str()).is_some() {
                 continue;
             }
-            add_files.push((add.path.as_str(), add.deletion_vector.as_ref()));
+            add_files.push(CdcFile {
+                path: add.path.as_str(),
+                partition_values: Some(&add.partition_values),
+                deletion_vector: add.deletion_vector.as_ref(),
+            });
         }
 
         let Some(adds_df) = self
@@ -3135,9 +3129,13 @@ impl DeltaTableInputEndpointInner {
         // The removes left unpaired by the loop above feed the `EXCEPT ALL`;
         // `cdc_side_dataframe` masks any with an active DV so only live rows
         // subtract.
-        let remove_files: Vec<(&str, Option<&DeletionVectorDescriptor>)> = removes_by_path
-            .iter()
-            .map(|(path, remove)| (*path, remove.deletion_vector.as_ref()))
+        let remove_files: Vec<CdcFile<'_>> = removes_by_path
+            .values()
+            .map(|remove| CdcFile {
+                path: remove.path.as_str(),
+                partition_values: remove.partition_values.as_ref(),
+                deletion_vector: remove.deletion_vector.as_ref(),
+            })
             .collect();
         let removes_df = self
             .cdc_side_dataframe(table, &remove_files, &description)
@@ -3154,11 +3152,15 @@ impl DeltaTableInputEndpointInner {
             &description,
         )?;
 
+        // Compile against this transaction's frame: a schema change between
+        // commits moves the columns the expression binds by index.
+        let delete_filter = self.compile_delete_filter(df.schema())?;
+
         let _record_count = self
             .execute_df(
                 df,
                 true,
-                cdc_delete_filter,
+                delete_filter,
                 &description,
                 input_stream,
                 receiver,
@@ -3259,24 +3261,118 @@ impl DeltaTableInputEndpointInner {
             .collect())
     }
 
+    /// Names of the table's partition columns.
+    ///
+    /// Delta keeps a partition column's value in the log action, never in the
+    /// data file, so the reader must add it back (see
+    /// [`add_partition_columns`](Self::add_partition_columns)).
+    fn partition_columns(&self) -> AnyResult<Vec<String>> {
+        Ok(self
+            .schema_snapshot()
+            .snapshot()
+            .map_err(|e| anyhow!("error accessing Delta table snapshot: {e}"))?
+            .metadata()
+            .partition_columns()
+            .to_vec())
+    }
+
+    /// The key the Delta log uses for each partition column: its physical name
+    /// under column mapping, its logical name otherwise.
+    fn partition_value_keys(&self) -> AnyResult<Vec<String>> {
+        let partition_columns = self.partition_columns()?;
+        Ok(self
+            .logical_schema()?
+            .fields()
+            .iter()
+            .filter(|field| partition_columns.contains(field.name()))
+            .map(|field| physical_name(field))
+            .collect())
+    }
+
+    /// Reproject `df` in table column order, supplying each partition column as
+    /// a constant from the file's log action. Every read side lays its columns
+    /// out the same way, so `UNION ALL` and `EXCEPT ALL` line up.
+    fn add_partition_columns(
+        &self,
+        df: DataFrame,
+        partition_values: Option<&HashMap<String, Option<String>>>,
+        description: &str,
+    ) -> AnyResult<DataFrame> {
+        let partition_columns = self.partition_columns()?;
+        if partition_columns.is_empty() {
+            return Ok(df);
+        }
+
+        let schema = df.schema().clone();
+        let mut projection: Vec<Expr> = Vec::new();
+        for field in self.logical_schema()?.fields() {
+            if partition_columns.contains(field.name()) {
+                // The log keys partition values by physical name. The Hive
+                // `key=value` directory layout is convention, not protocol, so
+                // a missing key is an error rather than a guess from the path.
+                let key = physical_name(field);
+                let value = partition_values
+                    .and_then(|values| values.get(&key))
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "error processing {description}: the Delta log action records no value for partition column '{}' (log key '{key}'); a partition column is not stored in the data file, so 'partitionValues' is the only source.",
+                            field.name()
+                        )
+                    })?;
+                // The log stores partition values as strings.
+                let literal = match value {
+                    Some(value) => lit(value.clone()),
+                    None => lit(ScalarValue::Null),
+                };
+                projection.push(
+                    literal
+                        .cast_to(field.data_type(), &schema)
+                        .map_err(|e| {
+                            anyhow!(
+                                "error processing {description}: cannot read partition column '{}' as {}: {e}",
+                                field.name(),
+                                field.data_type()
+                            )
+                        })?
+                        .alias(field.name()),
+                );
+            } else if schema.has_column_with_unqualified_name(field.name()) {
+                projection.push(col(field.name()));
+            }
+        }
+
+        df.select(projection).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error adding partition columns: {e}")
+        })
+    }
+
+    /// The Delta table's logical Arrow schema at the version being read.
+    fn logical_schema(&self) -> AnyResult<SchemaRef> {
+        Ok(self
+            .schema_snapshot()
+            .snapshot()
+            .map_err(|e| anyhow!("error accessing Delta table snapshot: {e}"))?
+            .snapshot()
+            .arrow_schema())
+    }
+
     /// Arrow schema for reading the raw data files, named as they appear on disk:
     /// the logical schema restricted to columns `keep` accepts (in schema order,
     /// so read sides line up), with each column-mapped field renamed to its
     /// physical (`col-<uuid>`) name so DataFusion matches by name. It recurses
     /// into nested struct, list, and map fields. Logical names are restored afterwards:
     /// top level in `project_physical_to_logical`, nested in `relabel_nested_columns`.
-    /// The kept logical schema when column mapping is off.
+    /// With column mapping off this is just the kept logical schema.
+    ///
+    /// Partition columns are always excluded: Delta never stores them in the data
+    /// file.
     fn physical_read_schema(&self, keep: impl Fn(&str) -> bool) -> AnyResult<SchemaRef> {
-        let schema_table = self.schema_snapshot();
-        let logical = schema_table
-            .snapshot()
-            .map_err(|e| anyhow!("error accessing Delta table snapshot: {e}"))?
-            .snapshot()
-            .arrow_schema();
+        let logical = self.logical_schema()?;
+        let partition_columns = self.partition_columns()?;
         let fields: Vec<FieldRef> = logical
             .fields()
             .iter()
-            .filter(|f| keep(f.name()))
+            .filter(|f| keep(f.name()) && !partition_columns.contains(f.name()))
             .map(field_to_physical)
             .collect();
         Ok(Arc::new(
@@ -3315,17 +3411,12 @@ impl DeltaTableInputEndpointInner {
 
     async fn create_parquet_table(
         &self,
-        files: Vec<String>,
+        urls: Vec<ListingTableUrl>,
         description: &str,
     ) -> AnyResult<ListingTable> {
         // Use the on-disk (physical) schema so the reader matches each file's
         // columns; `project_physical_to_logical` renames them back afterwards.
         let schema = self.physical_read_schema(|_| true)?;
-
-        let mut urls = Vec::with_capacity(files.len());
-        for file in files.iter() {
-            urls.push(ListingTableUrl::parse(file).map_err(|e| anyhow!("internal error processing {description}; {REPORT_ERROR}; error converting file path '{file}' to table URL: {e}"))?);
-        }
 
         let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
             .with_file_extension_opt(Some(".parquet"));
@@ -3339,8 +3430,9 @@ impl DeltaTableInputEndpointInner {
         })
     }
 
-    /// Build a streaming [`TableProvider`] over the data file at `path`
-    /// (relative and URL-encoded, as the Delta log stores it) that reads the
+    /// Build a streaming [`TableProvider`] over the data file at `path` (the
+    /// object-store key relative to the table root, which delta-rs decoded when
+    /// it read the log) that reads the
     /// rows `mode` picks out of `bitmap`: the file's live rows when applying a
     /// deletion vector ([`ReadMode::NotInBitmap`]), or a deletion-vector delta
     /// when following a same-path rewrite ([`ReadMode::InBitmap`]). The caller
@@ -3366,9 +3458,9 @@ impl DeltaTableInputEndpointInner {
         // back to logical.
         let read_schema = self.physical_read_schema(keep_column)?;
 
-        // Decode the URL-encoded Delta log path (per the spec) into an
-        // object-store key.
-        let file_path = Path::from_url_path(path)
+        // delta-rs already decoded the log's URL-encoded path, so `path` is the
+        // object-store key as written.
+        let file_path = Path::parse(path)
             .map_err(|e| anyhow!("invalid file path '{path}' in Delta log action: {e}"))?;
 
         filtered_parquet_table(
@@ -3415,7 +3507,7 @@ impl DeltaTableInputEndpointInner {
     /// [`Self::project_cdc_columns`] keeps), so they line up by position for the
     /// `EXCEPT ALL` in `build_cdc_dataframe` and never decode unused columns.
     ///
-    /// Plain files are addressed under the table root (see [`table_root_base`]),
+    /// Plain files are addressed under the table root (see [`file_listing_url`]),
     /// not the synthetic `delta-rs://` URL from `object_store_url()`. The latter
     /// folds the table path into the URL host (slashes become dashes), which
     /// routes DataFusion's object store but is malformed once joined with
@@ -3423,30 +3515,50 @@ impl DeltaTableInputEndpointInner {
     async fn cdc_side_dataframe(
         &self,
         table: &DeltaTable,
-        files: &[(&str, Option<&DeletionVectorDescriptor>)],
+        files: &[CdcFile<'_>],
         description: &str,
     ) -> AnyResult<Option<DataFrame>> {
         // Split by read strategy: files with an active DV are masked one by
-        // one; the rest are read together in one listing.
-        let mut plain: Vec<&str> = Vec::new();
-        let mut masked: Vec<(&str, &DeletionVectorDescriptor)> = Vec::new();
-        for &(path, dv) in files {
-            match dv.filter(|d| is_active_dv(d)) {
-                Some(dv) => masked.push((path, dv)),
-                None => plain.push(path),
+        // one; the rest are read together in one listing, grouped by partition
+        // so each group's constant partition columns apply to all its files.
+        // The key keeps the outer `Option`: a log that omits a partition column
+        // is not a log that records it as NULL, and grouping the two together
+        // would let whichever file the log listed first decide for both.
+        let mut plain: BTreeMap<Vec<Option<Option<String>>>, Vec<&CdcFile<'_>>> = BTreeMap::new();
+        let mut masked: Vec<(&CdcFile<'_>, &DeletionVectorDescriptor)> = Vec::new();
+        let partition_keys = self.partition_value_keys()?;
+        for file in files {
+            match file.deletion_vector.filter(|d| is_active_dv(d)) {
+                Some(dv) => masked.push((file, dv)),
+                None => plain
+                    .entry(
+                        partition_keys
+                            .iter()
+                            .map(|key| {
+                                file.partition_values
+                                    .and_then(|values| values.get(key))
+                                    .cloned()
+                            })
+                            .collect(),
+                    )
+                    .or_default()
+                    .push(file),
             }
         }
 
         let mut dfs: Vec<DataFrame> = Vec::new();
 
-        if !plain.is_empty() {
-            let base = table_root_base(table);
-            let files = plain.iter().map(|p| format!("{base}{p}")).collect();
-            let listing_table = Arc::new(self.create_parquet_table(files, description).await?);
+        for group in plain.values() {
+            let urls = group
+                .iter()
+                .map(|f| file_listing_url(table, f.path))
+                .collect::<AnyResult<Vec<_>>>()?;
+            let listing_table = Arc::new(self.create_parquet_table(urls, description).await?);
             let df = self.datafusion.read_table(listing_table).map_err(|e| {
                 anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet files: {e}")
             })?;
             let df = self.project_physical_to_logical(df)?;
+            let df = self.add_partition_columns(df, group[0].partition_values, description)?;
             // Drop unused columns when `skip_unused_columns` is set, so
             // DataFusion never reads them off disk.
             dfs.push(self.project_cdc_columns(df).map_err(|e| {
@@ -3454,10 +3566,10 @@ impl DeltaTableInputEndpointInner {
             })?);
         }
 
-        for (path, dv) in masked {
-            // Keep the same CDC read set as `project_cdc_columns` applies on the
-            // plain side (via `keeps_cdc_column`), so the two providers union
-            // cleanly.
+        for (file, dv) in masked {
+            let path = file.path;
+            // Read the same column set as the plain side; both are projected
+            // again below, after the partition columns go back in.
             let bitmap = self.decode_dv(table, Some(dv), description).await?;
             let provider = self
                 .file_provider(table, path, bitmap, ReadMode::NotInBitmap, |name| {
@@ -3467,7 +3579,11 @@ impl DeltaTableInputEndpointInner {
             let df = self.datafusion.read_table(provider).map_err(|e| {
                 anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading masked file '{path}': {e}")
             })?;
-            dfs.push(self.project_physical_to_logical(df)?);
+            let df = self.project_physical_to_logical(df)?;
+            let df = self.add_partition_columns(df, file.partition_values, description)?;
+            dfs.push(self.project_cdc_columns(df).map_err(|e| {
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; {e}")
+            })?);
         }
 
         let mut dfs = dfs.into_iter();
@@ -3498,6 +3614,7 @@ impl DeltaTableInputEndpointInner {
                     &add.path,
                     true,
                     add.deletion_vector.as_ref(),
+                    Some(&add.partition_values),
                     table,
                     used_columns,
                     input_stream,
@@ -3513,6 +3630,7 @@ impl DeltaTableInputEndpointInner {
                     &remove.path,
                     false,
                     remove.deletion_vector.as_ref(),
+                    remove.partition_values.as_ref(),
                     table,
                     used_columns,
                     input_stream,
@@ -3538,6 +3656,7 @@ impl DeltaTableInputEndpointInner {
         path: &str,
         polarity: bool,
         deletion_vector: Option<&DeletionVectorDescriptor>,
+        partition_values: Option<&HashMap<String, Option<String>>>,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -3561,9 +3680,8 @@ impl DeltaTableInputEndpointInner {
             })
             .await?
         } else {
-            let full_path = format!("{}{}", table_root_base(table), path);
             Arc::new(
-                self.create_parquet_table(vec![full_path], &description)
+                self.create_parquet_table(vec![file_listing_url(table, path)?], &description)
                     .await?,
             )
         };
@@ -3572,6 +3690,7 @@ impl DeltaTableInputEndpointInner {
             provider,
             polarity,
             used_columns,
+            partition_values,
             &description,
             table,
             input_stream,
@@ -3589,6 +3708,7 @@ impl DeltaTableInputEndpointInner {
         &self,
         action: &Action,
         path: &str,
+        partition_values: Option<&HashMap<String, Option<String>>>,
         dv_delta: Option<&RoaringTreemap>,
         polarity: bool,
         table: &DeltaTable,
@@ -3612,6 +3732,7 @@ impl DeltaTableInputEndpointInner {
                     provider,
                     polarity,
                     used_columns,
+                    partition_values,
                     &description,
                     table,
                     input_stream,
@@ -3648,6 +3769,7 @@ impl DeltaTableInputEndpointInner {
         provider: Arc<dyn TableProvider>,
         polarity: bool,
         used_columns: &[&str],
+        partition_values: Option<&HashMap<String, Option<String>>>,
         description: &str,
         table: &DeltaTable,
         input_stream: &mut dyn ArrowStream,
@@ -3660,6 +3782,7 @@ impl DeltaTableInputEndpointInner {
         // Translate column-mapped physical names back to logical before any
         // logical-name projection or filter.
         let df = self.project_physical_to_logical(df)?;
+        let df = self.add_partition_columns(df, partition_values, description)?;
 
         let df = apply_filter(df, self.config.filter.as_deref(), description, None)?;
 

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -22,6 +22,7 @@ use deltalake::kernel::{DataType, StructField};
 use deltalake::operations::create::CreateBuilder;
 use deltalake::protocol::SaveMode;
 use deltalake::{DeltaTable, DeltaTableBuilder, ensure_table_uri};
+use feldera_adapterlib::errors::controller::ControllerError;
 use feldera_macros::IsNone;
 use feldera_sqllib::Variant;
 use feldera_types::config::PipelineConfig;
@@ -4339,6 +4340,280 @@ async fn run_follow_filter_undeclared_column_test(filter_expr: &str) {
     read_pipeline.stop().unwrap();
 }
 
+/// A Delta table with `arrow_schema`'s columns, partitioned by `partition_columns`.
+async fn create_table_from_arrow(
+    table_uri: &str,
+    arrow_schema: &ArrowSchema,
+    partition_columns: &[&str],
+) -> DeltaTable {
+    let struct_fields: Vec<StructField> = arrow_schema
+        .fields()
+        .iter()
+        .map(|f| {
+            StructField::new(
+                f.name(),
+                DataType::try_from_arrow(f.data_type()).unwrap(),
+                f.is_nullable(),
+            )
+        })
+        .collect();
+
+    CreateBuilder::new()
+        .with_location(table_uri)
+        .with_save_mode(SaveMode::Ignore)
+        .with_columns(struct_fields)
+        .with_partition_columns(partition_columns.iter().copied())
+        .await
+        .unwrap()
+}
+
+/// Start a pipeline whose only input reads `table_uri` with `transport_config`.
+///
+/// The error callback runs on a worker thread, where a panic is swallowed, so
+/// errors go to `errors` for [`wait_or_connector_error`] to report.
+async fn delta_input_controller<T>(
+    table_uri: &str,
+    mut transport_config: Value,
+    relation: &[Field],
+    storage_dir: &Path,
+    errors: &Arc<Mutex<Vec<String>>>,
+) -> Result<Controller, ControllerError>
+where
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig, Variant>
+        + Sync,
+{
+    transport_config["uri"] = table_uri.into();
+    let pipeline_config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 4,
+        "storage_config": { "path": storage_dir },
+        "inputs": {
+            "test_input1": {
+                "stream": "test_input1",
+                "transport": {
+                    "name": "delta_table_input",
+                    "config": transport_config,
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    let relation = relation.to_vec();
+    let errors = errors.clone();
+    tokio::task::spawn_blocking(move || {
+        Controller::with_test_config(
+            move |workers| Ok(test_circuit::<T>(workers, &relation, &[Some("output")])),
+            &pipeline_config,
+            Box::new(move |e, _| errors.lock().unwrap().push(e.to_string())),
+        )
+    })
+    .await
+    .unwrap()
+}
+
+/// Write `rows` to a table partitioned by `partition_columns` and check that a
+/// follow read gets every column back.
+async fn run_follow_partition_test<T>(relation: &[Field], rows: &[T], partition_columns: &[&str])
+where
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig, Variant>
+        + Sync,
+{
+    init_logging();
+
+    let arrow_schema = ArrowSchema::new(relation_to_arrow_fields(relation, delta_schema_options()));
+    let table_dir = TempDir::new().unwrap();
+    let table_uri = table_dir.path().display().to_string();
+    let table = create_table_from_arrow(&table_uri, &arrow_schema, partition_columns).await;
+
+    let storage_dir = TempDir::new().unwrap();
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let read_pipeline = delta_input_controller::<T>(
+        &table_uri,
+        json!({ "mode": "follow" }),
+        relation,
+        storage_dir.path(),
+        &errors,
+    )
+    .await
+    .unwrap();
+    read_pipeline.start();
+
+    write_data_to_table(table, &arrow_schema, rows).await;
+    wait_or_connector_error(
+        &read_pipeline,
+        &SqlIdentifier::from("test_output1"),
+        rows,
+        &errors,
+    )
+    .await;
+
+    read_pipeline.stop().unwrap();
+}
+
+/// Delta keeps a partition column's value in the file path and the log, never in
+/// the data file, so follow mode must reconstruct it the way the snapshot read
+/// (which delegates to delta-rs) already does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_partition_column_test() {
+    use crate::test::TestStruct;
+
+    // `s` is the partition column. Its values need escaping in the file path, so
+    // this also covers the encoding round trip: Delta escapes the value into the
+    // directory name and the log stores that name URL-encoded again.
+    let rows: Vec<TestStruct> = (0..6)
+        .map(|id| TestStruct {
+            id,
+            b: false,
+            i: None,
+            s: if id.is_multiple_of(2) {
+                "us east"
+            } else {
+                "us/west"
+            }
+            .to_string(),
+        })
+        .collect();
+
+    run_follow_partition_test(&TestStruct::schema(), &rows, &["s"]).await;
+}
+
+/// A partition value reaches the connector as the string Delta wrote into the
+/// path, so every SQL type Delta can partition on must survive the cast back.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_partition_column_types_test() {
+    // Every scalar type in `DeltaTestStruct` except `binary`: delta-rs writes
+    // such a partition value as literal `\uXXXX` text (the byte 0xFE becomes
+    // six characters), which does not read back as the original bytes.
+    // `unused` is nullable and covers the NULL partition value.
+    const PARTITION_COLUMNS: &[&str] = &[
+        "bigint",
+        "boolean",
+        "date",
+        "decimal_10_3",
+        "double",
+        "float",
+        "int",
+        "smallint",
+        "string",
+        "timestamp_ntz",
+        "tinyint",
+        "unused",
+        "uuid",
+    ];
+
+    let mut rows: Vec<DeltaTestStruct> = (0..2).map(delta_test_record).collect();
+    rows[0].unused = None;
+    rows[1].unused = Some("present".to_string());
+
+    run_follow_partition_test(&DeltaTestStruct::schema(), &rows, PARTITION_COLUMNS).await;
+}
+
+/// CDC mode over a partitioned table: the adds side reads files that span two
+/// partitions, so each file's value must come back with its own rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delta_table_cdc_partition_column_test() {
+    use crate::test::TestStruct;
+    use arrow::array::{
+        Array, BooleanArray, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
+    };
+    use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+
+    init_logging();
+
+    let expect = |id: u32, s: &str| TestStruct {
+        id,
+        b: false,
+        i: None,
+        s: s.to_string(),
+    };
+
+    // The CDC marker columns are not part of the SQL relation, so the table's
+    // schema is built by hand rather than from `TestStruct::schema()`.
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, false),
+        ArrowField::new("b", ArrowDataType::Boolean, false),
+        ArrowField::new("s", ArrowDataType::Utf8, false),
+        ArrowField::new("__feldera_op", ArrowDataType::Utf8, false),
+        ArrowField::new(
+            "__feldera_ts",
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+    ]));
+
+    // Each tuple is (id, op, ts, s); `s` is the partition column.
+    let make_batch = |rows: &[(i64, &str, i64, &str)]| -> RecordBatch {
+        RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(rows.iter().map(|r| r.0))) as Arc<dyn Array>,
+                Arc::new(rows.iter().map(|_| Some(false)).collect::<BooleanArray>()),
+                Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.3))),
+                Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.1))),
+                Arc::new(TimestampMicrosecondArray::from_iter_values(
+                    rows.iter().map(|r| r.2),
+                )),
+            ],
+        )
+        .unwrap()
+    };
+
+    async fn append(delta: DeltaTable, batch: RecordBatch) -> DeltaTable {
+        delta
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap()
+    }
+
+    let table_dir = TempDir::new().unwrap();
+    let table_uri = table_dir.path().display().to_string();
+    let mut delta = create_table_from_arrow(&table_uri, &arrow_schema, &["s"]).await;
+
+    let storage_dir = TempDir::new().unwrap();
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let read_pipeline = delta_input_controller::<TestStruct>(
+        &table_uri,
+        json!({
+            "mode": "cdc",
+            "cdc_delete_filter": "__feldera_op = 'd'",
+            "cdc_order_by": "__feldera_ts asc",
+        }),
+        &TestStruct::schema(),
+        storage_dir.path(),
+        &errors,
+    )
+    .await
+    .unwrap();
+    read_pipeline.start();
+    let output = SqlIdentifier::from("test_output1");
+
+    // One commit, two partitions.
+    delta = append(
+        delta,
+        make_batch(&[(0, "i", 1_000, "a"), (1, "i", 1_000, "b")]),
+    )
+    .await;
+    wait_or_connector_error(
+        &read_pipeline,
+        &output,
+        &[expect(0, "a"), expect(1, "b")],
+        &errors,
+    )
+    .await;
+
+    // Deleting id 0 must match the row ingested from partition "a".
+    let _ = append(delta, make_batch(&[(0, "d", 2_000, "a")])).await;
+    wait_or_connector_error(&read_pipeline, &output, &[expect(1, "b")], &errors).await;
+
+    read_pipeline.stop().unwrap();
+}
+
 /// [`wait_for_records_materialized`], but report a connector error as soon as
 /// one arrives rather than waiting out the materialization timeout.
 async fn wait_or_connector_error<T>(
@@ -4373,6 +4648,43 @@ async fn delta_table_follow_filter_undeclared_column_test() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn delta_table_follow_filter_undeclared_struct_field_test() {
     run_follow_filter_undeclared_column_test("meta.tag = 'us'").await;
+}
+
+/// A `filter` that does not parse must fail the connector at startup, not on the
+/// first Delta commit: pure follow mode skipped validation entirely.
+///
+/// The directory holds no Delta table, so reaching it at all would fail with a
+/// different error: validation has to happen before the connector opens it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_invalid_filter_test() {
+    use crate::test::TestStruct;
+
+    init_logging();
+
+    let relation = TestStruct::schema();
+    let table_dir = TempDir::new().unwrap();
+    let table_uri = table_dir.path().display().to_string();
+
+    let storage_dir = TempDir::new().unwrap();
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let result = delta_input_controller::<TestStruct>(
+        &table_uri,
+        json!({ "mode": "follow", "filter": "s =" }),
+        &relation,
+        storage_dir.path(),
+        &errors,
+    )
+    .await;
+
+    let error = match result {
+        Ok(_) => panic!("the controller must not start with an invalid filter"),
+        Err(e) => e.to_string(),
+    };
+
+    assert!(
+        error.contains("'filter'"),
+        "expected the error to name 'filter', got: {error}"
+    );
 }
 
 /// Filtering before projecting must not widen the scan: DataFusion's projection

--- a/python/tests/platform/fixtures/cdc_delete_filter_drop.py
+++ b/python/tests/platform/fixtures/cdc_delete_filter_drop.py
@@ -1,0 +1,76 @@
+"""Build a Delta CDC table whose DROP COLUMN shifts the delete-marker column.
+
+``tests.utils.ensure_delta_spark_fixture`` runs this as a subprocess
+(``uv run --with "delta-spark>=4.2,<5" python cdc_delete_filter_drop.py
+<output_dir>``). DROP COLUMN needs column mapping, which only Delta Spark can
+write; neither ``delta-rs`` nor the ``deltalake`` wheel can drop a column.
+
+Bump ``FIXTURE_VERSION`` in ``test_delta_input_cdc_schema_drop.py`` on any
+change here: a cached fixture is reused based on its path alone.
+
+The table's history (one commit per step):
+
+* ``v0`` CREATE TABLE ``(id, b, extra, __feldera_op, s, __feldera_ts)``
+* ``v1`` INSERT ids 1 and 2, both with ``__feldera_op = 'i'``
+* ``v2`` DROP COLUMN ``extra``
+* ``v3`` INSERT a delete marker for id 1 (``__feldera_op = 'd'``)
+
+``__feldera_op`` sits at index 3 until the drop and at index 2 after it, which
+leaves ``s`` -- also a string -- where a ``cdc_delete_filter`` compiled against
+the pre-drop schema still reads. A connector that follows the shift would apply
+the v3 marker and leave only id 2; one that reads the stale index sees
+``s = 'd'``, never true, and inserts id 1 a second time.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def build(table_path: str) -> None:
+    """Create the column-mapped table at ``table_path`` with the drop history."""
+    from delta import configure_spark_with_delta_pip
+    from pyspark.sql import SparkSession
+
+    builder = (
+        SparkSession.builder.appName("feldera-cdc-drop-fixture")
+        .master("local[2]")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .config("spark.ui.showConsoleProgress", "false")
+    )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    try:
+        t = f"delta.`{table_path}`"
+        props = (
+            "TBLPROPERTIES ('delta.columnMapping.mode' = 'name',"
+            "               'delta.minReaderVersion' = '2',"
+            "               'delta.minWriterVersion' = '5')"
+        )
+        spark.sql(
+            f"CREATE TABLE {t} (id BIGINT, b BOOLEAN, extra STRING,"
+            " __feldera_op STRING, s STRING, __feldera_ts TIMESTAMP_NTZ)"
+            f" USING delta {props}"
+        )
+        spark.sql(
+            f"INSERT INTO {t} VALUES"
+            " (1,false,'x','i','keep',TIMESTAMP_NTZ'2020-01-01 00:00:01'),"
+            " (2,false,'x','i','keep',TIMESTAMP_NTZ'2020-01-01 00:00:01')"
+        )
+        spark.sql(f"ALTER TABLE {t} DROP COLUMN extra")
+        spark.sql(
+            f"INSERT INTO {t} VALUES"
+            " (1,false,'d','keep',TIMESTAMP_NTZ'2020-01-01 00:00:02')"
+        )
+    finally:
+        spark.stop()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: cdc_delete_filter_drop.py <output_dir>")
+    build(sys.argv[1])

--- a/python/tests/platform/fixtures/column_mapping_partitioned.py
+++ b/python/tests/platform/fixtures/column_mapping_partitioned.py
@@ -1,0 +1,75 @@
+"""Build a column-mapped Delta table partitioned by a string column.
+
+``tests.utils.ensure_delta_spark_fixture`` runs this as a subprocess
+(``uv run --with "delta-spark>=4.2,<5" python column_mapping_partitioned.py
+<output_dir>``). PySpark is the only writer that can enable column mapping;
+neither ``delta-rs`` nor the ``deltalake`` wheel can.
+
+Bump ``PARTITIONED_FIXTURE_VERSION`` in ``test_delta_input_column_mapping.py``
+on any change here: a cached fixture is reused based on its path alone.
+
+The table's history (one commit per step):
+
+* ``v0`` CREATE TABLE ``(id, full_name, region)`` PARTITIONED BY ``region``,
+  with ``delta.columnMapping.mode = 'name'``
+* ``v1`` INSERT three rows across two regions
+
+Delta keeps a partition column's value in the log, never in the data file, and
+under column mapping it keys ``partitionValues`` by the column's *physical*
+name (``col-<uuid>``) rather than its logical one. A follow read that looks the
+value up by logical name finds no entry and fails the commit. Column mapping
+also drops the Hive ``region=<value>`` directory in favour of an opaque prefix,
+so the path carries no partition value to fall back on.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+# Logical rows the connector must produce, whatever the physical layout.
+EXPECTED_ROWS = [
+    {"id": 1, "full_name": "alice", "region": "us east"},
+    {"id": 2, "full_name": "bob", "region": "us/west"},
+    {"id": 3, "full_name": "carol", "region": "us east"},
+]
+
+
+def build(table_path: str) -> None:
+    """Create the column-mapped, partitioned table at ``table_path``."""
+    from delta import configure_spark_with_delta_pip
+    from pyspark.sql import SparkSession
+
+    builder = (
+        SparkSession.builder.appName("feldera-column-mapping-partitioned-fixture")
+        .master("local[2]")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .config("spark.ui.showConsoleProgress", "false")
+    )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    try:
+        t = f"delta.`{table_path}`"
+        spark.sql(
+            f"CREATE TABLE {t} (id BIGINT, full_name STRING, region STRING)"
+            " USING delta PARTITIONED BY (region)"
+            " TBLPROPERTIES ('delta.columnMapping.mode' = 'name',"
+            "                'delta.minReaderVersion' = '2',"
+            "                'delta.minWriterVersion' = '5')"
+        )
+        spark.sql(
+            f"INSERT INTO {t} VALUES"
+            " (1,'alice','us east'),(2,'bob','us/west'),(3,'carol','us east')"
+        )
+    finally:
+        spark.stop()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: column_mapping_partitioned.py <output_dir>")
+    build(sys.argv[1])

--- a/python/tests/platform/fixtures/deletion_vectors.py
+++ b/python/tests/platform/fixtures/deletion_vectors.py
@@ -11,11 +11,12 @@ JARs download at runtime either way). ``tests.utils.ensure_delta_spark_fixture``
 invokes this file with::
 
     uv run --with "delta-spark>=4.2,<5" python deletion_vectors.py \\
-        <dest> <total_rows> <expected_active> [--cdc]
+        <dest> <total_rows> <expected_active> [--cdc] [--partitioned]
 
 Without ``--cdc``, it writes a two-version table:
 
-* v0: ``total_rows`` rows (``id``, ``name``, ``value``, ``meta``) with DVs enabled.
+* v0: ``total_rows`` rows (``id``, ``name``, ``value``, ``meta``) with DVs
+  enabled; ``--partitioned`` adds a ``grp`` column and partitions by it.
 * v1: ``DELETE`` of the even ``id`` rows, which produces deletion vectors.
 
 With ``--cdc``, it writes a four-version table shaped like a CDC event log
@@ -42,21 +43,31 @@ readable, then exits.
 import sys
 
 
-def _write_plain_fixture(spark, dest: str, total_rows: int) -> None:
-    """v0: `total_rows` rows; v1: DV `DELETE` of the even ids."""
-    (
+def _write_plain_fixture(spark, dest: str, total_rows: int, partitioned=False) -> None:
+    """v0: `total_rows` rows; v1: DV `DELETE` of the even ids.
+
+    When `partitioned`, the table is partitioned by `grp` = id % 3. That is
+    orthogonal to the delete predicate, so every partition keeps a mix of even
+    and odd ids and every file ends up carrying a deletion vector.
+    """
+    columns = [
+        "cast(id as int) as id",
+        "concat('user_', id) as name",
+        "cast(id * 1.5 as double) as value",
+        # Mirrors `value`, so a filter can name it as a struct field.
+        "struct(cast(id * 1.5 as double) as value) as meta",
+    ]
+    if partitioned:
+        columns.append("cast(id % 3 as string) as grp")
+    writer = (
         spark.range(1, total_rows + 1)
-        .selectExpr(
-            "cast(id as int) as id",
-            "concat('user_', id) as name",
-            "cast(id * 1.5 as double) as value",
-            # Mirrors `value`, so a filter can name it as a struct field.
-            "struct(cast(id * 1.5 as double) as value) as meta",
-        )
+        .selectExpr(*columns)
         .write.format("delta")
         .option("delta.enableDeletionVectors", "true")
-        .save(dest)
     )
+    if partitioned:
+        writer = writer.partitionBy("grp")
+    writer.save(dest)
     spark.sql("DELETE FROM delta.`" + dest + "` WHERE id % 2 = 0")
 
 
@@ -132,6 +143,7 @@ def main() -> None:
     expected_active = int(sys.argv[3])
     cdc = "--cdc" in sys.argv[4:]
     overwrite = "--overwrite" in sys.argv[4:]
+    partitioned = "--partitioned" in sys.argv[4:]
 
     builder = (
         SparkSession.builder.appName("feldera_dv_fixture")
@@ -155,7 +167,7 @@ def main() -> None:
         elif cdc:
             _write_cdc_fixture(spark, dest, total_rows)
         else:
-            _write_plain_fixture(spark, dest, total_rows)
+            _write_plain_fixture(spark, dest, total_rows, partitioned)
         active = spark.read.format("delta").load(dest).count()
         assert active == expected_active, (
             f"builder expected {expected_active} active rows after the "

--- a/python/tests/platform/test_delta_input_cdc_schema_drop.py
+++ b/python/tests/platform/test_delta_input_cdc_schema_drop.py
@@ -1,0 +1,113 @@
+"""A CDC `DROP COLUMN` must not silently repoint the compiled delete filter.
+
+`cdc_delete_filter` becomes a DataFusion `PhysicalExpr`, which binds each column
+by index and ignores its name. Dropping a column ahead of the delete marker
+shifts the indices under it: with the marker's old slot occupied by another
+string column, a stale expression would evaluate that column instead and land
+every delete as an insert, with no error anywhere. The connector compiles the
+expression against each transaction's own frame, so the delete still applies.
+
+DROP COLUMN needs column mapping, so PySpark seeds the fixture; the builder
+lives in `fixtures/cdc_delete_filter_drop.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
+
+from tests import TEST_CLIENT
+from tests.utils import DeltaTestLocation, ensure_delta_spark_fixture
+
+from .helper import api_url, gen_pipeline_name, get
+
+TABLE = "t"
+CONNECTOR = "delta_in"
+# Bump to invalidate cached MinIO copies when the fixture definition changes.
+FIXTURE_VERSION = "v1"
+
+_FIXTURE_BUILDER = Path(__file__).parent / "fixtures" / "cdc_delete_filter_drop.py"
+
+# v0 is the already-consumed empty baseline, so the replay covers v1..v3: the
+# two inserts, the DROP COLUMN, and the delete marker.
+_CONFIG = {
+    "version": 0,
+    "end_version": 3,
+    "cdc_delete_filter": "__feldera_op = 'd'",
+    "cdc_order_by": "__feldera_ts asc",
+}
+
+
+@gen_pipeline_name
+def test_delta_input_cdc_delete_filter_after_drop(pipeline_name):
+    loc = DeltaTestLocation.create(
+        pipeline_name,
+        mode="cdc",
+        stable_subpath=f"cdc_delete_filter_drop_{FIXTURE_VERSION}",
+    )
+    try:
+        ensure_delta_spark_fixture(loc, _FIXTURE_BUILDER)
+
+        config = dict(loc.connector_config)
+        config.update(_CONFIG)
+        connectors = json.dumps(
+            [
+                {
+                    "name": CONNECTOR,
+                    "transport": {"name": "delta_table_input", "config": config},
+                }
+            ]
+        ).replace("'", "''")
+        sql = (
+            f"CREATE TABLE {TABLE} (id BIGINT NOT NULL, b BOOLEAN, s VARCHAR)"
+            f" WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
+        )
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
+        ).create_or_replace()
+        pipeline.start()
+
+        # The replay is bounded by end_version, so it always reaches
+        # end-of-input.
+        pipeline.wait_for_completion(force_stop=False, timeout_s=300)
+
+        # The v3 marker deletes id 1. A stale expression would read `s`
+        # ("keep", never 'd'), turn the delete into an insert, and leave id 1
+        # in the table twice.
+        rows = sorted(
+            (
+                {"id": r["id"], "s": r["s"]}
+                for r in pipeline.query(f"SELECT * FROM {TABLE}")
+            ),
+            key=lambda r: r["id"],
+        )
+        assert rows == [{"id": 2, "s": "keep"}], (
+            f"expected the delete of id 1 to apply after the drop; got {rows}"
+        )
+
+        # `Pipeline.stats` omits the error payloads; only this selector returns
+        # them, so read the messages from the REST endpoint directly.
+        stats = get(
+            api_url(f"/pipelines/{pipeline_name}/stats?include_connector_errors=true")
+        ).json()
+        messages = [
+            err.get("message", "")
+            for entry in stats.get("inputs", [])
+            for err in (entry.get("parse_errors") or [])
+        ]
+        assert not messages, messages
+
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()

--- a/python/tests/platform/test_delta_input_column_mapping.py
+++ b/python/tests/platform/test_delta_input_column_mapping.py
@@ -28,16 +28,24 @@ from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
 
 from tests import TEST_CLIENT
 from tests.platform.fixtures.column_mapping import EXPECTED_ROWS
+from tests.platform.fixtures.column_mapping_partitioned import (
+    EXPECTED_ROWS as PARTITIONED_EXPECTED_ROWS,
+)
 from tests.utils import DeltaTestLocation, ensure_delta_spark_fixture
 
 TABLE = "t"
 CONNECTOR = "delta_in"
 # Bump to invalidate cached MinIO copies when the fixture definition changes.
 FIXTURE_VERSION = "v2"
+# Separate fixture: column-mapped and partitioned, no schema evolution.
+PARTITIONED_FIXTURE_VERSION = "partitioned_v1"
 
 # Spark builder that writes the column-mapped, schema-evolved table. It runs in
 # a subprocess (see ensure_delta_spark_fixture) rather than being imported here.
 _FIXTURE_BUILDER = Path(__file__).parent / "fixtures" / "column_mapping.py"
+_PARTITIONED_FIXTURE_BUILDER = (
+    Path(__file__).parent / "fixtures" / "column_mapping_partitioned.py"
+)
 
 
 # The final, post-evolution logical columns. Used unless a test reads only part
@@ -281,6 +289,62 @@ def test_delta_input_column_mapping_follow_end_version(pipeline_name):
             "replay up to v4 must read each commit against its own schema: "
             "'amount' present (dropped only at v5), 'full_name' NULL for the "
             f"pre-rename v1 rows; got {rows}"
+        )
+
+        pipeline.stop(force=True)
+    finally:
+        loc.cleanup()
+
+
+def test_delta_input_column_mapping_partitioned_follow(pipeline_name):
+    """Follow a column-mapped table partitioned by ``region``.
+
+    Delta keeps a partition column's value in the log, never in the data file,
+    and under column mapping it keys ``partitionValues`` by the physical
+    (``col-<uuid>``) name. A read that looks the value up by logical name finds
+    no entry, so every commit fails; column mapping also replaces the Hive
+    ``region=<value>`` directory with an opaque prefix, leaving the path with
+    nothing to fall back on.
+    """
+    loc = DeltaTestLocation.create(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        stable_subpath=f"column_mapping_partitioned_{PARTITIONED_FIXTURE_VERSION}",
+    )
+    try:
+        ensure_delta_spark_fixture(loc, _PARTITIONED_FIXTURE_BUILDER)
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=_build_sql(
+                loc,
+                extra_config={"version": 0, "end_version": 1},
+                columns="id BIGINT NOT NULL, full_name VARCHAR, region VARCHAR",
+            ),
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                logging="debug",
+            ),
+        ).create_or_replace()
+        pipeline.start()
+        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+        rows = sorted(
+            (
+                {
+                    "id": r["id"],
+                    "full_name": r["full_name"],
+                    "region": r["region"],
+                }
+                for r in pipeline.query(f"SELECT id, full_name, region FROM {TABLE}")
+            ),
+            key=lambda r: r["id"],
+        )
+        assert rows == PARTITIONED_EXPECTED_ROWS, (
+            "a follow read must reconstruct the partition column from the "
+            f"log action's physical-name key; got {rows}"
         )
 
         pipeline.stop(force=True)

--- a/python/tests/platform/test_delta_input_deletion_vectors.py
+++ b/python/tests/platform/test_delta_input_deletion_vectors.py
@@ -55,6 +55,8 @@ FOLLOW_DV_DELETE_INPUT_RECORDS = TOTAL_ROWS + DV_DELETED_ROWS
 FOLLOW_RESTORE_INPUT_RECORDS = EXPECTED_ROWS_AFTER_DV + DV_DELETED_ROWS
 # Bump to invalidate cached MinIO copies when the fixture definition changes.
 FIXTURE_VERSION = "dv_snapshot_v2"
+# Separate fixture: partitioned by `grp`, otherwise the same two commits.
+PARTITIONED_FIXTURE_VERSION = "dv_partitioned_v1"
 # CDC-shaped fixture (see fixtures/deletion_vectors.py --cdc): v0 inserts
 # TOTAL_ROWS events, v1 DV-deletes the even ids, v2 restores them (shrinking
 # the DVs away), v3 appends one event.
@@ -177,6 +179,7 @@ def _ingest_dv_fixture(
     expected_active: int = EXPECTED_ROWS_AFTER_DV,
     cdc: bool = False,
     overwrite: bool = False,
+    partitioned: bool = False,
     columns: str = "id INT NOT NULL, name VARCHAR, value DOUBLE",
     extra_config: dict | None = None,
 ) -> DvIngest:
@@ -185,7 +188,11 @@ def _ingest_dv_fixture(
     Owns the location's lifecycle (create/cleanup); the tests reduce to a
     call plus their assertions. Returns ``_run_to_completion``'s [`DvIngest`].
     """
-    builder_flags = (["--cdc"] if cdc else []) + (["--overwrite"] if overwrite else [])
+    builder_flags = (
+        (["--cdc"] if cdc else [])
+        + (["--overwrite"] if overwrite else [])
+        + (["--partitioned"] if partitioned else [])
+    )
     loc = DeltaTestLocation.create(
         pipeline_name,
         mode=mode,
@@ -247,6 +254,34 @@ def test_delta_input_follow_with_deletion_vectors(pipeline_name):
         f"{FOLLOW_DV_DELETE_INPUT_RECORDS} (snapshot {TOTAL_ROWS} + "
         f"{DV_DELETED_ROWS} deleted). A far larger count means the connector "
         "re-read the whole rewritten file instead of just the DV delta"
+    )
+
+
+def test_delta_input_follow_partitioned_with_dv(pipeline_name):
+    """Follow a DV commit on a partitioned table, filtering on the partition.
+
+    Delta keeps `grp` in the file path and the log, never in the data file, so
+    the DV-masked read has to add it back. The filter names it, so a partition
+    value that came back NULL would drop every row rather than fail loudly.
+    """
+    in_partition = [i for i in range(1, TOTAL_ROWS + 1) if i % 3 == 1]
+    kept = [i for i in in_partition if i % 2]
+    result = _ingest_dv_fixture(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        fixture_version=PARTITIONED_FIXTURE_VERSION,
+        partitioned=True,
+        columns="id INT NOT NULL, name VARCHAR, value DOUBLE, grp VARCHAR",
+        extra_config={"version": 0, "end_version": 1, "filter": "grp = '1'"},
+    )
+    assert result.total == len(kept), (
+        f"expected the {len(kept)} DV survivors in partition '1'; got "
+        f"{result.total}. The snapshot count ({len(in_partition)}) means the "
+        "follow side read the partition column as NULL, so the filter dropped "
+        "its retractions"
+    )
+    assert result.even_id_rows == 0, (
+        "the survivors must be the odd ids, not the deleted even ids"
     )
 
 


### PR DESCRIPTION
Delta keeps a partition column's value in the log, never in the data file. Snapshot mode delegates to delta-rs and gets it back; follow and CDC read raw Parquet, so the column arrived NULL, or the read failed when it was not nullable. The reader now takes the value from the log action, keyed by the column's physical name: that is how Delta writes it under column mapping, and by its logical name otherwise.

Three related fixes:

- File paths are no longer decoded twice. delta-rs decodes an action's
  path when it reads the log, so a partition value needing escaping
  listed no file and ingested zero rows without an error.
- `cdc_delete_filter` is compiled per transaction, against the frame it
  evaluates. DataFusion binds columns by index, so after a `DROP COLUMN`
  the expression compiled at startup read a same-typed neighbour and
  turned every delete into an insert.
- `filter` and `snapshot_filter` are validated at startup in every mode.
  Pure follow skipped validation, so a bad filter started healthy and
  failed on the first commit.
  
### Describe Manual Test Plan

relying on added tests

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?
not a breaking change

