### PR TITLE
[fda] Name 0.340.0 as the first release without the token command

### DIFF
--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -3928,7 +3928,7 @@ fn main() {
             if cli.host.ends_with("/") {
                 cli.host = cli.host.trim_end_matches('/').to_string();
             }
-            // Releases before 0.339.0 read this variable; a shell that still
+            // Releases before 0.340.0 read this variable; a shell that still
             // exports it would otherwise send no credential and see a bare 401.
             if cli.auth.is_none()
                 && cli.oidc_token_file.is_none()


### PR DESCRIPTION
Comment-only follow-up to #6979: v0.339.0 was cut from a commit that predates the change, so the first release that reads FELDERA_OIDC_TOKEN_FILE is 0.340.0. No behaviour change, no tests affected.