### PR TITLE
[adapters] pg-input: report query errors to the controller

### DIFF
--- a/crates/adapters/src/integrated/postgres/input.rs
+++ b/crates/adapters/src/integrated/postgres/input.rs
@@ -215,7 +215,11 @@ impl PostgresInputEndpointInner {
                     "postgres {}: error reading from postgres: {e}",
                     &self.endpoint_name
                 );
-                let _r = init_status_sender.send(Err(e)).await;
+                // Initialization already succeeded, so nobody is receiving on
+                // `init_status_sender` anymore.  Report the failure to the
+                // controller instead; sending it on the init channel would
+                // leave the pipeline stalled without an error.
+                self.consumer.error(true, anyhow!(e), None);
                 return;
             }
         };

--- a/crates/adapters/src/integrated/postgres/input.rs
+++ b/crates/adapters/src/integrated/postgres/input.rs
@@ -211,15 +211,12 @@ impl PostgresInputEndpointInner {
             }) {
             Ok(rows) => rows,
             Err(e) => {
-                error!(
-                    "postgres {}: error reading from postgres: {e}",
-                    &self.endpoint_name
-                );
                 // Initialization already succeeded, so nobody is receiving on
                 // `init_status_sender` anymore.  Report the failure to the
                 // controller instead; sending it on the init channel would
                 // leave the pipeline stalled without an error.
-                self.consumer.error(true, anyhow!(e), None);
+                self.consumer
+                    .error(true, anyhow!("error reading from Postgres: {e}"), None);
                 return;
             }
         };

--- a/crates/adapters/src/integrated/postgres/test.rs
+++ b/crates/adapters/src/integrated/postgres/test.rs
@@ -3189,6 +3189,120 @@ fn test_pg_input_tls() {
         .unwrap();
 }
 
+/// A runtime failure of the connector's query must be reported to the
+/// controller as a fatal input error.
+///
+/// Regression test: initialization succeeds because the connection to
+/// PostgreSQL can be established, so by the time the query executes, the
+/// init-status channel has been consumed. The query error used to be sent on
+/// that channel and silently dropped, so the connector terminated without
+/// notifying the controller and the pipeline stalled forever.
+#[test]
+#[serial]
+fn test_pg_input_query_error() {
+    let url = postgres_url();
+
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_owned();
+
+    let config = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 1,
+        "inputs": {
+            "pg_in": {
+                "stream": "test_input1",
+                "transport": {
+                    "name": "postgres_input",
+                    "config": {
+                        "uri": url,
+                        "query": "SELECT * FROM feldera_missing_table_regression",
+                    },
+                },
+            },
+        },
+        "outputs": {
+            "test_output1": {
+                "stream": "test_output1",
+                "transport": {
+                    "name": "file_output",
+                    "config": {
+                        "path": output_path,
+                    }
+                },
+                "format": {
+                    "name": "json",
+                    "config": {
+                        "update_format": "insert_delete",
+                        "array": false,
+                    }
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    let (err_sender, err_receiver) = crossbeam::channel::unbounded();
+    let controller = Controller::with_test_config(
+        move |workers| {
+            Ok({
+                let (circuit, catalog) = Runtime::init_circuit(workers, move |circuit| {
+                    let mut catalog = Catalog::new();
+                    let (input, hinput) = circuit.add_input_zset::<TestStruct>();
+
+                    let input_schema = serde_json::to_string(&Relation::new(
+                        "test_input1".into(),
+                        TestStruct::schema(),
+                        false,
+                        BTreeMap::new(),
+                    ))
+                    .unwrap();
+
+                    let output_schema = serde_json::to_string(&Relation::new(
+                        "test_output1".into(),
+                        TestStruct::schema(),
+                        false,
+                        BTreeMap::new(),
+                    ))
+                    .unwrap();
+
+                    catalog.register_materialized_input_zset::<_, TestStruct>(
+                        input.clone(),
+                        hinput,
+                        &input_schema,
+                    );
+
+                    catalog
+                        .register_materialized_output_zset::<_, TestStruct>(input, &output_schema);
+
+                    Ok(catalog)
+                })
+                .unwrap();
+                (circuit, Box::new(catalog))
+            })
+        },
+        &config,
+        Box::new(move |e, _| {
+            err_sender
+                .send(format!("test_pg_input_query_error: {e}"))
+                .unwrap()
+        }),
+    )
+    .unwrap();
+
+    controller.start();
+
+    wait(|| !err_receiver.is_empty(), 10_000)
+        .expect("timeout: postgres input query error was not reported to the controller");
+
+    let error = err_receiver.recv().unwrap();
+    assert!(
+        error.contains("error executing query"),
+        "unexpected error: {error}"
+    );
+
+    controller.stop().unwrap();
+}
+
 /// Build an output circuit identical to [`PostgresTestStruct::test_circuit`]'s
 /// inner circuit, but without a baked-in error callback so that callers can
 /// supply their own.  Used by the non-unique-key test below.


### PR DESCRIPTION
## Problem

When the Postgres input connector's snapshot `query` fails at runtime (e.g. the table is dropped after startup, or the query becomes invalid), the pipeline stalls forever: the connector thread exits without reporting anything to the controller. The pipeline never transitions to `Failed`, no input error surfaces to the user, and there is nothing in the API status beyond a silently wedged pipeline waiting for input.

## Root Cause

In `PostgresInputEndpointInner::worker_task_inner` (`crates/adapters/src/integrated/postgres/input.rs`), initialization errors are communicated to `PostgresInputReader::new` through a 1-capacity `init_status` channel:

1. `connect_to_postgres()` succeeds → `Ok(())` is sent and consumed by `new()`, which then returns the reader.
2. The query executes only afterwards (once the pipeline reaches `Running`).
3. If the query fails, the error was sent on that same `init_status_sender` — which no longer has a receiver. The message lands in the full channel buffer and is dropped when the sender is dropped.

The worker task then returns, so `consumer.eoi()` is never called and no fatal error is reported: the endpoint just disappears.

## Fix

Report the query failure as a fatal input error via `InputConsumer::error(true, ...)`, the same mechanism every other integrated/transport connector uses for runtime failures (e.g. the Postgres CDC connector). The stale send on the already-consumed init channel is removed.

## Regression Test

`test_pg_input_query_error` (in `crates/adapters/src/integrated/postgres/test.rs`) starts a pipeline whose Postgres input connector queries a non-existent table and asserts that the controller's error callback receives an `"error executing query"` error.

- Before this fix it times out after 10 s: `timeout: postgres input query error was not reported to the controller`.
- After this fix it passes immediately.

## Verification

Linux container (Debian bookworm, rustc 1.93.1 — workspace MSRV), Postgres 17 via Docker:

```
$ cargo test -p dbsp_adapters --lib --no-default-features --features with-postgres-cdc \
    integrated::postgres::test::test_pg_input_query_error   # on pristine main + test only
test integrated::postgres::test::test_pg_input_query_error ... FAILED
finished in 10.20s   # timeout, no error reported

$ # after the fix:
test integrated::postgres::test::test_pg_input_query_error ... ok
test result: ok. 1 passed; finished in 0.15s
```

Broader suite (same feature set):

```
$ cargo test -p dbsp_adapters --lib --no-default-features --features with-postgres-cdc \
    integrated::postgres::test:: -- --skip cdc
test result: FAILED. 20 passed; 2 failed
```

The 2 failures are `test_pg_input_tls` / `test_pg_simple_tls`, which require a TLS-enabled Postgres via `POSTGRES_SSL_URL`; they fail identically without this change (no TLS endpoint in the test environment).

```
$ cargo fmt -p dbsp_adapters -- --check     # clean
$ cargo clippy -p dbsp_adapters --lib --tests --no-default-features --features with-postgres-cdc
```

Clippy reports 4 pre-existing `approximate value of PI/E` lints in `cdc_input.rs` tests, untouched by this PR.

## Scope

- `crates/adapters/src/integrated/postgres/input.rs`: replace the dead init-channel send with `self.consumer.error(true, anyhow!(e), None)` (+ explanatory comment).
- `crates/adapters/src/integrated/postgres/test.rs`: new regression test.
