### PR TITLE
[profiler] Use appropriate aggregation semantics in compound nodes

### DIFF
--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
@@ -34,13 +34,14 @@
 <div class="metrics-block rounded-container bg-white-dark px-4 py-2 shadow-sm" data-block-id={id}>
   <div class="scrollbar overflow-x-auto overflow-y-visible">
   <div
-    class="grid min-w-96 items-baseline gap-x-3 gap-y-0 pb-2"
-    style="grid-template-columns: minmax(8rem, 1fr) 4rem 4rem 4rem 4.5rem;"
+    class="grid min-w-120 items-baseline gap-x-3 gap-y-0 pb-2"
+    style="grid-template-columns: minmax(8rem, 1fr) 4rem 4rem 4rem 4.5rem 4.5rem;"
   >
-    <!-- Header row: title + Avg / Min / Max headers. The rightmost (skew) column has no header
-         so the right edge is reserved for the per-row skew toggle. Sticky so it stays visible
-         while the block's rows scroll. The negative top/horizontal margins + padding extend
-         the white background out to cover the card's own padding when sticking. -->
+    <!-- Header row: title + Avg / Min / Max / Total headers. Total is blank for metrics that cannot
+         be added. The rightmost (skew) column has no header so the right edge is reserved for
+         the per-row skew toggle. Sticky so it stays visible while the block's rows scroll. The
+         negative top/horizontal margins + padding extend the white background out to cover the
+         card's own padding when sticking. -->
     {#if title}
       <h3 class={`${blockHeader} bg-white-dark text-base font-semibold text-surface-900-100`}>{title}</h3>
     {:else}
@@ -49,6 +50,7 @@
     <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Avg</div>
     <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Min</div>
     <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Max</div>
+    <div class={`${blockHeader} bg-white-dark text-right font-medium`}>Total</div>
     <div class={`${blockHeader} bg-white-dark`}></div>
 
     {#each entries as entry, i (i)}
@@ -56,6 +58,7 @@
         label={entry.label}
         metricId={entry.row.metric}
         cells={entry.row.cells}
+        total={entry.row.total}
         expanded={isExpanded(entry)}
         onToggle={() => toggle(entry)}
       />

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
@@ -16,8 +16,10 @@ import MetricsDistributionBlock from './MetricsDistributionBlock.svelte'
 const cells = (values: Array<CountValue | PercentValue>) =>
   values.map((value) => ({ value, percentile: 50 }))
 
-const entry = (label: string, row: Partial<TooltipRow> & Pick<TooltipRow, 'cells'>):
-  RenderableMetric => ({
+const entry = (
+  label: string,
+  row: Partial<TooltipRow> & Pick<TooltipRow, 'cells'>
+): RenderableMetric => ({
   label,
   row: { metric: label, isCurrentMetric: false, ...row }
 })
@@ -25,8 +27,9 @@ const entry = (label: string, row: Partial<TooltipRow> & Pick<TooltipRow, 'cells
 describe('MetricsDistributionBlock total column', () => {
   const adds = entry('records', {
     cells: cells([new CountValue(10), new CountValue(30)]),
-    // Two workers holding 10 and 30 records: the node holds 40.
-    total: new CountValue(40)
+    // Two workers holding 10 and 30 records: the node holds 40, and that is the most any node
+    // holds, so its cell saturates in the per-node view.
+    total: { value: new CountValue(40), percentile: 100 }
   })
   const doesNotAdd = entry('hit_rate', {
     cells: cells([new PercentValue(1, 2), new PercentValue(1, 4)])
@@ -64,6 +67,66 @@ describe('MetricsDistributionBlock total column', () => {
     expect(shown).toHaveLength(4)
     // Adding two rates would print an impossible 75%; the cell stays empty instead.
     expect(shown[3]).toBe('')
+  })
+
+  // The fourth cell of each row is the total. Read the declared background rather than the
+  // resolved color: the mix is expressed in theme tokens, which this page does not load.
+  const backgrounds = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.value-cell'))
+      .filter((_, i) => i % 4 === 3)
+      .map((c) => (c as HTMLElement).style.backgroundColor)
+
+  // Four totals spanning orders of magnitude, as a block routinely holds: a byte count in the
+  // billions beside a batch count in the hundreds.
+  const spread = [
+    entry('bytes', {
+      cells: cells([new CountValue(1)]),
+      total: { value: new CountValue(13_260_000_000), percentile: 100 }
+    }),
+    entry('records', {
+      cells: cells([new CountValue(1)]),
+      total: { value: new CountValue(5_930_000), percentile: 4 }
+    }),
+    entry('batches', {
+      cells: cells([new CountValue(1)]),
+      total: { value: new CountValue(4810), percentile: 1 }
+    }),
+    entry('hits', {
+      cells: cells([new CountValue(1)]),
+      total: { value: new CountValue(366), percentile: 0.2 }
+    }),
+    doesNotAdd
+  ]
+
+  // The standing itself is `profiler-lib`'s business (see `totalShare` and `categoryShares`
+  // there); the block's job is to paint it and to leave a row without a total unpainted.
+  it('paints each total at the standing it was given', async () => {
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: spread }
+    })
+    const shown = backgrounds(container)
+    expect(shown[0]).toContain('--bar-high) 100.00%')
+    expect(shown[1]).toContain('--bar-high) 4.00%')
+    expect(shown[3]).toContain('--bar-high) 0.20%')
+    // Distinct standings stay distinguishable rather than collapsing to one shade.
+    expect(new Set(shown.slice(0, 4)).size).toBe(4)
+    expect(shown[4]).toBe('transparent')
+  })
+
+  it('paints nothing behind a total of no standing', async () => {
+    // The fill starts at transparent rather than at a floor color: a grey cell would read as a
+    // value where there is none.
+    const none = entry('idle', {
+      cells: cells([new CountValue(0)]),
+      total: { value: new CountValue(0), percentile: 0 }
+    })
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: [none] }
+    })
+    const cell = container.querySelectorAll('.value-cell')[3] as HTMLElement
+    expect(cell.style.backgroundColor).toContain('transparent 100.00%')
+    expect(cell.style.backgroundColor).toContain('--bar-high) 0.00%')
+    expect(getComputedStyle(cell).backgroundColor).toBe('rgba(0, 0, 0, 0)')
   })
 
   it('keeps each row independent of the others', async () => {

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * The Total column shows a metric's readings added up across the node's workers, and only for
+ * metrics that add up. `profiler-lib` decides that: it fills `TooltipRow.total` for counts, byte
+ * sizes and durations and leaves it absent for rates, reported minima and maxima, flags and
+ * settings, where a total states nothing. This test pins both halves of the contract - the value
+ * appears when the row carries one, the cell stays blank when it does not - and the header's
+ * column count, which has to stay in step with the grid template.
+ */
+
+import { CountValue, PercentValue, type TooltipRow } from 'profiler-lib'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import type { RenderableMetric } from '../dispatch'
+import MetricsDistributionBlock from './MetricsDistributionBlock.svelte'
+
+const cells = (values: Array<CountValue | PercentValue>) =>
+  values.map((value) => ({ value, percentile: 50 }))
+
+const entry = (label: string, row: Partial<TooltipRow> & Pick<TooltipRow, 'cells'>):
+  RenderableMetric => ({
+  label,
+  row: { metric: label, isCurrentMetric: false, ...row }
+})
+
+describe('MetricsDistributionBlock total column', () => {
+  const adds = entry('records', {
+    cells: cells([new CountValue(10), new CountValue(30)]),
+    // Two workers holding 10 and 30 records: the node holds 40.
+    total: new CountValue(40)
+  })
+  const doesNotAdd = entry('hit_rate', {
+    cells: cells([new PercentValue(1, 2), new PercentValue(1, 4)])
+  })
+
+  const texts = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.value-cell')).map((c) => c.textContent?.trim())
+
+  it('heads the four statistics columns', async () => {
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: [adds] }
+    })
+    const headers = Array.from(container.querySelectorAll('.sticky')).map((h) =>
+      h.textContent?.trim()
+    )
+    expect(headers).toContain('Avg')
+    expect(headers).toContain('Min')
+    expect(headers).toContain('Max')
+    expect(headers).toContain('Total')
+  })
+
+  it('shows the total for a metric that adds up', async () => {
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: [adds] }
+    })
+    // Avg, Min, Max, Total.
+    expect(texts(container)).toEqual(['20', '10', '30', '40'])
+  })
+
+  it('leaves the total blank for a metric that does not add up', async () => {
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'Cache', entries: [doesNotAdd] }
+    })
+    const shown = texts(container)
+    expect(shown).toHaveLength(4)
+    // Adding two rates would print an impossible 75%; the cell stays empty instead.
+    expect(shown[3]).toBe('')
+  })
+
+  it('keeps each row independent of the others', async () => {
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'Mixed', entries: [adds, doesNotAdd] }
+    })
+    // The rate's Avg is the pooled 2/6, not the mean of the two rates.
+    expect(texts(container)).toEqual(['20', '10', '30', '40', '33.3%', '25.0%', '50.0%', ''])
+  })
+})

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
@@ -129,6 +129,41 @@ describe('MetricsDistributionBlock total column', () => {
     expect(getComputedStyle(cell).backgroundColor).toBe('rgba(0, 0, 0, 0)')
   })
 
+  const textColors = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.value-cell'))
+      .filter((_, i) => i % 4 === 3)
+      .map((c) => (c as HTMLElement).style.color)
+
+  // Past 70% of the way to `--bar-high` the fill is dark enough that the default dark text
+  // disappears into it, so the text turns white. Below that the cell keeps its inherited color.
+  it('turns a deeply colored total white', async () => {
+    const straddling = [
+      entry('above', {
+        cells: cells([new CountValue(1)]),
+        total: { value: new CountValue(9), percentile: 71 }
+      }),
+      entry('at', {
+        cells: cells([new CountValue(1)]),
+        total: { value: new CountValue(7), percentile: 70 }
+      }),
+      entry('below', {
+        cells: cells([new CountValue(1)]),
+        total: { value: new CountValue(5), percentile: 69 }
+      }),
+      doesNotAdd
+    ]
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: straddling }
+    })
+    const shown = textColors(container)
+    expect(shown[0]).toBe('white')
+    // The threshold is exclusive: 70% is still light enough to read dark text against.
+    expect(shown[1]).toBe('')
+    expect(shown[2]).toBe('')
+    // A row with no total has no fill to read against, so it is left alone.
+    expect(shown[3]).toBe('')
+  })
+
   it('keeps each row independent of the others', async () => {
     const { container } = render(MetricsDistributionBlock, {
       props: { id: 'b', title: 'Mixed', entries: [adds, doesNotAdd] }

--- a/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
@@ -40,6 +40,16 @@ export function heatColor(t: number): string {
   return `color-mix(in oklab, transparent ${(100 - p).toFixed(2)}%, var(--bar-high) ${p.toFixed(2)}%)`
 }
 
+/** Fraction of `--bar-high` past which a `heatColor` fill is too saturated to read dark text
+ *  against. */
+const heatTextThreshold = 0.7
+
+/** Text color over a `heatColor` fill: white once the fill passes `heatTextThreshold`,
+ *  `undefined` below it so the cell keeps its inherited color. */
+export function heatTextColor(t: number): string | undefined {
+  return clamp01(t) > heatTextThreshold ? 'white' : undefined
+}
+
 /** Skew text color: neutral up to ~0%, then interpolates to error. 50% skew saturates. */
 export function skewTextColor(skewPct: number): string {
   if (!Number.isFinite(skewPct) || skewPct <= 0) {

--- a/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/colors.ts
@@ -33,6 +33,13 @@ export function barColor(t: number): string {
   return lerpThemeColor(t, '--bar-low', '--bar-high')
 }
 
+/** Heat-map fill for a table cell: transparent at 0, saturating to `--bar-high`. Unlike
+ *  `barColor` there is no floor color. */
+export function heatColor(t: number): string {
+  const p = clamp01(t) * 100
+  return `color-mix(in oklab, transparent ${(100 - p).toFixed(2)}%, var(--bar-high) ${p.toFixed(2)}%)`
+}
+
 /** Skew text color: neutral up to ~0%, then interpolates to error. 50% skew saturates. */
 export function skewTextColor(skewPct: number): string {
   if (!Number.isFinite(skewPct) || skewPct <= 0) {

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Popover, Tooltip } from 'common-ui'
   import { MissingValue, type PropertyValue, type TooltipCell } from 'profiler-lib'
-  import { barColor, logScale01, skewTextColor } from '../colors'
+  import { barColor, heatColor, logScale01, skewTextColor } from '../colors'
 
   interface Props {
     label: string
@@ -11,8 +11,9 @@
      * so bar height and color express magnitude relative to the whole circuit. */
     cells: TooltipCell[]
     /** The cells added up, for metrics that add up. Absent for rates, reported minima and
-     * maxima, flags and settings, whose column stays blank. */
-    total?: PropertyValue | undefined
+     * maxima, flags and settings, whose column stays blank. `percentile` is where the total
+     * stands, which `profiler-lib` computes; it drives the cell's heat-map background. */
+    total?: TooltipCell | undefined
     expanded: boolean
     onToggle: () => void
   }
@@ -119,17 +120,26 @@
     <div class="text-sm text-surface-700-300">{metricId}</div>
   </Popover>
 </div>
-<!-- Cols 2-5: avg / min / max / total. Always rendered (same grid slots), opacity-driven
-     visibility so collapse/expand doesn't reflow the grid mid-transition. The total is blank for
-     metrics that do not add up. -->
-{#each [display.avg, display.min, display.max, total] as stat}
+<!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
+     collapse/expand doesn't reflow the grid mid-transition. -->
+{#each [display.avg, display.min, display.max] as stat}
 <div
-  class="value-cell text-right text-sm tabular-nums text-surface-700-300 {showValues ? 'opacity-100' : 'opacity-0'}"
+  class="value-cell text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
   aria-hidden={!showValues}
 >
-  {stat ? stat.toString() : ''}
+  {stat.toString()}
 </div>
 {/each}
+<!-- Col 5: total, blank for metrics that do not add up. Its background is a heat map over the
+     standing `profiler-lib` computed: the largest saturates to `--bar-high`, the smallest stays
+     at `--bar-low`. -->
+<div
+  class="value-cell rounded-sm px-1 text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
+  style:background-color={total ? heatColor(total.percentile / 100) : 'transparent'}
+  aria-hidden={!showValues}
+>
+  {total ? total.value.toString() : ''}
+</div>
 <!-- Col 5: skew toggle — always present, always pinned to the top-right -->
 <div class="flex items-center justify-end">
   <button

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Popover, Tooltip } from 'common-ui'
-  import { MissingValue, type TooltipCell } from 'profiler-lib'
+  import { MissingValue, type PropertyValue, type TooltipCell } from 'profiler-lib'
   import { barColor, logScale01, skewTextColor } from '../colors'
 
   interface Props {
@@ -10,10 +10,13 @@
      * statistics). `percentile` (0-100) is normalized against the metric's range across all nodes,
      * so bar height and color express magnitude relative to the whole circuit. */
     cells: TooltipCell[]
+    /** The cells added up, for metrics that add up. Absent for rates, reported minima and
+     * maxima, flags and settings, whose column stays blank. */
+    total?: PropertyValue | undefined
     expanded: boolean
     onToggle: () => void
   }
-  const { label, metricId, cells, expanded, onToggle }: Props = $props()
+  const { label, metricId, cells, total, expanded, onToggle }: Props = $props()
 
   /**
    * Collapsed-view preview style (avg/min/max numbers show in both):
@@ -116,14 +119,15 @@
     <div class="text-sm text-surface-700-300">{metricId}</div>
   </Popover>
 </div>
-<!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
-     collapse/expand doesn't reflow the grid mid-transition. -->
-{#each [display.avg, display.min, display.max] as stat}
+<!-- Cols 2-5: avg / min / max / total. Always rendered (same grid slots), opacity-driven
+     visibility so collapse/expand doesn't reflow the grid mid-transition. The total is blank for
+     metrics that do not add up. -->
+{#each [display.avg, display.min, display.max, total] as stat}
 <div
   class="value-cell text-right text-sm tabular-nums text-surface-700-300 {showValues ? 'opacity-100' : 'opacity-0'}"
   aria-hidden={!showValues}
 >
-  {stat.toString()}
+  {stat ? stat.toString() : ''}
 </div>
 {/each}
 <!-- Col 5: skew toggle — always present, always pinned to the top-right -->
@@ -145,9 +149,10 @@
 </div>
 
 <!-- Bar chart row spans full block width; container height + each bar height animate.
+     NOTE: keep the column span in step with the header in MetricsDistributionBlock.
      Each bar gets a hover tooltip showing the worker index and the formatted reading. -->
 <div
-  class="bar-chart col-span-5 flex items-end gap-0.5 mb-2"
+  class="bar-chart col-span-6 flex items-end gap-0.5 mb-2"
   style:min-height="{chartHeight}px"
   style:margin-top="{expanded ? "8px" : "2px"}"
 >

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Popover, Tooltip } from 'common-ui'
   import { MissingValue, type PropertyValue, type TooltipCell } from 'profiler-lib'
-  import { barColor, heatColor, logScale01, skewTextColor } from '../colors'
+  import { barColor, heatColor, heatTextColor, logScale01, skewTextColor } from '../colors'
 
   interface Props {
     label: string
@@ -132,10 +132,12 @@
 {/each}
 <!-- Col 5: total, blank for metrics that do not add up. Its background is a heat map over the
      standing `profiler-lib` computed: the largest saturates to `--bar-high`, the smallest stays
-     at `--bar-low`. -->
+     at `--bar-low`. Past the top of that range the fill is dark enough that the text turns
+     white to stay readable. -->
 <div
   class="value-cell rounded-sm px-1 text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
   style:background-color={total ? heatColor(total.percentile / 100) : 'transparent'}
+  style:color={total ? heatTextColor(total.percentile / 100) : undefined}
   aria-hidden={!showValues}
 >
   {total ? total.value.toString() : ''}

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -3,7 +3,7 @@
 import cytoscape, { type EdgeCollection, type EdgeDefinition, type ElementsDefinition, type EventObject, type NodeDefinition, type NodeSingular, type StylesheetJson } from 'cytoscape';
 import dblclick from 'cytoscape-dblclick';
 import { assert, Graph, OMap, Option, type EncodableAsString, NumericRange, Edge } from './util.js';
-import { CircuitProfile, ComplexNode, NodeAndMetric, PropertyValue, type NodeId } from './profile.js';
+import { categoryShares, CircuitProfile, ComplexNode, NodeAndMetric, PropertyValue, totalShare, type DisplayScales, type NodeId } from './profile.js';
 import { CircuitSelection } from './selection.js';
 import elk from 'cytoscape-elk';
 import { Sources } from './dataflow.js';
@@ -34,7 +34,7 @@ class MeasurementMatrix {
         // Keys are measurement names, arrays contain one element per column name.
         readonly attributes: Map<string, Array<SerializedMeasurement>>,
         // Values added up over the columns, for the metrics that add up.
-        readonly totals: Map<string, PropertyValue> = new Map()) {
+        readonly totals: Map<string, SerializedMeasurement> = new Map()) {
         for (const a of attributes.entries()) {
             assert(columnNames.length == a[1].length,
                 "Measurement count mismatch for '" + a[0] + "':" + columnNames.length + " vs " + a.length);
@@ -655,7 +655,8 @@ export class CytographRendering {
     }
 
     /** Compute the attributes for all cytograph nodes based on the circuit profile and current selection. */
-    computeAttributes(profile: CircuitProfile, selection: MetadataSelection) {
+    computeAttributes(profile: CircuitProfile, selection: MetadataSelection,
+        scales: DisplayScales) {
         let workers = selection.workersVisible.getSelectedElements(profile.getWorkerNames());
         // One column per visible worker. Aggregates such as min/max are not produced here:
         // consumers that want them compute them from the per-worker values themselves.
@@ -663,11 +664,12 @@ export class CytographRendering {
         for (const node of this.currentGraph!.nodes) {
             let profileNode = profile.getNode(node.getId()).unwrap();
             let data = new Map<string, Array<SerializedMeasurement>>();
-            let totals = new Map<string, PropertyValue>();
+            // Totals over the same workers the cells show, so they match what is displayed.
+            let values = new Map<string, PropertyValue>();
             // Select just the visible metrics
             // Compute per-worker attributes
             for (let metric of profileNode.measurements.getMetrics()) {
-                let range = profile.propertyRange(metric);
+                let range = scales.get(metric)?.range ?? NumericRange.empty();
                 let metrics = profileNode.getMeasurements(metric);
                 let selected = selection.workersVisible.getSelectedElements(metrics);
                 let measurements: Array<SerializedMeasurement> = [];
@@ -675,11 +677,21 @@ export class CytographRendering {
                     measurements.push(CytographRendering.toMeasurement(m, range));
                 }
                 data.set(metric, measurements);
-                // Over the same workers the cells show, so the total matches what is displayed.
                 let total = profileNode.totalOf(metric, selected);
                 if (total.isSome()) {
-                    totals.set(metric, total.unwrap());
+                    values.set(metric, total.unwrap());
                 }
+            }
+            // The toplevel node stands for the whole circuit, so it holds the largest total of
+            // every metric and has to be shaded against the metrics beside it instead.
+            const overview = node.getId() === this.rootNodeId;
+            const shares = overview ? categoryShares(values) : undefined;
+            let totals = new Map<string, SerializedMeasurement>();
+            for (const [metric, total] of values) {
+                const share = overview
+                    ? shares!.get(metric) ?? 0
+                    : totalShare(total, scales.get(metric)?.maximum);
+                totals.set(metric, new SerializedMeasurement(total, share));
             }
             // additional key-value per node attributes
             let kv = new Map();
@@ -709,24 +721,31 @@ export class CytographRendering {
     }
 
     /** Compute the "importance" of each node given a selection, i.e., the way it's highlighted in the rendering. */
-    computeImportance(profile: CircuitProfile, selection: MetadataSelection) {
-        let rangeO = profile.dataRange.get(selection.metric);
+    computeImportance(profile: CircuitProfile, selection: MetadataSelection,
+        scales: DisplayScales) {
+        let range = scales.get(selection.metric)?.range;
         for (const node of this.currentGraph!.nodes) {
             if (node.expanded) { continue; }
             let profileNode = profile.getNode(node.getId()).unwrap();
             let percents = 0;
-            if (rangeO.isSome()) {
-                let range = rangeO.unwrap();
-                if (!range.isEmpty() && !range.isPoint()) {
-                    let m = profileNode.getMeasurements(selection.metric);
-                    let values = m.map(v => v.getNumericValue()).filter(v => v.isSome()).map(v => v.unwrap());
-                    let max = Math.max(...values, 0);
-                    percents = range.percents(max);
-                }
+            if (range !== undefined && !range.isEmpty() && !range.isPoint()) {
+                let m = profileNode.getMeasurements(selection.metric);
+                let values = m.map(v => v.getNumericValue()).filter(v => v.isSome()).map(v => v.unwrap());
+                let max = Math.max(...values, 0);
+                percents = range.percents(max);
             }
             let rendered = this.getRenderedNode(node.getId());
             rendered.data("value", percents);
         }
+    }
+
+    /** The nodes whose readings set the scales: the ones actually drawn.  An expanded region is
+     * drawn as the nodes inside it, so those set the scale and it does not; a collapsed one
+     * stands for everything inside it.  The root is never drawn. */
+    private drawnNodes(): Array<NodeId> {
+        return this.currentGraph!.nodes
+            .filter(node => !node.expanded && node.getId() !== this.rootNodeId)
+            .map(node => node.getId());
     }
 
     /** The user has changed something in the way they want to visualize metadata; update the rendered graph. */
@@ -734,8 +753,12 @@ export class CytographRendering {
         if (this.currentGraph === null)
             return;
         this.metadataSelection = selection;
-        this.computeImportance(profile, selection);
-        this.computeAttributes(profile, selection);
+        // One pass over the drawn nodes feeds the node highlighting, the per-worker bars and the
+        // totals, so all three describe the same population.
+        const scales = profile.displayScales(this.drawnNodes(),
+            values => selection.workersVisible.getSelectedElements(values));
+        this.computeImportance(profile, selection, scales);
+        this.computeAttributes(profile, selection, scales);
         this.cy.style().update();
 
         // Refresh the tooltip if there's a node currently displayed
@@ -1036,11 +1059,12 @@ export class CytographRendering {
                     }
                 }
 
+                const total = attributes.matrix.totals.get(key);
                 tooltipData.rows.push({
                     metric: key,
                     isCurrentMetric: key === this.getCurrentMetric(),
                     cells,
-                    total: attributes.matrix.totals.get(key)
+                    total: total && { value: total.value, percentile: total.percentile }
                 });
             }
         }

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -32,7 +32,9 @@ class MeasurementMatrix {
         // Order that the metrics should be displayed in
         readonly metricOrder: Array<string>,
         // Keys are measurement names, arrays contain one element per column name.
-        readonly attributes: Map<string, Array<SerializedMeasurement>>) {
+        readonly attributes: Map<string, Array<SerializedMeasurement>>,
+        // Values added up over the columns, for the metrics that add up.
+        readonly totals: Map<string, PropertyValue> = new Map()) {
         for (const a of attributes.entries()) {
             assert(columnNames.length == a[1].length,
                 "Measurement count mismatch for '" + a[0] + "':" + columnNames.length + " vs " + a.length);
@@ -245,40 +247,10 @@ export class Cytograph {
 
     /** Given a metric, return the displayed nodes that have the top values for the metric. */
     topNodes(profile: CircuitProfile, metric: string): Array<NodeAndMetric> {
-        let result: Array<NodeAndMetric> = [];
-        let range = profile.propertyRange(metric);
-        if (range.isEmpty()) {
-            return result;
-        }
-        for (const node of this.nodes) {
-            if (node.expanded) { continue; }
-            let id = node.getId();
-            let profileNode = profile.getNode(id);
-            if (profileNode.isNone()) { continue; }
-            let values = profileNode.unwrap().getMeasurements(metric);
-            let maxValue: number | null = null;
-            let max: PropertyValue | null = null;
-            for (const pv of values) {
-                const num = pv.getNumericValue();
-                if (num.isNone()) { continue; }
-                if (maxValue === null) {
-                    maxValue = num.unwrap();
-                    max = pv;
-                } else if (num.unwrap() > maxValue) {
-                    maxValue = num.unwrap();
-                    max = pv;
-                }
-            }
-            if (maxValue === null) { continue; }
-            let normalized = range.percents(maxValue);
-            if (range.isPoint()) {
-                normalized = 0;
-            }
-            result.push(new NodeAndMetric(id, max!.toString(), node.label, normalized));
-        }
-        // Sort in decreasing order
-        result.sort((a, b) => b.normalizedValue - a.normalizedValue);
-        return result;
+        const displayed = this.nodes
+            .filter(node => !node.expanded)
+            .map(node => ({ id: node.getId(), label: node.label }));
+        return profile.rankNodes(metric, displayed);
     }
 
     // Create a Cytograph from a CircuitProfile filtered by the specified selection.
@@ -691,6 +663,7 @@ export class CytographRendering {
         for (const node of this.currentGraph!.nodes) {
             let profileNode = profile.getNode(node.getId()).unwrap();
             let data = new Map<string, Array<SerializedMeasurement>>();
+            let totals = new Map<string, PropertyValue>();
             // Select just the visible metrics
             // Compute per-worker attributes
             for (let metric of profileNode.measurements.getMetrics()) {
@@ -702,6 +675,11 @@ export class CytographRendering {
                     measurements.push(CytographRendering.toMeasurement(m, range));
                 }
                 data.set(metric, measurements);
+                // Over the same workers the cells show, so the total matches what is displayed.
+                let total = profileNode.totalOf(metric, selected);
+                if (total.isSome()) {
+                    totals.set(metric, total.unwrap());
+                }
             }
             // additional key-value per node attributes
             let kv = new Map();
@@ -716,7 +694,8 @@ export class CytographRendering {
                 const p = parent.unwrap();
                 kv.set("parent", p);
             }
-            let matrix = new MeasurementMatrix(columnNames, [...profileNode.measurements.getMetrics()], data);
+            let matrix = new MeasurementMatrix(
+                columnNames, [...profileNode.measurements.getMetrics()], data, totals);
             let attributes = new Attributes(matrix, kv);
             let rendered = this.getRenderedNode(node.getId());
             rendered.data("expanded", node.expanded);
@@ -1060,7 +1039,8 @@ export class CytographRendering {
                 tooltipData.rows.push({
                     metric: key,
                     isCurrentMetric: key === this.getCurrentMetric(),
-                    cells
+                    cells,
+                    total: attributes.matrix.totals.get(key)
                 });
             }
         }

--- a/js-packages/profiler-lib/src/index.ts
+++ b/js-packages/profiler-lib/src/index.ts
@@ -23,6 +23,8 @@ export {
     CountValue,
     TimeValue,
     BooleanValue,
+    PercentValue,
+    RatioValue,
     type JsonProfiles
 } from './profile.js';
 export { type Dataflow, type SourcePositionRange } from './dataflow.js';

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, it } from 'vitest'
 import {
+    AggregationMode,
     BooleanValue,
     BytesValue,
     CircuitProfile,
     ComplexNode,
     CountValue,
+    Measurement,
+    measurementCategory,
     MissingValue,
     PercentValue,
     PropertyValue,
+    RatioValue,
     SimpleNode,
     StringValue,
-    TimeValue
+    TimeValue,
+    type JsonProfiles
 } from './profile.js'
 import type { Dataflow } from './dataflow.js'
-import { NumericRange } from './util.js'
+import { NumericRange, Option } from './util.js'
 
 describe('CircuitProfile.isTop', () => {
     it('recognises the toplevel node by the parsed root id', () => {
@@ -150,6 +155,193 @@ describe('PercentValue', () => {
             new PercentValue(30, 100)
         ])
         expect(avg.getNumericValue().unwrap()).toBeCloseTo(20, 6)
+    })
+
+    it('WeightedRatio pools the terms instead of adding the rates', () => {
+        // Two nodes hitting a cache 50 times out of 100 lookups make a region that hit it 100
+        // times out of 200 -- 50%.
+        const pooled = new PercentValue(50, 100)
+            .aggregate(new PercentValue(50, 100), AggregationMode.WeightedRatio)
+        expect(pooled).toBeInstanceOf(PercentValue)
+        expect(pooled.getNumericValue().unwrap()).toBeCloseTo(50, 9)
+    })
+
+    it('CommonDenominator adds the numerators over the common total', () => {
+        // Three nodes taking 10%, 20% and 5% of one circuit runtime make up 35% of it.
+        const total = new PercentValue(10, 100)
+            .aggregate(new PercentValue(20, 100), AggregationMode.CommonDenominator)
+            .aggregate(new PercentValue(5, 100), AggregationMode.CommonDenominator)
+        expect(total.getNumericValue().unwrap()).toBeCloseTo(35, 9)
+    })
+
+    it('CommonDenominator pools when the denominators differ', () => {
+        // Different denominators mean the values do not divide by one common total after all;
+        // pooling is the reading that stays interpretable.
+        const folded = new PercentValue(5, 10)
+            .aggregate(new PercentValue(5, 90), AggregationMode.CommonDenominator)
+        expect(folded.getNumericValue().unwrap()).toBeCloseTo(10, 9)
+    })
+
+    it('both ratio modes ignore a missing reading', () => {
+        const half = new PercentValue(1, 2)
+        for (const mode of [AggregationMode.WeightedRatio, AggregationMode.CommonDenominator]) {
+            expect(half.aggregate(MissingValue.INSTANCE, mode)).toBe(half)
+            expect(MissingValue.INSTANCE.aggregate(half, mode)).toBe(half)
+        }
+    })
+
+    it('rejects a value of another kind, and a mode a percentage has no meaning for', () => {
+        const half = new PercentValue(1, 2)
+        expect(() => half.aggregate(new CountValue(1), AggregationMode.WeightedRatio)).toThrow()
+        expect(() => half.aggregate(half, AggregationMode.Sum)).toThrow()
+        expect(() => half.aggregate(half, AggregationMode.Or)).toThrow()
+        expect(() => half.aggregate(half, AggregationMode.CommonValue)).toThrow()
+    })
+})
+
+describe('RatioValue', () => {
+    // 100 batches of 10 records, and one batch of 1000 records.
+    const many = new RatioValue(new CountValue(1000), 100)
+    const one = new RatioValue(new CountValue(1000), 1)
+
+    it('reads as the quotient in the numerator kind', () => {
+        expect(many.getNumericValue().unwrap()).toBeCloseTo(10, 9)
+        expect(many.toString()).toBe('10')
+        const latency = new RatioValue(new TimeValue(2), 4)
+        expect(latency.toString()).toBe('500ms')
+        const size = new RatioValue(new BytesValue(4096), 2)
+        expect(size.toString()).toBe('2KiB')
+    })
+
+    const pool = (a: PropertyValue, b: PropertyValue) =>
+        a.aggregate(b, AggregationMode.WeightedRatio)
+
+    it('weighs each node by its own denominator', () => {
+        // The heavy node dominates: 2000 records over 101 batches, not the midpoint of 10
+        // and 1000 (505), and not the largest reading (1000).
+        const region = pool(many, one)
+        expect(region).toBeInstanceOf(RatioValue)
+        expect(region.getNumericValue().unwrap()).toBeCloseTo(2000 / 101, 9)
+    })
+
+    it('pooling is independent of the order regions are folded in', () => {
+        const third = new RatioValue(new CountValue(40), 4)
+        const left = pool(pool(many, one), third)
+        const right = pool(many, pool(one, third))
+        expect(left.getNumericValue().unwrap())
+            .toBeCloseTo(right.getNumericValue().unwrap(), 9)
+        expect(left.getNumericValue().unwrap()).toBeCloseTo(2040 / 105, 9)
+    })
+
+    it('reads as zero when nothing was observed', () => {
+        const idle = new RatioValue(new CountValue(0), 0)
+        expect(idle.getNumericValue().unwrap()).toBe(0)
+        expect(idle.toString()).toBe('0')
+    })
+
+    it('ignores a missing reading', () => {
+        expect(pool(many, MissingValue.INSTANCE)).toBe(many)
+        expect(pool(MissingValue.INSTANCE, many)).toBe(many)
+    })
+
+    it('rejects a value of another kind, and a mode an average has no meaning for', () => {
+        expect(() => pool(many, new CountValue(1))).toThrow()
+        expect(() => many.aggregate(one, AggregationMode.Sum)).toThrow()
+        expect(() => many.aggregate(one, AggregationMode.CommonDenominator)).toThrow()
+    })
+
+    it('average across workers is weighted by the denominators', () => {
+        const avg = many.average([one])
+        expect(avg.getNumericValue().unwrap()).toBeCloseTo(2000 / 101, 9)
+    })
+
+    it('average stays missing when no worker reported a ratio', () => {
+        expect(MissingValue.INSTANCE.average([MissingValue.INSTANCE])).toBeInstanceOf(MissingValue)
+    })
+
+    it('scale multiplies the numerator, leaving the denominator alone', () => {
+        const doubled = many.scale(2) as RatioValue
+        expect(doubled.getNumericValue().unwrap()).toBeCloseTo(20, 9)
+        expect(doubled.denominator).toBe(100)
+    })
+
+})
+
+describe('PropertyValue.min', () => {
+    it('picks the smaller reading', () => {
+        expect(new CountValue(5).min(new CountValue(1)).getNumericValue().unwrap()).toBe(1)
+        expect(new CountValue(1).min(new CountValue(5)).getNumericValue().unwrap()).toBe(1)
+    })
+
+    it('a missing reading never wins, from either side', () => {
+        // A missing value compares below every reading, so a plain comparison would return it
+        // and erase the readings of the other nodes.
+        const five = new CountValue(5)
+        expect(five.min(MissingValue.INSTANCE)).toBe(five)
+        expect(MissingValue.INSTANCE.min(five)).toBe(five)
+        expect(MissingValue.INSTANCE.min(MissingValue.INSTANCE)).toBeInstanceOf(MissingValue)
+    })
+
+    it('max likewise ignores a missing reading', () => {
+        const five = new CountValue(5)
+        expect(five.max(MissingValue.INSTANCE)).toBe(five)
+        expect(MissingValue.INSTANCE.max(five)).toBe(five)
+    })
+})
+
+describe('PropertyValue.aggregate', () => {
+    const a = new CountValue(4)
+    const b = new CountValue(6)
+
+    it('routes each mode a count supports to its operation', () => {
+        expect(a.aggregate(b, AggregationMode.Sum).getNumericValue().unwrap()).toBe(10)
+        expect(a.aggregate(b, AggregationMode.Min).getNumericValue().unwrap()).toBe(4)
+        expect(a.aggregate(b, AggregationMode.Max).getNumericValue().unwrap()).toBe(6)
+    })
+
+    it('rejects a reading of another kind under every mode', () => {
+        // Min and Max are implemented once for every kind, so they used to fold a count with a
+        // byte size and return whichever compared smaller -- changing the kind of the result.
+        for (const mode of [AggregationMode.Min, AggregationMode.Max, AggregationMode.Sum]) {
+            expect(() => a.aggregate(new BytesValue(3), mode), AggregationMode[mode]).toThrow()
+        }
+        expect(() => new RatioValue(new CountValue(10), 2)
+            .aggregate(a, AggregationMode.Min)).toThrow()
+        // A missing reading is not another kind: it contributes nothing to any fold.
+        expect(a.aggregate(MissingValue.INSTANCE, AggregationMode.Min)).toBe(a)
+        expect(a.aggregate(MissingValue.INSTANCE, AggregationMode.Max)).toBe(a)
+    })
+
+    it('rejects the modes a count has no meaning for', () => {
+        for (const mode of [AggregationMode.WeightedRatio, AggregationMode.CommonDenominator,
+        AggregationMode.Or, AggregationMode.CommonValue]) {
+            expect(() => a.aggregate(b, mode), AggregationMode[mode]).toThrow()
+        }
+    })
+
+    it('rejects a mode it does not know', () => {
+        expect(() => a.aggregate(b, 99 as AggregationMode)).toThrow()
+    })
+
+    it('a flag ORs and a setting agrees, and neither orders', () => {
+        const yes = new BooleanValue(true)
+        const no = new BooleanValue(false)
+        expect((yes.aggregate(no, AggregationMode.Or) as BooleanValue).value).toBe(true)
+        expect((no.aggregate(no, AggregationMode.Or) as BooleanValue).value).toBe(false)
+        const one = new StringValue('round-robin')
+        expect(one.aggregate(one, AggregationMode.CommonValue)).toBe(one)
+        expect(one.aggregate(new StringValue('least-loaded'), AggregationMode.CommonValue)
+            .toString()).toBe('<multiple values>')
+        expect(() => yes.aggregate(no, AggregationMode.Min)).toThrow()
+        expect(() => one.aggregate(one, AggregationMode.Max)).toThrow()
+    })
+
+    it('a missing reading contributes nothing under every mode', () => {
+        for (const mode of [AggregationMode.Sum, AggregationMode.WeightedRatio,
+        AggregationMode.CommonDenominator, AggregationMode.Min, AggregationMode.Max,
+        AggregationMode.Or, AggregationMode.CommonValue]) {
+            expect(MissingValue.INSTANCE.aggregate(a, mode), AggregationMode[mode]).toBe(a)
+        }
     })
 })
 
@@ -290,21 +482,82 @@ describe('near-zero values keep precision and unit text', () => {
 })
 
 describe('PropertyValue contract', () => {
+    const samples: PropertyValue[] = [
+        new CountValue(1),
+        new BytesValue(1),
+        new TimeValue(1),
+        new PercentValue(50, 100),
+        new RatioValue(new CountValue(10), 2),
+        new StringValue('x'),
+        new BooleanValue(true),
+        MissingValue.INSTANCE
+    ]
+
     it('every concrete subclass implements average and toString without throwing', () => {
-        const samples: PropertyValue[] = [
-            new CountValue(1),
-            new BytesValue(1),
-            new TimeValue(1),
-            new PercentValue(50, 100),
-            new StringValue('x'),
-            new BooleanValue(true),
-            MissingValue.INSTANCE
-        ]
         for (const v of samples) {
             expect(typeof v.toString()).toBe('string')
             // Self-average: every kind should accept an empty `others` array without throwing.
             expect(() => v.average([])).not.toThrow()
         }
+    })
+
+    it('every concrete subclass scales', () => {
+        for (const v of samples) {
+            expect(v.scale(2), v.constructor.name).toBeInstanceOf(PropertyValue)
+        }
+    })
+
+    // Which modes each kind answers to.
+    const ALL = [AggregationMode.Sum, AggregationMode.WeightedRatio,
+    AggregationMode.CommonDenominator, AggregationMode.Or, AggregationMode.CommonValue]
+    const ACCEPTED = new Map<string, AggregationMode[]>([
+        ['CountValue', [AggregationMode.Sum]],
+        ['BytesValue', [AggregationMode.Sum]],
+        ['TimeValue', [AggregationMode.Sum]],
+        ['PercentValue', [AggregationMode.WeightedRatio, AggregationMode.CommonDenominator]],
+        ['RatioValue', [AggregationMode.WeightedRatio]],
+        ['StringValue', [AggregationMode.CommonValue]],
+        ['BooleanValue', [AggregationMode.Or]],
+        ['MissingValue', ALL]
+    ])
+
+    it('every kind answers to exactly the modes that mean something for it', () => {
+        for (const v of samples) {
+            const accepted = ALL.filter(mode => {
+                try {
+                    v.aggregate(v, mode)
+                    return true
+                } catch {
+                    return false
+                }
+            })
+            expect(accepted.map(m => AggregationMode[m]), v.constructor.name).toEqual(
+                ACCEPTED.get(v.constructor.name)!.map(m => AggregationMode[m]))
+        }
+    })
+
+    it('folding a value with itself keeps its kind', () => {
+        for (const v of samples) {
+            for (const mode of ACCEPTED.get(v.constructor.name)!) {
+                expect(v.aggregate(v, mode), v.constructor.name + " " + AggregationMode[mode])
+                    .toBeInstanceOf(v.constructor as typeof PropertyValue)
+            }
+        }
+    })
+
+    it('scaling a magnitude by 2 doubles it', () => {
+        expect(new CountValue(3).scale(2).getNumericValue().unwrap()).toBe(6)
+        expect(new BytesValue(3).scale(2).getNumericValue().unwrap()).toBe(6)
+        expect(new TimeValue(3).scale(2).getNumericValue().unwrap()).toBe(6)
+        expect(new PercentValue(3, 100).scale(2).getNumericValue().unwrap()).toBeCloseTo(6, 9)
+    })
+
+    it('kinds without a magnitude scale to themselves', () => {
+        const s = new StringValue('x')
+        const b = new BooleanValue(true)
+        expect(s.scale(2)).toBe(s)
+        expect(b.scale(2)).toBe(b)
+        expect(MissingValue.INSTANCE.scale(2)).toBe(MissingValue.INSTANCE)
     })
 })
 
@@ -343,6 +596,433 @@ describe('NumericRange cross-node normalization', () => {
         expect(empty.union(nodeA)).toEqual(nodeA)
         const point = NumericRange.getRange([42, 42])
         expect(point.isPoint()).toBe(true)
+    })
+})
+
+// Every parse site states how its metric folds.
+describe('Measurement.parseValues tags the new-format metrics', () => {
+    const duration = (seconds: number) =>
+        ({ type: 'duration', value: { secs: Math.floor(seconds), nanos: 0 } })
+    const count = (value: number) => ({ type: 'count', value })
+
+    const parse = (metric: object): Map<string, Measurement> => {
+        const parsed = Measurement.parseValues(metric as any)
+        return new Map(parsed.map((m: Measurement) => [m.property, m]))
+    }
+
+    it('tags a batch-size summary by what each field reports', () => {
+        const parsed = parse({
+            metric_id: 'input_batches_stats',
+            value: {
+                batches_count: count(4), min_records_count: count(1),
+                max_records_count: count(9), avg_records_count: count(5),
+                total_records_count: count(20)
+            }
+        })
+        const modes = new Map([...parsed].map(([key, m]) => [key, m.aggregation]))
+        expect(modes.get('input_batches_stats.count')).toBe(AggregationMode.Sum)
+        expect(modes.get('input_batches_stats.record_count')).toBe(AggregationMode.Sum)
+        expect(modes.get('input_batches_stats.min_size')).toBe(AggregationMode.Min)
+        expect(modes.get('input_batches_stats.max_size')).toBe(AggregationMode.Max)
+        expect(modes.get('input_batches_stats.avg_size')).toBe(AggregationMode.WeightedRatio)
+        // The average keeps its terms: 20 records over 4 batches.
+        const avg = parsed.get('input_batches_stats.avg_size')!.value.unwrap()
+        expect(avg).toBeInstanceOf(RatioValue)
+        expect(avg.getNumericValue().unwrap()).toBe(5)
+    })
+
+    it('tags a node runtime part by the total it divides by, other percents by their own terms', () => {
+        const percent = (id: string) => parse({
+            metric_id: id, value: { type: 'percent', value: { numerator: 1, denominator: 4 } }
+        }).get(id)!.aggregation
+        expect(percent('runtime_percent')).toBe(AggregationMode.CommonDenominator)
+        expect(percent('nonblocking_percent')).toBe(AggregationMode.WeightedRatio)
+        expect(percent('bloom_filter_hit_rate_percent')).toBe(AggregationMode.WeightedRatio)
+    })
+
+    it('does not add up a wall clock that every worker and node repeats', () => {
+        // The circuit's elapsed time is one reading the profile repeats everywhere. Adding it up
+        // reported it multiplied by the worker count -- days, for a run of hours.
+        const elapsed = (id: string) => parse({
+            metric_id: id, value: { type: 'duration', value: { secs: 60, nanos: 0 } }
+        }).get(id)!.aggregation
+        expect(elapsed('circuit_runtime_elapsed_seconds')).toBe(AggregationMode.Max)
+        // A duration a node spent working is its own, and adds up.
+        expect(elapsed('runtime_seconds')).toBe(AggregationMode.Sum)
+        expect(elapsed('circuit_runtime_seconds')).toBe(AggregationMode.Sum)
+    })
+
+    it('takes the largest cache occupancy rather than adding the readings up', () => {
+        const parsed = parse({
+            metric_id: 'foreground_cache_occupancy',
+            value: { max: { type: 'bytes', value: 1024 }, used: { type: 'bytes', value: 512 } }
+        })
+        // One cache per worker, reported again by every node inside it.
+        expect(parsed.get('foreground_cache_occupancy.max')!.aggregation).toBe(AggregationMode.Max)
+        expect(parsed.get('foreground_cache_occupancy.used')!.aggregation).toBe(AggregationMode.Max)
+    })
+
+    it('reads the per-step merge averages the runtime actually reports', () => {
+        // The runtime serializes `avg_step_seconds` and `avg_step_cpu_seconds`; reading a field
+        // by another name dropped both readings without a word.
+        const parsed = parse({
+            metric_id: 'completed_merges',
+            labels: [['slot', '0']],
+            value: {
+                avg_step_seconds: duration(2), avg_step_cpu_seconds: duration(1),
+                batches: count(10), merges: count(3), steps: count(4)
+            }
+        })
+        const elapsed = parsed.get('completed_merges.slot:0.avg_step_seconds')!
+        expect(elapsed.aggregation).toBe(AggregationMode.WeightedRatio)
+        expect(elapsed.value.unwrap().getNumericValue().unwrap()).toBeCloseTo(2, 9)
+        expect(parsed.get('completed_merges.slot:0.avg_step_cpu_seconds')!.value.unwrap()
+            .getNumericValue().unwrap()).toBeCloseTo(1, 9)
+        expect(parsed.get('completed_merges.slot:0.steps')!.aggregation)
+            .toBe(AggregationMode.Sum)
+        const other = parse({
+            metric_id: 'completed_merges',
+            labels: [['slot', '1']],
+            value: {
+                avg_step_seconds: duration(1), avg_step_cpu_seconds: duration(1),
+                batches: count(1), merges: count(1), steps: count(1)
+            }
+        }).get('completed_merges.slot:1.avg_step_seconds')!
+        const folded = elapsed.value.unwrap()
+            .aggregate(other.value.unwrap(), AggregationMode.WeightedRatio)
+        expect(folded.getNumericValue().unwrap()).toBeCloseTo((2 * 4 + 1) / 5, 9)
+    })
+})
+
+// TODO: remove together with the rest of the legacy parsing path.
+describe('Measurement.parseLegacyValues tags the legacy metrics', () => {
+    const parsed = (datum: unknown[]) => Measurement.parseLegacyValues(datum as any)[0]!
+
+    const CASES: Array<[unknown[], string, AggregationMode]> = [
+        [['time%', [10, 1000]], 'PercentValue', AggregationMode.CommonDenominator],
+        [['merge reduction', [1, 2]], 'PercentValue', AggregationMode.WeightedRatio],
+        [['Bloom filter hit rate', [1, 2]], 'PercentValue', AggregationMode.WeightedRatio],
+        [['batches', 5], 'CountValue', AggregationMode.Sum],
+        [['storage size', 5], 'CountValue', AggregationMode.Sum],
+        [['time', { secs: 1, nanos: 0 }], 'TimeValue', AggregationMode.Sum],
+        [['runtime_elapsed', { secs: 1, nanos: 0 }], 'TimeValue', AggregationMode.Max],
+        [['balancer policy', 'round-robin'], 'StringValue', AggregationMode.CommonValue],
+        [['rebalancing in progress', true], 'BooleanValue', AggregationMode.Or]
+    ]
+
+    for (const [datum, kind, mode] of CASES) {
+        it(`reads ${datum[0]} as a ${kind} folded with ${AggregationMode[mode]}`, () => {
+            const m = parsed(datum)
+            expect(m.value.unwrap().constructor.name).toBe(kind)
+            expect(m.aggregation).toBe(mode)
+        })
+    }
+
+    // Batch-size summaries arrive nested under one name, and the entries inside it are spelled
+    // with a slash. Joining them with a dot left all five unparsed and uncategorized.
+    it('reads the nested batch-size summary that the format actually sends', () => {
+        const parsed = Measurement.parseLegacyValues(['input batches', {
+            entries: [['batches', 5], ['min size', 3], ['max size', 9], ['avg size', 7],
+            ['total records', 35]]
+        }] as any)
+        const read = parsed.map(m => [m.property, m.value.isSome()
+            ? m.value.unwrap().constructor.name : 'unparsed', AggregationMode[m.aggregation]])
+        expect(read).toEqual([
+            ['input batches/batches', 'CountValue', 'Sum'],
+            ['input batches/min size', 'CountValue', 'Min'],
+            ['input batches/max size', 'CountValue', 'Max'],
+            ['input batches/avg size', 'RatioValue', 'WeightedRatio'],
+            ['input batches/total records', 'CountValue', 'Sum']
+        ])
+        // The names have to match the category table too, or the metrics land under "Other".
+        expect(measurementCategory('input batches/min size')).toBe('storage')
+    })
+
+    it('leaves a metric it cannot turn into a number unparsed', () => {
+        expect(parsed(['key distribution', [1, 2, 3]]).value.isNone()).toBe(true)
+    })
+})
+
+// A region's value for a metric is folded from the nodes it contains
+describe('region aggregation', () => {
+    const count = (value: number) => ({ type: 'count', value })
+
+    type Leaf = {
+        batches: number, min: number, max: number, records: number,
+        runtime: [number, number], nonblocking: [number, number], memory: number
+    }
+
+    const readings = (leaf: Leaf) => [
+        {
+            metric_id: 'input_batches_stats',
+            value: {
+                batches_count: count(leaf.batches),
+                min_records_count: count(leaf.min),
+                max_records_count: count(leaf.max),
+                // The runtime reports the quotient too, rounded down; the parser recomputes it.
+                avg_records_count: count(Math.floor(leaf.records / leaf.batches)),
+                total_records_count: count(leaf.records)
+            }
+        },
+        {
+            metric_id: 'runtime_percent',
+            value: {
+                type: 'percent',
+                value: { numerator: leaf.runtime[0], denominator: leaf.runtime[1] }
+            }
+        },
+        {
+            metric_id: 'nonblocking_percent',
+            value: {
+                type: 'percent',
+                value: { numerator: leaf.nonblocking[0], denominator: leaf.nonblocking[1] }
+            }
+        },
+        { metric_id: 'used_memory_bytes', value: { type: 'bytes', value: leaf.memory } }
+    ]
+
+    // Region r1 holds two operators and a nested region r2 holding a third.
+    const graph = {
+        nodes: {
+            id: 'n', label: 'root', nodes: [{
+                Cluster: {
+                    id: 'r1', label: 'region', nodes: [
+                        { Simple: { id: 'n1', label: 'op1' } },
+                        { Simple: { id: 'n2', label: 'op2' } },
+                        {
+                            Cluster: {
+                                id: 'r2', label: 'subregion',
+                                nodes: [{ Simple: { id: 'n3', label: 'op3' } }]
+                            }
+                        }
+                    ]
+                }
+            }]
+        },
+        edges: []
+    }
+
+    const leaves: Record<string, Leaf> = {
+        n1: {
+            batches: 10, min: 5, max: 50, records: 100,
+            runtime: [10, 1000], nonblocking: [30, 60], memory: 1000
+        },
+        n2: {
+            batches: 1, min: 1, max: 20, records: 1000,
+            runtime: [20, 1000], nonblocking: [10, 40], memory: 2000
+        },
+        n3: {
+            batches: 4, min: 7, max: 70, records: 40,
+            runtime: [5, 1000], nonblocking: [5, 10], memory: 4000
+        }
+    }
+
+    const parse = (workers: Array<Record<string, Leaf>>) => {
+        const json = {
+            metrics: [],
+            worker_profiles: workers.map(w => ({
+                metadata: Object.fromEntries(
+                    Object.entries(w).map(([id, leaf]) => [id, readings(leaf)]))
+            })),
+            graph
+        }
+        return CircuitProfile.fromJson(json as unknown as JsonProfiles).profile
+    }
+
+    const value = (profile: CircuitProfile, region: string, metric: string, worker = 0) =>
+        profile.complexNodes.get(region).unwrap().getMeasurements(metric)[worker]!
+
+    const numeric = (profile: CircuitProfile, region: string, metric: string, worker = 0) =>
+        value(profile, region, metric, worker).getNumericValue().unwrap()
+
+    it('takes the smallest reading for a reported minimum', () => {
+        const profile = parse([leaves])
+        // min(5, 1, 7)
+        expect(numeric(profile, 'r1', 'input_batches_stats.min_size')).toBe(1)
+        expect(numeric(profile, 'r2', 'input_batches_stats.min_size')).toBe(7)
+    })
+
+    it('takes the largest reading for a reported maximum', () => {
+        const profile = parse([leaves])
+        expect(numeric(profile, 'r1', 'input_batches_stats.max_size')).toBe(70)
+    })
+
+    it('weighs an average by what each node observed', () => {
+        const profile = parse([leaves])
+        // 1140 records over 15 batches
+        expect(value(profile, 'r1', 'input_batches_stats.avg_size')).toBeInstanceOf(RatioValue)
+        expect(numeric(profile, 'r1', 'input_batches_stats.avg_size')).toBeCloseTo(1140 / 15, 9)
+        expect(value(profile, 'r1', 'input_batches_stats.avg_size').toString()).toBe('76')
+    })
+
+    it('adds up the shares of the circuit runtime', () => {
+        const profile = parse([leaves])
+        // 1% + 2% + 0.5%
+        expect(numeric(profile, 'r1', 'runtime_percent')).toBeCloseTo(3.5, 9)
+        expect(value(profile, 'r1', 'runtime_percent').toString()).toBe('3.5%')
+    })
+
+    it('pools the terms of a ratio the nodes computed for themselves', () => {
+        const profile = parse([leaves])
+        // 45 CPU-seconds out of 110 elapsed; the old rule reported the largest rate, 50%.
+        expect(numeric(profile, 'r1', 'nonblocking_percent')).toBeCloseTo(100 * 45 / 110, 9)
+    })
+
+    it('still adds up the metrics that add up, counting each node once', () => {
+        const profile = parse([leaves])
+        expect(numeric(profile, 'r1', 'used_memory_bytes')).toBe(7000)
+        expect(numeric(profile, 'r1', 'input_batches_stats.count')).toBe(15)
+        expect(numeric(profile, 'r1', 'input_batches_stats.record_count')).toBe(1140)
+        // The nested region must not be folded a second time through its own children.
+        expect(numeric(profile, 'r2', 'used_memory_bytes')).toBe(4000)
+    })
+
+    it('folds each worker separately', () => {
+        // Worker 0's smallest batch is in n1, worker 1's is in n2.
+        const swapped = {
+            n1: { ...leaves.n1!, min: 60 },
+            n2: { ...leaves.n2!, min: 3 },
+            n3: leaves.n3!
+        }
+        const profile = parse([leaves, swapped])
+        expect(numeric(profile, 'r1', 'input_batches_stats.min_size', 0)).toBe(1)
+        expect(numeric(profile, 'r1', 'input_batches_stats.min_size', 1)).toBe(3)
+    })
+})
+
+// A node's readings for one metric add up across workers only when the metric adds up. Totalling
+// a rate, a reported minimum or a flag would print a number with no meaning, so those have none.
+describe('SimpleNode.totalOf', () => {
+    const node = () => new SimpleNode('n1', 'op', 3)
+
+    const withMetric = (property: string, aggregation: AggregationMode,
+        values: PropertyValue[]) => {
+        const n = node()
+        values.forEach((value, worker) =>
+            n.addMeasurement(new Measurement(property, Option.some(value), aggregation), worker))
+        return n
+    }
+
+    it('adds up counts, byte sizes and durations', () => {
+        const counts = withMetric('records', AggregationMode.Sum,
+            [new CountValue(1), new CountValue(2), new CountValue(3)])
+        expect(counts.totalOf('records', counts.getMeasurements('records')).unwrap()
+            .getNumericValue().unwrap()).toBe(6)
+
+        const bytes = withMetric('memory', AggregationMode.Sum,
+            [new BytesValue(1024), new BytesValue(1024)])
+        const totalBytes = bytes.totalOf('memory', bytes.getMeasurements('memory')).unwrap()
+        expect(totalBytes).toBeInstanceOf(BytesValue)
+        expect(totalBytes.toString()).toBe('2KiB')
+
+        const times = withMetric('runtime', AggregationMode.Sum,
+            [new TimeValue(0.5), new TimeValue(1.5)])
+        expect(times.totalOf('runtime', times.getMeasurements('runtime')).unwrap().toString())
+            .toBe('2s')
+    })
+
+    it('has no total for the metrics that do not add up', () => {
+        const cases: Array<[string, AggregationMode, PropertyValue[]]> = [
+            ['hit_rate', AggregationMode.WeightedRatio,
+                [new PercentValue(1, 2), new PercentValue(1, 4)]],
+            ['runtime_percent', AggregationMode.CommonDenominator,
+                [new PercentValue(1, 10), new PercentValue(2, 10)]],
+            ['avg_size', AggregationMode.WeightedRatio,
+                [new RatioValue(new CountValue(10), 2), new RatioValue(new CountValue(9), 3)]],
+            ['min_size', AggregationMode.Min, [new CountValue(1), new CountValue(5)]],
+            ['max_size', AggregationMode.Max, [new CountValue(1), new CountValue(5)]],
+            ['rebalancing', AggregationMode.Or, [new BooleanValue(true), new BooleanValue(false)]],
+            ['policy', AggregationMode.CommonValue,
+                [new StringValue('round-robin'), new StringValue('round-robin')]]
+        ]
+        for (const [property, mode, values] of cases) {
+            const n = withMetric(property, mode, values)
+            expect(n.totalOf(property, n.getMeasurements(property)).isNone(), property).toBe(true)
+        }
+    })
+
+    it('skips workers that reported nothing, and totals only the workers it is given', () => {
+        const n = withMetric('records', AggregationMode.Sum,
+            [new CountValue(1), MissingValue.INSTANCE, new CountValue(3)])
+        const all = n.getMeasurements('records')
+        expect(n.totalOf('records', all).unwrap().getNumericValue().unwrap()).toBe(4)
+        // The caller passes the workers it displays; the total covers those only.
+        expect(n.totalOf('records', all.slice(0, 1)).unwrap().getNumericValue().unwrap()).toBe(1)
+    })
+
+    it('has no total when no worker reported the metric', () => {
+        const n = withMetric('records', AggregationMode.Sum,
+            [MissingValue.INSTANCE, MissingValue.INSTANCE])
+        expect(n.totalOf('records', n.getMeasurements('records')).isNone()).toBe(true)
+        // A metric this node never carried has none either.
+        expect(n.totalOf('absent', []).isNone()).toBe(true)
+    })
+})
+
+// The "top nodes" list ranks by the metric's total over a node's workers where the metric adds
+// up. Ranking by the largest single reading, as it did before, cannot tell a node that is busy on
+// every worker from one that is busy on a single worker.
+describe('CircuitProfile.rankNodes', () => {
+    // Four workers. `spread` works on all of them, `hot` only on the first, harder.
+    const profile = (property: string, mode: AggregationMode) => {
+        const p = new CircuitProfile(4, 'n')
+        const seen: number[] = []
+        const add = (id: string, values: number[]) => {
+            const node = new SimpleNode(id, id, 4)
+            values.forEach((v, worker) =>
+                node.addMeasurement(
+                    new Measurement(property, Option.some(new CountValue(v)), mode), worker))
+            p.simpleNodes.set(id, node)
+            seen.push(...values)
+        }
+        add('spread', [30, 30, 30, 30])
+        add('hot', [50, 0, 0, 0])
+        // `computePropertyRanges` walks the metrics seen while parsing JSON; these nodes were
+        // built directly, so the per-worker range is stated here instead.
+        p.dataRange.set(property, NumericRange.getRange(seen))
+        return p
+    }
+
+    const nodes = [{ id: 'spread', label: 'spread' }, { id: 'hot', label: 'hot' }]
+
+    it('ranks by the total where the metric adds up', () => {
+        const ranked = profile('records', AggregationMode.Sum).rankNodes('records', nodes)
+        // 120 records against 50: the busy-everywhere node comes first.
+        expect(ranked.map((r) => r.nodeId)).toEqual(['spread', 'hot'])
+        expect(ranked[0]!.label).toBe('120')
+        expect(ranked[1]!.label).toBe('50')
+        // Totals are normalized against each other, so the largest fills the bar.
+        expect(ranked[0]!.normalizedValue).toBe(100)
+    })
+
+    it('ranks by the largest worker reading where the metric does not add up', () => {
+        const ranked = profile('min_size', AggregationMode.Min).rankNodes('min_size', nodes)
+        expect(ranked.map((r) => r.nodeId)).toEqual(['hot', 'spread'])
+        expect(ranked[0]!.label).toBe('50')
+        expect(ranked[1]!.label).toBe('30')
+    })
+
+    it('leaves out nodes that never reported the metric', () => {
+        const p = profile('records', AggregationMode.Sum)
+        p.simpleNodes.set('silent', new SimpleNode('silent', 'silent', 4))
+        const ranked = p.rankNodes('records', [...nodes, { id: 'silent', label: 'silent' }])
+        expect(ranked.map((r) => r.nodeId)).toEqual(['spread', 'hot'])
+    })
+
+    it('gives every node the same standing when the totals are equal', () => {
+        const p = new CircuitProfile(2, 'n')
+        for (const id of ['a', 'b']) {
+            const node = new SimpleNode(id, id, 2)
+            for (const worker of [0, 1]) {
+                node.addMeasurement(new Measurement(
+                    'records', Option.some(new CountValue(7)), AggregationMode.Sum), worker)
+            }
+            p.simpleNodes.set(id, node)
+        }
+        p.dataRange.set('records', NumericRange.getRange([7, 7]))
+        const ranked = p.rankNodes('records', [{ id: 'a', label: 'a' }, { id: 'b', label: 'b' }])
+        // A single distinct total is a point range, which carries no standing to show.
+        expect(ranked.map((r) => r.normalizedValue)).toEqual([0, 0])
     })
 })
 

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -3,11 +3,12 @@ import {
     AggregationMode,
     BooleanValue,
     BytesValue,
+    categoryShares,
     CircuitProfile,
+    measurementCategory,
     ComplexNode,
     CountValue,
     Measurement,
-    measurementCategory,
     MissingValue,
     PercentValue,
     PropertyValue,
@@ -15,6 +16,7 @@ import {
     SimpleNode,
     StringValue,
     TimeValue,
+    totalShare,
     type JsonProfiles
 } from './profile.js'
 import type { Dataflow } from './dataflow.js'
@@ -561,12 +563,12 @@ describe('PropertyValue contract', () => {
     })
 })
 
-// The profiler colors per-worker bars against the metric's range across ALL nodes
-// (`CircuitProfile.dataRange`, built by unioning each node's per-worker values), not against the
-// current node's local spread. `computePropertyRanges` composes `NumericRange.union` + `percents`;
-// these tests pin that composition so a value's color depends on the whole circuit.
+// The profiler colors per-worker bars against the metric's range over the nodes on display, not
+// against the current node's own spread: `CircuitProfile.displayScales` unions each drawn node's
+// per-worker values and the rendering calls `percents` on the result. These tests pin that
+// composition, so a value's color depends on the other nodes it is shown beside.
 describe('NumericRange cross-node normalization', () => {
-    // Two nodes: A workers [10, 20], B workers [100, 200]. The global range unions to [10, 200].
+    // Two nodes: A workers [10, 20], B workers [100, 200]. The range over both is [10, 200].
     const nodeA = NumericRange.getRange([10, 20])
     const nodeB = NumericRange.getRange([100, 200])
     const global = nodeA.union(nodeB)
@@ -959,6 +961,146 @@ describe('SimpleNode.totalOf', () => {
     })
 })
 
+// In the per-node view the Total column shades a node's total against the largest total any node
+// reports for that metric, so the node holding the most is the reddest. The scale needs its own
+// maximum: a total is larger than any single worker reading, and a region holds more than any
+// node inside it, so a scale built from leaf worker readings pins every region at full red.
+// The toplevel node holds the whole circuit, so it reports the largest total of every metric and
+// `totalShare` would place all of them at 100 -- the bug where the overview came out uniformly
+// red. Its totals are placed against the others of their category instead.
+describe('categoryShares', () => {
+    // 'total size', 'allocated bytes' and 'batches' are all in the memory category; 'time' is in
+    // CPU, so it is scaled on its own.
+    const totals = new Map<string, PropertyValue>([
+        ['total size', new BytesValue(13_260_000_000)],
+        ['allocated bytes', new CountValue(5_930_000)],
+        ['batches', new CountValue(366)],
+        ['time', new TimeValue(170)]
+    ])
+
+    it('spreads totals that span orders of magnitude', () => {
+        const shares = categoryShares(totals)
+        // Log scale: the largest saturates and the smallest stays well clear of it, where a
+        // linear scale would put 366 out of 13 billion at 0.
+        expect(shares.get('total size')).toBe(100)
+        expect(shares.get('allocated bytes')!).toBeGreaterThan(60)
+        expect(shares.get('batches')!).toBeGreaterThan(20)
+        expect(shares.get('batches')!).toBeLessThan(30)
+    })
+
+    it('scales each category on its own', () => {
+        // The only CPU total, so it is that category's maximum however small it looks beside
+        // the byte counts.
+        expect(measurementCategory('time')).not.toBe(measurementCategory('total size'))
+        expect(categoryShares(totals).get('time')).toBe(100)
+    })
+
+    it('shades nothing when a category measured nothing', () => {
+        const shares = categoryShares(new Map([['total size', new BytesValue(0)]]))
+        expect(shares.get('total size')).toBe(0)
+    })
+})
+
+describe('CircuitProfile.displayScales', () => {
+    const readings = (bytes: number) =>
+        [{ metric_id: 'used_memory_bytes', value: { type: 'bytes', value: bytes } },
+        {
+            metric_id: 'input_batches_stats',
+            value: {
+                batches_count: { type: 'count', value: 2 },
+                min_records_count: { type: 'count', value: 1 },
+                max_records_count: { type: 'count', value: 9 },
+                avg_records_count: { type: 'count', value: 5 },
+                total_records_count: { type: 'count', value: 10 }
+            }
+        }]
+
+    // Two operators over two workers each, inside a region: totals are 2 and 100 bytes for the
+    // leaves, 102 for the region that holds them.
+    const profile = (() => {
+        const metadata = { small: readings(1), large: readings(50) }
+        const json = {
+            metrics: [],
+            worker_profiles: [{ metadata }, { metadata }],
+            graph: {
+                nodes: {
+                    id: 'n', label: 'root', nodes: [{
+                        Cluster: {
+                            id: 'r', label: 'region', nodes: [
+                                { Simple: { id: 'small', label: 'small' } },
+                                { Simple: { id: 'large', label: 'large' } }
+                            ]
+                        }
+                    }]
+                },
+                edges: []
+            }
+        }
+        return CircuitProfile.fromJson(json as unknown as JsonProfiles).profile
+    })()
+
+    const all = (values: PropertyValue[]) => values
+    const memory = (nodes: string[]) =>
+        profile.displayScales(nodes, all).get('used_memory_bytes')?.maximum
+
+    it('takes the largest total among the nodes it is given', () => {
+        expect(memory(['small', 'large'])).toBe(100)
+        expect(memory(['small'])).toBe(2)
+    })
+
+    it('scales by the region when it is collapsed and by its nodes when it is expanded', () => {
+        // Collapsed, the region stands for everything inside it and sets the scale itself.
+        expect(memory(['r'])).toBe(102)
+        // Expanded, the nodes inside it are what is drawn, so they set the scale instead.
+        expect(memory(['small', 'large'])).toBe(100)
+    })
+
+    it('ranges over worker readings and maxes over totals, from the same pass', () => {
+        const scales = profile.displayScales(['small', 'large'], all)
+        // Worker readings run 1 to 50; the largest node total is 100. Coloring a worker cell
+        // against the totals scale would leave every bar in the bottom half of the range.
+        expect(scales.get('used_memory_bytes')!.range.min).toBe(1)
+        expect(scales.get('used_memory_bytes')!.range.max).toBe(50)
+        expect(scales.get('used_memory_bytes')!.maximum).toBe(100)
+    })
+
+    it('covers only the workers on display', () => {
+        const firstWorker = (values: PropertyValue[]) => values.slice(0, 1)
+        const scales = profile.displayScales(['small', 'large'], firstWorker)
+        expect(scales.get('used_memory_bytes')!.maximum).toBe(50)
+        expect(scales.get('used_memory_bytes')!.range.max).toBe(50)
+    })
+
+    it('has no maximum for a metric that does not add up, but still ranges it', () => {
+        const scales = profile.displayScales(['small', 'large', 'absent'], all)
+        expect(scales.get('input_batches_stats.min_size')!.maximum).toBeUndefined()
+        // The bars still need a scale for the metrics that have no total.
+        expect(scales.get('input_batches_stats.min_size')!.range.max).toBe(1)
+        // Two batches per worker over two workers: 4 per node, and the maximum is per node.
+        expect(scales.get('input_batches_stats.count')!.maximum).toBe(4)
+    })
+})
+
+describe('totalShare', () => {
+    it('is the total as a percentage of the largest on display', () => {
+        expect(totalShare(new BytesValue(100), 100)).toBe(100)
+        expect(totalShare(new BytesValue(50), 100)).toBe(50)
+        expect(totalShare(new BytesValue(2), 100)).toBe(2)
+        expect(totalShare(new BytesValue(0), 100)).toBe(0)
+    })
+
+    it('shades nothing when there is nothing to compare against', () => {
+        expect(totalShare(new BytesValue(10), undefined)).toBe(0)
+        expect(totalShare(new BytesValue(10), 0)).toBe(0)
+        expect(totalShare(MissingValue.INSTANCE, 100)).toBe(0)
+    })
+
+    it('clamps a total that exceeds the largest on display', () => {
+        // An expanded region is left out of the scale, yet its own row still has to render.
+        expect(totalShare(new BytesValue(500), 100)).toBe(100)
+    })
+})
+
 // The "top nodes" list ranks by the metric's total over a node's workers where the metric adds
 // up. Ranking by the largest single reading, as it did before, cannot tell a node that is busy on
 // every worker from one that is busy on a single worker.
@@ -966,20 +1108,15 @@ describe('CircuitProfile.rankNodes', () => {
     // Four workers. `spread` works on all of them, `hot` only on the first, harder.
     const profile = (property: string, mode: AggregationMode) => {
         const p = new CircuitProfile(4, 'n')
-        const seen: number[] = []
         const add = (id: string, values: number[]) => {
             const node = new SimpleNode(id, id, 4)
             values.forEach((v, worker) =>
                 node.addMeasurement(
                     new Measurement(property, Option.some(new CountValue(v)), mode), worker))
             p.simpleNodes.set(id, node)
-            seen.push(...values)
         }
         add('spread', [30, 30, 30, 30])
         add('hot', [50, 0, 0, 0])
-        // `computePropertyRanges` walks the metrics seen while parsing JSON; these nodes were
-        // built directly, so the per-worker range is stated here instead.
-        p.dataRange.set(property, NumericRange.getRange(seen))
         return p
     }
 
@@ -1019,7 +1156,6 @@ describe('CircuitProfile.rankNodes', () => {
             }
             p.simpleNodes.set(id, node)
         }
-        p.dataRange.set('records', NumericRange.getRange([7, 7]))
         const ranked = p.rankNodes('records', [{ id: 'a', label: 'a' }, { id: 'b', label: 'b' }])
         // A single distinct total is a point range, which carries no standing to show.
         expect(ranked.map((r) => r.normalizedValue)).toEqual([0, 0])

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -77,7 +77,8 @@ interface StatsMetricValue extends MetricValue {
 }
 
 interface MergesMetricValue extends MetricValue {
-    avg_step_time: DurationMetricValue;
+    avg_step_seconds: DurationMetricValue;
+    avg_step_cpu_seconds: DurationMetricValue;
     batches: CountMetricValue;
     merges: CountMetricValue;
     steps: CountMetricValue;
@@ -210,6 +211,24 @@ function formatValue(val: number, base: number, prefixes: Array<string>): string
     return val.toLocaleString('en-US', opts) + prefixes[index];
 }
 
+/** How multiple metric measurements are combined for a node from the children measurements. */
+export enum AggregationMode {
+    /** Magnitudes add: counts, bytes, durations. */
+    Sum,
+    /** sum(numerator) / sum(denominator). */
+    WeightedRatio,
+    /** sum(numerator)/ denominator */
+    CommonDenominator,
+    /** Minimum value */
+    Min,
+    /** Maximum value */
+    Max,
+    /** Boolean OR */
+    Or,
+    /** Common value or "<multiple values>". */
+    CommonValue,
+}
+
 /** Base class for (numeric) property values; representation which abstracts away from the
  * JSON Serialization. */
 export abstract class PropertyValue implements Comparable<PropertyValue> {
@@ -233,12 +252,42 @@ export abstract class PropertyValue implements Comparable<PropertyValue> {
         }
     }
 
+    // A missing value compares below any reading, so it never wins.
     max(other: PropertyValue): PropertyValue {
         if (this.compareTo(other) >= 0) {
             return this;
         } else {
             return other;
         }
+    }
+
+    min(other: PropertyValue): PropertyValue {
+        if (other instanceof MissingValue) {
+            return this;
+        }
+        if (this instanceof MissingValue) {
+            return other;
+        }
+        return this.compareTo(other) <= 0 ? this : other;
+    }
+
+    /** Fold this value with the same metric's value from another node, as specified by `mode`. */
+    aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
+        // One metric holds one kind, so folding two kinds is a mistake whichever mode is asked
+        // for.  Each kind checks this for the modes it implements; Min and Max are implemented
+        // here for every kind, and so is their check.
+        const sameKind = other instanceof MissingValue
+            || other.constructor === this.constructor;
+        if (sameKind && this.isComparable()) {
+            if (mode === AggregationMode.Min) {
+                return this.min(other);
+            }
+            if (mode === AggregationMode.Max) {
+                return this.max(other);
+            }
+        }
+        fail("Cannot fold " + this.constructor.name + " with " + other.constructor.name +
+            " using " + AggregationMode[mode]);
     }
 
     toString(): string {
@@ -260,11 +309,12 @@ export abstract class PropertyValue implements Comparable<PropertyValue> {
         return true;
     }
 
-    /** Combine values from multiple operators; the semantics depends on the value kind. */
-    abstract combine(other: PropertyValue): PropertyValue;
+    /** This value multiplied by `factor`.  Used to render a ratio,
+     * e.g. 2000 records over 101 batches as a count of 19.8. */
+    abstract scale(factor: number): PropertyValue;
 
-    /** Average this value and `others` across workers. Distinct from `combine` because the
-     * per-kind semantics differ:
+    /** Average this value and `others` across workers.  Distinct from folding across nodes
+     * (`aggregate`) because the per-kind semantics differ:
      *   - counts/bytes/seconds: arithmetic mean of the underlying numbers.
      *   - percents: arithmetic mean of per-worker percents (not weighted — see PercentValue).
      *   - booleans / enum strings: the most common value across workers (the mode), so the
@@ -314,18 +364,33 @@ export class PercentValue extends PropertyValue {
         return value.toFixed(1) + "%";
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
         if (other instanceof PercentValue) {
-            if (this.denominator === other.denominator)
-                return new PercentValue(this.numerator + other.numerator, this.denominator);
-            return new PercentValue(
-                this.numerator * other.denominator + other.numerator * this.denominator,
-                this.denominator * other.denominator)
+            switch (mode) {
+                case AggregationMode.WeightedRatio:
+                    return PercentValue.pool(this, other);
+                case AggregationMode.CommonDenominator:
+                    if (this.denominator === other.denominator) {
+                        return new PercentValue(this.numerator + other.numerator, this.denominator);
+                    }
+                    // Nodes that disagree about the total do not divide by a common denominator
+                    // after all; pooling the terms is the reading that stays interpretable.
+                    return this.aggregate(other, AggregationMode.WeightedRatio);
+            }
         }
-        throw new Error("Cannot add PercentValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    /** Pool two ratios: pool(a/b, c/d) = (a+c) / (b+d) */
+    private static pool(a: PercentValue, b: PercentValue): PercentValue {
+        return new PercentValue(a.numerator + b.numerator, a.denominator + b.denominator);
+    }
+
+    override scale(factor: number): PropertyValue {
+        return new PercentValue(this.numerator * factor, this.denominator);
     }
 
     // Weighted mean across workers: sum(numerator) / sum(denominator). A worker that observed
@@ -371,14 +436,18 @@ export class CountValue extends PropertyValue {
         return Option.some(this.value);
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
-        if (other instanceof CountValue) {
+        if (other instanceof CountValue && mode === AggregationMode.Sum) {
             return new CountValue(this.value + other.value);
         }
-        throw new Error("Cannot add CountValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    override scale(factor: number): PropertyValue {
+        return new CountValue(this.value * factor);
     }
 
     override average(others: PropertyValue[]): PropertyValue {
@@ -415,14 +484,18 @@ export class BytesValue extends PropertyValue {
         return Option.some(this.value);
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
-        if (other instanceof BytesValue) {
+        if (other instanceof BytesValue && mode === AggregationMode.Sum) {
             return new BytesValue(this.value + other.value);
         }
-        throw new Error("Cannot add BytesValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    override scale(factor: number): PropertyValue {
+        return new BytesValue(this.value * factor);
     }
 
     override average(others: PropertyValue[]): PropertyValue {
@@ -470,14 +543,19 @@ export class BooleanValue extends PropertyValue {
         return this.value ? Option.some(1) : Option.some(0);
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
-        if (other instanceof BooleanValue) {
+        if (other instanceof BooleanValue && mode === AggregationMode.Or) {
             return new BooleanValue(this.value || other.value);
         }
-        throw new Error("Cannot add BooleanValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    // A flag has no magnitude to scale.
+    override scale(_factor: number): PropertyValue {
+        return this;
     }
 
     // The "average" of a set of booleans is the most common value (the mode), so the Avg
@@ -537,17 +615,22 @@ export class StringValue extends PropertyValue {
         return Option.none();
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
-        if (other instanceof StringValue) {
+        if (other instanceof StringValue && mode === AggregationMode.CommonValue) {
             if (this.value === other.value) {
                 return this;
             }
             return new StringValue("<multiple values>");
         }
-        throw new Error("Cannot add StringValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    // A string has no magnitude to scale.
+    override scale(_factor: number): PropertyValue {
+        return this;
     }
 
     // The "average" of a set of enum-like strings is the most common value (the mode), so the
@@ -604,8 +687,14 @@ export class MissingValue extends PropertyValue {
         return Option.none();
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    // A node that reported nothing contributes nothing, whatever the metric folds like.
+    override aggregate(other: PropertyValue, _mode: AggregationMode): PropertyValue {
         return other;
+    }
+
+    // Nothing to scale; the result is still missing.
+    override scale(_factor: number): PropertyValue {
+        return this;
     }
 
     // If any neighbour is non-missing, delegate to it so the result inherits the right kind;
@@ -640,14 +729,18 @@ export class TimeValue extends PropertyValue {
         return Option.some(this.seconds);
     }
 
-    override combine(other: PropertyValue): PropertyValue {
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
         if (other instanceof MissingValue) {
             return this;
         }
-        if (other instanceof TimeValue) {
+        if (other instanceof TimeValue && mode === AggregationMode.Sum) {
             return new TimeValue(this.seconds + other.seconds);
         }
-        throw new Error("Cannot add TimeValue to " + other);
+        return super.aggregate(other, mode);
+    }
+
+    override scale(factor: number): PropertyValue {
+        return new TimeValue(this.seconds * factor);
     }
 
     override average(others: PropertyValue[]): PropertyValue {
@@ -698,6 +791,71 @@ export class TimeValue extends PropertyValue {
                 String(secs).padStart(2, "0");
         }
         return value.toLocaleString('en-US', { maximumFractionDigits: 2 }) + "s";
+    }
+}
+
+/** An average kept as the two terms it was computed from. */
+export class RatioValue extends PropertyValue {
+    readonly numerator: PropertyValue;
+    readonly denominator: number;
+
+    constructor(numerator: PropertyValue, denominator: any) {
+        super();
+        this.numerator = numerator;
+        this.denominator = enforceNumber(denominator);
+    }
+
+    /** The quotient, as a value of the numerator's kind, so that a ratio of durations reads as a
+     * duration and a ratio of counts as a count. */
+    private quotient(): PropertyValue {
+        // Nothing was observed: read as zero.
+        if (this.denominator === 0) {
+            return this.numerator.scale(0);
+        }
+        return this.numerator.scale(1 / this.denominator);
+    }
+
+    getNumericValue(): Option<number> {
+        return this.quotient().getNumericValue();
+    }
+
+    override toString(): string {
+        return this.quotient().toString();
+    }
+
+    override aggregate(other: PropertyValue, mode: AggregationMode): PropertyValue {
+        if (other instanceof MissingValue) {
+            return this;
+        }
+        if (other instanceof RatioValue && mode === AggregationMode.WeightedRatio) {
+            return RatioValue.pool(this, other);
+        }
+        return super.aggregate(other, mode);
+    }
+
+    /** Pool two ratios pool(a/b, c/d) = (a+c)/(b+d). */
+    private static pool(a: RatioValue, b: RatioValue): RatioValue {
+        return new RatioValue(
+            a.numerator.aggregate(b.numerator, AggregationMode.Sum),
+            a.denominator + b.denominator);
+    }
+
+    // Weighted mean
+    override average(others: PropertyValue[]): PropertyValue {
+        // `this` is a ratio, so there is always something to average.
+        let numerator: PropertyValue = MissingValue.INSTANCE;
+        let denominator = 0;
+        for (const v of [this, ...others]) {
+            if (v instanceof RatioValue) {
+                numerator = numerator.aggregate(v.numerator, AggregationMode.Sum);
+                denominator += v.denominator;
+            }
+        }
+        return new RatioValue(numerator, denominator);
+    }
+
+    override scale(factor: number): PropertyValue {
+        return new RatioValue(this.numerator.scale(factor), this.denominator);
     }
 }
 
@@ -858,18 +1016,44 @@ export function measurementDescription(prop: string): { description: string, adv
     return { description: "", advanced: false };
 }
 
+/** A parsed legacy value together with the way its metric folds over a region.
+ * TODO: remove together with the rest of the legacy parsing path. */
+interface LegacyReading {
+    readonly value: PropertyValue;
+    readonly aggregation: AggregationMode;
+}
+
 // Decoded measurement value.
 export class Measurement {
+    /** Metric holding a node's part of the circuit's runtime: the profile divides every node's
+     * runtime by the same circuit-wide total.  Named "time%" in legacy profiles. */
+    public static readonly RUNTIME_PERCENT = "runtime_percent";
+
+    /** Metric holding the circuit's elapsed wall-clock time, which the profile reports again
+     * for every node and every worker.  Named "runtime_elapsed" in legacy profiles. */
+    public static readonly RUNTIME_ELAPSED = "circuit_runtime_elapsed_seconds";
+
     constructor(
         readonly property: string,
-        readonly value: Option<PropertyValue>) { };
+        readonly value: Option<PropertyValue>,
+        /** How the metric folds over the nodes of a region.  Stated where the measurement is
+         * parsed, since that is where the meaning of the metric is known. */
+        readonly aggregation: AggregationMode) { };
 
     public static fromJson(prefix: string, json: JsonMeasurement): Measurement {
         let name = prefix + (json[0] as string);
+        const reading = Measurement.parseLegacyPropertyValue(name, json.slice(1));
         return new Measurement(
             name,
-            Measurement.parseLegacyPropertyValue(name, json.slice(1))
+            reading.map(r => r.value),
+            // A value that did not parse is dropped, so its mode is never used.
+            reading.map(r => r.aggregation).unwrapOr(AggregationMode.Sum)
         );
+    }
+
+    private static tagged(value: PropertyValue, aggregation: AggregationMode):
+        Option<LegacyReading> {
+        return Option.some({ value, aggregation });
     }
 
     toString(): string {
@@ -889,17 +1073,17 @@ export class Measurement {
             case "bool": {
                 let m = metric.value as BoolMetricValue;
                 let value = BooleanValue.fromBoolMetric(m);
-                return [new Measurement(metric_id, Option.some(value))];
+                return [new Measurement(metric_id, Option.some(value), AggregationMode.Or)];
             }
             case "bytes": {
                 let m = metric.value as BytesMetricValue;
                 let bytes = BytesValue.fromBytesMetric(m);
-                return [new Measurement(metric_id, Option.some(bytes))];
+                return [new Measurement(metric_id, Option.some(bytes), AggregationMode.Sum)];
             }
             case "count": {
                 let m = metric.value as CountMetricValue;
                 let count = CountValue.fromCountMetric(m);
-                return [new Measurement(metric_id, Option.some(count))];
+                return [new Measurement(metric_id, Option.some(count), AggregationMode.Sum)];
             }
             case "hits":
             case "misses": {
@@ -907,38 +1091,44 @@ export class Measurement {
                 let count = new CountValue(s.value.count);
                 let bytes = new BytesValue(s.value.bytes);
                 let elapsed = TimeValue.fromSecondsNanos(s.value.elapsed.secs, s.value.elapsed.nanos);
-                let avg_latency = new TimeValue(count.value === 0 ? 0 : elapsed.seconds / count.value);
+                // Kept as elapsed/count so that a region's latency weighs each node by the
+                // number of accesses it served.
+                let avg_latency = new RatioValue(elapsed, count.value);
                 return [
-                    new Measurement(metric_id + ".count", Option.some(count)),
-                    new Measurement(metric_id + ".bytes", Option.some(bytes)),
-                    new Measurement(metric_id + ".elapsed", Option.some(elapsed)),
-                    new Measurement(metric_id + ".avg_latency", Option.some(avg_latency))
+                    new Measurement(metric_id + ".count", Option.some(count), AggregationMode.Sum),
+                    new Measurement(metric_id + ".bytes", Option.some(bytes), AggregationMode.Sum),
+                    new Measurement(metric_id + ".elapsed", Option.some(elapsed), AggregationMode.Sum),
+                    new Measurement(metric_id + ".avg_latency", Option.some(avg_latency), AggregationMode.WeightedRatio)
                 ];
             }
             case "stats": {
                 let s = metric.value as StatsMetricValue;
                 let count = CountValue.fromCountMetric(s.batches_count);
-                let avg_size = CountValue.fromCountMetric(s.avg_records_count);
                 let max_size = CountValue.fromCountMetric(s.max_records_count);
                 let min_size = CountValue.fromCountMetric(s.min_records_count);
                 let record_count = CountValue.fromCountMetric(s.total_records_count);
+                // The profile reports the average too, but as records/batches we can aggregate it correctly
+                let avg_size = new RatioValue(record_count, count.value);
                 return [
-                    new Measurement(metric_id + ".count", Option.some(count)),
-                    new Measurement(metric_id + ".avg_size", Option.some(avg_size)),
-                    new Measurement(metric_id + ".max_size", Option.some(max_size)),
-                    new Measurement(metric_id + ".min_size", Option.some(min_size)),
-                    new Measurement(metric_id + ".record_count", Option.some(record_count))
+                    new Measurement(metric_id + ".count", Option.some(count), AggregationMode.Sum),
+                    new Measurement(metric_id + ".avg_size", Option.some(avg_size), AggregationMode.WeightedRatio),
+                    new Measurement(metric_id + ".max_size", Option.some(max_size), AggregationMode.Max),
+                    new Measurement(metric_id + ".min_size", Option.some(min_size), AggregationMode.Min),
+                    new Measurement(metric_id + ".record_count", Option.some(record_count), AggregationMode.Sum)
                 ];
             }
             case "id": { // persistent_id
                 let s = metric.value as StringMetricValue;
                 let str = StringValue.fromString(s.value);
-                return [new Measurement(metric_id, Option.some(str))];
+                return [new Measurement(metric_id, Option.some(str), AggregationMode.CommonValue)];
             }
             case "percent": {
                 let s = metric.value as PercentMetricValue;
                 let perc = PercentValue.fromPercentMetric(s);
-                return [new Measurement(metric_id, Option.some(perc))];
+                const mode = metric.metric_id === Measurement.RUNTIME_PERCENT
+                    ? AggregationMode.CommonDenominator
+                    : AggregationMode.WeightedRatio;
+                return [new Measurement(metric_id, Option.some(perc), mode)];
             }
             case "seconds": {
                 if (metric.value === undefined) {
@@ -946,15 +1136,21 @@ export class Measurement {
                 }
                 let s = metric.value as DurationMetricValue;
                 let duration = TimeValue.fromDurationMetric(s);
-                return [new Measurement(metric_id, Option.some(duration))];
+                // Durations measure a node's own work on a worker's thread and add up, except
+                // for the circuit's elapsed time, which is one wall clock the profile repeats
+                // for every node and worker.
+                const mode = metric.metric_id === Measurement.RUNTIME_ELAPSED
+                    ? AggregationMode.Max
+                    : AggregationMode.Sum;
+                return [new Measurement(metric_id, Option.some(duration), mode)];
             }
             case "occupancy": {
                 let s = metric.value as OccupancyValue;
                 let max = BytesValue.fromBytesMetric(s.max);
                 let used = BytesValue.fromBytesMetric(s.used);
                 return [
-                    new Measurement(metric_id + ".max", Option.some(max)),
-                    new Measurement(metric_id + ".used", Option.some(used))
+                    new Measurement(metric_id + ".max", Option.some(max), AggregationMode.Max),
+                    new Measurement(metric_id + ".used", Option.some(used), AggregationMode.Max)
                 ];
             }
             case "bounds": {
@@ -976,7 +1172,8 @@ export class Measurement {
                 }
                 if (object.length !== 0) {
                     let str = object.join();
-                    result.push(new Measurement(metric_id + ".key_bounds", Option.some(new StringValue(str))));
+                    result.push(new Measurement(metric_id + ".key_bounds",
+                        Option.some(new StringValue(str)), AggregationMode.CommonValue));
                 }
 
                 object = [];
@@ -994,33 +1191,43 @@ export class Measurement {
                 }
                 if (object.length !== 0) {
                     let str = object.join();
-                    result.push(new Measurement(metric_id + ".value_bounds", Option.some(new StringValue(str))));
+                    result.push(new Measurement(metric_id + ".value_bounds",
+                        Option.some(new StringValue(str)), AggregationMode.CommonValue));
                 }
 
                 return result;
             }
             case "merges": {
                 let s = metric.value as MergesMetricValue;
-                let avg_step_time = undefined;
-                let result = [];
-                if (s.avg_step_time !== undefined) {
-                    avg_step_time = TimeValue.fromDurationMetric(s.avg_step_time);
-                    result.push(new Measurement(metric_id + ".avg_step_time", Option.some(avg_step_time)));
-                }
                 let batches = CountValue.fromCountMetric(s.batches);
                 let merges = CountValue.fromCountMetric(s.merges);
                 let steps = CountValue.fromCountMetric(s.steps);
+                let result = [];
+                // The profile reports the per-step averages already divided, so multiplying by
+                // the step count recovers the totals; a region then weighs each node by the
+                // steps it took.
+                for (const [field, average] of [
+                    ["avg_step_seconds", s.avg_step_seconds],
+                    ["avg_step_cpu_seconds", s.avg_step_cpu_seconds]] as const) {
+                    if (average === undefined) {
+                        continue;
+                    }
+                    const total = TimeValue.fromDurationMetric(average).scale(steps.value);
+                    result.push(new Measurement(metric_id + "." + field,
+                        Option.some(new RatioValue(total, steps.value)),
+                        AggregationMode.WeightedRatio));
+                }
                 result.push(
-                    new Measurement(metric_id + ".batches", Option.some(batches)),
-                    new Measurement(metric_id + ".merges", Option.some(merges)),
-                    new Measurement(metric_id + ".steps", Option.some(steps)),
+                    new Measurement(metric_id + ".batches", Option.some(batches), AggregationMode.Sum),
+                    new Measurement(metric_id + ".merges", Option.some(merges), AggregationMode.Sum),
+                    new Measurement(metric_id + ".steps", Option.some(steps), AggregationMode.Sum),
                 );
                 return result;
             }
             case "policy": {
                 let s = metric.value as StringMetricValue;
                 let str = StringValue.fromString(s.value);
-                return [new Measurement(metric_id, Option.some(str))];
+                return [new Measurement(metric_id, Option.some(str), AggregationMode.CommonValue)];
             }
         }
         return [];
@@ -1041,7 +1248,10 @@ export class Measurement {
                 }
                 let entries = value[0].entries;
                 for (const e of entries) {
-                    result.push(Measurement.fromJson(prefix + ".", e));
+                    // A slash, which is how these metrics are spelled in
+                    // `parseLegacyPropertyValue` and in `legacyMeasurementCategory`.  A dot
+                    // here left every one of them unparsed and uncategorized.
+                    result.push(Measurement.fromJson(prefix + "/", e));
                 }
                 break;
             case "foreground cache misses":
@@ -1049,15 +1259,12 @@ export class Measurement {
             case "background cache misses":
             case "background cache hits":
                 let count = value[0].count;
-                result.push(
-                    new Measurement(prefix + ".count", Option.some(new CountValue(count))));
+                result.push(new Measurement(prefix + ".count", Option.some(new CountValue(count)), AggregationMode.Sum));
                 let bytes = value[0].bytes;
-                result.push(
-                    new Measurement(prefix + ".bytes", Option.some(new CountValue(bytes))));
+                result.push(new Measurement(prefix + ".bytes", Option.some(new CountValue(bytes)), AggregationMode.Sum));
                 let elapsed = value[0].elapsed;
-                result.push(
-                    new Measurement(prefix + ".elapsed", Option.some(TimeValue.fromSecondsNanos(
-                        elapsed.secs, elapsed.nanos))));
+                result.push(new Measurement(prefix + ".elapsed",
+                    Option.some(TimeValue.fromSecondsNanos(elapsed.secs, elapsed.nanos)), AggregationMode.Sum));
                 break;
             default:
                 result.push(Measurement.fromJson("", json));
@@ -1068,15 +1275,32 @@ export class Measurement {
 
     static unknownProperties: Set<string> = new Set();
 
-    private static parseLegacyPropertyValue(prop: string, value: Array<any>): Option<PropertyValue> {
+    private static parseLegacyPropertyValue(prop: string, value: Array<any>): Option<LegacyReading> {
         switch (prop) {
             case "time%":
+                // Every node divides its own runtime by the same circuit-wide total.
+                return Measurement.tagged(new PercentValue(value[0][0], value[0][1]),
+                    AggregationMode.CommonDenominator);
             case "merge reduction":
             case "output redundancy":
             case "background cache hit rate":
             case "foreground cache hit rate":
             case "Bloom filter hit rate":
-                return Option.some(new PercentValue(value[0][0], value[0][1]));
+                return Measurement.tagged(new PercentValue(value[0][0], value[0][1]),
+                    AggregationMode.WeightedRatio);
+            case "input batches/avg size":
+            case "output batches/avg size":
+                // The legacy format reports the average pre-divided and does not say over how
+                // many batches, so each node counts once: a region reads as the mean of the
+                // averages of the nodes it contains.
+                return Measurement.tagged(new RatioValue(new CountValue(value[0]), 1),
+                    AggregationMode.WeightedRatio);
+            case "input batches/min size":
+            case "output batches/min size":
+                return Measurement.tagged(new CountValue(value[0]), AggregationMode.Min);
+            case "input batches/max size":
+            case "output batches/max size":
+                return Measurement.tagged(new CountValue(value[0]), AggregationMode.Max);
             case "Bloom filter size":
             case "Bloom filter bits/key":
             case "Bloom filter hits":
@@ -1097,30 +1321,29 @@ export class Measurement {
             case "inputs":
             case "steps":
             case "input batches/batches":
-            case "input batches/min size":
-            case "input batches/max size":
-            case "input batches/avg size":
             case "input batches/total records":
             case "output batches/batches":
-            case "output batches/min size":
-            case "output batches/max size":
-            case "output batches/avg size":
             case "output batches/total records":
             case "integral records to repartition":
             case "rebalancings":
             case "local shard size":
             case "accumulator records to repartition":
-                return Option.some(new CountValue(value[0]));
+                return Measurement.tagged(new CountValue(value[0]), AggregationMode.Sum);
+            case "runtime_elapsed":
+                // The legacy name of Measurement.RUNTIME_ELAPSED: one wall clock, repeated.
+                return Measurement.tagged(
+                    TimeValue.fromSecondsNanos(value[0].secs, value[0].nanos),
+                    AggregationMode.Max);
             case "wait_time":
             case "exchange_wait_time":
             case "merge backpressure wait":
             case "time":
             case "total_idle_time":
-            case "runtime_elapsed":
             case "total_runtime":
             case "total rebalancing time":
             case "in-progress rebalancing time":
-                return Option.some(TimeValue.fromSecondsNanos(value[0].secs, value[0].nanos));
+                return Measurement.tagged(
+                    TimeValue.fromSecondsNanos(value[0].secs, value[0].nanos), AggregationMode.Sum);
             case "persistent_id":
             case "foreground cache occupancy":
             case "background cache occupancy":
@@ -1141,9 +1364,9 @@ export class Measurement {
             case "slot 3 merging":
             case "slot 4 merging":
             case "balancer.policy":
-                return Option.some(new StringValue(value[0]));
+                return Measurement.tagged(new StringValue(value[0]), AggregationMode.CommonValue);
             case "rebalancing in progress":
-                return Option.some(new BooleanValue(value[0]));
+                return Measurement.tagged(new BooleanValue(value[0]), AggregationMode.Or);
             case "bounds":
             case "mir_node":
             case "key distribution":
@@ -1175,6 +1398,8 @@ export class NodeAndMetric {
  * Only stores numeric values! */
 class Measurements {
     readonly measurements: OMap<string, Array<PropertyValue>> = new OMap();
+    // How each metric folds over the nodes of a region; see `append`.
+    private readonly aggregations: OMap<string, AggregationMode> = new OMap();
 
     constructor(private worker_count: number) { }
 
@@ -1183,6 +1408,7 @@ class Measurements {
         if (m.property === "persistent_id") {
             return;
         }
+        this.aggregations.set(m.property, m.aggregation);
         let meas = this.measurements.get(m.property);
         let arr: Array<PropertyValue>;
         if (meas.isNone()) {
@@ -1206,20 +1432,33 @@ class Measurements {
         return result;
     }
 
+    /** How the metric named `key` is aggregated, if this set holds a reading for it. */
+    aggregationFor(key: string): Option<AggregationMode> {
+        return this.aggregations.get(key);
+    }
+
+    /** How the metric named `key` is aggregated. */
+    private aggregationOf(key: string): AggregationMode {
+        const mode = this.aggregationFor(key);
+        if (mode.isNone()) {
+            fail("No aggregation mode recorded for metric " + key);
+        }
+        return mode.unwrap();
+    }
+
+    /** Add all of `other`'s values to this set. */
     append(other: Measurements) {
         for (const [key, values] of other.measurements.entries()) {
             let existing = this.measurements.get(key);
             if (existing.isNone()) {
                 this.measurements.set(key, [...values]);
+                this.aggregations.set(key, other.aggregationOf(key));
             } else {
                 let arr = existing.unwrap();
                 assert(arr.length === values.length, "Mismatched measurement lengths");
+                const mode = this.aggregationOf(key);
                 for (let i = 0; i < values.length; i++) {
-                    if (key.includes("avg") || key.includes("min") || key.includes("percent") || key.includes("max"))
-                        // Heuristic
-                        arr[i] = arr[i]!.max(values[i]!);
-                    else
-                        arr[i] = arr[i]!.combine(values[i]!);
+                    arr[i] = arr[i]!.aggregate(values[i]!, mode);
                 }
             }
         }
@@ -1270,6 +1509,22 @@ export class SimpleNode implements JsonSimpleCircuitNode {
 
     getMeasurements(property: string): Array<PropertyValue> {
         return this.measurements.measurements.get(property).unwrapOr([]);
+    }
+
+    /** The metric's readings from `values` added up, for metrics that add up: counts, byte
+     * sizes and durations.  None for the others -- a total of ratios, of minima, of maxima, of
+     * flags or of settings states nothing.  `values` are this node's readings for the workers
+     * the caller is showing, so the total covers the same workers as the display. */
+    totalOf(property: string, values: Array<PropertyValue>): Option<PropertyValue> {
+        const mode = this.measurements.aggregationFor(property);
+        if (mode.isNone() || mode.unwrap() !== AggregationMode.Sum) {
+            return Option.none();
+        }
+        let total: PropertyValue = MissingValue.INSTANCE;
+        for (const value of values) {
+            total = total.aggregate(value, AggregationMode.Sum);
+        }
+        return total instanceof MissingValue ? Option.none() : Option.some(total);
     }
 
     // Add all the values from `measurements` into this node's measurements.
@@ -1425,6 +1680,54 @@ export class CircuitProfile {
             }
         }
         return Option.none();
+    }
+
+    /** The given nodes ranked by `metric`, largest first.
+     * A node is judged by the metric's total over its workers where the metric adds up, and by
+     * its largest worker reading otherwise: a node busy on every worker outranks one busy on a
+     * single worker, which ranking by the largest reading alone cannot express.  Nodes with no
+     * reading for the metric are left out. */
+    rankNodes(metric: string, nodes: Array<{ id: NodeId, label: string }>): Array<NodeAndMetric> {
+        // The range to normalize against depends on which of the two measures was used, which is
+        // only known once every node has been visited, so collect the readings first.
+        let ranked: Array<{ id: NodeId, label: string, value: PropertyValue, numeric: number }> = [];
+        let usedTotals = false;
+        for (const node of nodes) {
+            const profileNode = this.getNode(node.id);
+            if (profileNode.isNone()) { continue; }
+            const values = profileNode.unwrap().getMeasurements(metric);
+            const total = profileNode.unwrap().totalOf(metric, values);
+            let chosen: PropertyValue | null = null;
+            let numeric: number | null = null;
+            if (total.isSome()) {
+                usedTotals = true;
+                chosen = total.unwrap();
+                numeric = chosen.getNumericValue().unwrapOr(0);
+            } else {
+                for (const value of values) {
+                    const num = value.getNumericValue();
+                    if (num.isNone()) { continue; }
+                    if (numeric === null || num.unwrap() > numeric) {
+                        numeric = num.unwrap();
+                        chosen = value;
+                    }
+                }
+            }
+            if (numeric === null) { continue; }
+            ranked.push({ id: node.id, label: node.label, value: chosen!, numeric });
+        }
+        // A total is larger than any single worker's reading, so it does not belong to the
+        // metric's per-worker range; totals are placed against each other instead.
+        const range = usedTotals
+            ? NumericRange.getRange(ranked.map(r => r.numeric))
+            : this.propertyRange(metric);
+        if (range.isEmpty()) {
+            return [];
+        }
+        const result = ranked.map(r => new NodeAndMetric(
+            r.id, r.value.toString(), r.label, range.isPoint() ? 0 : range.percents(r.numeric)));
+        result.sort((a, b) => b.normalizedValue - a.normalizedValue);
+        return result;
     }
 
     // Get the topmost parent of a node which is not the toplevel graph node.

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -1248,9 +1248,9 @@ export class Measurement {
                 }
                 let entries = value[0].entries;
                 for (const e of entries) {
-                    // A slash, which is how these metrics are spelled in
-                    // `parseLegacyPropertyValue` and in `legacyMeasurementCategory`.  A dot
-                    // here left every one of them unparsed and uncategorized.
+                    // A slash, which is how these metrics are spelled in `parseLegacyPropertyValue`
+                    // and in `legacyMeasurementCategory`.  A dot here left every one of them
+                    // unparsed and uncategorized.
                     result.push(Measurement.fromJson(prefix + "/", e));
                 }
                 break;
@@ -1381,6 +1381,56 @@ export class Measurement {
                 return Option.none();
         }
     }
+}
+
+/** How one metric's readings are placed on screen. */
+export interface MetricScale {
+    /** Range of the individual worker readings, which colors the per-worker bars and the node
+     * highlighting. */
+    readonly range: NumericRange;
+    /** Largest total a drawn node reports, which shades the totals.  Absent for the metrics that
+     * do not add up, which have no total to shade. */
+    readonly maximum?: number;
+}
+
+/** The scales the rendering colors against, by metric, over the nodes currently drawn. */
+export type DisplayScales = Map<string, MetricScale>;
+
+/** A total as a percentage of the largest total on display, clamped to [0, 100]: 100 for the
+ * node holding the most, near zero for one holding a negligible share.  Zero when there is
+ * nothing on display to compare against. */
+export function totalShare(total: PropertyValue, largest: number | undefined): number {
+    const value = total.getNumericValue();
+    if (largest === undefined || largest <= 0 || value.isNone()) {
+        return 0;
+    }
+    return Math.max(0, Math.min(100, 100 * value.unwrap() / largest));
+}
+
+/** Shares for the totals of the toplevel node, which stands for the whole circuit.  It holds the
+ * largest total of every metric by construction, so `totalShare` would place all of them at 100.
+ * These place each total against the others of its category -- the group it is displayed
+ * alongside -- on a log scale, since a category's totals routinely span a byte count in the
+ * billions beside a batch count in the hundreds. */
+export function categoryShares(totals: Map<string, PropertyValue>): Map<string, number> {
+    const magnitudes = new Map<string, number>();
+    const largest = new Map<string, number>();
+    for (const [metric, total] of totals) {
+        const value = total.getNumericValue();
+        if (value.isNone()) {
+            continue;
+        }
+        const magnitude = Math.max(0, value.unwrap());
+        magnitudes.set(metric, magnitude);
+        const category = measurementCategory(metric);
+        largest.set(category, Math.max(largest.get(category) ?? 0, magnitude));
+    }
+    const shares = new Map<string, number>();
+    for (const [metric, magnitude] of magnitudes) {
+        const top = largest.get(measurementCategory(metric))!;
+        shares.set(metric, top > 0 ? 100 * Math.log1p(magnitude) / Math.log1p(top) : 0);
+    }
+    return shares;
 }
 
 /** A node, its operation, and the (maximum) value of a metric for that node.  The actual metric
@@ -1590,12 +1640,8 @@ export class CircuitProfile {
     public readonly complexNodes: OMap<NodeId, ComplexNode> = new OMap();
     // Maps each node id to it's immediate parent id.
     public readonly parents: OMap<NodeId, NodeId> = new OMap();
-    // Set of all metrics found in the profile.
-    private allMetrics: Set<string> = new Set();
     // Names of all worker threads
     private workerNames: Array<number> = new Array();
-    // For each measurement the aggregate range of values across all nodes.
-    readonly dataRange: OMap<string, NumericRange> = new OMap();
     // Index nodes by their persistent IDs
     readonly byPersistentId: OMap<string, SimpleNode> = new OMap();
     // Index nodes by table or view name (lowercase); filled from the dataflow graph.
@@ -1688,10 +1734,8 @@ export class CircuitProfile {
      * single worker, which ranking by the largest reading alone cannot express.  Nodes with no
      * reading for the metric are left out. */
     rankNodes(metric: string, nodes: Array<{ id: NodeId, label: string }>): Array<NodeAndMetric> {
-        // The range to normalize against depends on which of the two measures was used, which is
-        // only known once every node has been visited, so collect the readings first.
+        // The nodes are placed against each other, so collect the readings before scaling them.
         let ranked: Array<{ id: NodeId, label: string, value: PropertyValue, numeric: number }> = [];
-        let usedTotals = false;
         for (const node of nodes) {
             const profileNode = this.getNode(node.id);
             if (profileNode.isNone()) { continue; }
@@ -1700,7 +1744,6 @@ export class CircuitProfile {
             let chosen: PropertyValue | null = null;
             let numeric: number | null = null;
             if (total.isSome()) {
-                usedTotals = true;
                 chosen = total.unwrap();
                 numeric = chosen.getNumericValue().unwrapOr(0);
             } else {
@@ -1716,11 +1759,9 @@ export class CircuitProfile {
             if (numeric === null) { continue; }
             ranked.push({ id: node.id, label: node.label, value: chosen!, numeric });
         }
-        // A total is larger than any single worker's reading, so it does not belong to the
-        // metric's per-worker range; totals are placed against each other instead.
-        const range = usedTotals
-            ? NumericRange.getRange(ranked.map(r => r.numeric))
-            : this.propertyRange(metric);
+        // Each node is placed against the others in the list, whichever measure was used: a
+        // total is larger than any single worker's reading, so the two do not share a scale.
+        const range = NumericRange.getRange(ranked.map(r => r.numeric));
         if (range.isEmpty()) {
             return [];
         }
@@ -1881,22 +1922,41 @@ export class CircuitProfile {
     /** @param rootNodeId Id of the toplevel graph node, taken from the parsed profile. */
     constructor(readonly worker_count: number, readonly rootNodeId: NodeId) { }
 
-    // Scan the nodes and compute the range of each property
-    computePropertyRanges() {
-        for (const metric of this.allMetrics) {
-            let range = NumericRange.empty();
-            for (const node of this.simpleNodes.values()) {
-                let m = node.getMeasurements(metric);
-                let values = m.map(v => v.getNumericValue()).filter(v => v.isSome()).map(v => v.unwrap());
-                range = range.union(NumericRange.getRange(values));
+    /** The scales the display colors against, taken over the nodes it draws: an expanded region
+     * is drawn as the nodes inside it, so those count and the region does not, while a collapsed
+     * region stands for everything inside it and counts in their place.  `visible` selects the
+     * workers on display, so the scales cover the readings that are actually shown.
+     *
+     * Both scales come from one pass, since they walk the same readings. */
+    displayScales(nodes: Array<NodeId>,
+        visible: (values: Array<PropertyValue>) => Array<PropertyValue>): DisplayScales {
+        const scales: DisplayScales = new Map();
+        for (const id of nodes) {
+            const found = this.getNode(id);
+            if (found.isNone()) {
+                continue;
             }
-            this.dataRange.set(metric, range);
-        }
-    }
+            const node = found.unwrap();
+            for (const metric of node.measurements.getMetrics()) {
+                const shown = visible(node.getMeasurements(metric));
+                const numbers = shown.map(v => v.getNumericValue())
+                    .filter(v => v.isSome()).map(v => v.unwrap());
+                const previous = scales.get(metric);
+                const readings = NumericRange.getRange(numbers);
+                const range = previous === undefined
+                    ? readings
+                    : previous.range.union(readings);
 
-    // Given a property, compute the range of values across all nodes.
-    propertyRange(property: string): NumericRange {
-        return this.dataRange.get(property).unwrap();
+                let maximum = previous?.maximum;
+                const total = node.totalOf(metric, shown).map(t => t.getNumericValue());
+                if (total.isSome() && total.unwrap().isSome()) {
+                    const value = total.unwrap().unwrap();
+                    maximum = maximum === undefined ? value : Math.max(maximum, value);
+                }
+                scales.set(metric, maximum === undefined ? { range } : { range, maximum });
+            }
+        }
+        return scales;
     }
 
     // Decode the data in a worker profile; return a map from nodeId to an array of measurements for that node
@@ -1908,7 +1968,6 @@ export class CircuitProfile {
                 let measurements = Measurement.parseValues(datum);
                 for (const m of measurements) {
                     parsed.push(m);
-                    this.allMetrics.add(m.property);
                 }
             }
             metadata.set(nodeId, parsed);
@@ -1925,7 +1984,6 @@ export class CircuitProfile {
                 let measurements = Measurement.parseLegacyValues(datum);
                 for (const m of measurements) {
                     parsed.push(m);
-                    this.allMetrics.add(m.property);
                 }
             }
             metadata.set(nodeId, parsed);
@@ -2024,7 +2082,6 @@ export class CircuitProfile {
             }
         }
 
-        result.computePropertyRanges();
         return {
             profile: result,
             rootNodeId

--- a/js-packages/profiler-lib/src/profiler.ts
+++ b/js-packages/profiler-lib/src/profiler.ts
@@ -37,8 +37,9 @@ export interface TooltipRow {
     isCurrentMetric: boolean;
     cells: TooltipCell[];
     /** The cells added up, for metrics that add up: counts, byte sizes, durations.  Absent for
-     * ratios, minima, maxima, flags and settings, where a total states nothing. */
-    total?: PropertyValue | undefined;
+     * ratios, minima, maxima, flags and settings, where a total states nothing.  Its
+     * `percentile` is the share of the largest total any node reports for the metric. */
+    total?: TooltipCell | undefined;
 }
 
 /** Tooltip data structure */

--- a/js-packages/profiler-lib/src/profiler.ts
+++ b/js-packages/profiler-lib/src/profiler.ts
@@ -36,6 +36,9 @@ export interface TooltipRow {
     metric: string;
     isCurrentMetric: boolean;
     cells: TooltipCell[];
+    /** The cells added up, for metrics that add up: counts, byte sizes, durations.  Absent for
+     * ratios, minima, maxima, flags and settings, where a total states nothing. */
+    total?: PropertyValue | undefined;
 }
 
 /** Tooltip data structure */


### PR DESCRIPTION
This fixes two problems with the profile UI:
- metric aggregation for compound nodes is now using a more principled approach, depending on the metric type.
- in the tabular view we display a total for all workers for metrics which have a notion of total

In addition, top_nodes sorts now by total where the total is available, else it reverts to the previous behavior (computing top for considering each worker separately)

Fixes #6920
Addresses part of #5506

## Checklist

- [x] Unit tests added/updated

<img width="962" height="306" alt="image" src="https://github.com/user-attachments/assets/627ded5a-5a60-48c3-acca-970295673173" />

<img width="1005" height="403" alt="image" src="https://github.com/user-attachments/assets/a5cce9e5-9f39-44d2-bed8-cd81a053695f" />


