### PR TITLE
[web-console] Fix metrics graphs incorrectly drops excessive data points too early

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -19,8 +19,7 @@
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { formatDateTime, formatQty } from '$lib/functions/format'
   import { useElapsedTime } from '$lib/compositions/common/useElapsedTime'
-  import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
-  import { pushAsCircularBuffer } from '$lib/functions/pipelines/changeStream'
+  import { staleSampleCount, type PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import { JSONParser } from '@streamparser/json-whatwg'
   import type { ParsedElementInfo } from '@streamparser/json/utils/types/parsedElementInfo.js'
   import { getDeploymentStatusLabel, isMetricsAvailable } from '$lib/functions/pipelines/status'
@@ -34,6 +33,15 @@
   import { sleep } from '$lib/functions/common/promise'
 
   const RECONNECT_BACKOFF_MS = 1000
+  /** Time span the graphs plot. */
+  const GRAPH_WINDOW_MS = 60 * 1000
+  /**
+   * Time span of samples kept in `timeSeries`.
+   *
+   * Slightly wider than the plotted window so the line still reaches the left
+   * edge of the axis in between samples; the surplus is clipped by the axis.
+   */
+  const RETAIN_MS = GRAPH_WINDOW_MS + 3 * 1000
 
   const {
     pipeline,
@@ -121,11 +129,15 @@
 
     const runMetricsStream = async () => {
       // Not routed through `parseStream`: the load shedding is unnecessary for the metrics stream.
-      const appendRow = pushAsCircularBuffer(
-        () => timeSeries,
-        63,
-        (v: TimeSeriesEntry) => v
-      )
+      // Retention goes by sample age, not by sample count: a multihost pipeline
+      // reports one sample per host per tick, so the sample rate is unknown here.
+      const appendSample = (sample: TimeSeriesEntry) => {
+        timeSeries.push(sample)
+        const stale = staleSampleCount(timeSeries, RETAIN_MS)
+        if (stale > 0) {
+          timeSeries.splice(0, stale)
+        }
+      }
       while (!cancelled) {
         if (!metricsAvailable) {
           await sleep(RECONNECT_BACKOFF_MS)
@@ -163,7 +175,7 @@
                   pendingReplace = false
                   return
                 }
-                appendRow([entry])
+                appendSample(entry)
               }
             }),
             { signal: abortCtrl.signal }
@@ -332,7 +344,7 @@
                   {pipeline}
                   metrics={timeSeries}
                   refetchMs={1000}
-                  keepMs={60 * 1000}
+                  keepMs={GRAPH_WINDOW_MS}
                 ></PipelineThroughputGraph>
               </div>
               <div class="bg-white-dark relative h-52 w-full max-w-[700px] rounded">
@@ -340,7 +352,7 @@
                   {pipeline}
                   metrics={timeSeries}
                   refetchMs={1000}
-                  keepMs={60 * 1000}
+                  keepMs={GRAPH_WINDOW_MS}
                   memoryPressure={global.memory_pressure}
                 ></PipelineMemoryGraph>
               </div>
@@ -349,7 +361,7 @@
                   {pipeline}
                   metrics={timeSeries}
                   refetchMs={1000}
-                  keepMs={60 * 1000}
+                  keepMs={GRAPH_WINDOW_MS}
                 ></PipelineStorageGraph>
               </div>
             </div>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -35,13 +35,13 @@
   const RECONNECT_BACKOFF_MS = 1000
   /** Time span the graphs plot. */
   const GRAPH_WINDOW_MS = 60 * 1000
+  const RETAIN_MS = GRAPH_WINDOW_MS + 2000
   /**
-   * Time span of samples kept in `timeSeries`.
-   *
-   * One second wider than the plotted window, because the throughput series
-   * derives a rate from each pair of samples and so cannot plot the oldest one.
+   * Ceiling on samples kept in `timeSeries`, reached only if their timestamps
+   * stop advancing. Well above the rate any deployment reports: a 16-host
+   * pipeline sampling every second fills a fifth of it.
    */
-  const RETAIN_MS = GRAPH_WINDOW_MS + 1000
+  const MAX_SAMPLES = 5000
 
   const {
     pipeline,
@@ -130,10 +130,12 @@
     const runMetricsStream = async () => {
       // Not routed through `parseStream`: the load shedding is unnecessary for the metrics stream.
       // Retention goes by sample age, not by sample count: a multihost pipeline
-      // reports one sample per host per tick, so the sample rate is unknown here.
+      // reports one sample per host per tick, so the sample rate depends on the
+      // deployment and a count-based buffer plots a shorter span the more hosts
+      // the pipeline runs on.
       const appendSample = (sample: TimeSeriesEntry) => {
         timeSeries.push(sample)
-        const stale = staleSampleCount(timeSeries, RETAIN_MS)
+        const stale = staleSampleCount(timeSeries, RETAIN_MS, MAX_SAMPLES)
         if (stale > 0) {
           timeSeries.splice(0, stale)
         }

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -38,10 +38,10 @@
   /**
    * Time span of samples kept in `timeSeries`.
    *
-   * Slightly wider than the plotted window so the line still reaches the left
-   * edge of the axis in between samples; the surplus is clipped by the axis.
+   * One second wider than the plotted window, because the throughput series
+   * derives a rate from each pair of samples and so cannot plot the oldest one.
    */
-  const RETAIN_MS = GRAPH_WINDOW_MS + 3 * 1000
+  const RETAIN_MS = GRAPH_WINDOW_MS + 1000
 
   const {
     pipeline,

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
@@ -5,6 +5,7 @@ import { formatDuration } from './format'
 import {
   accumulatePipelineMetrics,
   multihostMemoryLimitMb,
+  staleSampleCount,
   timeSeriesAxisMax
 } from './pipelineMetrics'
 
@@ -24,6 +25,53 @@ describe('timeSeriesAxisMax', () => {
 
   it('falls back to the supplied time source when there are no samples', () => {
     expect(timeSeriesAxisMax([], () => 4242)).toBe(4242)
+  })
+})
+
+describe('staleSampleCount', () => {
+  /** `hosts` samples per second, as a multihost coordinator reports them. */
+  const seriesAt = (hosts: number, seconds: number, firstMs = 0) =>
+    Array.from({ length: hosts * seconds }, (_, i) =>
+      // Hosts report at a fixed phase offset within each second.
+      sampleAt(firstMs + Math.floor(i / hosts) * 1000 + (i % hosts) * 50)
+    )
+
+  it('keeps a series that fits the window', () => {
+    expect(staleSampleCount([sampleAt(1000), sampleAt(2000), sampleAt(3000)], 5000)).toBe(0)
+  })
+
+  it('drops samples older than the window', () => {
+    const samples = [sampleAt(1000), sampleAt(2000), sampleAt(3000), sampleAt(4000)]
+    // Measured from the newest sample: 1000 is 3000ms old, 2000 is exactly at the edge.
+    expect(staleSampleCount(samples, 2000)).toBe(1)
+  })
+
+  it('keeps a sample sitting exactly on the window edge', () => {
+    expect(staleSampleCount([sampleAt(1000), sampleAt(3000)], 2000)).toBe(0)
+  })
+
+  it('retains the same time span whatever the sample rate', () => {
+    // A multihost pipeline reports one sample per host per tick, so a count-based
+    // buffer would shrink the retained span in proportion to the host count.
+    const spanOf = (hosts: number) => {
+      const samples = seriesAt(hosts, 90)
+      const kept = samples.slice(staleSampleCount(samples, 60_000))
+      return kept.at(-1)!.t - kept[0]!.t
+    }
+    expect(spanOf(1)).toBe(60_000)
+    expect(spanOf(2)).toBe(60_000)
+    expect(spanOf(4)).toBe(60_000)
+  })
+
+  it('drops a stale sample that arrived behind fresher ones', () => {
+    // The scan walks back from the newest sample, so an out-of-order straggler
+    // takes everything older than itself with it.
+    const samples = [sampleAt(9000), sampleAt(1000), sampleAt(9500), sampleAt(10_000)]
+    expect(staleSampleCount(samples, 2000)).toBe(2)
+  })
+
+  it('has nothing to drop in an empty series', () => {
+    expect(staleSampleCount([], 60_000)).toBe(0)
   })
 })
 

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
@@ -29,50 +29,103 @@ describe('timeSeriesAxisMax', () => {
   })
 })
 
+const WINDOW_MS = 60 * 1000
+/** No cap in tests that exercise retention by age alone. */
+const NO_CAP = Number.MAX_SAFE_INTEGER
+
 describe('staleSampleCount', () => {
-  /** `hosts` samples per second, as a multihost coordinator reports them. */
-  const seriesAt = (hosts: number, seconds: number, firstMs = 0) =>
+  /** `hosts` samples per tick, as a multihost coordinator reports them. */
+  const seriesAt = (hosts: number, seconds: number, intervalMs = 1000) =>
     Array.from({ length: hosts * seconds }, (_, i) =>
-      // Hosts report at a fixed phase offset within each second.
-      sampleAt(firstMs + Math.floor(i / hosts) * 1000 + (i % hosts) * 50)
+      // Hosts report at a fixed phase offset within each tick.
+      sampleAt(Math.round(Math.floor(i / hosts) * intervalMs + (i % hosts) * 50), i)
     )
 
+  /**
+   * How much of the left edge of the plotted window the rate series misses
+   * after retention has trimmed `samples`.
+   */
+  const windowGapMs = (samples: TimeSeriesEntry[]) => {
+    const kept = samples.slice(staleSampleCount(samples, WINDOW_MS, NO_CAP))
+    const { series } = calcPipelineThroughput(kept)
+    return series[0]!.value[0] - (kept.at(-1)!.t - WINDOW_MS)
+  }
+
+  /** Widest interval between consecutive samples, the granularity of the plot. */
+  const widestIntervalMs = (samples: TimeSeriesEntry[]) =>
+    Math.max(...samples.slice(1).map((sample, i) => sample.t - samples[i]!.t))
+
   it('keeps a series that fits the window', () => {
-    expect(staleSampleCount([sampleAt(1000), sampleAt(2000), sampleAt(3000)], 5000)).toBe(0)
+    expect(staleSampleCount([sampleAt(1000), sampleAt(2000), sampleAt(3000)], 5000, NO_CAP)).toBe(0)
   })
 
   it('drops samples older than the window', () => {
+    const samples = [sampleAt(0), sampleAt(1000), sampleAt(2000), sampleAt(3000), sampleAt(4000)]
+    // Measured from the newest sample, the window starts at 2000; 1000 is kept
+    // as the rate anchor, so only 0 is stale.
+    expect(staleSampleCount(samples, 2000, NO_CAP)).toBe(1)
+  })
+
+  it('keeps the newest sample outside the window as the rate anchor', () => {
     const samples = [sampleAt(1000), sampleAt(2000), sampleAt(3000), sampleAt(4000)]
-    // Measured from the newest sample: 1000 is 3000ms old, 2000 is exactly at the edge.
-    expect(staleSampleCount(samples, 2000)).toBe(1)
+    expect(staleSampleCount(samples, 2000, NO_CAP)).toBe(0)
   })
 
   it('keeps a sample sitting exactly on the window edge', () => {
-    expect(staleSampleCount([sampleAt(1000), sampleAt(3000)], 2000)).toBe(0)
+    expect(staleSampleCount([sampleAt(1000), sampleAt(3000)], 2000, NO_CAP)).toBe(0)
   })
 
-  it('retains the same time span whatever the sample rate', () => {
+  it('retains the plotted window whatever the host count', () => {
     // A multihost pipeline reports one sample per host per tick, so a count-based
     // buffer would shrink the retained span in proportion to the host count.
-    const spanOf = (hosts: number) => {
+    for (const hosts of [1, 2, 4]) {
       const samples = seriesAt(hosts, 90)
-      const kept = samples.slice(staleSampleCount(samples, 60_000))
-      return kept.at(-1)!.t - kept[0]!.t
+      expect(windowGapMs(samples)).toBe(0)
     }
-    expect(spanOf(1)).toBe(60_000)
-    expect(spanOf(2)).toBe(60_000)
-    expect(spanOf(4)).toBe(60_000)
+  })
+
+  it('retains the plotted window whatever the sample interval', () => {
+    // The retained span is derived from the samples themselves, so a stats
+    // thread lagging to 2s, or jittering off 1s, still fills the graph.
+    for (const intervalMs of [1000, 1050, 2000, 5000]) {
+      const samples = seriesAt(1, 90, intervalMs)
+      const gap = windowGapMs(samples)
+      // Nothing can be plotted between the window edge and the first sample
+      // after it, so a gap below one sample interval is all the plot can do.
+      expect(gap).toBeGreaterThanOrEqual(0)
+      expect(gap).toBeLessThan(widestIntervalMs(samples))
+    }
   })
 
   it('drops a stale sample that arrived behind fresher ones', () => {
     // The scan walks back from the newest sample, so an out-of-order straggler
-    // takes everything older than itself with it.
-    const samples = [sampleAt(9000), sampleAt(1000), sampleAt(9500), sampleAt(10_000)]
-    expect(staleSampleCount(samples, 2000)).toBe(2)
+    // anchors the window and the samples before it are dropped, even the ones
+    // that fall inside it.
+    const samples = [
+      sampleAt(8000),
+      sampleAt(1000),
+      sampleAt(9000),
+      sampleAt(9500),
+      sampleAt(10_000)
+    ]
+    expect(staleSampleCount(samples, 2000, NO_CAP)).toBe(1)
   })
 
   it('has nothing to drop in an empty series', () => {
-    expect(staleSampleCount([], 60_000)).toBe(0)
+    expect(staleSampleCount([], WINDOW_MS, NO_CAP)).toBe(0)
+  })
+
+  it('caps a series whose timestamps stopped advancing', () => {
+    // Every sample sits inside the window, so only the cap bounds the series.
+    const samples = Array.from({ length: 500 }, () => sampleAt(1000))
+    expect(staleSampleCount(samples, WINDOW_MS, 100)).toBe(400)
+  })
+
+  it('leaves a series under the cap to the window', () => {
+    const samples = seriesAt(4, 90)
+    expect(staleSampleCount(samples, WINDOW_MS, 10_000)).toBe(
+      staleSampleCount(samples, WINDOW_MS, NO_CAP)
+    )
   })
 })
 
@@ -87,15 +140,6 @@ describe('calcPipelineThroughput', () => {
       [2000, 30],
       [3000, 70]
     ])
-  })
-
-  it('covers the plotted window once one extra sample interval is retained', () => {
-    // Why `RETAIN_MS` exceeds the plotted window: the oldest sample yields no
-    // point, so retaining exactly the window would leave the line short of it.
-    const samples = Array.from({ length: 62 }, (_, i) => sampleAt(i * 1000, i))
-    const { series } = calcPipelineThroughput(samples)
-    expect(series.length).toBe(samples.length - 1)
-    expect(series.at(-1)!.value[0] - series[0]!.value[0]).toBe(60_000)
   })
 
   it('reports the newest rate as the current one', () => {

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.spec.ts
@@ -4,14 +4,15 @@ import type { TimeSeriesEntry } from '$lib/types/pipelineManager'
 import { formatDuration } from './format'
 import {
   accumulatePipelineMetrics,
+  calcPipelineThroughput,
   multihostMemoryLimitMb,
   staleSampleCount,
   timeSeriesAxisMax
 } from './pipelineMetrics'
 
-const sampleAt = (timeMs: number): TimeSeriesEntry => ({
+const sampleAt = (timeMs: number, records = 0): TimeSeriesEntry => ({
   t: timeMs,
-  r: 0,
+  r: records,
   m: 0,
   s: 0
 })
@@ -72,6 +73,39 @@ describe('staleSampleCount', () => {
 
   it('has nothing to drop in an empty series', () => {
     expect(staleSampleCount([], 60_000)).toBe(0)
+  })
+})
+
+describe('calcPipelineThroughput', () => {
+  it('reports the records added since the preceding sample', () => {
+    const { series } = calcPipelineThroughput([
+      sampleAt(1000, 0),
+      sampleAt(2000, 30),
+      sampleAt(3000, 100)
+    ])
+    expect(series.map((p) => p.value)).toEqual([
+      [2000, 30],
+      [3000, 70]
+    ])
+  })
+
+  it('covers the plotted window once one extra sample interval is retained', () => {
+    // Why `RETAIN_MS` exceeds the plotted window: the oldest sample yields no
+    // point, so retaining exactly the window would leave the line short of it.
+    const samples = Array.from({ length: 62 }, (_, i) => sampleAt(i * 1000, i))
+    const { series } = calcPipelineThroughput(samples)
+    expect(series.length).toBe(samples.length - 1)
+    expect(series.at(-1)!.value[0] - series[0]!.value[0]).toBe(60_000)
+  })
+
+  it('reports the newest rate as the current one', () => {
+    expect(calcPipelineThroughput([sampleAt(1000, 0), sampleAt(2000, 5)]).current).toBe(5)
+  })
+
+  it('has no rate to report for fewer than two samples', () => {
+    expect(calcPipelineThroughput([]).series).toEqual([])
+    expect(calcPipelineThroughput([sampleAt(1000, 7)]).series).toEqual([])
+    expect(calcPipelineThroughput([sampleAt(1000, 7)]).current).toBe(0)
   })
 })
 

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -238,6 +238,29 @@ export const timeSeriesAxisMax = (metrics: TimeSeriesEntry[], now: () => number 
   metrics.at(-1)?.t ?? now()
 
 /**
+ * Number of oldest samples to drop so that the series spans at most `windowMs`.
+ *
+ * The scan starts at the newest sample and walks back to the first sample that
+ * falls outside the window; that sample and every older one are dropped.
+ *
+ * @param samples - Series ordered oldest first.
+ * @param windowMs - How far back from the newest sample to retain.
+ */
+export const staleSampleCount = (samples: TimeSeriesEntry[], windowMs: number): number => {
+  const newest = samples.at(-1)?.t
+  if (newest === undefined) {
+    return 0
+  }
+  const oldestKept = newest - windowMs
+  for (let i = samples.length - 1; i >= 0; i--) {
+    if (samples[i].t < oldestKept) {
+      return i + 1
+    }
+  }
+  return 0
+}
+
+/**
  * Memory limit on a multi-host deployment, in MB.
  *
  * `memory_mb_max` is the individual host's limit, but the reported memory metric

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -277,7 +277,14 @@ export const multihostMemoryLimitMb = (
 ): number | undefined => (perHostMemoryMb ? perHostMemoryMb * Math.max(hosts ?? 1, 1) : undefined)
 
 /**
- * @returns Time series of throughput with smoothing window over 3 data intervals
+ * Throughput time series: records added between consecutive samples, stamped
+ * with the newer sample of each pair.
+ *
+ * A rate needs two samples, so the series holds one point fewer than `metrics`
+ * and starts one sample interval after the oldest sample.
+ *
+ * @returns Series of `[timestamp, records]`, plus the latest and mean rate and
+ * the y-axis bounds.
  */
 export const calcPipelineThroughput = (metrics: TimeSeriesEntry[]) => {
   const series = discreteDerivative(metrics, (n1, n0) => ({

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -238,26 +238,41 @@ export const timeSeriesAxisMax = (metrics: TimeSeriesEntry[], now: () => number 
   metrics.at(-1)?.t ?? now()
 
 /**
- * Number of oldest samples to drop so that the series spans at most `windowMs`.
+ * Number of oldest samples to drop to keep the series within its bounds.
  *
- * The scan starts at the newest sample and walks back to the first sample that
- * falls outside the window; that sample and every older one are dropped.
+ * Every sample within `windowMs` of the newest one is kept, and so is the
+ * newest sample that falls outside it. That one extra sample is what lets a
+ * rate series, which needs a pair of samples per point, cover the whole window:
+ * keeping its age rather than a fixed cushion holds at any sample interval.
+ *
+ * `maxSamples` bounds the series should the timestamps stop advancing, which
+ * leaves every sample inside the window; set it well above the sample rate any
+ * deployment reports.
  *
  * @param samples - Series ordered oldest first.
  * @param windowMs - How far back from the newest sample to retain.
+ * @param maxSamples - Ceiling on the retained sample count.
  */
-export const staleSampleCount = (samples: TimeSeriesEntry[], windowMs: number): number => {
+export const staleSampleCount = (
+  samples: TimeSeriesEntry[],
+  windowMs: number,
+  maxSamples: number
+): number => {
   const newest = samples.at(-1)?.t
   if (newest === undefined) {
     return 0
   }
   const oldestKept = newest - windowMs
+  let stale = 0
   for (let i = samples.length - 1; i >= 0; i--) {
     if (samples[i].t < oldestKept) {
-      return i + 1
+      // Sample `i` is the newest one outside the window: it anchors the first
+      // rate that the window can plot, so only samples older than it are stale.
+      stale = i
+      break
     }
   }
-  return 0
+  return Math.max(stale, samples.length - maxSamples)
 }
 
 /**
@@ -281,7 +296,9 @@ export const multihostMemoryLimitMb = (
  * with the newer sample of each pair.
  *
  * A rate needs two samples, so the series holds one point fewer than `metrics`
- * and starts one sample interval after the oldest sample.
+ * and starts at the second-oldest sample. Retaining one sample older than the
+ * plotted window is therefore what makes the rate cover that window; see
+ * `staleSampleCount`.
  *
  * @returns Series of `[timestamp, records]`, plus the latest and mean rate and
  * the y-axis bounds.


### PR DESCRIPTION
This drops the expectation that the metrics time series has a certain number of data points per second
Also: reduce buffer for kept datapoints - extra 3 seconds of data are not needed because no smoothing over multiple datapoints is performed (an old change).

Testing: added unit tests

Fix https://github.com/feldera/feldera/issues/6816