### PR TITLE
[fda] Replace --auth-token-command with --oidc-token-file

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -17,17 +17,15 @@ fn pipeline_names(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
     let Ok(cli) = Cli::try_parse_from(["fda", "pipelines"]) else {
         return completions;
     };
-    // Never resolve `--auth-token-command` for completion: it would execute the
-    // user's token command (e.g. `gcloud auth print-access-token`) on every Tab
-    // press. Static API keys are cheap, so pass those through; token-command
-    // users simply get no pipeline-name completion (a failed/anonymous list
-    // returns nothing rather than panicking).
+    // Both credentials are cheap to resolve on every Tab press: a static key
+    // and a file read. A failed or anonymous list returns nothing rather
+    // than panicking.
     let Ok(client) = make_client(crate::ClientOpts {
         host: cli.host,
         insecure: cli.insecure,
         tls_cert: cli.tls_cert,
         auth: cli.auth,
-        auth_token_command: None,
+        oidc_token_file: cli.oidc_token_file,
         timeout_secs: cli.timeout,
         tenant: cli.tenant,
         retries: cli.retries,
@@ -125,32 +123,31 @@ pub struct Cli {
         help_heading = "Global Options"
     )]
     pub auth: Option<String>,
-    /// Shell command that prints a bearer token on stdout.
+    /// File holding a bearer token, typically an OIDC identity token.
     ///
-    /// Run once per `fda` invocation; the trimmed stdout becomes the
+    /// Read once per `fda` invocation; the trimmed contents become the
     /// `Authorization: Bearer <token>` header for every request that
-    /// invocation makes. Use for OIDC workload-identity flows with short-lived
-    /// tokens: because the command runs on every invocation, a rotated token is
-    /// picked up automatically. Conflicts with `--auth`.
+    /// invocation makes. Use for workload-identity flows with short-lived
+    /// tokens: whatever keeps the file current (a Kubernetes projected
+    /// volume, `feldera/oidc-auth-action` in GitHub Actions) rotates the
+    /// credential without `fda` holding a copy. Conflicts with `--auth`.
     ///
     /// Examples:
     ///
     /// Kubernetes projected service-account token:
-    /// `--auth-token-command 'cat /var/run/secrets/kubernetes.io/serviceaccount/token'`
+    /// `--oidc-token-file /var/run/secrets/kubernetes.io/serviceaccount/token`
     ///
     /// AWS EKS, IAM roles for service accounts:
-    /// `--auth-token-command 'cat $AWS_WEB_IDENTITY_TOKEN_FILE'`
-    ///
-    /// Google Cloud, where an ID token is a JWT and an access token is not:
-    /// `--auth-token-command 'gcloud auth print-identity-token'`
+    /// `--oidc-token-file "$AWS_WEB_IDENTITY_TOKEN_FILE"`
     #[arg(
         long,
-        env = "FELDERA_AUTH_TOKEN_COMMAND",
+        env = "FELDERA_OIDC_TOKEN_FILE",
+        value_hint = ValueHint::FilePath,
         global = true,
         help_heading = "Global Options",
         conflicts_with = "auth"
     )]
-    pub auth_token_command: Option<String>,
+    pub oidc_token_file: Option<PathBuf>,
     /// The client timeout for requests in seconds.
     ///
     /// In almost all cases you should not need to set this value, but it can

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -88,8 +88,8 @@ pub(crate) struct ClientOpts {
     pub tls_cert: Option<std::path::PathBuf>,
     /// Static API key.
     pub auth: Option<String>,
-    /// Shell command that prints a bearer token; overrides `auth`.
-    pub auth_token_command: Option<String>,
+    /// File holding a bearer token; overrides `auth`.
+    pub oidc_token_file: Option<std::path::PathBuf>,
     pub timeout_secs: Option<u64>,
     /// Sent as the `Feldera-Tenant` header on every request.
     pub tenant: Option<String>,
@@ -104,7 +104,7 @@ impl ClientOpts {
             insecure: cli.insecure,
             tls_cert: cli.tls_cert.clone(),
             auth: cli.auth.clone(),
-            auth_token_command: cli.auth_token_command.clone(),
+            oidc_token_file: cli.oidc_token_file.clone(),
             timeout_secs: cli.timeout,
             tenant: cli.tenant.clone(),
             retries: cli.retries,
@@ -119,7 +119,7 @@ pub(crate) fn make_client(opts: ClientOpts) -> Result<Client, Box<dyn std::error
         insecure,
         tls_cert,
         auth,
-        auth_token_command,
+        oidc_token_file,
         timeout_secs,
         tenant,
         retries,
@@ -161,8 +161,8 @@ pub(crate) fn make_client(opts: ClientOpts) -> Result<Client, Box<dyn std::error
     }
 
     // The tenant selector is not a credential and travels on any scheme;
-    // bearer credentials go over https alone. Only execute the auth-token
-    // command if the credentials will actually be sent.
+    // bearer credentials go over https alone. Only read the token file if
+    // the credentials will actually be sent.
     let mut headers = HeaderMap::new();
     if let Some(tenant) = &tenant {
         headers.insert(
@@ -172,12 +172,12 @@ pub(crate) fn make_client(opts: ClientOpts) -> Result<Client, Box<dyn std::error
         );
     }
     if host.starts_with("https://") {
-        let resolved_auth = match auth_token_command {
-            Some(cmd) => Some(run_auth_token_command(&cmd)?),
+        let resolved_auth = match oidc_token_file {
+            Some(path) => Some(read_oidc_token_file(&path)?),
             None => auth,
         };
         headers.extend(make_auth_headers(&resolved_auth)?);
-    } else if host.starts_with("http://") && (auth.is_some() || auth_token_command.is_some()) {
+    } else if host.starts_with("http://") && (auth.is_some() || oidc_token_file.is_some()) {
         warn!(
             "The provided credentials are not added to the request because {host} does not use `https`."
         );
@@ -192,35 +192,29 @@ pub(crate) fn make_client(opts: ClientOpts) -> Result<Client, Box<dyn std::error
     Ok(Client::new_with_client(host.as_str(), client, retry_policy))
 }
 
-/// Execute the user-supplied auth-token command through the platform's shell and
-/// return trimmed stdout. Errors if the command fails or prints nothing.
-fn run_auth_token_command(cmd: &str) -> Result<String, Box<dyn std::error::Error>> {
-    // Windows has no `sh`; `cmd /C` is what runs a command line there.
-    let (shell, shell_flag) = if cfg!(windows) {
-        ("cmd", "/C")
-    } else {
-        ("sh", "-c")
-    };
-    let output = std::process::Command::new(shell)
-        .arg(shell_flag)
-        .arg(cmd)
-        .output()
-        .map_err(|e| format!("failed to spawn auth-token-command `{cmd}`: {e}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "auth-token-command `{cmd}` exited with {}: {}",
-            output.status,
-            stderr.trim()
-        )
-        .into());
-    }
-    let token = String::from_utf8(output.stdout)
-        .map_err(|e| format!("auth-token-command `{cmd}` produced non-UTF-8 output: {e}"))?
+/// Read the bearer token in `path`, trimmed. Errors if the file is unreadable,
+/// holds nothing but whitespace, or holds a character that cannot travel in a
+/// header value, which is what a second line is.
+fn read_oidc_token_file(path: &std::path::Path) -> Result<String, Box<dyn std::error::Error>> {
+    let token = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read OIDC token file `{}`: {e}", path.display()))?
         .trim()
         .to_string();
     if token.is_empty() {
-        return Err(format!("auth-token-command `{cmd}` produced empty output").into());
+        return Err(format!("OIDC token file `{}` is empty", path.display()).into());
+    }
+    // The header rejects the same set; checking here names the file and the
+    // spot instead of a bare "failed to parse header value".
+    if let Some(offset) = token.find(|c: char| c.is_ascii_control() && c != '\t') {
+        let found = match token.as_bytes()[offset] {
+            b'\n' | b'\r' => "a line break",
+            _ => "a control character",
+        };
+        return Err(format!(
+            "OIDC token file `{}` does not hold a single-line token: found {found} at byte {offset}",
+            path.display()
+        )
+        .into());
     }
     Ok(token)
 }
@@ -3906,12 +3900,17 @@ async fn cluster(format: OutputFormat, action: ClusterAction, client: Client) {
     }
 }
 
-fn main() {
-    // reqwest is built without a rustls provider, so the process default decides
-    // which one it uses.
+/// reqwest is built without a rustls provider, so the process default decides
+/// which one it uses.
+fn install_crypto_provider() {
+    // Err means a provider is already installed, which is the state wanted.
     let _ = rustls::crypto::CryptoProvider::install_default(
         rustls::crypto::aws_lc_rs::default_provider(),
     );
+}
+
+fn main() {
+    install_crypto_provider();
     init_logging("warn");
 
     tokio::runtime::Builder::new_multi_thread()
@@ -3928,6 +3927,16 @@ fn main() {
             // we remove it here.
             if cli.host.ends_with("/") {
                 cli.host = cli.host.trim_end_matches('/').to_string();
+            }
+            // Releases before 0.339.0 read this variable; a shell that still
+            // exports it would otherwise send no credential and see a bare 401.
+            if cli.auth.is_none()
+                && cli.oidc_token_file.is_none()
+                && std::env::var_os("FELDERA_AUTH_TOKEN_COMMAND").is_some()
+            {
+                warn!(
+                    "FELDERA_AUTH_TOKEN_COMMAND is no longer read. Point FELDERA_OIDC_TOKEN_FILE at a file holding the token, or pass the command's output as --auth \"$(...)\"."
+                );
             }
 
             let client_opts = ClientOpts::from_cli(&cli);
@@ -3978,7 +3987,10 @@ fn init_logging(default_level: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClientOpts, format_program_errors, make_client, run_auth_token_command};
+    use super::{
+        ClientOpts, format_program_errors, install_crypto_provider, make_client,
+        read_oidc_token_file,
+    };
     use feldera_rest_api::types::{
         ProgramError, RustCompilationInfo, SqlCompilationInfo, SqlCompilerMessage,
     };
@@ -4007,7 +4019,7 @@ aC3Oy4iVrYGOq9v6uP9iblE=\n\
             insecure: false,
             tls_cert: Some(tls_cert),
             auth: None,
-            auth_token_command: None,
+            oidc_token_file: None,
             timeout_secs: None,
             tenant: None,
             retries: 0,
@@ -4069,27 +4081,83 @@ aC3Oy4iVrYGOq9v6uP9iblE=\n\
         }
     }
 
-    #[cfg(unix)]
     #[test]
-    fn auth_token_command_trims_stdout() {
-        let token = run_auth_token_command("printf '  tok-123\\n'").expect("command succeeds");
+    fn oidc_token_file_trims_contents() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.write_all(b"  tok-123\n").expect("write temp file");
+        let token = read_oidc_token_file(file.path()).expect("readable file");
         assert_eq!(token, "tok-123");
     }
 
-    #[cfg(unix)]
     #[test]
-    fn auth_token_command_empty_output_is_error() {
-        let err = run_auth_token_command("true").expect_err("empty output must error");
-        assert!(err.to_string().contains("empty output"), "{err}");
+    fn oidc_token_file_whitespace_only_is_error() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.write_all(b"\n\t \n").expect("write temp file");
+        let err = read_oidc_token_file(file.path()).expect_err("blank file must error");
+        assert!(err.to_string().contains("is empty"), "{err}");
     }
 
-    #[cfg(unix)]
     #[test]
-    fn auth_token_command_nonzero_exit_is_error() {
-        let err = run_auth_token_command("echo boom >&2; exit 3").expect_err("failure must error");
+    fn oidc_token_file_missing_is_error() {
+        let missing = std::path::Path::new("/definitely/not/a/real/path-fda-token");
+        let err = read_oidc_token_file(missing).expect_err("missing file must error");
         let msg = err.to_string();
-        assert!(msg.contains("exited with"), "{msg}");
-        assert!(msg.contains("boom"), "stderr should be surfaced: {msg}");
+        assert!(msg.contains("failed to read OIDC token file"), "{msg}");
+        assert!(
+            msg.contains("path-fda-token"),
+            "path should be named: {msg}"
+        );
+    }
+
+    #[test]
+    fn oidc_token_file_second_line_is_error() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.write_all(b"tok-1\ntok-2\n").expect("write temp file");
+        let err = read_oidc_token_file(file.path()).expect_err("two lines must error");
+        let msg = err.to_string();
+        assert!(msg.contains("does not hold a single-line token"), "{msg}");
+        assert!(msg.contains("a line break at byte 5"), "{msg}");
+    }
+
+    /// Options for a client whose only credential is a token file.
+    fn token_file_opts(host: &str, oidc_token_file: std::path::PathBuf) -> ClientOpts {
+        ClientOpts {
+            host: host.to_string(),
+            insecure: false,
+            tls_cert: None,
+            auth: None,
+            oidc_token_file: Some(oidc_token_file),
+            timeout_secs: None,
+            tenant: None,
+            retries: 0,
+        }
+    }
+
+    #[test]
+    fn make_client_reads_token_file_for_https_only() {
+        install_crypto_provider();
+        let missing = std::path::PathBuf::from("/definitely/not/a/real/path-fda-token");
+        // Plain http sends no credential, so the file is never opened.
+        make_client(token_file_opts("http://example.invalid", missing.clone()))
+            .expect("http host must not read the token file");
+        let err = make_client(token_file_opts("https://example.invalid", missing))
+            .expect_err("https host must fail on a missing token file");
+        assert!(
+            err.to_string().contains("failed to read OIDC token file"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn make_client_rejects_blank_token_file_for_https() {
+        install_crypto_provider();
+        let file = tempfile::NamedTempFile::new().expect("create temp file");
+        let err = make_client(token_file_opts(
+            "https://example.invalid",
+            file.path().to_path_buf(),
+        ))
+        .expect_err("blank token file must fail rather than send nothing");
+        assert!(err.to_string().contains("is empty"), "{err}");
     }
 
     #[test]

--- a/crates/fda/tests/cli_auth.rs
+++ b/crates/fda/tests/cli_auth.rs
@@ -1,0 +1,87 @@
+//! Credential selection at the command line: one credential at a time, and a
+//! note for shells that still export the variable read before 0.339.0.
+
+use std::process::{Command, Output};
+
+/// `fda pipelines` against a port nothing listens on, with the credential
+/// variables cleared so a developer shell cannot leak into a case.
+fn fda() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_fda"));
+    for var in [
+        "FELDERA_HOST",
+        "FELDERA_API_KEY",
+        "FELDERA_OIDC_TOKEN_FILE",
+        "FELDERA_AUTH_TOKEN_COMMAND",
+    ] {
+        command.env_remove(var);
+    }
+    command.args([
+        "--host",
+        "https://127.0.0.1:1",
+        "--retries",
+        "0",
+        "--timeout",
+        "5",
+        "pipelines",
+    ]);
+    command
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_conflict(output: Output) {
+    assert_eq!(output.status.code(), Some(2), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains("cannot be used with"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn auth_and_token_file_conflict_as_flags() {
+    let output = fda()
+        .args(["--auth", "apikey:x", "--oidc-token-file", "/t"])
+        .output()
+        .expect("run fda");
+    assert_conflict(output);
+}
+
+#[test]
+fn auth_and_token_file_conflict_from_env() {
+    let output = fda()
+        .env("FELDERA_API_KEY", "apikey:x")
+        .env("FELDERA_OIDC_TOKEN_FILE", "/t")
+        .output()
+        .expect("run fda");
+    assert_conflict(output);
+}
+
+#[test]
+fn removed_token_command_variable_is_called_out() {
+    let output = fda()
+        .env("FELDERA_AUTH_TOKEN_COMMAND", "true")
+        .output()
+        .expect("run fda");
+    assert!(
+        stderr(&output).contains("FELDERA_AUTH_TOKEN_COMMAND is no longer read"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn removed_token_command_variable_is_silent_next_to_a_credential() {
+    let output = fda()
+        .env("FELDERA_AUTH_TOKEN_COMMAND", "true")
+        .env("FELDERA_API_KEY", "apikey:x")
+        .output()
+        .expect("run fda");
+    assert!(
+        !stderr(&output).contains("FELDERA_AUTH_TOKEN_COMMAND"),
+        "{}",
+        stderr(&output)
+    );
+}

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,26 +14,32 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
-        - Breaking change (SQL): `=`, `<>` and `!=` are no longer allowed between
-          `ROW` values, so some programs that used to compile are now rejected.
-          The previous implementation of these operations did not follow the
-          standard SQL semantics, which requires that `ROW(NULL) = ROW(NULL)` evaluates
-          to `NULL` (in our implementation it would evaluate to `TRUE`).
+        - Output connectors can be paused, like input connectors: a paused
+          output connector discards the output of its view instead of writing it
+          to its sink, which lets a pipeline run on while a sink is unavailable.
+          Set `paused` in the connector configuration to create it paused, and
+          use `POST /v0/pipelines/{pipeline}/views/{view}/connectors/{connector}/{start,pause}`
+          or `fda connector <pipeline> <view> <connector> start|pause` at
+          runtime. The connector status reports a `paused` field, the web console
+          shows it, and the paused state survives a restart. Output produced
+          while a connector is paused is not replayed when it is started. See
+          [connector orchestration](/connectors/orchestration#output-connectors).
 
-          Instead of these operators, use `IS NOT DISTINCT FROM` (or its
-          shorthand `<=>`) and `IS DISTINCT FROM` instead.  A user-defined type declared with
-          `CREATE TYPE ... AS (...)` is a `ROW` type, so the restriction covers its
-          values too.
+        - Python: `Pipeline.pause_input_connector` and
+          `Pipeline.start_input_connector` (and their `FelderaClient`
+          counterparts) name the kind of connector they act on, matching the new
+          `pause_output_connector` and `start_output_connector`.
+          `pause_connector` and `resume_connector` still work but are
+          deprecated and now raise a `DeprecationWarning`.
 
-          The restriction also covers the forms that ask for `ROW` equality without
-          writing `=`: a join condition, `NATURAL JOIN`, `USING`, `IN`,
-          `CASE value WHEN`, `NULLIF`, and a comparison between two row constructors
-          such as `(a, b) = (c, d)`.  See
-          [comparing `ROW` values](https://docs.feldera.com/sql/comparisons#comparing-row-values)
-          for the accepted rewrite of each form.
+        - Breaking change (fda): `--auth-token-command` and
+          `FELDERA_AUTH_TOKEN_COMMAND` are removed. `--oidc-token-file` and
+          `FELDERA_OIDC_TOKEN_FILE` take the path of a file holding a bearer
+          token, which `fda` reads once per invocation; `feldera/oidc-auth-action`
+          v3.0.1 and later export that variable. For a command that prints a
+          token, pass its output as `--auth "$(...)"`.
 
-        - Joining on `ROW` values is now supported, using
-          `ON left.r IS NOT DISTINCT FROM right.r` (#3398).
+        ## v0.337.0
 
         - Breaking change (SQL): comparing a `UUID` with a character or binary value
           now converts that value to a `UUID`, the same direction as comparing a
@@ -60,30 +66,28 @@ import TabItem from '@theme/TabItem';
           the pipeline restarts.  If it does, the operation itself must be restarted
           (the most common use of the Python API does this automatically).
 
-        - Output connectors can be paused, like input connectors: a paused
-          output connector discards the output of its view instead of writing it
-          to its sink, which lets a pipeline run on while a sink is unavailable.
-          Set `paused` in the connector configuration to create it paused, and
-          use `POST /v0/pipelines/{pipeline}/views/{view}/connectors/{connector}/{start,pause}`
-          or `fda connector <pipeline> <view> <connector> start|pause` at
-          runtime. The connector status reports a `paused` field, the web console
-          shows it, and the paused state survives a restart. Output produced
-          while a connector is paused is not replayed when it is started. See
-          [connector orchestration](/connectors/orchestration#output-connectors).
+        ## v0.333.0
 
-        - Python: `Pipeline.pause_input_connector` and
-          `Pipeline.start_input_connector` (and their `FelderaClient`
-          counterparts) name the kind of connector they act on, matching the new
-          `pause_output_connector` and `start_output_connector`.
-          `pause_connector` and `resume_connector` still work but are
-          deprecated and now raise a `DeprecationWarning`.
+        - Breaking change (SQL): `=`, `<>` and `!=` are no longer allowed between
+          `ROW` values, so some programs that used to compile are now rejected.
+          The previous implementation of these operations did not follow the
+          standard SQL semantics, which requires that `ROW(NULL) = ROW(NULL)` evaluates
+          to `NULL` (in our implementation it would evaluate to `TRUE`).
 
-        - Breaking change (fda): `--auth-token-command` and
-          `FELDERA_AUTH_TOKEN_COMMAND` are removed. `--oidc-token-file` and
-          `FELDERA_OIDC_TOKEN_FILE` take the path of a file holding a bearer
-          token, which `fda` reads once per invocation; `feldera/oidc-auth-action`
-          v3.0.1 and later export that variable. For a command that prints a
-          token, pass its output as `--auth "$(...)"`.
+          Instead of these operators, use `IS NOT DISTINCT FROM` (or its
+          shorthand `<=>`) and `IS DISTINCT FROM` instead.  A user-defined type declared with
+          `CREATE TYPE ... AS (...)` is a `ROW` type, so the restriction covers its
+          values too.
+
+          The restriction also covers the forms that ask for `ROW` equality without
+          writing `=`: a join condition, `NATURAL JOIN`, `USING`, `IN`,
+          `CASE value WHEN`, `NULLIF`, and a comparison between two row constructors
+          such as `(a, b) = (c, d)`.  See
+          [comparing `ROW` values](https://docs.feldera.com/sql/comparisons#comparing-row-values)
+          for the accepted rewrite of each form.
+
+        - Joining on `ROW` values is now supported, using
+          `ON left.r IS NOT DISTINCT FROM right.r` (#3398).
 
         ## v0.330.0
 

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -78,6 +78,13 @@ import TabItem from '@theme/TabItem';
           `pause_connector` and `resume_connector` still work but are
           deprecated and now raise a `DeprecationWarning`.
 
+        - Breaking change (fda): `--auth-token-command` and
+          `FELDERA_AUTH_TOKEN_COMMAND` are removed. `--oidc-token-file` and
+          `FELDERA_OIDC_TOKEN_FILE` take the path of a file holding a bearer
+          token, which `fda` reads once per invocation; `feldera/oidc-auth-action`
+          v3.0.1 and later export that variable. For a command that prints a
+          token, pass its output as `--auth "$(...)"`.
+
         ## v0.330.0
 
         - Feldera's membership table now authorizes every login: a user acts

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -210,6 +210,24 @@ right. Go to **Manage API Keys** and click **Generate new key**.
 
 :::
 
+### Authenticating with a short-lived token
+
+Workloads can use short lived bearer tokens from a file, typically an OIDC identity token
+that the platform rotates: a Kubernetes service-account token, or the one
+[`feldera/oidc-auth-action`](https://github.com/feldera/oidc-auth-action)
+keeps current for a GitHub Actions job. The environment variable `FELDERA_OIDC_TOKEN_FILE` and the command line
+argument `--oidc-token-file` both take the path to that file.
+
+```bash
+fda --host https://feldera.internal --oidc-token-file /var/run/secrets/kubernetes.io/serviceaccount/token pipelines
+# or via environment:
+export FELDERA_OIDC_TOKEN_FILE="$AWS_WEB_IDENTITY_TOKEN_FILE"
+fda --host https://feldera.internal pipelines
+```
+
+The instance accepts such a token only where an OIDC trust matches its issuer, subject and audience; see
+`fda oidc-trust create --help`. `--oidc-token-file` and `--auth` are mutually exclusive.
+
 ### Connecting to HTTPS with a custom CA
 
 When the Feldera manager is served over HTTPS with a certificate issued by a private CA, or with a self-signed

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -4,7 +4,6 @@ import logging
 import os
 import platform
 import re
-import subprocess
 import time
 import json
 import unittest
@@ -48,9 +47,9 @@ def _get_effective_api_key():
 def feldera_bearer_token() -> Optional[str]:
     """The bearer token to send with a request issued now.
 
-    A configured OIDC login flow wins, then whatever CI exports: a token file
-    that feldera/oidc-auth-action keeps current for the life of the job, or a
-    command that prints one. Then the static API key, and None when nothing is
+    A configured OIDC login flow wins, then the token file named by
+    FELDERA_OIDC_TOKEN_FILE, which feldera/oidc-auth-action keeps current for
+    the life of a CI job. Then the static API key, and None when nothing is
     configured, which is how a local instance without authentication runs.
 
     Callers that build their own requests resolve this per request: a CI token
@@ -62,16 +61,6 @@ def feldera_bearer_token() -> Optional[str]:
     token_file = os.environ.get("FELDERA_OIDC_TOKEN_FILE")
     if token_file:
         return Path(token_file).read_text().strip()
-    token_command = os.environ.get("FELDERA_AUTH_TOKEN_COMMAND")
-    if token_command:
-        return subprocess.run(
-            token_command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        ).stdout.strip()
     return API_KEY
 
 
@@ -111,7 +100,6 @@ class _LazyClient:
                 api_key=(
                     feldera_bearer_token
                     if os.environ.get("FELDERA_OIDC_TOKEN_FILE")
-                    or os.environ.get("FELDERA_AUTH_TOKEN_COMMAND")
                     else feldera_bearer_token()
                 ),
             )

--- a/python/tests/platform/TEST_AUTH.md
+++ b/python/tests/platform/TEST_AUTH.md
@@ -136,13 +136,14 @@ uv run pytest tests/platform -v
 The platform tests automatically select authentication in this order:
 
 1. **OIDC Token** (if all OIDC environment variables are set)
-2. **GitHub Actions ID token** (if `ACTIONS_ID_TOKEN_REQUEST_URL` is set)
+2. **Token file** (if `FELDERA_OIDC_TOKEN_FILE` names a file; in CI,
+   `feldera/oidc-auth-action` exports it and keeps the file current)
 3. **API Key** (if `FELDERA_API_KEY` is set)
 4. **No Authentication** (fallback for development)
 
 `feldera.testutils.feldera_bearer_token()` resolves this order. Call it per
-request rather than caching what it returns: an ID token expires well inside a
-long suite, and the function re-mints one shortly before its expiry.
+request rather than caching what it returns: a CI token expires well inside a
+long suite, and each call reads whatever the file holds now.
 
 ## CI/CD Configuration
 


### PR DESCRIPTION
`FELDERA_AUTH_TOKEN_COMMAND` ran arbitrary shell from an environment variable on every `fda` invocation. `FELDERA_OIDC_TOKEN_FILE` / `--oidc-token-file` names a file instead: `fda` reads and trims it once per invocation and sends the contents as the bearer token, so whatever keeps the file current (a Kubernetes projected volume, `feldera/oidc-auth-action`) rotates the credential without `fda` holding a copy. Same rules as before: conflicts with `--auth`, sent over HTTPS only.

The Python test helper (`feldera.testutils.feldera_bearer_token`) drops the command path too; it already preferred the file.

Rollout: `oidc-auth-action` v3.0.1, which CI pins, exports both variables, so nothing here depends on a new action release. The action drops its `FELDERA_AUTH_TOKEN_COMMAND` export in v4.0.0, to be tagged once a release ships this `fda`; the same change to CI scripts in feldera-qa and infrastructure is prepared separately.

### Describe Manual Test Plan

- `cargo test -p fda`: three unit tests on the file reader (trims, blank file errors, missing file errors with the path in the message).
- Debug binary end to end: `--help` lists the flag; `FELDERA_OIDC_TOKEN_FILE` wires through; missing and empty files fail with named errors; an `http://` host warns and sends nothing; `--auth` plus the file is rejected by clap whether given as flags or env vars.
- Local TLS stub confirmed the trimmed file contents arrive as `Authorization: Bearer <token>`.
- `feldera.testutils.feldera_bearer_token()` returns the file contents when the variable is set and the API key otherwise.
- clippy `-D warnings`, fmt, ruff, pre-commit hooks clean.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [x] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

`--auth-token-command` and `FELDERA_AUTH_TOKEN_COMMAND` are removed. Use `--oidc-token-file` / `FELDERA_OIDC_TOKEN_FILE` with a path to a file holding the token; for a command that prints one, pass its output directly: `fda --auth "$(gcloud auth print-identity-token)" ...`.
