### PR TITLE
[SQL] Do not crash in code generation for CONNECTOR_METADATA when visiting an expression DAG

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -1115,6 +1115,12 @@ public class ToRustInnerVisitor extends InnerVisitor {
         }
 
         @Override
+        protected void set(IDBSPInnerNode node, IDBSPInnerNode translation) {
+            if (this.maybeGet(node) == null)
+                super.set(node, translation);
+        }
+
+        @Override
         public void postorder(DBSPHandleErrorExpression expression) {
             // Strip source positions from these initializers for now
             DBSPExpression source = this.getE(expression.source);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -78,6 +78,16 @@ public class CatalogTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue6957() {
+        var ccs = this.getCCS("""
+                CREATE TABLE T(
+                  W VARCHAR NOT NULL DEFAULT COALESCE(CAST(CONNECTOR_METADATA()['topic'] AS VARCHAR), '')
+                );""");
+        String rust = ccs.getRustSources();
+        Assert.assertTrue(rust.contains("connector_metadata: &Option<Variant>"));
+    }
+
+    @Test
     public void issue4019a() {
         this.getCCS("""
                 CREATE TABLE row_tbl(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -1125,8 +1125,11 @@ public class MetadataTests extends BaseSQLTests {
     @Test
     public void testDefaultConnectorMetadata() throws IOException, InterruptedException, SQLException {
         String sql = """
-                CREATE TABLE T (KAFKA_TOPIC VARCHAR DEFAULT CAST(CONNECTOR_METADATA()['kafka_topic'] AS VARCHAR));
-                CREATE VIEW V AS SELECT KAFKA_TOPIC FROM T;""";
+                CREATE TABLE T (
+                    KAFKA_TOPIC VARCHAR DEFAULT CAST(CONNECTOR_METADATA()['kafka_topic'] AS VARCHAR),
+                    TOPIC_OR_EMPTY VARCHAR NOT NULL DEFAULT COALESCE(CAST(CONNECTOR_METADATA()['topic'] AS VARCHAR), '')
+                );
+                CREATE VIEW V AS SELECT KAFKA_TOPIC, TOPIC_OR_EMPTY FROM T;""";
         File file = createInputScript(sql);
         CompilerMessages messages = CompilerMain.execute("-q", "-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         messages.print();


### PR DESCRIPTION
Fixes #6957

## Checklist

- [x] Unit tests added/updated
