### PR TITLE
[SQL] Compile SET statements before all other statements

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -290,6 +290,26 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         this.messages.setErrorContext(range);
     }
 
+    /** Point error messages at {@code node}, unless the compiler synthesized it. */
+    void setErrorContext(ParsedStatement node) {
+        this.setErrorContext(node.visible()
+                ? new SourcePositionRange(node.statement().getParserPosition())
+                : SourcePositionRange.INVALID);
+    }
+
+    /** Compile the SET statements in {@code parsed}, ignoring all other statements. */
+    void compileSqlSettings(List<ParsedStatement> parsed) {
+        for (ParsedStatement node : parsed) {
+            if (node.statement().getKind() != SqlKind.SET_OPTION)
+                continue;
+            this.setErrorContext(node);
+            RelStatement set = this.sqlToRelCompiler.compile(node, this.sources);
+            if (set != null)
+                this.relToDBSPCompiler.compile(set);
+        }
+        this.setErrorContext(SourcePositionRange.INVALID);
+    }
+
     static final String WARNINGS_ARE_ERRORS = "FELDERA_WARNINGS_ARE_ERRORS";
 
     boolean warningsAreErrors() {
@@ -457,8 +477,8 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         System.err.println(this.messages);
     }
 
+    /** Parse using Calcite. */
     List<ParsedStatement> runParser() {
-        // Parse using Calcite
         List<ParsedStatement> parsed = new ArrayList<>();
         for (SqlStatements stat : this.toCompile) {
             try {
@@ -467,9 +487,9 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                         this.sqlToRelCompiler.emptyStatement();
                         continue;
                     }
-                    parsed.addAll(this.sqlToRelCompiler.parseStatements(stat.statement, stat.visible));
+                    parsed.addAll(this.sqlToRelCompiler.parseStatements(stat.statement, stat.visible, false));
                 } else {
-                    SqlNode node = this.sqlToRelCompiler.parse(stat.statement, stat.visible);
+                    SqlNode node = this.sqlToRelCompiler.parse(stat.statement, stat.visible, false);
                     parsed.add(new ParsedStatement(node, stat.visible));
                 }
                 if (this.hasErrors())
@@ -629,12 +649,20 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         if (this.hasErrors())
             return null;
 
-        if (this.options.ioOptions.anonymize || this.options.ioOptions.format) {
-            this.emitSql(parsed);
-            return null;
-        }
-
         try {
+            // SET statements apply to the whole program irrespective of their position,
+            // so they are compiled before the other statements are even validated:
+            // validation emits warnings which the settings may silence or turn into errors.
+            this.compileSqlSettings(parsed);
+            parsed = Linq.map(parsed, this.sqlToRelCompiler::postParsingProcess);
+            if (this.hasErrors())
+                return null;
+
+            if (this.options.ioOptions.anonymize || this.options.ioOptions.format) {
+                this.emitSql(parsed);
+                return null;
+            }
+
             // across all tables
             List<ForeignKey> foreignKeys = new ArrayList<>();
             // All UDFs which have no bodies in SQL
@@ -716,17 +744,11 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                 this.sqlToRelCompiler.addOperatorTable(newAggregates);
             }
 
-            // Compile all statements which do not define functions or types
+            // Compile all statements which do not define functions, types, or settings
             for (ParsedStatement node : parsed) {
-                if (node.visible()) {
-                    this.setErrorContext(
-                            new SourcePositionRange(node.statement()
-                                    .getParserPosition()));
-                } else {
-                    this.setErrorContext(SourcePositionRange.INVALID);
-                }
+                this.setErrorContext(node);
                 SqlKind kind = node.statement().getKind();
-                if (kind == SqlKind.CREATE_FUNCTION || kind == SqlKind.CREATE_TYPE)
+                if (kind == SqlKind.CREATE_FUNCTION || kind == SqlKind.CREATE_TYPE || kind == SqlKind.SET_OPTION)
                     continue;
                 if (node.statement() instanceof SqlLateness)
                     continue;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -806,11 +806,12 @@ public class SqlToRelCompiler implements IWritesLogs {
     /** Given a SQL statement returns a SqlNode - a calcite AST
      * representation of the query.
      * @param sql  SQL query to compile
-     * @param saveLines  True if the lines "take space": are accounted as part of the input program */
-    public SqlNode parse(String sql, boolean saveLines) throws SqlParseException {
+     * @param saveLines  True if the lines "take space": are accounted as part of the input program
+     * @param postprocess  If false, skip {@link #postParsingProcess(ParsedStatement)} */
+    public SqlNode parse(String sql, boolean saveLines, boolean postprocess) throws SqlParseException {
         SqlParser sqlParser = this.createSqlParser(sql, saveLines);
         SqlNode result = sqlParser.parseStmt();
-        return this.postParsingProcess(result, saveLines);
+        return postprocess ? this.postParsingProcess(result, saveLines) : result;
     }
 
     /** Remove calls to unary plus */
@@ -869,26 +870,32 @@ public class SqlToRelCompiler implements IWritesLogs {
     }
 
     public SqlNode parse(String sql) throws SqlParseException {
-        SqlNode result = this.parse(sql, true);
-        return this.postParsingProcess(result, true);
+        return this.parse(sql, true, true);
     }
 
     /** Given a list of statements separated by semicolons, parse all of them.
-     * @param saveLines True if the lines are from the user program; false if they are internally generated. */
-    public List<ParsedStatement> parseStatements(String statements, boolean saveLines) throws SqlParseException {
+     * @param saveLines True if the lines are from the user program; false if they are internally generated.
+     * @param postprocess If false, skip {@link #postParsingProcess(ParsedStatement)}. */
+    public List<ParsedStatement> parseStatements(String statements, boolean saveLines, boolean postprocess)
+            throws SqlParseException {
         SqlParser sqlParser = this.createSqlParser(statements, saveLines);
         List<ParsedStatement> result = new ArrayList<>();
         SqlNodeList sqlNodes = sqlParser.parseStmtList();
         for (SqlNode node: sqlNodes) {
-            SqlNode sqlNode = this.postParsingProcess(node, saveLines);
-            ParsedStatement stat = new ParsedStatement(sqlNode, saveLines);
-            result.add(stat);
+            ParsedStatement stat = new ParsedStatement(node, saveLines);
+            result.add(postprocess ? this.postParsingProcess(stat) : stat);
         }
         return result;
     }
 
+    /** Validate a freshly parsed statement, and apply some rewrites. */
+    public ParsedStatement postParsingProcess(ParsedStatement statement) {
+        SqlNode node = this.postParsingProcess(statement.statement(), statement.visible());
+        return new ParsedStatement(node, statement.visible());
+    }
+
     public List<ParsedStatement> parseStatements(String statements) throws SqlParseException {
-        return this.parseStatements(statements, true);
+        return this.parseStatements(statements, true, true);
     }
 
     RelNode optimize(RelNode rel, boolean visible, RelBuilder relBuilder) {
@@ -1165,7 +1172,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                     .append(sql)
                     .newline();
             SqlToRelCompiler clone = new SqlToRelCompiler(this);
-            List<ParsedStatement> list = clone.parseStatements(sql, false);
+            List<ParsedStatement> list = clone.parseStatements(sql, false, true);
             RelStatement lastStatement = null;
             for (ParsedStatement node : list) {
                 lastStatement = clone.compile(node, sources);
@@ -1224,7 +1231,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                     .append(sql)
                     .newline();
             SqlToRelCompiler clone = new SqlToRelCompiler(this);
-            List<ParsedStatement> list = clone.parseStatements(sql, false);
+            List<ParsedStatement> list = clone.parseStatements(sql, false, true);
             RelStatement lastStatement = null;
             for (ParsedStatement node : list) {
                 lastStatement = clone.compile(node, sources);
@@ -1600,7 +1607,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                     .append(sql)
                     .newline();
             SqlToRelCompiler clone = new SqlToRelCompiler(this);
-            List<ParsedStatement> list = clone.parseStatements(sql, true);
+            List<ParsedStatement> list = clone.parseStatements(sql, true, true);
             RelStatement statement = null;
             for (ParsedStatement node : list) {
                 statement = clone.compile(node, sources);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -2330,6 +2330,17 @@ public class MetadataTests extends BaseSQLTests {
     }
 
     @Test
+    public void testSetAfterOtherStatements() {
+        // SET applies to the whole program: the warning emitted while validating
+        // the table is an error even though the SET statement follows the table.
+        this.statementsFailingInCompilation("""
+            CREATE TABLE T(x DECIMAL);
+            CREATE VIEW V AS SELECT x FROM T;
+            SET FELDERA_WARNINGS_ARE_ERRORS = ON;""",
+                "DECIMAL precision and scale unspecified");
+    }
+
+    @Test
     public void issue5896() throws IOException, SQLException {
         String sql = "CREATE VIEW v AS select cot(0)";
         File file = createInputScript(sql);


### PR DESCRIPTION
Fixes #6969

## Checklist

- [x] Unit tests added/updated

This bug was flagged by a review for #6940 

Have to compile these statements even before we perform parsing post-processing on other statements, so we had to push their processing earlier in the pipeline.