### PR TITLE
[fda] Use PipelineFieldSelector::Status where appropriate

### DIFF
--- a/crates/fda/src/debug.rs
+++ b/crates/fda/src/debug.rs
@@ -374,6 +374,7 @@ async fn unbundle_support_bundle(
                 let res = client
                     .get_pipeline()
                     .pipeline_name(pipeline_name.clone())
+                    .selector(PipelineFieldSelector::Status)
                     .send()
                     .await;
                 if res.is_ok() {

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -1156,6 +1156,7 @@ async fn wait_for_status_one_of(
         let pc = client
             .get_pipeline()
             .pipeline_name(name.clone())
+            .selector(PipelineFieldSelector::Status)
             .send()
             .await
             .map_err(handle_errors_fatal(
@@ -1210,6 +1211,7 @@ async fn wait_for_storage_status(
         let pc = client
             .get_pipeline()
             .pipeline_name(name.clone())
+            .selector(PipelineFieldSelector::Status)
             .send()
             .await
             .map_err(handle_errors_fatal(
@@ -1313,6 +1315,7 @@ async fn get_pipeline_tags(client: &Client, name: &str) -> Vec<String> {
     client
         .get_pipeline()
         .pipeline_name(name)
+        .selector(PipelineFieldSelector::Status)
         .send()
         .await
         .map_err(handle_errors_fatal(
@@ -3423,6 +3426,7 @@ async fn program(format: OutputFormat, action: ProgramAction, client: Client) {
             let response = client
                 .get_pipeline()
                 .pipeline_name(name)
+                .selector(PipelineFieldSelector::Status)
                 .send()
                 .await
                 .map_err(handle_errors_fatal(

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -2126,6 +2126,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
             let response = client
                 .get_pipeline()
                 .pipeline_name(name)
+                .selector(PipelineFieldSelector::Status)
                 .send()
                 .await
                 .map_err(handle_errors_fatal(
@@ -3511,6 +3512,7 @@ async fn program(format: OutputFormat, action: ProgramAction, client: Client) {
             let response = client
                 .get_pipeline()
                 .pipeline_name(name)
+                .selector(PipelineFieldSelector::Status)
                 .send()
                 .await
                 .map_err(handle_errors_fatal(


### PR DESCRIPTION
Reduce pressure on the backend and make fda faster by only selecting pipeline status info whenever it's all that's needed to complete an operation.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
