### PR TITLE
ci: migrate build-fda-native cache to feldera-gcs-cache

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -183,16 +183,15 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Cache Cargo registry and index
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/feldera-gcs-cache
         with:
           # registry/src excluded — cargo regenerates it from registry/cache.
+          # These are native (non-container) runners, so CARGO_HOME is the
+          # default ~/.cargo and tilde paths resolve correctly per-OS.
           path: |
-            # Absolute paths: CARGO_HOME is /home/ubuntu/.cargo (feldera-dev image
-            # env), while ~ expands to the runner's HOME (/github/home in container
-            # jobs), so tilde paths would cache a directory cargo never writes.
-            /home/ubuntu/.cargo/registry/cache
-            /home/ubuntu/.cargo/registry/index
-            /home/ubuntu/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
           key: build-rust-fda-native-cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             build-rust-fda-native-cargo-${{ runner.os }}-${{ matrix.target }}-

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -182,16 +182,18 @@ jobs:
       - name: Add Rust target
         run: rustup target add ${{ matrix.target }}
 
+      - name: Resolve CARGO_HOME
+        shell: bash
+        run: echo "CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}" >> "$GITHUB_ENV"
+
       - name: Cache Cargo registry and index
         uses: ./.github/actions/feldera-gcs-cache
         with:
           # registry/src excluded — cargo regenerates it from registry/cache.
-          # These are native (non-container) runners, so CARGO_HOME is the
-          # default ~/.cargo and tilde paths resolve correctly per-OS.
           path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
+            ${{ env.CARGO_HOME }}/registry/cache
+            ${{ env.CARGO_HOME }}/registry/index
+            ${{ env.CARGO_HOME }}/git/db
           key: build-rust-fda-native-cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             build-rust-fda-native-cargo-${{ runner.os }}-${{ matrix.target }}-

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -187,7 +187,7 @@ jobs:
         run: echo "CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}" >> "$GITHUB_ENV"
 
       - name: Cache Cargo registry and index
-        uses: ./.github/actions/feldera-gcs-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           # registry/src excluded — cargo regenerates it from registry/cache.
           path: |


### PR DESCRIPTION
This was the last actions/cache usage in the repo; every other job already caches against the GCS bucket via feldera-gcs-cache. Also fixes the cache paths, that never matched anything on the native macOS/Windows runners this job actually uses.
