### PR TITLE
[SQL] Desugar e = expr(now()) into e <= expr(now()) AND e >= expr(now())

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/DesugarNowEquality.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/DesugarNowEquality.java
@@ -1,0 +1,76 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerRewriteVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitCloneVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
+
+/** Rewrites 'e = expr(now())' in filter conditions into 'e >= expr(now()) AND e <= expr(now())'. */
+public class DesugarNowEquality extends CircuitCloneVisitor {
+    final Rewriter rewriter;
+
+    public DesugarNowEquality(DBSPCompiler compiler) {
+        super(compiler, false);
+        this.rewriter = new Rewriter(compiler);
+    }
+
+    static class Rewriter extends InnerRewriteVisitor {
+        final ContainsNow containsNow;
+
+        Rewriter(DBSPCompiler compiler) {
+            super(compiler, false);
+            this.containsNow = new ContainsNow(compiler, true);
+        }
+
+        boolean hasNow(DBSPExpression expression) {
+            this.containsNow.apply(expression);
+            return this.containsNow.found;
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPBinaryExpression expression) {
+            if (expression.opcode != DBSPOpcode.EQ
+                    || !expression.left.getType().is(DBSPTypeBaseType.class)
+                    || this.hasNow(expression.left) == this.hasNow(expression.right))
+                return super.preorder(expression);
+            this.push(expression);
+            DBSPExpression left = this.transform(expression.left);
+            DBSPExpression right = this.transform(expression.right);
+            this.pop(expression);
+            DBSPExpression ge = new DBSPBinaryExpression(
+                    expression.getNode(), expression.getType(), DBSPOpcode.GTE, left, right);
+            DBSPExpression le = new DBSPBinaryExpression(
+                    expression.getNode(), expression.getType(), DBSPOpcode.LTE,
+                    left.deepCopy(), right.deepCopy());
+            DBSPExpression result = new DBSPBinaryExpression(
+                    expression.getNode(), expression.getType(), DBSPOpcode.AND, ge, le);
+            this.map(expression, result);
+            return VisitDecision.STOP;
+        }
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator filter) {
+        DBSPClosureExpression function = filter.getClosureFunction();
+        if (!ContainsNow.find(this.compiler(), function)) {
+            super.postorder(filter);
+            return;
+        }
+        DBSPClosureExpression rewritten = this.rewriter
+                .apply(function.ensureTree(this.compiler()))
+                .to(DBSPClosureExpression.class);
+        if (rewritten == function) {
+            super.postorder(filter);
+            return;
+        }
+        DBSPFilterOperator replacement = new DBSPFilterOperator(
+                filter.getRelNode(), rewritten, this.mapped(filter.input()));
+        this.map(filter, replacement);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/FindComparisons.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/FindComparisons.java
@@ -42,7 +42,7 @@ class FindComparisons {
             add(DBSPOpcode.LTE);
             add(DBSPOpcode.GTE);
             add(DBSPOpcode.GT);
-            add(DBSPOpcode.EQ);
+            // EQ is desugared by DesugarNowEquality
         }};
 
         DBSPClosureExpression clo = closure.to(DBSPClosureExpression.class);
@@ -151,7 +151,7 @@ class FindComparisons {
         if (me == null || !me.mayBeMonotone())
             return false;
 
-        DBSPOpcode opcode = leftHasNow ? RewriteNow.inverse(binary.opcode) : binary.opcode;
+        DBSPOpcode opcode = leftHasNow ? RewriteNow.swappedOpcode(binary.opcode) : binary.opcode;
         TemporalFilter comp = new TemporalFilter(this.parameter, withoutNow, withNow, opcode);
         this.comparisons.add(comp);
         return true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ImplementNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ImplementNow.java
@@ -23,6 +23,7 @@ public class ImplementNow extends Passes {
         CircuitTransform mergeFilters = new MergeFilters(compiler);
         // Check if there is any operator containing NOW
         this.passes.add(cn);
+        this.passes.add(new Conditional(compiler, new DesugarNowEquality(compiler), cn::found));
         this.passes.add(new Conditional(compiler, new ReorderTemporalFilters(compiler), cn::found));
         // Break filters that contain NOW into simpler filters
         this.passes.add(new Conditional(compiler, breakFilters, cn::found));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ReorderTemporalFilters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ReorderTemporalFilters.java
@@ -121,16 +121,53 @@ public class ReorderTemporalFilters extends Passes {
     @Nullable
     public static DBSPExpression timestampExpression(DBSPCompiler compiler, DBSPFilterOperator filter,
                                                      DBSPParameter parameter, DBSPExpression conjunct) {
+        TemporalFilter only = temporalFilter(compiler, filter, parameter, conjunct);
+        if (only == null)
+            return null;
+        return only.noNow();
+    }
+
+    /** The temporal filter implementing `conjunct`, or null if no window can implement it.
+     * This returns a result only if the conjunct contains exactly 1 temporal filter.
+     *
+     * @param filter    Parent operator
+     * @param parameter Parameter of the closure containing the conjunct
+     * @param conjunct  A single conjunct of the filter's condition. */
+    @Nullable
+    static TemporalFilter temporalFilter(DBSPCompiler compiler, DBSPFilterOperator filter,
+                                         DBSPParameter parameter, DBSPExpression conjunct) {
         DBSPClosureExpression single = conjunct.deepCopy().wrapBoolIfNeeded().closure(parameter)
                 .ensureTree(compiler).to(DBSPClosureExpression.class);
         List<BooleanExpression> classified =
                 FindComparisons.decomposeIntoTemporalFilters(compiler, filter, single);
         if (classified.size() != 1)
             return null;
-        BooleanExpression only = classified.get(0);
-        if (!only.is(TemporalFilter.class))
-            return null;
-        return only.to(TemporalFilter.class).noNow();
+        return classified.get(0).as(TemporalFilter.class);
+    }
+
+    /**
+     * Among `conjuncts`, the fingerprints of the timestamp groups whose window has no lower bound.
+     *
+     * @param filter    Parent operator
+     * @param parameter Parameter of the closure containing the conjuncts.
+     * @param conjuncts Top-level conjuncts of the filter's condition. */
+    static Set<String> unboundedLowerGroups(
+            DBSPCompiler compiler, DBSPFilterOperator filter, DBSPParameter parameter,
+            List<DBSPExpression> conjuncts) {
+        Map<String, Boolean> groupHasLowerBound = new LinkedHashMap<>();
+        for (DBSPExpression conjunct : conjuncts) {
+            String fingerprint = timestampFingerprint(compiler, filter, parameter, conjunct);
+            if (fingerprint == null)
+                continue;
+            TemporalFilter temporal = temporalFilter(compiler, filter, parameter, conjunct);
+            boolean lower = temporal != null && RewriteNow.isGreater(temporal.opcode());
+            groupHasLowerBound.merge(fingerprint, lower, Boolean::logicalOr);
+        }
+        Set<String> result = new LinkedHashSet<>();
+        for (Map.Entry<String, Boolean> group : groupHasLowerBound.entrySet())
+            if (!group.getValue())
+                result.add(group.getKey());
+        return result;
     }
 
     /**
@@ -464,20 +501,32 @@ public class ReorderTemporalFilters extends Passes {
             DBSPParameter parameter = condition.parameters[0];
             Predicate<DBSPExpression> temporal = conjunct ->
                     timestampExpression(this.compiler(), filter, parameter, conjunct) != null;
+            Function<DBSPExpression, String> fingerprint = conjunct ->
+                    timestampFingerprint(this.compiler(), filter, parameter, conjunct);
             Integer chosen = this.chosenConjunct.get(filter);
+            List<DBSPExpression> conjuncts = topLevelConjuncts(condition);
 
             // If the input will NOT be shared, move all temporal filters last.
             // If the input will be shared, hoist only the conjuncts on the shared timestamp.
             DBSPExpression result;
+            String sharedFingerprint = null;
             if (chosen == null) {
                 result = reorder(condition.body, FilterOrderPolicy.LAST, temporal);
             } else {
+                DBSPExpression sharedConjunct = conjuncts.get(chosen);
+                sharedFingerprint = fingerprint.apply(sharedConjunct);
                 result = reorderAroundSharedTimestamp(
-                        condition.body,
-                        conjunct -> timestampFingerprint(
-                                this.compiler(), filter, parameter, conjunct),
-                        topLevelConjuncts(condition).get(chosen));
+                        condition.body, fingerprint, sharedConjunct);
             }
+
+            // Among the windows, one without a lower bound runs last.
+            // A shared window stays first: its integral is shared, not narrowed.
+            Set<String> unboundedLower = unboundedLowerGroups(
+                    this.compiler(), filter, parameter, conjuncts);
+            unboundedLower.remove(sharedFingerprint);
+            if (!unboundedLower.isEmpty())
+                result = reorder(result, FilterOrderPolicy.LAST,
+                        conjunct -> unboundedLower.contains(fingerprint.apply(conjunct)));
             if (result == condition.body) {
                 super.postorder(filter);
                 return;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
@@ -250,12 +250,13 @@ public class RewriteNow extends CircuitCloneVisitor {
         return opcode == DBSPOpcode.GTE || opcode == DBSPOpcode.GT;
     }
 
-    static DBSPOpcode inverse(DBSPOpcode opcode) {
+    /** The opcode comparing the swapped operands: 'a OP b' iff 'b swappedOpcode(OP) a'. */
+    static DBSPOpcode swappedOpcode(DBSPOpcode opcode) {
         return switch (opcode) {
-            case LT -> DBSPOpcode.GTE;
-            case GTE -> DBSPOpcode.LT;
-            case LTE -> DBSPOpcode.GT;
-            case GT -> DBSPOpcode.LTE;
+            case LT -> DBSPOpcode.GT;
+            case GTE -> DBSPOpcode.LTE;
+            case LTE -> DBSPOpcode.GTE;
+            case GT -> DBSPOpcode.LT;
             case EQ -> DBSPOpcode.EQ;
             default -> throw new InternalCompilerError(opcode.toString());
         };

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -1813,24 +1813,171 @@ public class IncrementalRegressionTests extends SqlIoTest {
 
     @Test
     public void windowErrorTest() {
-        this.getCCS("""
+        var ccs = this.getCCS("""
                 CREATE TABLE T (
                     ts TIMESTAMP NOT NULL LATENESS INTERVAL 24 HOURS,
                     p VARCHAR,
                     m DECIMAL(38, 7)
                 );
-                
-                CREATE VIEW V0 AS
+
+                CREATE LOCAL VIEW V0 AS
                 SELECT *
                 FROM T
                 WHERE ts >= NOW() - INTERVAL 1 MINUTE
                 AND p IS NOT NULL
                 AND m > 0;
-                
+
                 CREATE VIEW V1 AS
                 SELECT COUNT(*)
                 FROM V0
                 GROUP BY p;""");
+        ccs.step("""
+                INSERT INTO now VALUES('2024-01-01 12:00:00');
+                INSERT INTO T VALUES('2024-01-01 11:59:30', 'a', 1.0);
+                INSERT INTO T VALUES('2024-01-01 11:59:40', 'a', 2.0);
+                -- outside the 1 minute window
+                INSERT INTO T VALUES('2024-01-01 11:58:00', 'a', 3.0);
+                -- p is NULL
+                INSERT INTO T VALUES('2024-01-01 11:59:50', NULL, 4.0);
+                -- m is not positive
+                INSERT INTO T VALUES('2024-01-01 11:59:50', 'b', 0.0);
+                INSERT INTO T VALUES('2024-01-01 11:59:55', 'b', 5.0);""",
+                """
+                 count | weight
+                ----------------
+                 2     | 1
+                 1     | 1""");
+        // Time advances past the window, so all rows expire.
+        ccs.step("INSERT INTO now VALUES('2024-01-01 12:01:00');",
+                """
+                 count | weight
+                ----------------
+                 2     | -1
+                 1     | -1""");
+        // A row that arrives after the window has moved, but is still inside it.
+        // The second row precedes the window yet is within the 24 hour lateness bound.
+        ccs.step("""
+                INSERT INTO T VALUES('2024-01-01 12:00:50', 'a', 1.0);
+                INSERT INTO T VALUES('2024-01-01 06:00:00', 'a', 1.0);""",
+                """
+                 count | weight
+                ----------------
+                 1     | 1""");
+        ccs.step("REMOVE FROM T VALUES('2024-01-01 12:00:50', 'a', 1.0);",
+                """
+                 count | weight
+                ----------------
+                 1     | -1""");
+    }
+
+    @Test
+    public void windowErrorNullTimestampTest() {
+        // Same as windowErrorTest, but 'ts' is nullable and some rows have a NULL timestamp.
+        var ccs = this.getCCS("""
+                CREATE TABLE T (
+                    ts TIMESTAMP LATENESS INTERVAL 24 HOURS,
+                    p VARCHAR,
+                    m DECIMAL(38, 7)
+                );
+
+                CREATE LOCAL VIEW V0 AS
+                SELECT *
+                FROM T
+                WHERE ts >= NOW() - INTERVAL 1 MINUTE
+                AND p IS NOT NULL
+                AND m > 0;
+
+                CREATE VIEW V1 AS
+                SELECT COUNT(*)
+                FROM V0
+                GROUP BY p;""");
+        // NULL >= NOW() - INTERVAL 1 MINUTE is NULL, so rows with a NULL timestamp never
+        // reach V1, no matter what the other columns hold.
+        ccs.step("""
+                INSERT INTO now VALUES('2024-01-01 12:00:00');
+                INSERT INTO T VALUES('2024-01-01 11:59:30', 'a', 1.0);
+                INSERT INTO T VALUES(NULL, 'a', 2.0);
+                INSERT INTO T VALUES(NULL, NULL, 3.0);
+                INSERT INTO T VALUES(NULL, 'b', 0.0);
+                INSERT INTO T VALUES('2024-01-01 11:59:55', 'b', 5.0);""",
+                """
+                 count | weight
+                ----------------
+                 1     | 2""");
+        // Group 'a' grows to two rows; the new NULL timestamp changes nothing.
+        ccs.step("""
+                INSERT INTO T VALUES('2024-01-01 11:59:59', 'a', 7.0);
+                INSERT INTO T VALUES(NULL, 'c', 9.0);""",
+                """
+                 count | weight
+                ----------------
+                 1     | -1
+                 2     | 1""");
+        // Deleting a NULL timestamp row changes nothing either.
+        ccs.step("REMOVE FROM T VALUES(NULL, 'a', 2.0);",
+                """
+                 count | weight
+                ----------------""");
+        // The window slides to 11:59:45, so 'a's oldest row expires.
+        ccs.step("INSERT INTO now VALUES('2024-01-01 12:00:45');",
+                """
+                 count | weight
+                ----------------
+                 2     | -1
+                 1     | 1""");
+        // The window slides past every timestamp, so both groups disappear.
+        ccs.step("INSERT INTO now VALUES('2024-01-01 12:01:00');",
+                """
+                 count | weight
+                ----------------
+                 1     | -2""");
+    }
+
+    @Test
+    public void windowNullGroupKeyTest() {
+        // A nullable column narrowed by IS NOT NULL, combined with a NOW() filter, and then
+        // used both as a GROUP BY key and as an output column.  The key must stay nullable:
+        // narrowing it would make the aggregate unwrap a NULL key and panic the worker.
+        var ccs = this.getCCS("""
+                CREATE TABLE t (
+                    ts  TIMESTAMP NOT NULL LATENESS INTERVAL 24 HOURS,
+                    k   VARCHAR,
+                    v   DECIMAL(38,7)
+                );
+
+                CREATE LOCAL VIEW filtered AS
+                SELECT * FROM t
+                WHERE ts >= NOW() - INTERVAL 1 MINUTE
+                  AND k IS NOT NULL;
+
+                CREATE VIEW agg AS
+                SELECT k, COUNT(*) FROM filtered GROUP BY k;""").withStringTrim();
+        ccs.step("""
+                INSERT INTO now VALUES('2024-01-01 12:00:00');
+                INSERT INTO t VALUES('2024-01-01 11:59:30', 'a', 1.0);
+                INSERT INTO t VALUES('2024-01-01 11:59:40', NULL, 2.0);""",
+                """
+                 k | count | weight
+                --------------------
+                 a | 1     | 1""");
+        // Retracting a NULL key, as a CDC before-image does.
+        ccs.step("REMOVE FROM t VALUES('2024-01-01 11:59:40', NULL, 2.0);",
+                """
+                 k | count | weight
+                --------------------""");
+        // The window slides past the surviving row.
+        ccs.step("INSERT INTO now VALUES('2024-01-01 12:01:00');",
+                """
+                 k | count | weight
+                --------------------
+                 a | 1     | -1""");
+        // Only NULL keys, so no group ever forms.
+        ccs.step("""
+                INSERT INTO t VALUES('2024-01-01 12:00:50', NULL, 3.0);
+                INSERT INTO t VALUES('2024-01-01 12:00:55', NULL, 4.0);""",
+                """
+                 k | count | weight
+                --------------------""");
     }
 
     // Check that the maximum width in a circuit (except inputs) is less than the specified one.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -2416,6 +2416,286 @@ public class StreamingTests extends StreamingTestBase {
     }
 
     @Test
+    public void nowEquality() {
+        // `ts = NOW()` is a documented temporal filter (docs/sql/datetime.md, "inequality
+        // or equality comparisons"), but it compiles into the window [MIN, now()), so the
+        // view holds every row strictly before now() and drops the row that equals it.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts = now()""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // Only id 2 has ts = 12:00.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 12:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 13:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1""");
+        // The clock moves to 13:00: id 2 leaves the view and id 3 enters.
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | -1
+                 3  | 1""");
+    }
+
+    @Test
+    public void nowEqualityReversed() {
+        // now() on the left
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE now() = ts AND id > 1""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // id 1 also has ts = 12:00, but is excluded by id > 1.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 12:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 12:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 13:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1""");
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | -1
+                 3  | 1""");
+    }
+
+    @Test
+    public void nowEqualityOffset() {
+        // Equality against a monotone expression of now()
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts = NOW() - INTERVAL 1 HOUR""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // At 12:00 the window is [11:00, 11:00], so only id 2 qualifies.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 10:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 12:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1""");
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | -1
+                 3  | 1""");
+    }
+
+    @Test
+    public void nowEqualityNonMonotone() {
+        // MINUTE(now()) is not monotone
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts INT
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts = MINUTE(NOW())""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // No window
+        ccs.visit(new Inspector(ccs.compiler, 0, 1, 0));
+        ccs.step("""
+                 INSERT INTO t VALUES (1, 0);
+                 INSERT INTO t VALUES (2, 30);
+                 INSERT INTO now VALUES ('2024-01-01 12:30:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1""");
+    }
+
+    @Test
+    public void separatedBoundsMakeOneWindow() {
+        // The two bounds are separated by a non-temporal conjunct.  Reordering moves the
+        // temporal conjuncts into an adjacent block and filter merging reunites them, so a
+        // single window carries both bounds.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP,
+                  a INT
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts >= now() - INTERVAL 1 HOUR AND a > 2 AND ts <= now()""";
+        CompilerCircuit cc = this.getCC(sql);
+        cc.visit(new Inspector(cc.compiler, 1, 1, 1));
+    }
+
+    @Test
+    public void unboundedLowerWindowLast() {
+        // ts2's window has no lower bound, so it should be applied after ts's bounded window
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP,
+                  ts2 TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts2 <= now() AND ts >= now() - INTERVAL 1 HOUR""";
+        CompilerCircuit cc = this.getCC(sql);
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            final List<DBSPWindowOperator> windows = new ArrayList<>();
+
+            @Override
+            public void postorder(DBSPWindowOperator operator) {
+                this.windows.add(operator);
+            }
+
+            @Override
+            public void endVisit() {
+                // Postorder is topological, so the bounded window must be visited first.
+                Assert.assertEquals(2, this.windows.size());
+                Assert.assertFalse(this.windows.get(0).lowerUnbounded);
+                Assert.assertTrue(this.windows.get(1).lowerUnbounded);
+            }
+        });
+    }
+
+    @Test
+    public void unboundedLowerWindowLastData() {
+        // Same query; the reordering must not change the results.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP,
+                  ts2 TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts2 <= now() AND ts >= now() - INTERVAL 1 HOUR""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:30:00', '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 10:00:00', '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 11:30:00', '2024-01-01 13:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | 1""");
+        // At 13:00 id 1 ages out of the bounded window; id 3's ts is now too old as well.
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | -1""");
+    }
+
+    @Test
+    public void nowReversedComparisonBoundary() {
+        // now() on the left of a plain inequality.  Swapping the operands must preserve
+        // inclusivity: the boundary row (ts equal to now()) is included by <=.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE now() <= ts""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 12:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 13:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1
+                 3  | 1""");
+        // At 13:00 the boundary moves: id 2 leaves, id 3 sits on the new boundary and stays.
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | -1""");
+    }
+
+    @Test
+    public void nowInequality() {
+        // ts <> now() is not a temporal filter
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts <> NOW()""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // No window
+        ccs.visit(new Inspector(ccs.compiler, 0, 1, 0));
+        // At 12:00 every row except id 2 qualifies.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 12:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 13:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | 1
+                 3  | 1""");
+        // At 13:00 id 2 enters and id 3 leaves.
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 13:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1
+                 3  | -1""");
+    }
+
+    @Test
     public void issue2003() {
         String sql = """
                 CREATE TABLE event(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ShareWindowIntegralsTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ShareWindowIntegralsTests.java
@@ -61,6 +61,26 @@ public class ShareWindowIntegralsTests extends SqlIoTest {
     }
 
     @Test
+    public void equalityHoistedToShare() {
+        // ts = NOW() decomposes into its two bounds
+        WindowInputStats windows = WindowInputStats.windows(this.getCC(PREAMBLE + """
+                CREATE VIEW V1 AS SELECT b FROM T WHERE a > 2 AND ts = NOW();
+                CREATE VIEW V2 AS SELECT c FROM T WHERE a < 9 AND ts = NOW() - INTERVAL 1 HOURS;"""));
+        Assert.assertEquals(2, windows.leftInputIds.size());
+        Assert.assertEquals(1, windows.distinctInputCount());
+    }
+
+    @Test
+    public void equalitySharesWithInequality() {
+        // The same, mixing an equality with a one-sided window on the same timestamp.
+        WindowInputStats windows = WindowInputStats.windows(this.getCC(PREAMBLE + """
+                CREATE VIEW V1 AS SELECT b FROM T WHERE a > 2 AND ts = NOW();
+                CREATE VIEW V2 AS SELECT c FROM T WHERE a < 9 AND ts >= NOW() - INTERVAL 2 HOURS;"""));
+        Assert.assertEquals(2, windows.leftInputIds.size());
+        Assert.assertEquals(1, windows.distinctInputCount());
+    }
+
+    @Test
     public void resultsSurviveSharing() {
         // Checks that non-temporal filters are not lost
         String sql = PREAMBLE + """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TemporalFilterTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TemporalFilterTests.java
@@ -162,7 +162,7 @@ public class TemporalFilterTests extends SqlIoTest {
         this.test(sql, Linq.list("TemporalFilter[" + param +
                         ", noNow=((*p0).3), withNow=(now() - (ShortInterval(MINUTES))300000000), opcode=>]",
                 "TemporalFilter[" + param +
-                        ", noNow=(2020-01-01 00:00:00 +? ((ShortInterval?(DAYS))((*p0).0))), withNow=now(), opcode=>=]"));
+                        ", noNow=(2020-01-01 00:00:00 +? ((ShortInterval?(DAYS))((*p0).0))), withNow=now(), opcode=>]"));
 
         sql = "CREATE VIEW V AS SELECT * FROM T WHERE EXTRACT(DAY FROM ts) > EXTRACT(DAY FROM NOW());";
         this.test(sql, Linq.list("NonTemporalFilter[expression=(extract_day_TimestampN(((*p0).3)) ?> extract_day_Timestamp(now()))]"));


### PR DESCRIPTION
Fixes #6963 

The desugaring reduces the handling of equalities to the well-tested handling of inequalities.

This PR fixes actually one more bug related to temporal windows, discovered by the many tests added (see swappedOpcode).
It also slightly improves the window order when some windows are unbounded below.

## Checklist

- [x] Unit tests added/updated
