### PR TITLE
[python] serialize the shared Delta fixture build

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -211,16 +211,25 @@ def _log_row_diff(label: str, rows: list) -> None:
         log(json.dumps(row, default=str))
 
 
+def suite_tag() -> str:
+    """Identifier of the test suite this process belongs to, or "" outside CI.
+
+    CI runs `python` and `python-multihost` concurrently against one Feldera
+    instance and one MinIO bucket. Only `python-multihost` sets
+    FELDERA_TEST_TAG_SUFFIX (to "m"), which is enough to keep anything the two
+    would otherwise share disjoint.
+    """
+    return os.getenv("FELDERA_TEST_TAG_SUFFIX", "")
+
+
 def unique_pipeline_name(base_name: str) -> str:
     """
     In CI, multiple tests of different runs can run against the same Feldera instance, we
     make sure the pipeline names they use are unique by appending the first 5 characters
-    of the commit SHA or 'local' if not in CI. FELDERA_TEST_TAG_SUFFIX distinguishes
+    of the commit SHA or 'local' if not in CI. The suite tag distinguishes
     test suites of the same commit running concurrently against one instance.
     """
-    ci_tag = os.getenv("GITHUB_SHA", "local")[:5] + os.getenv(
-        "FELDERA_TEST_TAG_SUFFIX", ""
-    )
+    ci_tag = os.getenv("GITHUB_SHA", "local")[:5] + suite_tag()
     name = f"{ci_tag}_{base_name}"
     # The pipeline name becomes a Kubernetes label value (max 63 chars). Fail here
     # with a clear message rather than letting provisioning hit a cryptic 422.

--- a/python/tests/runtime/test_checkpoint_runtime_upgrade.py
+++ b/python/tests/runtime/test_checkpoint_runtime_upgrade.py
@@ -258,7 +258,11 @@ def _row(idx: int) -> dict:
 
 
 def _ensure_delta_source(source: DeltaTestLocation) -> None:
-    """Generate the Delta source if the cache is missing or wrong-sized."""
+    """Generate the Delta source if the cache is missing or wrong-sized.
+
+    Needs no build lock: one atomic Delta commit of deterministic content, so a
+    racing writer rewrites the same rows rather than mixing two builds.
+    """
 
     cached = source.row_count(missing_ok=True)
     if cached == TABLE_ROWS:

--- a/python/tests/unit/test_delta_fixture_build_lock.py
+++ b/python/tests/unit/test_delta_fixture_build_lock.py
@@ -1,0 +1,202 @@
+"""Concurrent builders of one cached Delta fixture must not collide.
+
+``ensure_delta_spark_fixture`` caches at a path shared by every test needing
+that fixture, so xdist workers reach it at once. The build is not idempotent
+(data file and physical column names are fresh per build), so two builders
+placing a tree at once leave a log describing files the tree does not have.
+
+The builder subprocess is stubbed: this covers the locking, not PySpark.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+import types
+import uuid
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from tests.utils import LOCAL_FIXTURE_ROOT, DeltaTestLocation  # noqa: E402
+
+# Wide enough that an unlocked second builder lands inside the first's window.
+_BUILD_SECONDS = 1.0
+_BUILDERS = 2
+
+
+def _write_fake_delta_tree(staging: pathlib.Path, seed: int) -> None:
+    """Write a minimal Delta tree whose data file name is unique to ``seed``.
+
+    The log names a data file only this build produced, which is what makes a
+    concurrent build destructive.
+    """
+    log_dir = staging / "_delta_log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    data_file = f"part-00000-{seed}.parquet"
+    (staging / data_file).write_text(str(seed), encoding="utf-8")
+    (log_dir / "00000000000000000000.json").write_text(
+        json.dumps({"add": {"path": data_file}}), encoding="utf-8"
+    )
+
+
+def _build_fixture(subpath: str, build_log: str, barrier) -> None:
+    """Child process: build the fixture once, recording that it did.
+
+    Spawned, so the ``flock`` is crossed by real processes as xdist does it.
+    """
+    # Drive the local backend; the S3 branch wants MinIO credentials.
+    os.environ.pop("CI", None)
+
+    from tests import utils
+
+    def fake_builder_run(cmd, check=False, **kwargs):
+        staging = pathlib.Path(cmd[-1])
+        time.sleep(_BUILD_SECONDS)
+        _write_fake_delta_tree(staging, seed=os.getpid())
+        with open(build_log, "a", encoding="utf-8") as handle:
+            handle.write(f"{os.getpid()}\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    utils.subprocess = types.SimpleNamespace(
+        run=fake_builder_run,
+        CalledProcessError=subprocess.CalledProcessError,
+    )
+
+    loc = utils.DeltaTestLocation.create("fixture_lock_test", stable_subpath=subpath)
+    barrier.wait()
+    utils.ensure_delta_spark_fixture(loc, "stub_builder.py")
+
+
+@pytest.fixture(name="fixture_subpath")
+def fixture_subpath_fixture():
+    """A cache path of this test's own, removed afterwards."""
+    subpath = f"build_lock_test_{uuid.uuid4().hex}"
+    yield subpath
+    shutil.rmtree(LOCAL_FIXTURE_ROOT / subpath, ignore_errors=True)
+
+
+def test_concurrent_builders_build_once(tmp_path, fixture_subpath):
+    """Racing builders produce exactly one build and one coherent tree."""
+    if shutil.which("uv") is None:
+        pytest.skip("ensure_delta_spark_fixture requires `uv` on PATH")
+
+    build_log = tmp_path / "builds.txt"
+    ctx = multiprocessing.get_context("spawn")
+    barrier = ctx.Barrier(_BUILDERS)
+    workers = [
+        ctx.Process(
+            target=_build_fixture,
+            args=(fixture_subpath, str(build_log), barrier),
+        )
+        for _ in range(_BUILDERS)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=120)
+        # A wedged builder is the failure under test: reap it, or
+        # multiprocessing's atexit join hangs pytest instead of failing it.
+        if worker.is_alive():
+            worker.terminate()
+            worker.join(timeout=10)
+
+    builds = build_log.read_text(encoding="utf-8").split() if build_log.exists() else []
+    assert len(builds) == 1, (
+        f"exactly one process may build the fixture, but {len(builds)} did "
+        f"({builds}); the losers must wait on the lock and then see the "
+        "finished fixture instead of rebuilding over it"
+    )
+
+    assert [worker.exitcode for worker in workers] == [0] * _BUILDERS, (
+        "a non-zero exit means the builders tripped over each other's place-tree"
+    )
+
+    fixture_dir = LOCAL_FIXTURE_ROOT / fixture_subpath
+    assert (fixture_dir / DeltaTestLocation.READY_MARKER).is_file(), (
+        "the completion marker must be present once the tree is placed"
+    )
+
+    log_file = fixture_dir / "_delta_log" / "00000000000000000000.json"
+    added = json.loads(log_file.read_text(encoding="utf-8"))["add"]["path"]
+    assert (fixture_dir / added).is_file(), (
+        f"the log names data file '{added}' which is not in the tree: the "
+        "fixture is a mix of two builds"
+    )
+
+
+def test_half_placed_fixture_is_rebuilt(monkeypatch, fixture_subpath):
+    """A tree left behind by a builder that died mid-place must not be reused.
+
+    It already has a ``_delta_log``, so the log-existence check alone would
+    hand the wreckage to every later test.
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("ensure_delta_spark_fixture requires `uv` on PATH")
+
+    monkeypatch.delenv("CI", raising=False)
+
+    from tests import utils
+
+    # Log placed, data file and marker never written.
+    fixture_dir = LOCAL_FIXTURE_ROOT / fixture_subpath
+    (fixture_dir / "_delta_log").mkdir(parents=True, exist_ok=True)
+    (fixture_dir / "_delta_log" / "00000000000000000000.json").write_text(
+        json.dumps({"add": {"path": "part-00000-vanished.parquet"}}), encoding="utf-8"
+    )
+    assert utils.DeltaTestLocation.create(
+        "fixture_lock_test", stable_subpath=fixture_subpath
+    ).delta_log_exists(), "precondition: the half-placed tree looks present"
+
+    builds = []
+
+    def fake_builder_run(cmd, check=False, **kwargs):
+        _write_fake_delta_tree(pathlib.Path(cmd[-1]), seed=len(builds))
+        builds.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(
+        utils,
+        "subprocess",
+        types.SimpleNamespace(
+            run=fake_builder_run,
+            CalledProcessError=subprocess.CalledProcessError,
+        ),
+    )
+
+    loc = utils.DeltaTestLocation.create(
+        "fixture_lock_test", stable_subpath=fixture_subpath
+    )
+    utils.ensure_delta_spark_fixture(loc, "stub_builder.py")
+
+    assert len(builds) == 1, (
+        "a fixture without the completion marker must be rebuilt, not reused"
+    )
+    assert (fixture_dir / DeltaTestLocation.READY_MARKER).is_file()
+    assert not (fixture_dir / "part-00000-vanished.parquet").exists(), (
+        "the rebuild must replace the half-placed tree, not merge with it"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"), [("multihost", "suite-multihost"), ("", "suite")]
+)
+def test_stable_path_is_suite_namespaced(monkeypatch, tag, expected):
+    """Concurrent CI suites must not share a fixture path in the MinIO bucket."""
+    from tests import utils
+
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("FELDERA_TEST_TAG_SUFFIX", tag)
+    monkeypatch.setenv("CI_K8S_MINIO_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("CI_K8S_MINIO_SECRET_ACCESS_KEY", "secret")
+
+    loc = utils.DeltaTestLocation.create("p", stable_subpath="column_mapping_v3")
+
+    assert loc.root_path.endswith(f"_fixtures/{expected}/column_mapping_v3")

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -1,15 +1,20 @@
+import contextlib
+import fcntl
 import logging
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+from feldera.testutils import suite_tag
 
 if TYPE_CHECKING:
     from feldera.output_handler import OutputHandler
@@ -26,6 +31,21 @@ MINIO_PROVIDER = os.environ.get("CI_MINIO_PROVIDER", "Minio")
 KAFKA_BOOTSTRAP = os.environ.get(
     "KAFKA_BOOTSTRAP_SERVERS", "ci-kafka-bootstrap.kafka:9092"
 )
+LOCAL_FIXTURE_ROOT = pathlib.Path("/tmp/feldera_fixtures")
+
+
+def fixture_suite_dir() -> str:
+    """Bucket subdirectory holding one test suite's cached fixtures.
+
+    CI runs `python` and `python-multihost` concurrently against one MinIO
+    bucket. A fixture build is not byte-reproducible (fresh `col-<uuid>`
+    physical names, fresh Parquet file names), so two suites building at one
+    path overwrite each other's identically-named `_delta_log/*.json` and the
+    surviving log describes columns its data files do not have. In CI that
+    gives `suite-m` for `python-multihost` and `suite` for `python`.
+    """
+    tag = suite_tag()
+    return f"suite-{tag}" if tag else "suite"
 
 
 def env_truthy(name: str) -> bool:
@@ -60,6 +80,10 @@ class DeltaTestLocation:
     # cached fixture instead of paying to rebuild it.
     stable: bool = False
 
+    # Written last by ``_place_tree``: a builder killed mid-upload leaves a
+    # tree that already satisfies ``delta_log_exists``.
+    READY_MARKER = "_fixture_ready"
+
     @classmethod
     def create(
         cls,
@@ -73,20 +97,25 @@ class DeltaTestLocation:
         :param mode: Value of the connector's ``mode`` field. Output
             connectors use ``"truncate"`` (the default); input connectors
             should pass ``"snapshot"``.
-        :param stable_subpath: When set, locates the table at a fixed,
-            shared path (``_fixtures/<stable_subpath>``) that is *not*
-            namespaced by the pipeline name or commit SHA, so a fixture
-            built once is reused by every later run and every commit.
-            When unset, a fresh random subpath under ``pipeline_name`` is
-            used (the original behavior). Use a stable path only for
-            fixtures whose contents are deterministic across runs.
+        :param stable_subpath: When set, locates the table at a fixed path
+            (``_fixtures/<suite>/<stable_subpath>``) that is *not* namespaced
+            by the pipeline name or commit SHA, so every test needing that
+            fixture shares one build of it. When unset, a fresh random subpath
+            under ``pipeline_name`` is used (the original behavior). Use a
+            stable path only for fixtures whose contents are deterministic
+            across runs.
+
+            The cache spans runs locally, but not in CI: MinIO and its volume
+            are created fresh per integration-test run, so each suite rebuilds
+            every fixture once per run. See :func:`fixture_suite_dir` for why
+            suites must not share the path.
         """
 
         if runs_in_ci():
             access_key = required_env("CI_K8S_MINIO_ACCESS_KEY_ID")
             secret_key = required_env("CI_K8S_MINIO_SECRET_ACCESS_KEY")
             if stable_subpath is not None:
-                prefix = f"_fixtures/{stable_subpath}"
+                prefix = f"_fixtures/{fixture_suite_dir()}/{stable_subpath}"
             else:
                 prefix = f"{pipeline_name}/{uuid.uuid4().hex}"
             root_path = f"{MINIO_BUCKET}/{prefix}"
@@ -117,7 +146,8 @@ class DeltaTestLocation:
             )
 
         if stable_subpath is not None:
-            local_dir = pathlib.Path("/tmp/feldera_fixtures") / stable_subpath
+            # No suite split: one suite per developer machine.
+            local_dir = LOCAL_FIXTURE_ROOT / stable_subpath
             local_dir.mkdir(parents=True, exist_ok=True)
         else:
             local_dir = pathlib.Path(
@@ -281,6 +311,21 @@ class DeltaTestLocation:
         except FileNotFoundError:
             return False
 
+    def fixture_is_complete(self) -> bool:
+        """Return True when a fully placed fixture tree is present here.
+
+        A half-placed tree lacks the ``READY_MARKER`` and so reads as absent.
+        """
+        if self.local_dir is not None:
+            return (self.local_dir / self.READY_MARKER).is_file()
+
+        import pyarrow.fs as pafs
+
+        info = self._s3_filesystem().get_file_info(
+            f"{self.root_path}/{self.READY_MARKER}"
+        )
+        return info.type == pafs.FileType.File
+
     def _place_tree(self, staging: pathlib.Path) -> None:
         """Copy a locally-built Delta table tree to where this location stores
         its data: the local directory, or the S3/MinIO bucket, depending on
@@ -291,19 +336,30 @@ class DeltaTestLocation:
         ``self.local_dir`` is deleted before the copy. S3/MinIO targets get
         the data files first and ``_delta_log`` last, so a reader observing
         the upload mid-flight never sees a log referencing a missing parquet.
+        The ``READY_MARKER`` is removed before the first write and written
+        last of all, so a reader that finds it knows the whole tree landed.
         """
         if self.local_dir is not None:
             if self.local_dir.exists():
                 shutil.rmtree(self.local_dir)
-            shutil.copytree(staging, self.local_dir)
+            # `dirs_exist_ok`: an unlocked `create()` elsewhere may have
+            # recreated the directory between the rmtree and here.
+            shutil.copytree(staging, self.local_dir, dirs_exist_ok=True)
+            (self.local_dir / self.READY_MARKER).write_text("", encoding="utf-8")
             return
 
         fs = self._s3_filesystem()
+        # Marker off before the first byte lands, on after the last, so a
+        # reader that finds it never sees a half-replaced tree.
+        with contextlib.suppress(FileNotFoundError):
+            fs.delete_file(f"{self.root_path}/{self.READY_MARKER}")
         files = [path for path in sorted(staging.rglob("*")) if path.is_file()]
         for path in sorted(files, key=lambda p: ("_delta_log" in p.parts, p.name)):
             rel = path.relative_to(staging).as_posix()
             with fs.open_output_stream(f"{self.root_path}/{rel}") as out:
                 out.write(path.read_bytes())
+        with fs.open_output_stream(f"{self.root_path}/{self.READY_MARKER}") as out:
+            out.write(b"")
 
     def cleanup(self) -> None:
         """Remove the local temp directory, if any.
@@ -490,6 +546,25 @@ class IcebergTestLocation:
             self.cleanup_dir = None
 
 
+@contextlib.contextmanager
+def _fixture_build_lock(key: str) -> Iterator[None]:
+    """Serialize the check-then-build of the fixture at ``key`` across processes.
+
+    :func:`fixture_suite_dir` keeps the other suite off this path, so every
+    contender is an xdist worker on this host and a local ``flock`` suffices
+    even for a remote fixture. The kernel drops it if a builder dies.
+    """
+    lock_dir = LOCAL_FIXTURE_ROOT / ".locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{re.sub(r'[^A-Za-z0-9._-]', '_', key)}.lock"
+    with open(lock_path, "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
 def ensure_delta_spark_fixture(
     loc: DeltaTestLocation,
     builder_script: str | os.PathLike[str],
@@ -505,9 +580,9 @@ def ensure_delta_spark_fixture(
     can only be written by Delta Spark, not by delta-rs or the ``deltalake``
     wheel. This builds such a fixture once and reuses it:
 
-    * If the fixture is already present (``is_present``, defaulting to
-      :meth:`DeltaTestLocation.delta_log_exists`), do nothing — so a
-      ``stable_subpath`` cache is reused across runs.
+    * If the fixture is already present (the completion marker is there and
+      ``is_present``, defaulting to :meth:`DeltaTestLocation.delta_log_exists`,
+      agrees), do nothing, so every test needing it shares one build.
     * Otherwise run ``builder_script`` in an isolated environment
       (``uv run --no-project --with <delta_spark_spec> python <builder_script>
       <staging> *builder_args``), staging into a temp dir so a half-finished
@@ -522,17 +597,23 @@ def ensure_delta_spark_fixture(
     :param builder_args: Extra positional arguments passed after the staging
         directory. Each is stringified verbatim with ``str()`` — pass
         primitives; ``None`` would become the literal string ``"None"``.
-    :param is_present: Predicate deciding whether the fixture already exists;
-        also re-checked after upload to catch partial uploads.
+    :param is_present: Predicate deciding whether the fixture already holds the
+        content this caller wants; also re-checked after upload. It is ANDed
+        with :meth:`DeltaTestLocation.fixture_is_complete`, which is what rules
+        out a partially placed tree.
     :param max_attempts: How many times to run the builder before giving up.
         Spark resolves the delta-spark dependency tree from Maven Central on
         this path; that download is prone to transient failures (0-byte
         artifacts, half-written Ivy cache files, gateway timeouts) that clear on
         a fresh attempt, so retry rather than fail the test on infra flakiness.
     """
-    present = (
+    matches = (
         is_present if is_present is not None else DeltaTestLocation.delta_log_exists
     )
+
+    def present(location: DeltaTestLocation) -> bool:
+        return location.fixture_is_complete() and matches(location)
+
     if present(loc):
         return
 
@@ -541,6 +622,31 @@ def ensure_delta_spark_fixture(
             "`uv` is required on PATH to build the PySpark Delta fixture "
             f"(builder runs via `uv run --with {delta_spark_spec}`)."
         )
+
+    with _fixture_build_lock(loc.root_path):
+        _build_delta_spark_fixture(
+            loc,
+            builder_script,
+            builder_args,
+            delta_spark_spec=delta_spark_spec,
+            present=present,
+            max_attempts=max_attempts,
+        )
+
+
+def _build_delta_spark_fixture(
+    loc: DeltaTestLocation,
+    builder_script: str | os.PathLike[str],
+    builder_args: Sequence[object],
+    *,
+    delta_spark_spec: str,
+    present: Callable[[DeltaTestLocation], bool],
+    max_attempts: int,
+) -> None:
+    """Build and place the fixture at ``loc``. Call under the build lock."""
+    # Whoever held the lock before us may have built it already.
+    if present(loc):
+        return
 
     for attempt in range(1, max_attempts + 1):
         # Fresh staging each attempt: a builder that died mid-write must not


### PR DESCRIPTION
ensure_delta_spark_fixture did an unguarded check-then-build at a path shared by two concurrent suites and by xdist workers. Concurrent builders overwrote each other's identically-named _delta_log/*.json while both sets of randomly-named data files survived, leaving a log naming col-<uuid> columns absent from the Parquet it pointed at. Follow/CDC then read every mapped column as NULL and NOT NULL dropped the rows.

Namespace the fixture prefix per suite, flock the check-then-build, and require a completion marker written last so a half-placed tree is rebuilt.


fixes https://github.com/feldera/cloud/issues/1952