### PR TITLE
Add new oauth_provider option to kafka input

### DIFF
--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -57,6 +57,15 @@ pub struct KafkaInputConfig {
     /// The AWS region to use while connecting to AWS Managed Streaming for Kafka (MSK).
     pub region: Option<String>,
 
+    /// Identity provider used to mint SASL/OAUTHBEARER tokens.
+    ///
+    /// Skipped when serializing so that a manager that knows this field can
+    /// still drive an older runtime that does not: such a runtime folds the
+    /// unknown key into the flattened `kafka_options: BTreeMap<String, String>`
+    /// and rejects a null value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth_provider: Option<KafkaOauthProvider>,
+
     /// The list of Kafka partitions to read from.
     ///
     /// Only the specified partitions will be consumed. If this field is not set,
@@ -191,6 +200,7 @@ impl KafkaInputConfig {
             poller_threads: None,
             start_from: KafkaStartFromConfig::default(),
             region: None,
+            oauth_provider: None,
             partitions: None,
             resume_earliest_if_data_expires: false,
             include_headers: None,
@@ -431,6 +441,30 @@ pub enum KafkaLogLevel {
     Debug,
 }
 
+/// Identity provider used to mint SASL/OAUTHBEARER tokens for the Kafka
+/// broker.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum KafkaOauthProvider {
+    /// Mint an AWS Signature V4 token to authenticate to AWS Managed
+    /// Streaming for Kafka (MSK).
+    ///
+    /// This is the default provider, for backward compatibility.  `region` must
+    /// be set, either directly or via the `AWS_REGION` environment variable.
+    #[default]
+    Aws,
+
+    /// Mint a Google OAuth2 access token to authenticate to GCP Managed
+    /// Service for Apache Kafka.
+    ///
+    /// The token is obtained from Application Default Credentials: a
+    /// service account key or user credentials file (as set up by, e.g.,
+    /// `gcloud auth application-default login`), or, failing that, the
+    /// GKE metadata server (which supplies credentials automatically when
+    /// Workload Identity is configured).
+    Gcp,
+}
+
 /// On startup, the endpoint waits to join the consumer group.
 /// This constant defines the default wait timeout.
 pub const fn default_group_join_timeout_secs() -> u32 {
@@ -645,6 +679,14 @@ pub struct KafkaOutputConfig {
 
     /// The AWS region to use while connecting to AWS Managed Streaming for Kafka (MSK).
     pub region: Option<String>,
+
+    /// Identity provider used to mint SASL/OAUTHBEARER tokens.  See
+    /// [`KafkaOauthProvider`].
+    ///
+    /// Skipped when serializing, for the same reason as in
+    /// [`KafkaInputConfig::oauth_provider`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth_provider: Option<KafkaOauthProvider>,
 }
 
 /// Fault tolerance configuration for Kafka output connector.
@@ -724,7 +766,7 @@ mod compat {
 
     use serde::Deserialize;
 
-    use crate::transport::kafka::{KafkaLogLevel, KafkaStartFromConfig};
+    use crate::transport::kafka::{KafkaLogLevel, KafkaOauthProvider, KafkaStartFromConfig};
 
     #[derive(Deserialize)]
     pub struct KafkaInputConfigCompat {
@@ -765,6 +807,9 @@ mod compat {
 
         /// The AWS region to use while connecting to AWS Managed Streaming for Kafka (MSK).
         region: Option<String>,
+
+        /// Identity provider used to mint SASL/OAUTHBEARER tokens.
+        oauth_provider: Option<KafkaOauthProvider>,
 
         /// The Kafka partitions to read from.
         partitions: Option<Vec<i32>>,
@@ -859,6 +904,7 @@ mod compat {
                 poller_threads: compat.poller_threads,
                 start_from,
                 region: compat.region,
+                oauth_provider: compat.oauth_provider,
                 partitions: compat.partitions,
                 resume_earliest_if_data_expires: compat.resume_earliest_if_data_expires,
                 include_headers: compat.include_headers,
@@ -870,6 +916,108 @@ mod compat {
                 header_filter: compat.header_filter,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod oauth_provider_tests {
+    use std::collections::BTreeMap;
+
+    use serde::Deserialize;
+
+    use super::{
+        KafkaInputConfig, KafkaOauthProvider, KafkaOutputConfig,
+        default_initialization_timeout_secs,
+    };
+
+    #[test]
+    fn oauth_provider_is_optional() {
+        let config: KafkaInputConfig =
+            serde_json::from_str(r#"{"topic": "t", "bootstrap.servers": "localhost:9092"}"#)
+                .unwrap();
+        assert_eq!(config.oauth_provider, None);
+    }
+
+    #[test]
+    fn oauth_provider_gcp_round_trips() {
+        let config: KafkaInputConfig = serde_json::from_str(
+            r#"{"topic": "t", "bootstrap.servers": "localhost:9092", "oauth_provider": "gcp"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.oauth_provider, Some(KafkaOauthProvider::Gcp));
+    }
+
+    /// A manager that knows `oauth_provider` must not send the key to a runtime
+    /// that does not: an older runtime folds the unknown key into its flattened
+    /// `kafka_options: BTreeMap<String, String>`, where a null value fails
+    /// deserialization with a non-actionable error.
+    #[test]
+    fn unset_oauth_provider_is_not_serialized() {
+        let config = KafkaInputConfig::default(
+            BTreeMap::from([("bootstrap.servers".into(), "localhost:9092".into())]),
+            "t",
+        );
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("oauth_provider"));
+
+        let output_config = KafkaOutputConfig {
+            kafka_options: BTreeMap::from([("bootstrap.servers".into(), "localhost:9092".into())]),
+            topic: "t".into(),
+            headers: Vec::new(),
+            log_level: None,
+            initialization_timeout_secs: default_initialization_timeout_secs(),
+            fault_tolerance: None,
+            kafka_service: None,
+            region: None,
+            oauth_provider: None,
+        };
+        let json = serde_json::to_value(&output_config).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("oauth_provider"));
+    }
+
+    #[test]
+    fn set_oauth_provider_is_serialized() {
+        let mut config = KafkaInputConfig::default(
+            BTreeMap::from([("bootstrap.servers".into(), "localhost:9092".into())]),
+            "t",
+        );
+        config.oauth_provider = Some(KafkaOauthProvider::Gcp);
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["oauth_provider"], serde_json::json!("gcp"));
+    }
+
+    /// Demonstrates the failure that `skip_serializing_if` avoids: an old
+    /// runtime, modeled here by a config whose unknown keys flatten into a
+    /// string map, cannot deserialize `"oauth_provider": null`.
+    #[test]
+    fn old_runtime_rejects_null_oauth_provider() {
+        #[derive(Deserialize)]
+        struct OldRuntimeConfig {
+            #[serde(flatten)]
+            #[allow(dead_code)]
+            kafka_options: BTreeMap<String, String>,
+            #[allow(dead_code)]
+            topic: String,
+        }
+
+        assert!(
+            serde_json::from_str::<OldRuntimeConfig>(r#"{"topic": "t", "oauth_provider": null}"#)
+                .is_err()
+        );
+        assert!(serde_json::from_str::<OldRuntimeConfig>(r#"{"topic": "t"}"#).is_ok());
+    }
+
+    #[test]
+    fn legacy_region_only_config_still_deserializes() {
+        // Configs written before `oauth_provider` existed set only `region`;
+        // they must still deserialize, with `oauth_provider` defaulting to
+        // `None` (interpreted as AWS by the adapter, for backward compatibility).
+        let config: KafkaInputConfig = serde_json::from_str(
+            r#"{"topic": "t", "bootstrap.servers": "localhost:9092", "region": "us-east-1"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.region, Some("us-east-1".to_string()));
+        assert_eq!(config.oauth_provider, None);
     }
 }
 

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -426,6 +426,7 @@ It contains the following fields:
         feldera_types::transport::kafka::KafkaHeader,
         feldera_types::transport::kafka::KafkaHeaderValue,
         feldera_types::transport::kafka::KafkaLogLevel,
+        feldera_types::transport::kafka::KafkaOauthProvider,
         feldera_types::transport::kafka::KafkaInputConfig,
         feldera_types::transport::kafka::KafkaOutputConfig,
         feldera_types::transport::kafka::KafkaOutputFtConfig,

--- a/openapi.json
+++ b/openapi.json
@@ -11580,6 +11580,14 @@
             ],
             "nullable": true
           },
+          "oauth_provider": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KafkaOauthProvider"
+              }
+            ],
+            "nullable": true
+          },
           "partitions": {
             "type": "array",
             "items": {
@@ -11635,6 +11643,14 @@
           "debug"
         ]
       },
+      "KafkaOauthProvider": {
+        "type": "string",
+        "description": "Identity provider used to mint SASL/OAUTHBEARER tokens for the Kafka\nbroker.",
+        "enum": [
+          "aws",
+          "gcp"
+        ]
+      },
       "KafkaOutputConfig": {
         "type": "object",
         "description": "Configuration for writing data to a Kafka topic with `OutputTransport`.",
@@ -11672,6 +11688,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/KafkaLogLevel"
+              }
+            ],
+            "nullable": true
+          },
+          "oauth_provider": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KafkaOauthProvider"
               }
             ],
             "nullable": true


### PR DESCRIPTION
Adding this field that is introduced in #6902 because testing with custom runtime version is failing due to dependency on pipeline manager having types updated

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
