### PR TITLE
[python] wait_for_completion: fail fast on a fatal input error

### DIFF
--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -382,7 +382,8 @@ class Pipeline:
             the pipeline to complete. The default is None, which means wait
             indefinitely.
 
-        :raises RuntimeError: If the pipeline returns unknown metrics.
+        :raises RuntimeError: If the pipeline returns unknown metrics, or an
+            input connector failed fatally and can no longer complete.
         """
 
         if self.status() not in [
@@ -431,6 +432,19 @@ class Pipeline:
             elif pipeline_complete:
                 wait_for_completion.done()
                 break
+
+            # A fatally errored input connector never issues end-of-input, so
+            # waiting on it only hides the error behind a timeout.
+            fatal_errors = [
+                f"{endpoint.endpoint_name}: {endpoint.fatal_error}"
+                for endpoint in latest_stats.inputs
+                if endpoint.fatal_error
+            ]
+            if fatal_errors:
+                raise RuntimeError(
+                    f"input connector(s) of pipeline '{self.name}' failed fatally"
+                    f" and cannot complete: {'; '.join(fatal_errors)}"
+                )
 
             wait_for_completion.check()
             time.sleep(1)

--- a/python/tests/unit/test_wait_for_completion.py
+++ b/python/tests/unit/test_wait_for_completion.py
@@ -1,0 +1,76 @@
+"""Tests for Pipeline.wait_for_completion's handling of fatal input errors."""
+
+import pytest
+
+from feldera.enums import PipelineStatus
+from feldera.pipeline import Pipeline
+from feldera.stats import PipelineStatistics
+
+BASE_STATS = {
+    "global_metrics": {
+        "state": "running",
+        "incarnation_uuid": "00000000-0000-0000-0000-000000000000",
+        "start_time": 0,
+        "transaction_status": "NoTransaction",
+        "total_processed_records": 0,
+        "total_input_records": 0,
+        "pipeline_complete": False,
+    },
+    "inputs": [],
+    "outputs": [],
+}
+
+INPUT_STATUS = {
+    "endpoint_name": "t.input",
+    "config": {},
+    "metrics": {},
+    "paused": False,
+    "barrier": False,
+}
+
+
+def stats(complete: bool, fatal_error: str | None = None) -> PipelineStatistics:
+    d = {
+        **BASE_STATS,
+        "global_metrics": {
+            **BASE_STATS["global_metrics"],
+            "pipeline_complete": complete,
+        },
+        "inputs": [{**INPUT_STATUS, "fatal_error": fatal_error}],
+    }
+    return PipelineStatistics.from_dict(d)
+
+
+class FakePipeline(Pipeline):
+    """A pipeline that replays a fixed sequence of `/stats` replies."""
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+
+    @property
+    def name(self) -> str:
+        return "test"
+
+    def status(self) -> PipelineStatus:
+        return PipelineStatus.RUNNING
+
+    def stats(self) -> PipelineStatistics:
+        # The last reply repeats, so a wait that should raise instead hangs to
+        # its timeout -- the behaviour these tests guard against.
+        return self.replies.pop(0) if len(self.replies) > 1 else self.replies[0]
+
+
+def test_fatal_input_error_raises():
+    pipeline = FakePipeline([stats(complete=False, fatal_error="no field named meta")])
+    with pytest.raises(RuntimeError, match="no field named meta"):
+        pipeline.wait_for_completion(timeout_s=30)
+
+
+def test_completion_wins_over_a_late_fatal_error():
+    pipeline = FakePipeline([stats(complete=True, fatal_error="already reported")])
+    pipeline.wait_for_completion(timeout_s=30)
+
+
+def test_healthy_pipeline_waits_for_completion():
+    pipeline = FakePipeline([stats(complete=False), stats(complete=True)])
+    pipeline.wait_for_completion(timeout_s=30)


### PR DESCRIPTION
A fatally errored input connector never issues end-of-input, so the call hung until its timeout and hid the error. Raise with the connector name and its error instead.

this seems logical, but i'm not much aware about intended use of this method by others, so may or may not be correct. If correct, shall we do similar fix for fda ( if not already there )


## Breaking Changes?

Mark if you think the answer is yes for any of these components:


- [x] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))


### Describe Incompatible Changes

wait_for_completion would raise an error instead of timing out