### PR TITLE
Optimize profile collection to use compression and streaming at all steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,6 +4221,7 @@ dependencies = [
  "feldera-storage",
  "feldera-types",
  "feldera_rust_decimal",
+ "flate2",
  "form_urlencoded",
  "futures",
  "futures-timer",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -182,7 +182,7 @@ dbsp_nexmark = { workspace = true, features = [], optional = true }
 enum-map = { workspace = true }
 google-cloud-pubsub = { workspace = true, optional = true }
 google-cloud-gax = { workspace = true, optional = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 home = { workspace = true }
 datafusion = { workspace = true }
@@ -255,6 +255,7 @@ vergen-gitcl = { workspace = true }
 
 [dev-dependencies]
 actix-test = { workspace = true }
+flate2 = { workspace = true }
 rcgen = { workspace = true }
 bstr = { workspace = true, features = ["serde1"] }
 feldera-macros = { workspace = true }

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -35,6 +35,7 @@ use actix_web::{
     get,
     http::StatusCode,
     http::header,
+    middleware::Compress,
     post, rt,
     web::{self, Data as WebData, Payload, Query},
 };
@@ -46,6 +47,7 @@ use clap::Parser;
 use colored::Colorize;
 use dbsp::circuit::Layout;
 use dbsp::circuit::checkpointer::Checkpointer;
+use dbsp::profile::{DbspProfile, ProfileJsonWriter};
 use dbsp::{DBSPHandle, circuit::CircuitConfig};
 use dbsp::{RootCircuit, Runtime};
 use dyn_clone::DynClone;
@@ -1422,7 +1424,15 @@ where
         .service(metadata)
         .service(heap_profile)
         .service(dump_profile)
-        .service(dump_json_profile)
+        // Compressed when the client's `Accept-Encoding` admits it. `Compress` is
+        // only used for profiles; the other live streams (`/egress`,
+        // `/ingress`, `/time_series_stream`) are uncompressed, because gzip
+        // frame buffering stalls their readers (see PR #5626).
+        .service(
+            web::resource("/dump_json_profile")
+                .wrap(Compress::default())
+                .route(web::get().to(dump_json_profile)),
+        )
         .service(samply_profile)
         .service(get_samply_profile)
         .service(lir)
@@ -2057,21 +2067,166 @@ async fn heap_profile() -> impl Responder {
     }
 }
 
+// Profile downloads.
+//
+// `/dump_json_profile` delivers a circuit profile.
+// The profile size is O(workers x operators).
+// The data flow is:
+//
+//   pipeline process:  [1] workers --> [2] circuit thread --> [3] blocking pool --> [4] actix worker
+//   coordinator:       --> [5] (multihost only) combines the hosts' profiles
+//   manager service:   --> [6] streaming proxy, or support-data collector
+//   client:            --> [7] REST client, or the profiler UI reading a support bundle
+//
+// [1] Profiler (`dbsp::profile::Profiler`)
+//     - runs on: every worker thread of the pipeline process
+//     - what it does: walks the circuit and collects each operator's metadata
+//     - produces: a `WorkerProfile`, i.e., `Map<operatorId, OperatorMeta>`
+//
+// [2] Circuit thread (`controller.rs`, `run_commands`)
+//     - runs on: the controller's circuit thread, between circuit steps
+//     - what it does: `DBSPHandle::retrieve_profile` assembles worker replies
+//     - produces: a `DbspProfile` (every worker's `WorkerProfile` plus the
+//       circuit `Graph`)
+//
+// [3] Serializer (`json_profile_body`, this file)
+//     - runs on: a Tokio blocking-pool thread, one `spawn_blocking` call per worker
+//     - what it does: `ProfileJsonWriter` serializes one worker's profile into a `Vec<u8>`
+//     - produces: one JSON chunk per worker
+//
+// [4] HTTP handler (`dump_json_profile`, this file)
+//     - runs on: an actix worker thread
+//     - what it does: yields each chunk as the client reads; the `Compress`
+//       middleware gzips them when the client's `Accept-Encoding` requires it
+//     - produces: a chunked HTTP response (never whole in memory), `application/json`,
+//       with `Content-Encoding: gzip` when negotiated
+//
+// [5] Coordinator (`feldera-coordinator`, `crates/coord` in the cloud repository)
+//     - runs on: its own process, in multihost pipelines only
+//     - what it does: fetches each host's profile and combines them
+//     - produces: one JSON response with the hosts' `worker_profiles`
+//       concatenated
+//
+// [6] Pipeline manager, one of two variants
+//     - runs on: the manager service
+//     - what it does:
+//         - the streaming proxy (`runner/interaction.rs`) serves the
+//            public `circuit_profile`, `circuit_json_profile` and
+//            `heap_profile` endpoints;
+//          - the support-data collector (`api/support_data_collector.rs`)
+//            fetches the profile on request, or every few minutes for
+//            running pipelines
+//     - produces:
+//          - the proxy: the body unchanged, headers included;
+//          - the collector: a database row holding the gzip-compressed JSON,
+//            inserted in the support bundle as `circuit_profile.json.gz`
+//
+// [7] Client, one of two variants
+//     - runs on: outside Feldera
+//     - what it does:
+//          - a REST client (`fda`, `curl`) writes the body to a file;
+//          - the profiler UI (`js-packages/profiler-layout`) inflates the
+//            `circuit_profile.json.gz` entry of a support bundle and parses the
+//            JSON in the browser
+//     - produces:
+//          - the REST client: a file;
+//          - the profiler UI: the profile displayed in the browser
+//
+// Within the pipeline process:
+// - The circuit thread is busy only while the workers collect metadata; the
+//   handler awaits the reply and never blocks it.
+// - Serialization runs on the blocking pool, one worker at a time; at most one
+//   worker's JSON exists in memory, never the whole profile.
+// - actix polls the stream only as the client reads, so a slow client stalls
+//   the serializer, not the circuit; a disconnected client drops the stream,
+//   and no further worker is serialized.
+
+/// The JSON profile as a stream of one chunk per worker.
+///
+/// Each worker is serialized on the blocking pool, in order, and its chunk is
+/// yielded before the next worker is started, so at most one worker's JSON
+/// exists at a time. An error aborts the body, which the client sees as a
+/// truncated transfer.
+fn json_profile_body(
+    profile: DbspProfile,
+) -> impl futures::Stream<Item = Result<Bytes, std::io::Error>> {
+    let DbspProfile {
+        metrics,
+        worker_profiles,
+        graph,
+    } = profile;
+    async_stream::try_stream! {
+        let mut json = ProfileJsonWriter::begin(Vec::new(), Some(metrics))?;
+        for worker in worker_profiles {
+            json = spawn_blocking(move || -> std::io::Result<_> {
+                json.worker(&worker)?;
+                Ok(json)
+            })
+            .await
+            .map_err(std::io::Error::other)??;
+            yield Bytes::from(std::mem::take(json.writer_mut()));
+        }
+        yield Bytes::from(json.finish(&graph)?);
+    }
+}
+
+#[cfg(test)]
+mod json_profile_body_tests {
+    use super::*;
+    use dbsp::profile::WorkerProfile;
+    use futures::TryStreamExt;
+
+    /// The chunks concatenate to exactly `DbspProfile::as_json`, one chunk per
+    /// worker plus the closing one.
+    #[tokio::test]
+    async fn chunks_concatenate_to_as_json() {
+        for workers in [0, 1, 3] {
+            let profile = DbspProfile::new(vec![WorkerProfile::default(); workers], None);
+            let expected = profile.as_json();
+            let chunks: Vec<Bytes> = json_profile_body(profile).try_collect().await.unwrap();
+            let expected_chunks = if workers == 0 { 1 } else { workers + 1 };
+            assert_eq!(chunks.len(), expected_chunks);
+            assert_eq!(chunks.concat(), expected.as_bytes());
+        }
+    }
+}
+
 #[get("/dump_profile")]
 async fn dump_profile(state: WebData<ServerState>) -> Result<HttpResponse, PipelineError> {
+    let profile = state.controller()?.async_graph_profile().await?;
+    // `ZipWriter` needs a synchronous `Write` sink, so the archive goes to an
+    // anonymous temporary file (removed when closed) and is streamed from there;
+    // memory consumption stays bounded.
+    let body = async_stream::try_stream! {
+        let file = spawn_blocking(move || -> std::io::Result<std::fs::File> {
+            let mut file = profile
+                .write_zip(tempfile::tempfile()?)
+                .map_err(std::io::Error::other)?;
+            std::io::Seek::seek(&mut file, std::io::SeekFrom::Start(0))?;
+            Ok(file)
+        })
+        .await
+        .map_err(std::io::Error::other)??;
+        let mut chunks = tokio_util::io::ReaderStream::new(tokio::fs::File::from_std(file));
+        while let Some(chunk) = futures::StreamExt::next(&mut chunks).await {
+            yield chunk?;
+        }
+    };
     Ok(HttpResponse::Ok()
         .insert_header(header::ContentType("application/zip".parse().unwrap()))
         .insert_header(header::ContentDisposition::attachment("profile.zip"))
         .insert_header(header::ContentEncoding::Identity)
-        .body(state.controller()?.async_graph_profile().await?.as_zip()))
+        .streaming::<_, std::io::Error>(body))
 }
 
-#[get("/dump_json_profile")]
+/// Registered in [`build_app`] behind a `Compress` middleware, which negotiates
+/// the response encoding with the client.
 async fn dump_json_profile(state: WebData<ServerState>) -> Result<HttpResponse, PipelineError> {
+    let profile = state.controller()?.async_json_profile().await?;
     Ok(HttpResponse::Ok()
         .insert_header(header::ContentType("application/json".parse().unwrap()))
         .insert_header(header::ContentDisposition::attachment("profile.json"))
-        .body(state.controller()?.async_json_profile().await?.as_json()))
+        .streaming::<_, std::io::Error>(json_profile_body(profile)))
 }
 
 /// Dump the low-level IR of the circuit.
@@ -4070,6 +4225,78 @@ outputs:
         }
 
         (server, state_ret)
+    }
+
+    /// Downloads both circuit profiles from a running pipeline.
+    #[actix_web::test]
+    async fn test_profiles_stream_from_running_pipeline() {
+        use std::io::Read;
+        crate::ensure_default_crypto_provider();
+
+        let server = start_test_server(
+            r#"
+name: test
+inputs:
+outputs:
+"#,
+            Uuid::new_v4(),
+        )
+        .await;
+        start_pipeline(&server).await;
+
+        // Without `Accept-Encoding` the JSON profile streams uncompressed.
+        let mut plain = server
+            .get("/dump_json_profile")
+            .no_decompress()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(plain.status(), StatusCode::OK);
+        assert!(plain.headers().get("content-encoding").is_none());
+        assert_eq!(
+            plain.headers().get("transfer-encoding").unwrap(),
+            "chunked",
+            "the profile must stream rather than be buffered"
+        );
+        let plain_body = plain.body().limit(64 << 20).await.unwrap();
+        let plain_json: serde_json::Value = serde_json::from_slice(&plain_body).unwrap();
+        let workers = plain_json["worker_profiles"].as_array().unwrap().len();
+        assert!(workers > 0);
+
+        // With `Accept-Encoding: gzip` it arrives gzip-compressed, with the same content.
+        let mut gz = server
+            .get("/dump_json_profile")
+            .insert_header(("accept-encoding", "gzip"))
+            .no_decompress()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(gz.status(), StatusCode::OK);
+        assert_eq!(gz.headers().get("content-encoding").unwrap(), "gzip");
+        let gz_body = gz.body().limit(64 << 20).await.unwrap();
+        let mut decoded = Vec::new();
+        flate2::read::GzDecoder::new(&gz_body[..])
+            .read_to_end(&mut decoded)
+            .unwrap();
+        let gz_json: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+        assert_eq!(
+            gz_json["worker_profiles"].as_array().unwrap().len(),
+            workers
+        );
+        assert_eq!(gz_json["graph"], plain_json["graph"]);
+
+        // The dot profile is a zip with one `.dot` and `.txt` per worker plus a Makefile.
+        let mut dot = server.get("/dump_profile").send().await.unwrap();
+        assert_eq!(dot.status(), StatusCode::OK);
+        assert_eq!(
+            dot.headers().get("content-type").unwrap(),
+            "application/zip"
+        );
+        let dot_body = dot.body().limit(64 << 20).await.unwrap();
+        // Zip local headers carry entry names uncompressed, so they are visible as bytes.
+        assert!(dot_body.starts_with(b"PK\x03\x04"));
+        let contains = |name: &[u8]| dot_body.windows(name.len()).any(|w| w == name);
+        assert!(contains(b"0.dot") && contains(b"0.txt") && contains(b"Makefile"));
     }
 
     /// Simulate an ungraceful crash of a fault-tolerant pipeline: terminate the

--- a/crates/dbsp/src/profile.rs
+++ b/crates/dbsp/src/profile.rs
@@ -24,11 +24,11 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Write,
     fs::{self, create_dir_all},
-    io::{Cursor as IoCursor, Error as IoError, Write as _},
+    io::{Error as IoError, Write as IoWrite},
     path::{Path, PathBuf},
     time::Duration,
 };
-use zip::{ZipWriter, write::SimpleFileOptions};
+use zip::{ZipWriter, result::ZipResult, write::SimpleFileOptions};
 
 mod cpu;
 pub use cpu::{CPUProfiler, RuntimeIdle};
@@ -194,22 +194,23 @@ $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))
         Ok(dir_path)
     }
 
-    /// Returns a Zip archive containing all the profile `.dot` files.
-    pub fn as_zip(&self) -> Vec<u8> {
-        let mut zip = ZipWriter::new(IoCursor::new(Vec::with_capacity(65536)));
+    /// Writes a Zip archive containing all the profile `.dot` and `.txt` files
+    /// to `writer`.
+    ///
+    /// Each worker's text is rendered and compressed one worker at a time, so
+    /// the full archive is never held in memory.
+    pub fn write_zip<W: IoWrite>(&self, writer: W) -> ZipResult<W> {
+        let mut zip = ZipWriter::new_stream(writer);
         for (graph, worker) in self.worker_graphs.iter().zip(self.worker_offset..) {
-            zip.start_file(format!("{worker}.dot"), SimpleFileOptions::default())
-                .unwrap();
-            zip.write_all(graph.to_dot().as_bytes()).unwrap();
+            zip.start_file(format!("{worker}.dot"), SimpleFileOptions::default())?;
+            zip.write_all(graph.to_dot().as_bytes())?;
 
-            zip.start_file(format!("{worker}.txt"), SimpleFileOptions::default())
-                .unwrap();
-            zip.write_all(graph.to_string().as_bytes()).unwrap();
+            zip.start_file(format!("{worker}.txt"), SimpleFileOptions::default())?;
+            zip.write_all(graph.to_string().as_bytes())?;
         }
-        zip.start_file("Makefile", SimpleFileOptions::default())
-            .unwrap();
-        zip.write_all(Self::MAKEFILE.as_bytes()).unwrap();
-        zip.finish().unwrap().into_inner()
+        zip.start_file("Makefile", SimpleFileOptions::default())?;
+        zip.write_all(Self::MAKEFILE.as_bytes())?;
+        Ok(zip.finish()?.into_inner())
     }
 }
 
@@ -220,6 +221,51 @@ pub struct DbspProfile {
     pub metrics: &'static [CircuitMetric],
     pub worker_profiles: Vec<WorkerProfile>,
     pub graph: Option<Graph>,
+}
+
+/// Writes a [`DbspProfile`] document as JSON.
+/// (This abstraction is reused by the coordinator)
+pub struct ProfileJsonWriter<W: IoWrite> {
+    writer: W,
+    workers: usize,
+}
+
+impl<W: IoWrite> ProfileJsonWriter<W> {
+    /// Starts the document.
+    pub fn begin<M: Serialize + ?Sized>(
+        mut writer: W,
+        metrics: Option<&M>,
+    ) -> Result<Self, IoError> {
+        writer.write_all(b"{")?;
+        if let Some(metrics) = metrics {
+            writer.write_all(b"\"metrics\":")?;
+            serde_json::to_writer(&mut writer, metrics)?;
+            writer.write_all(b",")?;
+        }
+        writer.write_all(b"\"worker_profiles\":[")?;
+        Ok(Self { writer, workers: 0 })
+    }
+
+    pub fn worker<T: Serialize + ?Sized>(&mut self, worker: &T) -> Result<(), IoError> {
+        if self.workers > 0 {
+            self.writer.write_all(b",")?;
+        }
+        serde_json::to_writer(&mut self.writer, worker)?;
+        self.workers += 1;
+        Ok(())
+    }
+
+    pub fn finish<G: Serialize + ?Sized>(mut self, graph: &G) -> Result<W, IoError> {
+        self.writer.write_all(b"],\"graph\":")?;
+        serde_json::to_writer(&mut self.writer, graph)?;
+        self.writer.write_all(b"}")?;
+        Ok(self.writer)
+    }
+
+    /// The underlying writer
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
 }
 
 impl DbspProfile {
@@ -480,5 +526,85 @@ impl Profiler {
 
             (output, importance)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::circuit_builder::NodeId;
+    use std::io::Read;
+
+    /// A worker profile with three operators carrying two metrics each.
+    fn worker_profile(seed: u64) -> WorkerProfile {
+        let mut metadata = HashMap::new();
+        for node in 0..3 {
+            let mut meta = OperatorMeta::new();
+            meta.extend([
+                MetricReading::new(
+                    USED_MEMORY_BYTES,
+                    Vec::new(),
+                    MetaItem::Bytes(HumanBytes::new(seed * 100 + node as u64)),
+                ),
+                MetricReading::new(INVOCATIONS_COUNT, Vec::new(), MetaItem::Count(node)),
+            ]);
+            metadata.insert(GlobalNodeId::from_path(&[NodeId::new(node)]), meta);
+        }
+        WorkerProfile::new(metadata)
+    }
+
+    fn profile(workers: u64, graph: Option<Graph>) -> DbspProfile {
+        DbspProfile::new((0..workers).map(worker_profile).collect(), graph)
+    }
+
+    #[test]
+    fn profile_json_writer_phases() {
+        let mut json = ProfileJsonWriter::begin(Vec::new(), None::<&str>).unwrap();
+        assert_eq!(json.writer_mut().as_slice(), b"{\"worker_profiles\":[");
+        json.worker(&1).unwrap();
+        json.worker(&2).unwrap();
+        let so_far = std::mem::take(json.writer_mut());
+        assert_eq!(so_far, b"{\"worker_profiles\":[1,2");
+        let rest = json.finish(&"g").unwrap();
+        assert_eq!(rest, b"],\"graph\":\"g\"}");
+    }
+
+    /// The phased writer produces the same bytes as `as_json`.
+    #[test]
+    fn profile_json_writer_matches_as_json() {
+        for (workers, graph) in [(0, None), (1, None), (3, Some(Graph::default()))] {
+            let profile = profile(workers, graph);
+            let expected = profile.as_json();
+            let mut json = ProfileJsonWriter::begin(Vec::new(), Some(profile.metrics)).unwrap();
+            for worker in &profile.worker_profiles {
+                json.worker(worker).unwrap();
+            }
+            let streamed = json.finish(&profile.graph).unwrap();
+            assert_eq!(String::from_utf8(streamed).unwrap(), expected);
+        }
+    }
+
+    /// The streamed archive is a valid zip naming one `.dot` and one `.txt`
+    /// per worker, plus the Makefile.
+    #[test]
+    fn write_zip_lists_every_worker() {
+        let profile = GraphProfile {
+            elapsed_time: Duration::from_secs(1),
+            worker_offset: 4,
+            worker_graphs: vec![Graph::default(); 2],
+        };
+        let streamed = profile.write_zip(Vec::new()).unwrap();
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(streamed)).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        assert_eq!(names, ["4.dot", "4.txt", "5.dot", "5.txt", "Makefile"]);
+        let mut makefile = String::new();
+        archive
+            .by_name("Makefile")
+            .unwrap()
+            .read_to_string(&mut makefile)
+            .unwrap();
+        assert_eq!(makefile, GraphProfile::MAKEFILE);
     }
 }

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -1717,19 +1717,20 @@ pub(crate) async fn get_pipeline_heap_profile(
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
+    body: web::Payload,
 ) -> Result<HttpResponse, ManagerError> {
     let pipeline_name = path.into_inner();
+    // Streamed, like the circuit profiles
     state
         .runner
-        .forward_http_request_to_pipeline_by_name(
+        .forward_streaming_http_request_to_pipeline_by_name(
             client.as_ref(),
             *tenant_id,
             &pipeline_name,
-            Method::GET,
             "heap_profile",
-            request.query_string(),
-            None,
-            None,
+            request,
+            body,
+            Some(Duration::from_secs(120)),
         )
         .await
 }

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
@@ -96,6 +96,7 @@ impl SupportBundleZip {
         let mut zip = ZipWriter::new(std::io::Cursor::new(&mut zip_buffer));
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(CompressionMethod::Deflated);
+        let options_for = |method: CompressionMethod| options.compression_method(method);
 
         let combined_status = CombinedStatus::new(
             pipeline.deployment_resources_status,
@@ -123,13 +124,16 @@ impl SupportBundleZip {
         for data in bundles.iter() {
             let directory = unique_directory(&timestamp_dir(&data.time), &mut used_dirs);
             let dir_prefix = directory.clone();
-            let mut add_to_zip =
-                |filename: &str, content: &[u8]| -> Result<(), Box<dyn std::error::Error>> {
-                    let path = format!("{}/{}", dir_prefix, filename);
-                    zip.start_file(&path, options)?;
-                    zip.write_all(content)?;
-                    Ok(())
-                };
+            // Already-compressed items (gzip, zip) are stored verbatim
+            let mut add_to_zip = |filename: &str,
+                                  content: &[u8],
+                                  method: CompressionMethod|
+             -> Result<(), Box<dyn std::error::Error>> {
+                let path = format!("{}/{}", dir_prefix, filename);
+                zip.start_file(&path, options_for(method))?;
+                zip.write_all(content)?;
+                Ok(())
+            };
 
             let summary = data
                 .push_to_zip(&mut add_to_zip, params)
@@ -436,6 +440,16 @@ mod tests {
                     .iter()
                     .any(|n| n == &format!("{dir}/circuit_profile.zip")),
                 "missing circuit_profile.zip in {dir}"
+            );
+            // The JSON profile is stored gzip-compressed, exactly as collected.
+            let json_gz = archive
+                .by_name(&format!("{dir}/circuit_profile.json.gz"))
+                .expect("missing circuit_profile.json.gz");
+            assert_eq!(json_gz.compression(), CompressionMethod::Stored);
+            assert_eq!(
+                json_gz.size(),
+                3,
+                "stored bytes must be the collected bytes"
             );
             assert!(
                 names

--- a/crates/pipeline-manager/src/api/support_data_collector.rs
+++ b/crates/pipeline-manager/src/api/support_data_collector.rs
@@ -32,9 +32,11 @@ use utoipa::{IntoParams, ToSchema};
 const COLLECTION_TIMEOUT: Duration = Duration::from_secs(120);
 const SKIPPED_BY_USER: &str = "Skipped due to user request";
 
-const EXTENDED_RESPONSE_SIZE_LIMIT: usize = 300 * 1024 * 1024; // Applies to profiles which can be very large
-
 type BundleResult<T> = Result<T, String>;
+
+/// Size cap for pipeline response. Counts transferred bytes: an item fetched
+/// compressed can be much larger.  Applies to e.g., profiles collected.
+const EXTENDED_RESPONSE_SIZE_LIMIT: usize = 300 * 1024 * 1024;
 
 fn collect() -> bool {
     true
@@ -131,10 +133,11 @@ async fn fetch_pipeline_data(
     query_string: &str,
     timeout_duration: Option<Duration>,
     body_size_limit: Option<usize>,
+    accept_encoding: Option<&str>,
 ) -> Result<HttpResponse, ManagerError> {
     state
         .runner
-        .forward_http_request_to_pipeline_by_name(
+        .forward_http_request_to_pipeline_by_name_with_accept_encoding(
             client,
             tenant_id,
             pipeline_name,
@@ -143,6 +146,7 @@ async fn fetch_pipeline_data(
             query_string,
             timeout_duration,
             body_size_limit,
+            accept_encoding,
         )
         .await
 }
@@ -216,6 +220,47 @@ fn gz_decompress(data: &[u8]) -> Result<Vec<u8>, String> {
     Ok(decompressed)
 }
 
+/// A `Content-Encoding` the collector accepts from a pipeline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TransportEncoding {
+    Identity,
+    Gzip,
+}
+
+/// Parses a `Content-Encoding` header value; an absent header is identity.
+fn parse_transport_encoding(value: &str) -> BundleResult<TransportEncoding> {
+    match value.to_ascii_lowercase().as_str() {
+        "" | "identity" => Ok(TransportEncoding::Identity),
+        "gzip" | "x-gzip" => Ok(TransportEncoding::Gzip),
+        other => Err(format!("unsupported Content-Encoding {other:?}")),
+    }
+}
+
+/// Undoes the transport encoding of `body`.
+fn decode_transport_encoding(body: Vec<u8>, content_encoding: &str) -> BundleResult<Vec<u8>> {
+    match parse_transport_encoding(content_encoding)? {
+        TransportEncoding::Identity => Ok(body),
+        TransportEncoding::Gzip => gz_decompress(&body),
+    }
+}
+
+/// Converts a pipeline's JSON profile response to the stored form,
+/// gzip-compressed JSON, whether it arrived gzip-compressed, as plain JSON, or
+/// as a zip holding `profile.json`. Legacy pipelines send the last two.
+fn stored_json_profile(
+    body: Vec<u8>,
+    content_type: &str,
+    content_encoding: &str,
+) -> BundleResult<Vec<u8>> {
+    match parse_transport_encoding(content_encoding)? {
+        TransportEncoding::Gzip => Ok(body),
+        TransportEncoding::Identity if content_type.contains("application/zip") => {
+            extract_from_zip(&body, "profile.json").and_then(gz_compress)
+        }
+        TransportEncoding::Identity => gz_compress(body),
+    }
+}
+
 /// Extract a specific file from a ZIP archive
 fn extract_from_zip(zip_data: &[u8], filename: &str) -> Result<Vec<u8>, String> {
     use std::io::Read;
@@ -238,36 +283,37 @@ fn extract_from_zip(zip_data: &[u8], filename: &str) -> Result<Vec<u8>, String> 
 async fn response_to_bundle_result(
     response: Result<HttpResponse, ManagerError>,
 ) -> BundleResult<Vec<u8>> {
-    response_to_bundle_result_with_transform(response, |body, _| Ok(body)).await
+    response_to_bundle_result_with_transform(response, |body, _, _| Ok(body)).await
 }
 
-/// Convert the HTTP response from a pipeline to a bundle result,
-/// applying a transformer function to the response body.
-///
-/// The transformer receives (body_bytes, content_type) and returns
-/// a transformed BundleResult<Vec<u8>>.
+/// Convert the HTTP response from a pipeline to a bundle result, passing a
+/// successful body through `transform(body, content_type, content_encoding)`.
 async fn response_to_bundle_result_with_transform<F>(
     response: Result<HttpResponse, ManagerError>,
     transform: F,
 ) -> BundleResult<Vec<u8>>
 where
-    F: FnOnce(Vec<u8>, &str) -> BundleResult<Vec<u8>>,
+    F: FnOnce(Vec<u8>, &str, &str) -> BundleResult<Vec<u8>>,
 {
     match response {
         Ok(response) if response.status().is_success() => {
-            let content_type = response
-                .headers()
-                .get(actix_web::http::header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("")
-                .to_string();
+            let header_value = |name| {
+                response
+                    .headers()
+                    .get(name)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string()
+            };
+            let content_type = header_value(actix_web::http::header::CONTENT_TYPE);
+            let content_encoding = header_value(actix_web::http::header::CONTENT_ENCODING);
 
             let body_bytes = actix_web::body::to_bytes(response.into_body())
                 .await
                 .map(|bytes| bytes.to_vec())
                 .map_err(|e| e.to_string())?;
 
-            transform(body_bytes, &content_type)
+            transform(body_bytes, &content_type, &content_encoding)
         }
         Ok(response) => {
             let mut error_string = format!("HTTP {}", response.status());
@@ -438,9 +484,7 @@ impl SupportBundleData {
         }
 
         let (
-            circuit_profile,
-            json_circuit_profile,
-            heap_profile,
+            (circuit_profile, json_circuit_profile, heap_profile),
             metrics,
             logs,
             stats,
@@ -449,27 +493,26 @@ impl SupportBundleData {
             dataflow_graph,
             pipeline_events,
         ) = tokio::join!(
+            // Profiles can be very large: fetching them one after another keeps the
+            // pipeline memory bounded.
             async {
-                if params.circuit_profile {
+                let circuit_profile = if params.circuit_profile {
                     Self::collect_circuit_profile(state, client, tenant_id, pipeline_name).await
                 } else {
                     skipped()
-                }
-            },
-            async {
-                if params.circuit_profile {
+                };
+                let json_circuit_profile = if params.circuit_profile {
                     Self::collect_json_circuit_profile(state, client, tenant_id, pipeline_name)
                         .await
                 } else {
                     skipped()
-                }
-            },
-            async {
-                if params.heap_profile {
+                };
+                let heap_profile = if params.heap_profile {
                     Self::collect_heap_profile(state, client, tenant_id, pipeline_name).await
                 } else {
                     skipped()
-                }
+                };
+                (circuit_profile, json_circuit_profile, heap_profile)
             },
             async {
                 if params.metrics {
@@ -553,10 +596,14 @@ impl SupportBundleData {
             "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
+            Some("gzip"),
         )
         .await;
 
-        response_to_bundle_result(response).await
+        response_to_bundle_result_with_transform(response, |body, _, encoding| {
+            decode_transport_encoding(body, encoding)
+        })
+        .await
     }
 
     async fn collect_json_circuit_profile(
@@ -574,23 +621,11 @@ impl SupportBundleData {
             "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
+            Some("gzip"),
         )
         .await;
 
-        // Transform the response based on Content-Type:
-        // - Old pipelines return application/zip with profile.json inside
-        // - New pipelines return plain JSON
-        // Both are normalized to gzip-compressed JSON for storage.
-        response_to_bundle_result_with_transform(response, |body_bytes, content_type| {
-            if content_type.contains("application/zip") {
-                // Extract JSON from ZIP, then compress for storage
-                extract_from_zip(&body_bytes, "profile.json").and_then(gz_compress)
-            } else {
-                // Plain JSON, compress for storage
-                gz_compress(body_bytes)
-            }
-        })
-        .await
+        response_to_bundle_result_with_transform(response, stored_json_profile).await
     }
 
     async fn collect_heap_profile(
@@ -608,10 +643,14 @@ impl SupportBundleData {
             "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
+            Some("gzip"),
         )
         .await;
 
-        response_to_bundle_result(response).await
+        response_to_bundle_result_with_transform(response, |body, _, encoding| {
+            decode_transport_encoding(body, encoding)
+        })
+        .await
     }
 
     async fn collect_metrics(
@@ -628,6 +667,7 @@ impl SupportBundleData {
             "metrics",
             "",
             Some(COLLECTION_TIMEOUT),
+            None,
             None,
         )
         .await;
@@ -665,6 +705,7 @@ impl SupportBundleData {
             "stats",
             "include_connector_errors=true",
             Some(COLLECTION_TIMEOUT),
+            None,
             None,
         )
         .await;
@@ -718,19 +759,28 @@ impl SupportBundleData {
         serde_json::to_vec_pretty(&events).map_err(|e| e.to_string())
     }
 
+    /// Adds this collection's files to a bundle. `add_to_zip` receives the file
+    /// name, its bytes, and how to store them: items that are already
+    /// compressed (gzip, zip) are stored verbatim, everything else deflated.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn push_to_zip(
         &self,
-        add_to_zip: &mut dyn FnMut(&str, &[u8]) -> Result<(), Box<dyn std::error::Error>>,
+        add_to_zip: &mut dyn FnMut(
+            &str,
+            &[u8],
+            zip::CompressionMethod,
+        ) -> Result<(), Box<dyn std::error::Error>>,
         params: &SupportBundleParameters,
     ) -> Result<CollectionSummary, Box<dyn std::error::Error>> {
+        use zip::CompressionMethod::{Deflated, Stored};
+
         let mut summary = CollectionSummary::default();
 
         // Add circuit profile
         if params.circuit_profile {
             match &self.circuit_profile {
                 Ok(content) => {
-                    let _ = add_to_zip("circuit_profile.zip", content);
+                    let _ = add_to_zip("circuit_profile.zip", content, Stored);
                     summary.collected("circuit_profile.zip");
                 }
                 Err(e) => {
@@ -740,51 +790,39 @@ impl SupportBundleData {
                 }
             };
             match &self.json_circuit_profile {
-                Ok(content) => {
-                    if self.version >= 4 {
-                        match gz_decompress(content) {
-                            Ok(decompressed) => {
-                                let _ = add_to_zip("circuit_profile.json", &decompressed);
-                                summary.collected("circuit_profile.json");
-                            }
-                            Err(e) => {
-                                summary.failed(
-                                    "circuit_profile.json",
-                                    format!("Failed to decompress: {}", e),
-                                );
-                            }
-                        }
-                    } else {
-                        match extract_from_zip(content, "profile.json") {
-                            Ok(json_content) => {
-                                let _ = add_to_zip("circuit_profile.json", &json_content);
-                                summary.collected("circuit_profile.json");
-                            }
-                            Err(e) => {
-                                summary.failed(
-                                    "circuit_profile.json",
-                                    format!("Failed to extract from ZIP: {}", e),
-                                );
-                            }
-                        }
-                    }
+                // Since data version 4 the profile is stored as gzip-compressed JSON,
+                // which the bundle carries unchanged: a large profile is never
+                // inflated on the manager.
+                Ok(content) if self.version >= 4 => {
+                    let _ = add_to_zip("circuit_profile.json.gz", content, Stored);
+                    summary.collected("circuit_profile.json.gz");
                 }
+                // Older versions hold a zip with `profile.json` inside.
+                Ok(content) => match extract_from_zip(content, "profile.json").and_then(|json| {
+                    gz_compress(json).map_err(|e| format!("Failed to compress: {e}"))
+                }) {
+                    Ok(gz) => {
+                        let _ = add_to_zip("circuit_profile.json.gz", &gz, Stored);
+                        summary.collected("circuit_profile.json.gz");
+                    }
+                    Err(reason) => summary.failed("circuit_profile.json.gz", reason),
+                },
                 Err(e) => {
                     if e != SKIPPED_BY_USER {
-                        summary.failed("circuit_profile.json", e.clone());
+                        summary.failed("circuit_profile.json.gz", e.clone());
                     }
                 }
             }
         } else {
             summary.skipped("circuit_profile.zip");
-            summary.skipped("circuit_profile.json");
+            summary.skipped("circuit_profile.json.gz");
         }
 
         // Add heap profile
         if params.heap_profile {
             match &self.heap_profile {
                 Ok(content) => {
-                    let _ = add_to_zip("heap_profile.pb.gz", content);
+                    let _ = add_to_zip("heap_profile.pb.gz", content, Stored);
                     summary.collected("heap_profile.pb.gz");
                 }
                 Err(e) => {
@@ -801,7 +839,7 @@ impl SupportBundleData {
         if params.metrics {
             match &self.metrics {
                 Ok(content) => {
-                    let _ = add_to_zip("metrics.txt", content);
+                    let _ = add_to_zip("metrics.txt", content, Deflated);
                     summary.collected("metrics.txt");
                 }
                 Err(e) => {
@@ -818,7 +856,7 @@ impl SupportBundleData {
         if params.logs {
             match &self.logs {
                 Ok(content) => {
-                    let _ = add_to_zip("logs.txt", content.as_bytes());
+                    let _ = add_to_zip("logs.txt", content.as_bytes(), Deflated);
                     summary.collected("logs.txt");
                 }
                 Err(e) => {
@@ -835,7 +873,7 @@ impl SupportBundleData {
         if params.stats {
             match &self.stats {
                 Ok(content) => {
-                    let _ = add_to_zip("stats.json", content);
+                    let _ = add_to_zip("stats.json", content, Deflated);
                     summary.collected("stats.json");
                 }
                 Err(e) => {
@@ -857,7 +895,7 @@ impl SupportBundleData {
                     if self.version > 0 {
                         match gz_decompress(content) {
                             Ok(decompressed) => {
-                                let _ = add_to_zip("pipeline_config.json", &decompressed);
+                                let _ = add_to_zip("pipeline_config.json", &decompressed, Deflated);
                                 summary.collected("pipeline_config.json");
                             }
                             Err(e) => {
@@ -868,7 +906,7 @@ impl SupportBundleData {
                             }
                         }
                     } else {
-                        let _ = add_to_zip("pipeline_config.json.gz", content);
+                        let _ = add_to_zip("pipeline_config.json.gz", content, Stored);
                         summary.collected("pipeline_config.json.gz");
                     }
                 }
@@ -891,7 +929,7 @@ impl SupportBundleData {
         if params.system_config {
             match &self.system_config {
                 Ok(content) => {
-                    let _ = add_to_zip("system_config.json", content);
+                    let _ = add_to_zip("system_config.json", content, Deflated);
                     summary.collected("system_config.json");
                 }
                 Err(e) => {
@@ -908,7 +946,7 @@ impl SupportBundleData {
         if params.dataflow_graph {
             match &self.dataflow_graph {
                 Ok(content) => {
-                    let _ = add_to_zip("dataflow_graph.json", content);
+                    let _ = add_to_zip("dataflow_graph.json", content, Deflated);
                     summary.collected("dataflow_graph.json");
                 }
                 Err(e) => {
@@ -927,7 +965,7 @@ impl SupportBundleData {
         if params.pipeline_events {
             match &self.pipeline_events {
                 Ok(content) => {
-                    let _ = add_to_zip("pipeline_events.json", content);
+                    let _ = add_to_zip("pipeline_events.json", content, Deflated);
                     summary.collected("pipeline_events.json");
                 }
                 Err(e) => {
@@ -1500,6 +1538,113 @@ mod tests {
         );
     }
 
+    /// Storage holds gzip-compressed JSON whatever shape the pipeline sent.
+    #[test]
+    fn stored_json_profile_normalizes_every_wire_shape() {
+        use std::io::Write as _;
+        let json = br#"{"worker_profiles":[]}"#.to_vec();
+
+        // Compressed by the pipeline: stored byte for byte.
+        let gz = gz_compress(json.clone()).unwrap();
+        assert_eq!(
+            stored_json_profile(gz.clone(), "application/json", "gzip").unwrap(),
+            gz
+        );
+
+        // Plain JSON: compressed here.
+        let stored = stored_json_profile(json.clone(), "application/json", "").unwrap();
+        assert_eq!(gz_decompress(&stored).unwrap(), json);
+
+        // Legacy zip holding `profile.json`: unpacked, then compressed.
+        let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        archive
+            .start_file("profile.json", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        archive.write_all(&json).unwrap();
+        let legacy = archive.finish().unwrap().into_inner();
+        let stored = stored_json_profile(legacy, "application/zip", "identity").unwrap();
+        assert_eq!(gz_decompress(&stored).unwrap(), json);
+
+        // Unknown encodings are refused rather than stored as garbage.
+        assert!(stored_json_profile(json, "application/json", "br").is_err());
+    }
+
+    #[test]
+    fn decode_transport_encoding_undoes_gzip_only() {
+        let payload = b"PK\x03\x04 pretend zip".to_vec();
+        assert_eq!(
+            decode_transport_encoding(payload.clone(), "").unwrap(),
+            payload
+        );
+        assert_eq!(
+            decode_transport_encoding(payload.clone(), "identity").unwrap(),
+            payload
+        );
+        let gz = gz_compress(payload.clone()).unwrap();
+        assert_eq!(
+            decode_transport_encoding(gz.clone(), "GZIP").unwrap(),
+            payload
+        );
+        assert_eq!(decode_transport_encoding(gz, "x-gzip").unwrap(), payload);
+        assert!(decode_transport_encoding(payload, "br").is_err());
+    }
+
+    /// Data collected before version 4 holds the JSON profile inside a zip;
+    /// the bundle still carries it as `circuit_profile.json.gz`. A corrupt
+    /// archive is reported properly.
+    #[tokio::test]
+    async fn push_to_zip_converts_legacy_json_profile() {
+        use std::io::Write as _;
+        let json = br#"{"worker_profiles":[]}"#;
+        let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        archive
+            .start_file("profile.json", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        archive.write_all(json).unwrap();
+        let legacy_zip = archive.finish().unwrap().into_inner();
+
+        let params = SupportBundleParameters::default();
+        let mut entries = Vec::new();
+        let mut add = |name: &str, content: &[u8], method: zip::CompressionMethod| {
+            entries.push((name.to_string(), content.to_vec(), method));
+            Ok(())
+        };
+
+        let mut legacy = SupportBundleData::test_data();
+        legacy.version = 3;
+        legacy.json_circuit_profile = Ok(legacy_zip);
+        let converted = legacy.push_to_zip(&mut add, &params).await.unwrap();
+
+        let mut corrupt = SupportBundleData::test_data();
+        corrupt.version = 3;
+        corrupt.json_circuit_profile = Ok(b"not a zip".to_vec());
+        let rejected = corrupt.push_to_zip(&mut add, &params).await.unwrap();
+
+        assert!(
+            converted
+                .collected
+                .iter()
+                .any(|file| file == "circuit_profile.json.gz")
+        );
+        let (_, gz, method) = entries
+            .iter()
+            .find(|(name, _, _)| name == "circuit_profile.json.gz")
+            .unwrap();
+        assert_eq!(*method, zip::CompressionMethod::Stored);
+        assert_eq!(gz_decompress(gz).unwrap(), json);
+
+        let failure = rejected
+            .failed
+            .iter()
+            .find(|failure| failure.file == "circuit_profile.json.gz")
+            .unwrap();
+        assert!(
+            failure.reason.starts_with("Invalid ZIP"),
+            "{}",
+            failure.reason
+        );
+    }
+
     #[tokio::test]
     async fn push_to_zip_with_ignores() {
         let bundle_data = SupportBundleData {
@@ -1527,8 +1672,8 @@ mod tests {
 
         let summary = bundle_data
             .push_to_zip(
-                &mut |filename, content| {
-                    zip_entries.push((filename.to_string(), content.to_vec()));
+                &mut |filename, content, method| {
+                    zip_entries.push((filename.to_string(), content.to_vec(), method));
                     Ok(())
                 },
                 &all_enabled,
@@ -1540,6 +1685,18 @@ mod tests {
         assert_eq!(summary.failed.len(), 0);
         assert_eq!(summary.skipped.len(), 0);
         assert_eq!(zip_entries.len(), 10);
+
+        // The gzip-compressed JSON profile goes into the bundle as is,
+        // stored rather than deflated.
+        let json_entry = zip_entries
+            .iter()
+            .find(|(name, _, _)| name == "circuit_profile.json.gz")
+            .expect("circuit_profile.json.gz in bundle");
+        assert_eq!(
+            &json_entry.1,
+            bundle_data.json_circuit_profile.as_ref().unwrap()
+        );
+        assert_eq!(json_entry.2, zip::CompressionMethod::Stored);
 
         // Test with some parameters disabled
         let some_disabled = SupportBundleParameters {
@@ -1560,8 +1717,8 @@ mod tests {
 
         let summary = bundle_data
             .push_to_zip(
-                &mut |filename, content| {
-                    zip_entries.push((filename.to_string(), content.to_vec()));
+                &mut |filename, content, method| {
+                    zip_entries.push((filename.to_string(), content.to_vec(), method));
                     Ok(())
                 },
                 &some_disabled,

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -24,9 +24,8 @@ use crate::db::types::resources_status::ResourcesStatus;
 use actix_http::encoding::Decoder;
 use feldera_types::runtime_status::RuntimeStatus;
 
-/// Max non-streaming decompressed HTTP response body size returned by the pipeline.
-/// The awc default is 2MiB, which is not enough to, for example, retrieve
-/// a large circuit profile.
+/// Max non-streaming HTTP response body size returned by the pipeline, counted
+/// as transferred bytes. The awc default is 2MiB.
 const RESPONSE_SIZE_LIMIT: usize = 50 * 1024 * 1024;
 
 /// Pick the subprotocol to echo back on a WebSocket handshake.
@@ -244,7 +243,8 @@ impl RunnerInteraction {
     }
 
     /// Makes a new HTTP request without body to the pipeline.
-    /// The response is fully composed before returning including headers.
+    /// The response is fully composed before returning including headers, with
+    /// the body and its `Content-Encoding` as the pipeline sent them.
     ///
     /// This method is static as it is directly provided the pipeline
     /// identifier and location. It thus does not need to retrieve it
@@ -260,6 +260,7 @@ impl RunnerInteraction {
         query_string: &str,
         timeout: Option<Duration>,
         body_size_limit: Option<usize>,
+        accept_encoding: Option<&str>,
     ) -> Result<HttpResponse, ManagerError> {
         // Perform request to the pipeline
         let url = format_pipeline_url(
@@ -273,7 +274,15 @@ impl RunnerInteraction {
             query_string,
         );
         let timeout = timeout.unwrap_or(Self::PIPELINE_HTTP_REQUEST_TIMEOUT);
-        let request = client.request(method, &url).timeout(timeout).force_close();
+        // `.no_decompress()` also suppresses awc's own `Accept-Encoding` header.
+        let mut request = client
+            .request(method, &url)
+            .timeout(timeout)
+            .force_close()
+            .no_decompress();
+        if let Some(accept_encoding) = accept_encoding {
+            request = request.insert_header((header::ACCEPT_ENCODING, accept_encoding));
+        }
         let request_str = Self::format_request(&request);
 
         let mut original_response = request.send().await.map_err(|e| match e {
@@ -311,25 +320,31 @@ impl RunnerInteraction {
         // Add all the same headers as the original response, excluding:
         // - `connection`: hop-by-hop header, must not be forwarded by proxies
         //   (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#Directives)
-        // - `content-encoding`: awc auto-decompresses the body, so the body we forward is already
-        //   decoded — forwarding the original Content-Encoding would make the caller try to
-        //   decompress an already-plain body.
-        // - `content-length`: after decompression the body size differs from the
-        //   original Content-Length; let actix-web recompute it.
-        for (header_name, header_value) in original_response.headers().iter().filter(|(h, _)| {
-            *h != "connection" && *h != "content-length" && *h != "content-encoding"
-        }) {
+        // - `content-length`: let actix-web recompute it for the body it sends.
+        for (header_name, header_value) in original_response
+            .headers()
+            .iter()
+            .filter(|(h, _)| *h != "connection" && *h != "content-length")
+        {
             response_builder.insert_header((header_name.clone(), header_value.clone()));
         }
 
         // Copy over the original response body
+        let body_size_limit = body_size_limit.unwrap_or(RESPONSE_SIZE_LIMIT);
         let response_body = original_response
             .body()
-            .limit(body_size_limit.unwrap_or(RESPONSE_SIZE_LIMIT))
+            .limit(body_size_limit)
             .await
-            .map_err(|e| RunnerError::PipelineInteractionInvalidResponse {
-                pipeline_name: pipeline_name.to_string(),
-                error: format!("unable to reconstruct response body due to: {e}"),
+            .map_err(|e| {
+                warn!(
+                    pipeline = pipeline_name,
+                    pipeline_id = "N/A",
+                    "Rejected the response body of {request_str} (limit {body_size_limit} bytes): {e}"
+                );
+                RunnerError::PipelineInteractionInvalidResponse {
+                    pipeline_name: pipeline_name.to_string(),
+                    error: format!("unable to reconstruct response body due to: {e}"),
+                }
             })?;
         Ok(response_builder.body(response_body))
     }
@@ -351,6 +366,35 @@ impl RunnerInteraction {
         timeout: Option<Duration>,
         body_size_limit: Option<usize>,
     ) -> Result<HttpResponse, ManagerError> {
+        self.forward_http_request_to_pipeline_by_name_with_accept_encoding(
+            client,
+            tenant_id,
+            pipeline_name,
+            method,
+            endpoint,
+            query_string,
+            timeout,
+            body_size_limit,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`Self::forward_http_request_to_pipeline_by_name`], sending the
+    /// given `Accept-Encoding` so the pipeline may compress the body.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn forward_http_request_to_pipeline_by_name_with_accept_encoding(
+        &self,
+        client: &awc::Client,
+        tenant_id: TenantId,
+        pipeline_name: &str,
+        method: Method,
+        endpoint: &str,
+        query_string: &str,
+        timeout: Option<Duration>,
+        body_size_limit: Option<usize>,
+        accept_encoding: Option<&str>,
+    ) -> Result<HttpResponse, ManagerError> {
         let (location, cache_hit) = self.check_pipeline(tenant_id, pipeline_name).await?;
         let r = RunnerInteraction::forward_http_request_to_pipeline(
             &self.common_config,
@@ -362,6 +406,7 @@ impl RunnerInteraction {
             query_string,
             timeout,
             body_size_limit,
+            accept_encoding,
         )
         .await;
 
@@ -381,16 +426,19 @@ impl RunnerInteraction {
                     let mut cache = self.endpoint_cache.write().unwrap();
                     cache.remove(&(tenant_id, pipeline_name.to_string()));
                     drop(cache);
-                    Box::pin(self.forward_http_request_to_pipeline_by_name(
-                        client,
-                        tenant_id,
-                        pipeline_name,
-                        method,
-                        endpoint,
-                        query_string,
-                        timeout,
-                        body_size_limit,
-                    ))
+                    Box::pin(
+                        self.forward_http_request_to_pipeline_by_name_with_accept_encoding(
+                            client,
+                            tenant_id,
+                            pipeline_name,
+                            method,
+                            endpoint,
+                            query_string,
+                            timeout,
+                            body_size_limit,
+                            accept_encoding,
+                        ),
+                    )
                     .await
                 }
             }
@@ -638,8 +686,9 @@ impl RunnerInteraction {
 /// the response back. Extracted from [`RunnerInteraction`] so it can be
 /// unit-tested without a database.
 ///
-/// Strips the client's `Accept-Encoding` and forces `Content-Encoding: identity`
-/// on the response (prevents gzip frame buffering that blocks streaming clients).
+/// The client and the pipeline negotiate compression directly: the client's
+/// `Accept-Encoding` is forwarded and the pipeline's `Content-Encoding` is
+/// relayed unchanged.
 pub(crate) async fn streaming_proxy(
     client: &awc::Client,
     url: &str,
@@ -648,22 +697,20 @@ pub(crate) async fn streaming_proxy(
     body: Payload,
     timeout: Duration,
 ) -> Result<HttpResponse, ManagerError> {
+    // `.no_decompress()` suppresses awc's own `Accept-Encoding` header and keeps the
+    // pipeline's bytes as they are; the manager never decodes a streamed body.
     let mut new_request = client
         .request(request.method().clone(), url)
         .timeout(timeout)
         .force_close()
         .no_decompress();
 
-    // Strip `Accept-Encoding` to prevent compressed responses from the pipeline —
-    // compression causes gzip frame buffering that blocks streaming clients (see the
-    // `Content-Encoding: identity` override below). `.no_decompress()` above suppresses
-    // awc's own `Accept-Encoding` header; here we also strip the client's.
     // `authorization` has already been handled by the API server, and is thus not needed
     // to be forwarded to the pipeline itself.
     for header in request
         .headers()
         .into_iter()
-        .filter(|(h, _)| *h != "connection" && *h != "accept-encoding" && *h != "authorization")
+        .filter(|(h, _)| *h != "connection" && *h != "authorization")
     {
         new_request = new_request.append_header(header);
     }
@@ -707,8 +754,12 @@ pub(crate) async fn streaming_proxy(
     for header in response.headers().into_iter() {
         builder.append_header(header);
     }
-    // Disable compression to avoid gzip frame buffering that causes clients to block
-    builder.insert_header(actix_http::ContentEncoding::Identity);
+    // An explicit `Content-Encoding` keeps the `Compress` middleware on the manager's
+    // `App` (`api/main.rs`) from encoding the stream, which would buffer a live stream
+    // in gzip frames.
+    if !response.headers().contains_key(header::CONTENT_ENCODING) {
+        builder.insert_header(actix_http::ContentEncoding::Identity);
+    }
     Ok(builder.streaming(response))
 }
 
@@ -717,7 +768,7 @@ mod tests {
     use super::*;
     use actix_web::body::to_bytes;
     use actix_web::test::TestRequest;
-    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn setup() {
@@ -745,45 +796,29 @@ mod tests {
         to_bytes(resp.into_body()).await.unwrap().to_vec()
     }
 
-    /// Test that streaming_proxy strips Accept-Encoding from the forwarded request
-    /// (verified via wiremock expect(0)) and forces Content-Encoding: identity
-    /// on the response.
+    /// The client's `Accept-Encoding` reaches the pipeline; a response without
+    /// `Content-Encoding` is relayed as identity, explicitly, so the manager's
+    /// `Compress` middleware (installed on the `App` in `api/main.rs`) leaves the stream alone.
     #[actix_web::test]
-    async fn test_streaming_proxy() {
+    async fn test_streaming_proxy_forwards_accept_encoding_and_defaults_to_identity() {
         setup();
         let mock_server = MockServer::start().await;
 
         let plain = b"{\"profile\":\"data\"}";
-
-        // Fallback: matches any GET regardless of headers, returns the plain body.
-        // Registered first so wiremock checks it *last*.
         Mock::given(method("GET"))
             .and(path("/dump_json_profile"))
+            .and(header("accept-encoding", "gzip"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_bytes(plain.to_vec())
                     .insert_header("content-type", "application/json"),
             )
-            .mount(&mock_server)
-            .await;
-
-        // Registered second so wiremock checks it *first*: if accept-encoding
-        // is present this more-specific mock matches instead of the fallback.
-        // expect(0) makes the test fail if this mock is ever hit — proving the
-        // proxy stripped the header before it reached the upstream.
-        Mock::given(method("GET"))
-            .and(path("/dump_json_profile"))
-            .and(header_exists("accept-encoding"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(0)
-            .named("should-not-receive-accept-encoding")
+            .expect(1)
             .mount(&mock_server)
             .await;
 
         let url = format!("{}/dump_json_profile", mock_server.uri());
         let client = awc::Client::default();
-
-        // Even though the original client sends Accept-Encoding, the proxy strips it.
         let (req, payload) = test_get_request(&[("accept-encoding", "gzip")]);
         let resp = streaming_proxy(
             &client,
@@ -797,14 +832,48 @@ mod tests {
         .unwrap();
 
         assert_eq!(resp.status(), 200);
-        assert_eq!(
-            resp.headers().get("content-encoding").unwrap(),
-            "identity",
-            "streaming_proxy must force Content-Encoding: identity"
-        );
-        let body = read_body(resp).await;
-        assert_eq!(body, plain);
-        // Dropping mock_server verifies the expect(0) assertion.
+        assert_eq!(resp.headers().get("content-encoding").unwrap(), "identity");
+        assert_eq!(read_body(resp).await, plain);
+    }
+
+    /// The pipeline's compressed bytes and `Content-Encoding` reach the client
+    /// untouched: the manager neither decodes nor relabels them.
+    #[actix_web::test]
+    async fn test_streaming_proxy_relays_upstream_content_encoding() {
+        setup();
+        let mock_server = MockServer::start().await;
+
+        let compressed = b"\x1f\x8b not really gzip, but the proxy must not care".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/dump_json_profile"))
+            .and(header("accept-encoding", "gzip"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(compressed.clone())
+                    .insert_header("content-type", "application/json")
+                    .insert_header("content-encoding", "gzip"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let url = format!("{}/dump_json_profile", mock_server.uri());
+        let client = awc::Client::default();
+        let (req, payload) = test_get_request(&[("accept-encoding", "gzip")]);
+        let resp = streaming_proxy(
+            &client,
+            &url,
+            "test-pipeline",
+            &req,
+            payload,
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.headers().get("content-encoding").unwrap(), "gzip");
+        assert_eq!(read_body(resp).await, compressed);
     }
 
     fn selected_protocol(subprotocols: Option<&str>) -> Option<String> {

--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.test.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.test.ts
@@ -64,6 +64,41 @@ describe('processProfileFiles without a circuit profile', () => {
   })
 })
 
+/** Build a ZipItem whose `read()` returns `bytes`. */
+function binaryFile(filename: string, bytes: Uint8Array): ZipItem {
+  return { filename, comment: '', read: () => bytes }
+}
+
+async function gzip(text: string): Promise<Uint8Array> {
+  const compressed = new Blob([text]).stream().pipeThrough(new CompressionStream('gzip'))
+  return new Uint8Array(await new Response(compressed).arrayBuffer())
+}
+
+describe('processProfileFiles with a gzip-compressed circuit profile', () => {
+  const profile = { metrics: [], worker_profiles: [], graph: { nodes: [], edges: [] } }
+
+  it('recognises circuit_profile.json.gz as a collection file', async () => {
+    const collections = selectProfiles([
+      binaryFile(`${TIMESTAMP}/circuit_profile.json.gz`, await gzip('{}'))
+    ])
+    expect(collections).toHaveLength(1)
+  })
+
+  it('inflates circuit_profile.json.gz before parsing it', async () => {
+    const result = await processProfileFiles([
+      binaryFile(`${TIMESTAMP}/circuit_profile.json.gz`, await gzip(JSON.stringify(profile)))
+    ])
+    expect(result.profile).toEqual(profile)
+  })
+
+  it('still parses a plain circuit_profile.json', async () => {
+    const result = await processProfileFiles([
+      file(`${TIMESTAMP}/circuit_profile.json`, JSON.stringify(profile))
+    ])
+    expect(result.profile).toEqual(profile)
+  })
+})
+
 describe('processProfileFiles runtimeConfig', () => {
   it('extracts runtime_config from pipeline_config.json', async () => {
     const runtime_config = { workers: 8, storage: { backend: { name: 'default' } } }

--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
@@ -4,7 +4,9 @@ import sortOn from 'sort-on'
 import { groupBy } from './array'
 import type { GlobalMetrics } from './globalMetrics'
 
-const circuitProfileRegex = /circuit_profile\.json$/
+// Bundles store the JSON profile gzip-compressed (`.json.gz`);
+// but legacy bundles may still carry plain `.json`.
+const circuitProfileRegex = /circuit_profile\.json(\.gz)?$/
 const dataflowGraphRegex = /dataflow_graph\.json$/
 const pipelineConfigRegex = /pipeline_config\.json$/
 const logsRegex = /logs\.txt$/
@@ -105,6 +107,21 @@ export function selectProfiles(files: ZipItem[]): [Date, ZipItem[]][] {
 }
 
 /**
+ * Returns the contents of a zip entry, gunzipped when the entry name ends in `.gz`.
+ * `file.read()` performs the unzip.
+ */
+async function readZipItem(file: ZipItem): Promise<Uint8Array> {
+  const bytes = await file.read()
+  if (!file.filename.endsWith('.gz')) {
+    return bytes
+  }
+  const inflated = new Blob([new Uint8Array(bytes)])
+    .stream()
+    .pipeThrough(new DecompressionStream('gzip'))
+  return new Uint8Array(await new Response(inflated).arrayBuffer())
+}
+
+/**
  * Process a specific set of profile files (already unzipped) into structured data.
  * Use this with the files from getSuitableProfiles() for efficient processing.
  * @param files Array of ZipItem files for a specific profile timestamp
@@ -117,7 +134,7 @@ export async function processProfileFiles(files: ZipItem[]): Promise<ProcessedPr
   const profileFile = files.find((file) => circuitProfileRegex.test(file.filename))
   let profile: JsonProfiles | undefined
   if (profileFile) {
-    profile = JSON.parse(decoder.decode(await profileFile.read())) as JsonProfiles
+    profile = JSON.parse(decoder.decode(await readZipItem(profileFile))) as JsonProfiles
   }
 
   const dataflowFile = files.find((file) => dataflowGraphRegex.test(file.filename))

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -802,7 +802,18 @@ class TestPipeline(SharedTestPipeline):
             with zipfile.ZipFile(io.BytesIO(support_bundle_bytes), "r") as zip_file:
                 file_list = zip_file.namelist()
                 # Files now live inside per-collection timestamp directories.
-                assert any(item.endswith("/circuit_profile.json") for item in file_list)
+                # The JSON profile is stored gzip-compressed, as the pipeline sent it.
+                json_profiles = [
+                    item
+                    for item in file_list
+                    if item.endswith("/circuit_profile.json.gz")
+                ]
+                assert json_profiles, file_list
+                with zip_file.open(json_profiles[0]) as member:
+                    with gzip.GzipFile(fileobj=member) as gz:
+                        profile = json.load(gz)
+                assert "worker_profiles" in profile
+                assert any(item.endswith("/circuit_profile.zip") for item in file_list)
                 assert "metadata.txt" in file_list
                 assert "metadata.json" in file_list
         except zipfile.BadZipFile:


### PR DESCRIPTION
Fixes #6559 

(But a separate independent fix is needed for multi-host, which I will submit separately).

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated

Here is a summary of the end-to-end flow, which appears also as a comment in `server.rs:

# Profile downloads.

`/dump_json_profile` delivers a circuit profile.
The profile size is O(workers x operators).
The data flow is:

  pipeline process:  [1] workers --> [2] circuit thread --> [3] blocking pool --> [4] actix worker
  coordinator:       --> [5] (multihost only) combines the hosts' profiles
  manager service:   --> [6] streaming proxy, or support-data collector
  client:            --> [7] REST client, or the profiler UI reading a support bundle

[1] Profiler (`dbsp::profile::Profiler`)
    - runs on: every worker thread of the pipeline process
    - what it does: walks the circuit and collects each operator's metadata
    - produces: a `WorkerProfile`, i.e., `Map<operatorId, OperatorMeta>``

[2] Circuit thread (`controller.rs`, `run_commands`)
    - runs on: the controller's circuit thread, between circuit steps
    - what it does: `DBSPHandle::retrieve_profile` assembles worker replies
    - produces: a `DbspProfile` (every worker's `WorkerProfile` plus the
      circuit `Graph`)

[3] Serializer (`stream_from_blocking_writer`, this file)
    - runs on: a Tokio blocking-pool thread
    - what it does: `DbspProfile::write_json` serializes one worker at a time
      into a `ChannelWriter`
    - produces: JSON text in `ChannelWriter::CHUNK_SIZE` chunks,
      gzip-compressed when negotiated

[4] HTTP handler (`dump_json_profile`, this file)
    - runs on: an actix worker thread
    - what it does: turns the channel's `ReceiverStream` into the response body
    - produces: a chunked HTTP response (never whole in memory), `application/json`,
      with `Content-Encoding: gzip` when negotiated

[5] Coordinator (`feldera-coordinator`, `crates/coord` in the cloud repository)
    - runs on: its own process, in multihost pipelines only
    - what it does: fetches each host's profile and combines them
    - produces: one JSON response with the hosts' `worker_profiles`
      concatenated

[6] Pipeline manager, one of two variants
    - runs on: the manager service
    - what it does:
        - the streaming proxy (`runner/interaction.rs`) serves the
           public `circuit_profile`, `circuit_json_profile` and
           `heap_profile` endpoints;
         - the support-data collector (`api/support_data_collector.rs`)
           fetches the profile on request, or every few minutes for
           running pipelines
    - produces:
         - the proxy: the body unchanged, headers included;
         - the collector: a database row holding the gzip-compressed JSON,
           inserted in the support bundle as `circuit_profile.json.gz`

[7] Client, one of two variants
    - runs on: outside Feldera
    - what it does:
         - a REST client (`fda`, `curl`) writes the body to a file;
         - the profiler UI (`js-packages/profiler-layout`) inflates the
           `circuit_profile.json.gz` entry of a support bundle and parses the
           JSON in the browser
    - produces:
         - the REST client: a file;
         - the profiler UI: the profile displayed in the browser

Within the pipeline process:
- The circuit thread is busy only while the workers collect metadata; the
  handler awaits the reply and never blocks it.
- Serialization runs on the blocking pool, one worker at a time, into
  `ChannelWriter::CHUNK_SIZE` chunks; the whole JSON never exists in memory.
- The channel is bounded (`ChannelWriter::CHANNEL_CAPACITY`): a slow client
  stalls the serializer, not the circuit; a disconnected client surfaces as
  `BrokenPipe` and ends it.
