### PR TITLE
[SQL] Fix incorrect bound computation when intersecting two windows

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/MergeFilters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/MergeFilters.java
@@ -29,13 +29,17 @@ public class MergeFilters extends CircuitCloneVisitor {
                 source.getClosureFunction().ensureTree(this.compiler).to(DBSPClosureExpression.class));
         var f = FindComparisons.decomposeIntoTemporalFilters(this.compiler, filter,
                 filter.getClosureFunction().ensureTree(this.compiler).to(DBSPClosureExpression.class));
-        if (s.size() != 1 || f.size() != 1)
+        if (s.isEmpty() || f.size() != 1)
             return false;
-        BooleanExpression se = s.get(0);
         BooleanExpression fe = f.get(0);
-        if (!se.is(TemporalFilter.class) || !fe.is(TemporalFilter.class))
+        if (!fe.is(TemporalFilter.class))
             return false;
-        return se.compatible(fe);
+        // The source may hold several such bounds.
+        for (BooleanExpression se : s) {
+            if (!se.is(TemporalFilter.class) || !se.compatible(fe))
+                return false;
+        }
+        return true;
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilter.java
@@ -37,9 +37,10 @@ record TemporalFilter(DBSPParameter parameter, DBSPExpression noNow,
         EquivalenceContext context = new EquivalenceContext();
         context.leftDeclaration.newContext();
         context.rightDeclaration.newContext();
+        // The two filters may come from different closures, so their parameters may differ.
         context.leftDeclaration.substitute(this.parameter.name, this.parameter);
-        context.rightDeclaration.substitute(this.parameter.name, this.parameter);
-        context.leftToRight.put(this.parameter, this.parameter);
+        context.rightDeclaration.substitute(o.parameter.name, o.parameter);
+        context.leftToRight.put(this.parameter, o.parameter);
         return context.equivalent(this.noNow, o.noNow);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBound.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBound.java
@@ -8,7 +8,9 @@ import org.dbsp.util.Utilities;
 record WindowBound(boolean inclusive, DBSPExpression expression) {
     WindowBound combine(WindowBound with, boolean lower) {
         Utilities.enforce(this.inclusive == with.inclusive);
-        DBSPOpcode opcode = lower ? DBSPOpcode.MIN : DBSPOpcode.MAX;
+        // Two bounds on the same side fold into the tighter one: the larger lower bound,
+        // the smaller upper bound.
+        DBSPOpcode opcode = lower ? DBSPOpcode.MAX : DBSPOpcode.MIN;
         DBSPExpression expression = ExpressionCompiler.makeBinaryExpression(this.expression.getNode(),
                 this.expression.getType(), opcode, this.expression, with.expression);
         return new WindowBound(this.inclusive, expression);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -2295,6 +2295,127 @@ public class StreamingTests extends StreamingTestBase {
     }
 
     @Test
+    public void twoLowerNowBounds() {
+        // The window's lower bound must be the tighter of the two.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts >= now() - INTERVAL 10 MINUTES
+                  AND ts >= now() - INTERVAL 100 MINUTES""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // At now() = 12:00 the bounds are ts >= 11:50 and ts >= 10:20; only id 1 satisfies both.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:55:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 10:30:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | 1""");
+    }
+
+    @Test
+    public void twoUpperNowBounds() {
+        // The mirror image: two upper bounds fold into the tighter one, the minimum.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts <= now() - INTERVAL 10 MINUTES
+                  AND ts <= now() - INTERVAL 100 MINUTES""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // At now() = 12:00 the bounds are ts <= 11:50 and ts <= 10:20; only id 2 satisfies both.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 10:00:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 2  | 1""");
+    }
+
+    @Test
+    public void twoLowerAndTwoUpperNowBounds() {
+        // Both sides fold: the window is [now() - 50 MINUTES, now() - 20 MINUTES], the
+        // tighter bound on each side.  The bounds are interleaved.
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts >= now() - INTERVAL 100 MINUTES
+                  AND ts <= now() - INTERVAL 10 MINUTES
+                  AND ts >= now() - INTERVAL 50 MINUTES
+                  AND ts <= now() - INTERVAL 20 MINUTES""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        ccs.visit(new Inspector(ccs.compiler, 1, 1, 1));
+        // At 12:00 the window is [11:10, 11:40].  Ids 2 and 3 are inside the looser
+        // bounds only; ids 4 and 5 should be selected.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, '2024-01-01 11:30:00');
+                 INSERT INTO t VALUES (2, '2024-01-01 11:00:00');
+                 INSERT INTO t VALUES (3, '2024-01-01 11:45:00');
+                 INSERT INTO t VALUES (4, '2024-01-01 11:10:00');
+                 INSERT INTO t VALUES (5, '2024-01-01 11:40:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | 1
+                 4  | 1
+                 5  | 1""");
+        // At 12:30 the window is [11:40, 12:10]: ids 1 and 4 leave, id 3 enters, id 5 stays.
+        ccs.step("""
+                 INSERT INTO now VALUES ('2024-01-01 12:30:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | -1
+                 4  | -1
+                 3  | 1""");
+    }
+
+    @Test
+    public void nowBoundsBroughtTogetherByReordering() {
+        String sql = """
+                CREATE TABLE t (
+                  id INT NOT NULL PRIMARY KEY,
+                  x  INT,
+                  ts TIMESTAMP
+                );
+                CREATE VIEW v AS
+                SELECT id FROM t
+                WHERE ts >= now() - INTERVAL 10 MINUTES
+                  AND x > 5
+                  AND ts >= now() - INTERVAL 100 MINUTES""";
+        CompilerCircuitStream ccs = this.getCCS(sql);
+        // At now() = 12:00 the bounds are ts >= 11:50 and ts >= 10:20; only id 1 satisfies both.
+        ccs.step("""
+                 INSERT INTO t VALUES (1, 6, '2024-01-01 11:55:00');
+                 INSERT INTO t VALUES (2, 6, '2024-01-01 10:30:00');
+                 INSERT INTO now VALUES ('2024-01-01 12:00:00');
+                 """,
+                """
+                 id | weight
+                -------------
+                 1  | 1""");
+    }
+
+    @Test
     public void issue2003() {
         String sql = """
                 CREATE TABLE event(


### PR DESCRIPTION
Fixes #6962

When you intersect two windows you have to choose the bounds for the smaller one.
The PR allows for multiple windows to be intersected; previously only two were considered.

## Checklist

- [x] Unit tests added/updated
