### PR TITLE
[adapters] Add the set of running syncs to CheckpointSyncStatus.

### DIFF
--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -107,6 +107,7 @@ use std::hash::{BuildHasherDefault, DefaultHasher, Hash, Hasher};
 use std::io::ErrorKind;
 use std::mem::take;
 use std::path::{Path, PathBuf};
+use std::sync::MutexGuard;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::{
@@ -185,35 +186,12 @@ impl PipelinePhase {
 }
 
 #[derive(Clone, Debug, Default)]
-struct CheckpointSyncState {
-    status: CheckpointSyncStatus,
-}
-
-impl CheckpointSyncState {
-    fn completed(&mut self, uuid: uuid::Uuid, result: Result<(), Arc<ControllerError>>) {
-        match result {
-            Ok(_) => self.status.success = Some(uuid),
-            Err(e) => {
-                self.status.failure = Some(CheckpointSyncFailure {
-                    uuid,
-                    error: e.to_string(),
-                })
-            }
-        }
-    }
-
-    fn completed_periodic(&mut self, uuid: uuid::Uuid) {
-        self.status.periodic = Some(uuid);
-    }
-}
-
-#[derive(Clone, Debug, Default)]
 struct CheckpointState {
     /// Sequence number for the next checkpoint request.
     next_seq: u64,
 
     /// The UUID of the last checkpoint.
-    last_checkpoint: Option<uuid::Uuid>,
+    last_checkpoint: Option<Uuid>,
 
     /// Status to report to user (success/failure only; `activity` is computed
     /// live from the watch channel).
@@ -283,7 +261,7 @@ pub(crate) struct ServerState {
     checkpoint_state: Mutex<CheckpointState>,
 
     /// Leaf lock.
-    sync_checkpoint_state: Mutex<CheckpointSyncState>,
+    sync_checkpoint_status: Mutex<CheckpointSyncStatus>,
 
     /// Leaf lock.
     /// Samply profiling state.
@@ -406,7 +384,7 @@ impl ServerState {
             desired_status_change: Arc::default(),
             metadata: md,
             checkpoint_state: Default::default(),
-            sync_checkpoint_state: Default::default(),
+            sync_checkpoint_status: Default::default(),
             desired_status: Mutex::new(desired_status),
             bootstrap_config: Mutex::new(bootstrap_config),
             deployment_id,
@@ -595,6 +573,10 @@ impl ServerState {
         if recorded {
             self.desired_status_change.notify_waiters();
         }
+    }
+
+    fn sync_checkpoint_status(&self) -> MutexGuard<'_, CheckpointSyncStatus> {
+        self.sync_checkpoint_status.lock().unwrap()
     }
 }
 
@@ -2230,6 +2212,91 @@ fn get_checkpoints(state: &ServerState) -> Result<VecDeque<CheckpointMetadata>, 
     })
 }
 
+/// Starts syncing the checkpoint named by `uuid` to object storage, in the
+/// background.
+///
+/// A sync already running for `uuid` coalesces with it: this starts no second
+/// sync and reports no error, because the sync the caller asked for is under
+/// way.  Both callers answer `202 Accepted` either way, so a retried request
+/// means "the sync is in progress", not "a fresh sync started".
+fn sync_checkpoint(state: WebData<ServerState>, controller: Controller, uuid: Uuid) {
+    /// Tracks state for an ongoing checkpoint sync.
+    struct CheckpointSyncGuard {
+        state: WebData<ServerState>,
+        uuid: Option<Uuid>,
+    }
+
+    impl CheckpointSyncGuard {
+        /// Tries to create a new `CheckpointSyncGuard` for `uuid`, and succeeds if
+        /// there is not already one for that UUID.
+        fn try_new(state: &WebData<ServerState>, uuid: Uuid) -> Option<Self> {
+            state
+                .sync_checkpoint_status()
+                .running
+                .insert(uuid)
+                .then(|| Self {
+                    state: state.clone(),
+                    uuid: Some(uuid),
+                })
+        }
+
+        /// Records the checkpoint sync of `uuid` as complete.
+        fn completed(mut self, result: Result<(), Arc<ControllerError>>) {
+            // Prevent the `Drop` implementation from trying to delete the UUID
+            // again.
+            let uuid = self
+                .uuid
+                .take()
+                .expect("CheckpointSyncGuard has not yet been dropped");
+
+            let mut status = self.state.sync_checkpoint_status();
+
+            // Remove `uuid` from the running sync.
+            if !status.running.remove(&uuid) {
+                error!("checkpoint sync for {uuid} unexpectedly already completed");
+            }
+
+            // Record the outcome.
+            //
+            // `success` and `failure` each name the last sync to reach that
+            // outcome, so re-syncing a checkpoint would otherwise leave the same
+            // UUID in both with nothing to say which came last.  Recording an
+            // outcome therefore clears the opposite one when it names `uuid`: the
+            // newer result replaces the stale one.
+            match result {
+                Ok(()) => {
+                    status.success = Some(uuid);
+                    status.failure.take_if(|failure| failure.uuid == uuid);
+                }
+                Err(e) => {
+                    status.failure = Some(CheckpointSyncFailure {
+                        uuid,
+                        error: e.to_string(),
+                    });
+                    if status.success == Some(uuid) {
+                        status.success = None;
+                    }
+                }
+            }
+        }
+    }
+
+    impl Drop for CheckpointSyncGuard {
+        fn drop(&mut self) {
+            if let Some(uuid) = self.uuid.take() {
+                self.state.sync_checkpoint_status().running.remove(&uuid);
+            }
+        }
+    }
+
+    if let Some(guard) = CheckpointSyncGuard::try_new(&state, uuid) {
+        spawn(async move {
+            let result = controller.async_sync_checkpoint(uuid).await;
+            guard.completed(result);
+        });
+    }
+}
+
 #[post("/checkpoint/sync")]
 async fn checkpoint_sync(state: WebData<ServerState>) -> Result<HttpResponse, PipelineError> {
     let controller = state.controller()?;
@@ -2254,14 +2321,7 @@ async fn checkpoint_sync(state: WebData<ServerState>) -> Result<HttpResponse, Pi
     };
 
     let incarnation_uuid = state.incarnation_uuid;
-    spawn(async move {
-        let result = controller.async_sync_checkpoint(last_checkpoint).await;
-        state
-            .sync_checkpoint_state
-            .lock()
-            .unwrap()
-            .completed(last_checkpoint, result);
-    });
+    sync_checkpoint(state, controller, last_checkpoint);
 
     Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(
         last_checkpoint,
@@ -2299,14 +2359,7 @@ async fn coordination_checkpoint_push(
     }
 
     let incarnation_uuid = state.incarnation_uuid;
-    spawn(async move {
-        let result = controller.async_sync_checkpoint(uuid).await;
-        state
-            .sync_checkpoint_state
-            .lock()
-            .unwrap()
-            .completed(uuid, result);
-    });
+    sync_checkpoint(state, controller, uuid);
 
     Ok(HttpResponse::Accepted().json(CheckpointSyncResponse::new(uuid, incarnation_uuid)))
 }
@@ -2390,15 +2443,14 @@ async fn sync_checkpoint_status(
     params: web::Query<CheckpointStatusQuery>,
 ) -> Result<HttpResponse, PipelineError> {
     check_incarnation_uuid(&state, params.incarnation_uuid)?;
-
-    let mut sync_state = state.sync_checkpoint_state.lock().unwrap();
+    let mut sync_status = state.sync_checkpoint_status();
 
     let controller = state.controller()?;
     if let Some(chk) = controller.last_checkpoint_sync().id {
-        sync_state.completed_periodic(chk);
+        sync_status.periodic = Some(chk);
     }
 
-    Ok(HttpResponse::Ok().json(sync_state.status.clone()))
+    Ok(HttpResponse::Ok().json(sync_status.clone()))
 }
 
 /// Suspends the pipeline and terminate the circuit.

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -110,8 +110,12 @@ pub struct CheckpointStatusQuery {
 
 /// Checkpoint status returned by the `/checkpoint/sync_status` endpoint.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
 pub struct CheckpointSyncStatus {
     /// Most recently successful checkpoint sync.
+    ///
+    /// If `success` and `failure` would otherwise name the same UUID, then the
+    /// most recent result is set and the other is cleared.
     pub success: Option<Uuid>,
 
     /// Most recently failed checkpoint sync, and the associated error.
@@ -119,6 +123,14 @@ pub struct CheckpointSyncStatus {
 
     /// Most recently successful automated periodic checkpoint sync.
     pub periodic: Option<Uuid>,
+
+    /// Checkpoint syncs running right now.
+    ///
+    /// A UUID leaves `running` and lands in `success` or `failure` at the same
+    /// moment.
+    ///
+    /// Periodic syncs do not appear here.
+    pub running: BTreeSet<Uuid>,
 }
 
 /// Information about a failed checkpoint sync.

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -282,6 +282,12 @@ along with the UUID of the pipeline process that accepted the request:
 Pass `incarnation_uuid` to `sync_status` while waiting for the sync, as described
 under [detecting a pipeline restart](#detecting-a-pipeline-restart).
 
+Requesting a sync for a checkpoint that is already syncing joins the sync in
+progress rather than starting a second one.  The response is `202 Accepted`
+either way, so treat it as "a sync for this checkpoint is under way", not as
+proof that a fresh one started; watch `running` in
+[sync status](#checking-sync-status) to follow it.
+
 ## Checking sync status
 
 The status of the sync operation can be checked with:
@@ -297,18 +303,46 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
 | `success`  | `uuid \| null`   | UUID of the most recently successful manually triggered checkpoint sync (`POST /checkpoint/sync`).          |
 | `failure`  | `object \| null` | Details of the most recently failed manually triggered checkpoint sync. Contains `uuid` and `error` fields. |
 | `periodic` | `uuid \| null`   | UUID of the most recently successful automatic periodic checkpoint sync (configured via `push_interval`).   |
+| `running`  | `uuid[]`         | UUIDs of the checkpoint syncs running right now.  Empty when none is in progress.                           |
 
 `success` and `periodic` track different sync mechanisms:
 
 - `success` is updated only by manual syncs triggered via `POST /checkpoint/sync`.
 - `periodic` is updated only by automatic syncs configured via `push_interval`.
 
+`success`, `failure` and `periodic` are sticky: each keeps naming the last sync
+to reach that outcome, long after it finished.  `running` is the field that says
+what is happening now, so a UUID that appears in both `running` and `failure` is
+a sync in progress that failed on an earlier attempt.
+
+If `success` and `failure` would otherwise name the same UUID, then
+the most recent result is kept and the other is set to `null`.
+
+`running` lists only manual syncs.  Automatic periodic syncs do not pass through
+the endpoint that records it, so an in-flight periodic sync leaves `running`
+empty; watch `periodic` for its result instead.
+
+A pipeline older than the release that introduced `running` omits the field
+entirely.  Absent means "this pipeline cannot report progress", which is not the
+same as the empty list.
+
 ### Response examples
 
 **No syncs yet:**
 
 ```json
-{ "success": null, "failure": null, "periodic": null }
+{ "success": null, "failure": null, "periodic": null, "running": [] }
+```
+
+**Manual sync in progress:**
+
+```json
+{
+    "success": null,
+    "failure": null,
+    "periodic": null,
+    "running": ["019779b4-8760-75f2-bdf0-71b825e63610"]
+}
 ```
 
 **Successful manual sync:**
@@ -317,7 +351,8 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
 {
     "success": "019779b4-8760-75f2-bdf0-71b825e63610",
     "failure": null,
-    "periodic": null
+    "periodic": null,
+    "running": []
 }
 ```
 
@@ -330,7 +365,8 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
         "uuid": "019779c1-8317-7a71-bd78-7b971f4a3c43",
         "error": "Error pushing checkpoint to object store: ... SignatureDoesNotMatch ..."
     },
-    "periodic": null
+    "periodic": null,
+    "running": []
 }
 ```
 
@@ -340,7 +376,8 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
 {
     "success": null,
     "failure": null,
-    "periodic": "019779c1-8317-7a71-bd78-7b971f4a3c43"
+    "periodic": "019779c1-8317-7a71-bd78-7b971f4a3c43",
+    "running": []
 }
 ```
 
@@ -350,7 +387,8 @@ curl 'http://localhost/v0/pipelines/{PIPELINE_NAME}/checkpoint/sync_status'
 {
     "success": "019779b4-8760-75f2-bdf0-71b825e63610",
     "failure": null,
-    "periodic": "019779c1-8317-7a71-bd78-7b971f4a3c43"
+    "periodic": "019779c1-8317-7a71-bd78-7b971f4a3c43",
+    "running": []
 }
 ```
 

--- a/openapi.json
+++ b/openapi.json
@@ -8643,18 +8643,31 @@
                 "$ref": "#/components/schemas/CheckpointSyncFailure"
               }
             ],
+            "default": null,
             "nullable": true
           },
           "periodic": {
             "type": "string",
             "format": "uuid",
             "description": "Most recently successful automated periodic checkpoint sync.",
+            "default": null,
             "nullable": true
+          },
+          "running": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Checkpoint syncs running right now.\n\nA UUID leaves `running` and lands in `success` or `failure` at the same\nmoment.\n\nPeriodic syncs do not appear here.",
+            "default": [],
+            "uniqueItems": true
           },
           "success": {
             "type": "string",
             "format": "uuid",
-            "description": "Most recently successful checkpoint sync.",
+            "description": "Most recently successful checkpoint sync.\n\nIf `success` and `failure` would otherwise name the same UUID, then the\nmost recent result is set and the other is cleared.",
+            "default": null,
             "nullable": true
           }
         }

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1213,12 +1213,17 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         return self.client.get_remote_checkpoints(self.name)
 
     def sync_checkpoint_status(
-        self, uuid: str, incarnation_uuid: Optional[str] = None
+        self, uuid: UUID | str, incarnation_uuid: Optional[str] = None
     ) -> CheckpointStatus:
-        """
-        Checks the status of the given checkpoint sync operation.
+        """Checks the status of the given checkpoint sync operation.
         If the checkpoint is currently being synchronized, returns
-        `CheckpointStatus.Unknown`.
+        `CheckpointStatus.InProgress`.
+
+        `CheckpointStatus.Unknown` means either that the pipeline is
+        too old to report whether checkpoint sync is in progress, or
+        such a sync never started, or its success or failure
+        indication was displaced by the sync of a different
+        checkpoint.
 
         Failures are not raised as runtime errors and must be explicitly
         checked.
@@ -1227,13 +1232,19 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         :param incarnation_uuid: The `incarnation_uuid` returned alongside
             `uuid` by `sync_checkpoint`, if known, to allow pipeline restarts
             to be clearly reported as `IncarnationUuidMismatch`.
+
         """
+
+        # Allow a UUID object to be passed in.
+        uuid = str(uuid)
 
         resp = self.client.sync_checkpoint_status(self.name, incarnation_uuid)
         success = resp.get("success")
         periodic = resp.get("periodic")
 
-        fail = resp.get("failure") or {}
+        running = resp.get("running")
+        if running is not None and uuid in running:
+            return CheckpointStatus.InProgress
 
         if uuid == success or uuid == periodic:
             return CheckpointStatus.Success
@@ -1245,8 +1256,11 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
             logging.error(f"failed to sync checkpoint '{uuid}': {failure.error}")
             return failure
 
-        if (success is None) or UUID(uuid) > UUID(success):
-            return CheckpointStatus.InProgress
+        if running is None:
+            # The pipeline is too old to report the running checkpoint
+            # sync operations, but we can make an educated guess.
+            if (success is None) or UUID(uuid) > UUID(success):
+                return CheckpointStatus.InProgress
 
         return CheckpointStatus.Unknown
 

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -31,6 +31,19 @@ from .helper import wait_for_condition
 
 
 LOGGER = logging.getLogger(__name__)
+
+# An S3 endpoint that cannot be reached: port 1 on the pipeline's own loopback,
+# where nothing listens.  A sync pointed here stays in progress for as long as
+# the test needs, because the sync retries a connection failure rather than
+# giving up on it.  A sync against a working endpoint, by contrast, can finish
+# before the first status request arrives, leaving no window to observe.
+#
+# The window comes from that retrying, not from how the network treats the
+# address, so this holds wherever the tests run.  An unroutable address (say
+# TEST-NET-1) would rely on the network dropping the packets rather than
+# rejecting them; loopback never leaves the pod and is refused immediately
+# everywhere, which the retry loop then rides out just the same.
+UNREACHABLE_S3_ENDPOINT = "http://127.0.0.1:1"
 _CHECKPOINT_SYNC_BUCKET_ARCH = platform.machine().lower()
 
 
@@ -432,6 +445,56 @@ class TestCheckpointSync(SharedTestPipeline):
             assert self.pipeline.status() == PipelineStatus.STANDBY
             self.pipeline.activate()
 
+    def _sync_status(self) -> dict:
+        """Return the raw `/checkpoint/sync_status` response.
+
+        The SDK's `sync_checkpoint_status` collapses the response into a
+        `CheckpointStatus`, which hides `running`.
+        """
+        return self.pipeline.client.sync_checkpoint_status(self.pipeline.name)
+
+    def _drain_sync(self, uuid, timeout_s: float = 120.0) -> tuple[dict, bool]:
+        """Poll `/checkpoint/sync_status` until the sync of *uuid* finishes.
+
+        Asserts on every sample that *uuid* is visible, that is, that it is
+        either in `running` or recorded in `success`/`failure`.  The pipeline
+        inserts *uuid* into `running` before answering the sync request, and
+        moves it from `running` to `success`/`failure` under a single lock, so
+        a caller that polls after a sync request can never see the UUID
+        disappear.
+
+        `running` alone decides when the sync is over.  `success` and `failure`
+        are sticky records of the last sync to reach each outcome, so re-syncing
+        a UUID that already failed starts out matching `running` and `failure`
+        at once; reading the sticky record as completion would report the new
+        sync as finished before it began.
+
+        Returns the final status, and whether the poll caught the sync in
+        `running`: a sync that ends within one status round-trip is already over
+        by the first sample.
+        """
+        saw_running = False
+        end = time.monotonic() + timeout_s
+        while True:
+            status = self._sync_status()
+            if uuid in (status.get("running") or []):
+                saw_running = True
+            else:
+                terminal = (
+                    status.get("success"),
+                    (status.get("failure") or {}).get("uuid"),
+                )
+                assert uuid in terminal, (
+                    f"sync '{uuid}' is neither running nor finished: {status}"
+                )
+                return status, saw_running
+
+            if time.monotonic() > end:
+                raise TimeoutError(
+                    f"timed out after {timeout_s}s waiting for sync '{uuid}': {status}"
+                )
+            time.sleep(0.05)
+
     # =========================================================================
     # Tests
     # =========================================================================
@@ -814,6 +877,149 @@ class TestCheckpointSync(SharedTestPipeline):
         self.assertIsNone(
             status.get("periodic"),
             f"periodic should be None after failed sync, got: {status}",
+        )
+
+        self.pipeline.stop(force=True)
+        self.pipeline.clear_storage()
+
+    @enterprise_only
+    @single_host_only
+    def test_sync_status_running(self):
+        """
+        CREATE TABLE t0 (c0 INT, c1 VARCHAR);
+        CREATE MATERIALIZED VIEW v0 AS SELECT * FROM t0;
+        """
+        # `push_interval` defaults to None, so no periodic sync competes for
+        # `running` and the only entry can be the manual sync below.
+        self._configure_and_start()
+        processed, _ = self._insert_data_and_wait()
+        self.pipeline.checkpoint(wait=True)
+        chk_uuid, _ = self._latest_checkpoint(processed)
+
+        self.assertEqual(
+            self._sync_status().get("running"),
+            [],
+            "no sync has been requested yet",
+        )
+
+        uuid = self.pipeline.sync_checkpoint()
+        self.assertEqual(str(uuid), str(chk_uuid))
+
+        status, _ = self._drain_sync(uuid)
+        self.assertEqual(
+            status.get("success"), uuid, f"sync should have succeeded: {status}"
+        )
+
+        self.pipeline.stop(force=True)
+        self.pipeline.clear_storage()
+
+    @enterprise_only
+    @single_host_only
+    def test_sync_status_in_flight(self):
+        """
+        CREATE TABLE t0 (c0 INT, c1 VARCHAR);
+        CREATE MATERIALIZED VIEW v0 AS SELECT * FROM t0;
+        """
+        # The sync cannot finish against an endpoint nothing answers on, so the
+        # window in which it is running is as wide as the test needs.  Without
+        # that, a sync can start and finish between the 202 and the first
+        # status request, and an implementation that never populated `running`
+        # would be indistinguishable from one that does.
+        self.pipeline.set_runtime_config(
+            build_runtime_config(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=FaultToleranceModel.AtLeastOnce,
+                storage=Storage(
+                    config=storage_cfg(
+                        self.pipeline.name, endpoint=UNREACHABLE_S3_ENDPOINT
+                    )
+                ),
+                checkpoint_interval_secs=60,
+            )
+        )
+        self.pipeline.start()
+        processed, _ = self._insert_data_and_wait()
+        self.pipeline.checkpoint(wait=True)
+        chk_uuid, _ = self._latest_checkpoint(processed)
+
+        uuid = self.pipeline.sync_checkpoint()
+        self.assertEqual(str(uuid), str(chk_uuid))
+
+        def sync_is_running() -> bool:
+            return uuid in (self._sync_status().get("running") or [])
+
+        wait_for_condition(
+            f"checkpoint sync '{uuid}' is reported as running",
+            sync_is_running,
+            timeout_s=30.0,
+            poll_interval_s=0.2,
+        )
+
+        # Requesting the same checkpoint again while it is syncing coalesces
+        # with the sync in progress: same UUID back, and still one entry.
+        self.assertEqual(self.pipeline.sync_checkpoint(), uuid)
+        status = self._sync_status()
+        self.assertEqual(
+            status.get("running"),
+            [uuid],
+            f"a duplicate request must not add a second entry: {status}",
+        )
+        self.assertIsNone(
+            status.get("success"), f"nothing can have succeeded yet: {status}"
+        )
+
+        # Stopping while the sync is still in flight exercises the guard's
+        # release-on-drop path; the pipeline must stop rather than wait it out.
+        self.pipeline.stop(force=True)
+        self.pipeline.clear_storage()
+
+    @enterprise_only
+    @single_host_only
+    def test_sync_status_running_after_failure(self):
+        """
+        CREATE TABLE t0 (c0 INT, c1 VARCHAR);
+        CREATE MATERIALIZED VIEW v0 AS SELECT * FROM t0;
+        """
+        # Bad credentials fail every sync, which checks that a sync releases
+        # its slot in `running` however it ends.  A leaked slot would wedge the
+        # checkpoint: later requests to sync it are dropped as duplicates, and
+        # the status keeps reporting a sync that is no longer running.
+        self.pipeline.set_runtime_config(
+            build_runtime_config(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=FaultToleranceModel.AtLeastOnce,
+                storage=Storage(config=storage_cfg(self.pipeline.name, auth_err=True)),
+                checkpoint_interval_secs=60,
+            )
+        )
+        self.pipeline.start()
+        processed, _ = self._insert_data_and_wait()
+        self.pipeline.checkpoint(wait=True)
+        chk_uuid, _ = self._latest_checkpoint(processed)
+
+        uuid = self.pipeline.sync_checkpoint()
+        self.assertEqual(str(uuid), str(chk_uuid))
+
+        status, _ = self._drain_sync(uuid)
+        self.assertEqual(
+            (status.get("failure") or {}).get("uuid"),
+            uuid,
+            f"sync should have failed on bad credentials: {status}",
+        )
+
+        # Re-syncing the same checkpoint is accepted rather than rejected as
+        # already-failed, and fails the same way.  A local MinIO 403 usually
+        # lands before the first status request, so this does not try to catch
+        # the second sync in `running`; `test_sync_status_in_flight` covers that
+        # against an endpoint that cannot answer.
+        self.assertEqual(self.pipeline.sync_checkpoint(), uuid)
+        status, _ = self._drain_sync(uuid)
+        self.assertEqual(
+            (status.get("failure") or {}).get("uuid"),
+            uuid,
+            f"re-sync should have failed too: {status}",
         )
 
         self.pipeline.stop(force=True)

--- a/python/tests/unit/test_checkpoint_sync_status.py
+++ b/python/tests/unit/test_checkpoint_sync_status.py
@@ -1,0 +1,168 @@
+"""Tests for Pipeline.sync_checkpoint_status(), which classifies the
+`/checkpoint/sync_status` response into a CheckpointStatus.
+
+The classification is what `Pipeline.sync_checkpoint(wait=True)` polls, so a
+misread of the response either hangs that loop or fails it on a stale result
+from an earlier sync of the same checkpoint.
+"""
+
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from feldera.enums import CheckpointStatus
+from feldera.pipeline import Pipeline
+
+# `running` is absent, `success` present, `periodic` absent, and so on: the
+# heuristic for pipelines that predate `running` orders UUIDs, so these three
+# are ordered LOW < SUBJECT < HIGH.
+LOW = "00000000-0000-0000-0000-000000000005"
+SUBJECT = "00000000-0000-0000-0000-00000000000a"
+HIGH = "00000000-0000-0000-0000-00000000000f"
+
+
+@pytest.fixture()
+def pipeline() -> Pipeline:
+    """A `Pipeline` whose only live dependency is the sync status response."""
+    client = MagicMock()
+    p = Pipeline(client)
+    p._inner = MagicMock()
+    p._inner.name = "test-pipeline"
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clear_failure_error():
+    """Reset the error that `sync_checkpoint_status` writes onto the enum.
+
+    `CheckpointStatus.Failure` is a single shared member, so an error recorded
+    by one test would otherwise leak into the next.
+    """
+    yield
+    CheckpointStatus.Failure.error = None
+
+
+def status_for(pipeline: Pipeline, resp: dict) -> CheckpointStatus:
+    pipeline.client.sync_checkpoint_status.return_value = resp
+    return pipeline.sync_checkpoint_status(SUBJECT)
+
+
+@pytest.mark.parametrize(
+    "description,resp,expected",
+    [
+        (
+            "sync registered and not yet finished",
+            {"running": [SUBJECT], "success": None, "periodic": None},
+            CheckpointStatus.InProgress,
+        ),
+        (
+            "re-sync in flight outranks the earlier success",
+            {"running": [SUBJECT], "success": SUBJECT, "periodic": None},
+            CheckpointStatus.InProgress,
+        ),
+        (
+            "re-sync in flight outranks the earlier failure",
+            {
+                "running": [SUBJECT],
+                "success": None,
+                "failure": {"uuid": SUBJECT, "error": "stale"},
+            },
+            CheckpointStatus.InProgress,
+        ),
+        (
+            "manual sync succeeded",
+            {"running": [], "success": SUBJECT, "periodic": None},
+            CheckpointStatus.Success,
+        ),
+        (
+            "periodic sync succeeded",
+            {"running": [], "success": None, "periodic": SUBJECT},
+            CheckpointStatus.Success,
+        ),
+        (
+            "sync failed",
+            {
+                "running": [],
+                "success": None,
+                "failure": {"uuid": SUBJECT, "error": "SignatureDoesNotMatch"},
+            },
+            CheckpointStatus.Failure,
+        ),
+        (
+            # A current pipeline never reports this: recording an outcome
+            # clears the opposite slot when it names the same checkpoint.  One
+            # that predates that fix can, and the two slots carry no ordering,
+            # so the SDK has to pick.  It prefers `success` because the
+            # reachable history is retry-after-failure, where the success is
+            # the newer fact; preferring `failure` would raise from
+            # `sync_checkpoint(wait=True)` for a sync that did complete.
+            "legacy pipeline reports the same checkpoint as both",
+            {
+                "running": [],
+                "success": SUBJECT,
+                "failure": {"uuid": SUBJECT, "error": "stale"},
+            },
+            CheckpointStatus.Success,
+        ),
+        (
+            "pipeline has no record of this checkpoint",
+            {"running": [], "success": HIGH, "periodic": None},
+            CheckpointStatus.Unknown,
+        ),
+        (
+            # Same response as the last case below, minus `running`, and the
+            # answer differs: `running` is authoritative, so its absence from
+            # an empty set is proof the sync request never landed.
+            "no record of this checkpoint, only an earlier one has synced",
+            {"running": [], "success": LOW, "periodic": None},
+            CheckpointStatus.Unknown,
+        ),
+        (
+            "old pipeline, nothing synced yet",
+            {"success": None, "periodic": None},
+            CheckpointStatus.InProgress,
+        ),
+        (
+            "old pipeline, a later checkpoint has synced",
+            {"success": HIGH, "periodic": None},
+            CheckpointStatus.Unknown,
+        ),
+        (
+            "old pipeline, only an earlier checkpoint has synced",
+            {"success": LOW, "periodic": None},
+            CheckpointStatus.InProgress,
+        ),
+    ],
+)
+def test_classification(pipeline: Pipeline, description, resp, expected):
+    assert status_for(pipeline, resp) == expected, description
+
+
+def test_failure_carries_the_error(pipeline: Pipeline):
+    status = status_for(
+        pipeline,
+        {
+            "running": [],
+            "success": None,
+            "failure": {"uuid": SUBJECT, "error": "SignatureDoesNotMatch"},
+        },
+    )
+    assert status == CheckpointStatus.Failure
+    assert status.get_error() == "SignatureDoesNotMatch"
+
+
+def test_other_checkpoints_running_are_ignored(pipeline: Pipeline):
+    """Only the requested checkpoint's presence in `running` matters."""
+    resp = {"running": [LOW, HIGH], "success": SUBJECT, "periodic": None}
+    assert status_for(pipeline, resp) == CheckpointStatus.Success
+
+
+def test_accepts_a_uuid_object(pipeline: Pipeline):
+    """`sync_checkpoint` returns a str, but callers hold UUID objects too."""
+    pipeline.client.sync_checkpoint_status.return_value = {
+        "running": [SUBJECT],
+        "success": None,
+        "periodic": None,
+    }
+    assert pipeline.sync_checkpoint_status(UUID(SUBJECT)) == CheckpointStatus.InProgress


### PR DESCRIPTION
CheckpointSyncStatus reports the status of checkpoint sync activity, but it didn't give enough information to tell what syncs were currently in progress.  This adds a new field `running` to track that.

### Describe Manual Test Plan

This is just unit tests so far.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

No, it's careful to avoid them.