### PR TITLE
[adapters] Read INT96 Parquet timestamps as microseconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,8 +3358,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3413,8 +3412,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3438,8 +3436,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3461,8 +3458,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3486,8 +3482,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "futures",
  "log",
@@ -3497,8 +3492,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3532,8 +3526,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3556,8 +3549,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3579,8 +3571,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3603,8 +3594,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3633,14 +3623,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3662,8 +3650,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3685,8 +3672,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3698,8 +3684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3730,8 +3715,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3752,8 +3736,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3777,8 +3760,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -3802,8 +3784,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3818,8 +3799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3836,8 +3816,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3846,8 +3825,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -3857,8 +3835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "chrono",
@@ -3877,8 +3854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3901,8 +3877,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3916,8 +3891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3933,8 +3907,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3952,8 +3925,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3984,8 +3956,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a387aaef949dc16bb6abc81bd1af850ec7449183aef011214f9724957495738"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "chrono",
@@ -4012,8 +3983,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e614c7c53a9c304c6a850b821010bb492e57300311835f1180613f9d2c63d9"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4023,8 +3993,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4040,8 +4009,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4054,8 +4022,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+source = "git+https://github.com/feldera/datafusion.git?rev=bee5811ee4c1cfea159bc2e6ece0309c59a66b9f#bee5811ee4c1cfea159bc2e6ece0309c59a66b9f"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,3 +374,57 @@ debug = true
 
 [profile.release]
 debug = "line-tables-only"
+
+# Feldera fork of datafusion: release 53.1.0 + 1 patch, on branch
+# `int96-preserve-field-metadata-53.1.0`.
+#
+#   - Preserve field metadata when coercing INT96 timestamps.
+#     `Int96Coercer` rebuilds struct, list and map fields with `Field::new_*`,
+#     which start from empty metadata, so reading a file that holds an INT96
+#     column strips `PARQUET:field_id` from every container field. A Delta
+#     table with column mapping pairs its columns to the read schema by that
+#     id, so a struct column silently reads as NULL.
+#     Upstream issue:  https://github.com/apache/datafusion/issues/24786
+#     Upstream branch: https://github.com/ryzhyk/datafusion/tree/int96-preserve-field-metadata
+#     Repro:           https://github.com/ryzhyk/coerce_int96_bug
+#
+# Patching one crate pulls its siblings in from the fork, so every datafusion
+# crate in the graph must be patched or the same crate resolves twice, once
+# from the fork and once from crates.io, and the build fails on mismatched
+# types. `datafusion-functions-json` is a third-party crate, not part of the
+# datafusion workspace, so it stays on crates.io.
+#
+# Drop this section once the fix is released upstream.
+[patch.crates-io]
+datafusion = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-catalog = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-catalog-listing = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-common-runtime = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-arrow = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-csv = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-json = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-doc = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-execution = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-aggregate = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-aggregate-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-nested = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-table = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-window = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-window-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-macros = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr-adapter = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-plan = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-proto = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-proto-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-pruning = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-session = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-sql = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }

--- a/crates/adapters/src/format/parquet.rs
+++ b/crates/adapters/src/format/parquet.rs
@@ -9,6 +9,7 @@ use arrow::datatypes::{
     TimeUnit,
 };
 use bytes::Bytes;
+use datafusion::datasource::file_format::parquet::coerce_int96_to_resolution;
 use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_adapterlib::ConnectorMetadata;
@@ -20,7 +21,11 @@ use feldera_types::serde_with_context::serde_config::{
 };
 use feldera_types::serde_with_context::{DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat};
 use parquet::arrow::ArrowWriter;
-use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReader,
+    ParquetRecordBatchReaderBuilder,
+};
+use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
 use serde::Deserialize;
 use serde_arrow::ArrayBuilder;
@@ -55,6 +60,58 @@ pub const fn default_arrow_serde_config() -> &'static SqlSerdeConfig {
         binary_format: BinaryFormat::Array,
         uuid_format: UuidFormat::String,
     }
+}
+
+/// Time unit Feldera decodes deprecated INT96 Parquet timestamps at.
+///
+/// Spark and Databricks still write timestamps as INT96, which spans a wider
+/// date range than 64-bit nanoseconds. arrow-rs converts INT96 to nanoseconds
+/// unless told otherwise, wrapping silently: 4000-12-31 becomes 2247-05-04.
+/// Microseconds cover the whole INT96 range and match Feldera's own TIMESTAMP
+/// precision, so avoiding the nanosecond conversion preserves the value.
+pub(crate) const INT96_TIME_UNIT: TimeUnit = TimeUnit::Microsecond;
+
+/// [`INT96_TIME_UNIT`] as datafusion spells it in its
+/// `execution.parquet.coerce_int96` setting.
+pub(crate) const INT96_TIME_UNIT_NAME: &str = "us";
+
+/// Retype `metadata`'s INT96 timestamp columns as [`INT96_TIME_UNIT`], or
+/// return `None` when the file declares no such column.
+///
+/// Rebuilding the metadata restates the options it was loaded with, so the
+/// caller passes the same `options` it used; defaulting them here would drop
+/// the caller's settings on exactly the files that contain an INT96 column.
+pub(crate) fn int96_as_micros(
+    metadata: &ArrowReaderMetadata,
+    options: &ArrowReaderOptions,
+) -> Result<Option<ArrowReaderMetadata>, ParquetError> {
+    let Some(schema) = coerce_int96_to_resolution(
+        metadata.parquet_schema(),
+        metadata.schema(),
+        &INT96_TIME_UNIT,
+    ) else {
+        return Ok(None);
+    };
+    ArrowReaderMetadata::try_new(
+        Arc::clone(metadata.metadata()),
+        options.clone().with_schema(Arc::new(schema)),
+    )
+    .map(Some)
+}
+
+/// Open `data` for reading.
+fn open_parquet_reader(
+    data: Bytes,
+    batch_size: usize,
+) -> Result<ParquetRecordBatchReader, ParquetError> {
+    let options = ArrowReaderOptions::default();
+    let mut metadata = ArrowReaderMetadata::load(&data, options.clone())?;
+    if let Some(coerced) = int96_as_micros(&metadata, &options)? {
+        metadata = coerced;
+    }
+    ParquetRecordBatchReaderBuilder::new_with_metadata(data, metadata)
+        .with_batch_size(batch_size)
+        .build()
 }
 
 /// CSV format parser.
@@ -115,7 +172,7 @@ impl Parser for ParquetParser {
 
         let bytes = Bytes::copy_from_slice(data);
 
-        let parquet_reader = match ParquetRecordBatchReader::try_new(bytes, 1_000_000) {
+        let parquet_reader = match open_parquet_reader(bytes, 1_000_000) {
             Ok(parquet_reader) => parquet_reader,
             Err(e) => {
                 return (

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -6,10 +6,14 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
-use arrow::array::RecordBatch;
+use arrow::array::{Array, ListArray, RecordBatch, StructArray, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, TimeUnit};
+use bytes::Bytes;
+use chrono::DateTime;
 use dbsp::OrdZSet;
 use dbsp::utils::Tup2;
 use feldera_adapterlib::transport::OutputBatchType;
+use feldera_sqllib::Timestamp;
 use feldera_sqllib::Variant;
 use feldera_types::format::json::JsonFlavor;
 use feldera_types::format::parquet::ParquetEncoderConfig;
@@ -28,9 +32,18 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::{
     catalog::SerBatchReader,
-    format::{Encoder, parquet::ParquetEncoder},
+    format::{Encoder, parquet::ParquetEncoder, parquet::open_parquet_reader},
     static_compile::seroutput::SerBatchImpl,
-    test::{DEFAULT_TIMEOUT_MS, MockOutputConsumer, TestStruct2, mock_input_pipeline, wait},
+    test::{
+        DEFAULT_TIMEOUT_MS, MockOutputConsumer, TestStruct2, TimestampTestStruct,
+        mock_input_pipeline,
+        parquet_timestamps::{
+            TimestampEncoding, timestamp_test_data, write_mixed_column_parquet,
+            write_nested_int96_parquet, write_sub_microsecond_int96_parquet,
+            write_timestamp_parquet,
+        },
+        wait,
+    },
 };
 
 /// Parse Parquet file into an array of `T`.
@@ -117,6 +130,203 @@ fn parquet_input_test(compression: Compression) {
     for (i, upd) in zset.state().flushed.iter().enumerate() {
         assert_eq!(upd.unwrap_insert(), &test_data[i]);
     }
+}
+
+/// The `parquet` input format decodes INT96 timestamps without going through
+/// nanoseconds, so a far-future or far-past date survives ingest.
+#[test]
+fn parquet_input_int96_timestamps() {
+    let test_data = timestamp_test_data();
+    let temp_file = NamedTempFile::new().unwrap();
+    write_timestamp_parquet(temp_file.path(), &test_data, TimestampEncoding::Int96);
+
+    let config = serde_json::from_value(json!({
+        "stream": "test_input",
+        "transport": {
+            "name": "file_input",
+            "config": {
+                "path": temp_file.path()
+            }
+        },
+        "format": {
+            "name": "parquet"
+        }
+    }))
+    .unwrap();
+
+    let (endpoint, _consumer, _parser, zset) =
+        mock_input_pipeline::<TimestampTestStruct, TimestampTestStruct>(
+            config,
+            Relation::new(
+                "test".into(),
+                TimestampTestStruct::schema(),
+                false,
+                BTreeMap::new(),
+            ),
+        )
+        .unwrap();
+    endpoint.extend();
+    wait(
+        || {
+            endpoint.queue(false);
+            zset.state().flushed.len() == test_data.len()
+        },
+        DEFAULT_TIMEOUT_MS,
+    )
+    .unwrap();
+
+    for (i, upd) in zset.state().flushed.iter().enumerate() {
+        assert_eq!(upd.unwrap_insert(), &test_data[i]);
+    }
+}
+
+/// Sub-microsecond precision in an INT96 timestamp is dropped, not rounded.
+///
+/// INT96 counts nanoseconds within the day, so a writer can store a remainder
+/// finer than Feldera's `TIMESTAMP` holds. `Int96::to_micros` truncates it
+/// toward zero, which is a floor even before the epoch, where the negative
+/// part sits in the day number rather than the nanoseconds.
+///
+/// Each row below reads back as exactly the microsecond it was built from, and
+/// every remainder is large enough that rounding would give the next one.
+#[test]
+fn parquet_input_int96_truncates_sub_microseconds() {
+    fn at(rfc3339: &str) -> Timestamp {
+        Timestamp::from_dateTime(DateTime::parse_from_rfc3339(rfc3339).unwrap().to_utc())
+    }
+
+    let rows = [
+        (at("2024-06-01T12:00:00.123456Z"), 789),
+        // Before the epoch, so the day number is negative while the
+        // nanoseconds within the day stay positive.
+        (at("1600-01-01T00:00:00.123456Z"), 789),
+        // Past the nanosecond range, and one nanosecond below a whole
+        // microsecond.
+        (at("4000-12-31T00:00:00.999999Z"), 999),
+    ];
+
+    let temp_file = NamedTempFile::new().unwrap();
+    write_sub_microsecond_int96_parquet(temp_file.path(), &rows);
+
+    let data = Bytes::from(std::fs::read(temp_file.path()).unwrap());
+    let batches: Vec<RecordBatch> = open_parquet_reader(data, 1024)
+        .unwrap()
+        .map(|batch| batch.unwrap())
+        .collect();
+    let column = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .expect("INT96 must decode at microsecond resolution");
+
+    let read_back: Vec<i64> = column.values().to_vec();
+    let expected: Vec<i64> = rows.iter().map(|(ts, _)| ts.microseconds()).collect();
+    assert_eq!(read_back, expected);
+}
+
+/// A file whose two timestamp columns carry different physical encodings
+/// decodes each one on its own terms: the INT96 column reads back retyped to
+/// microseconds, the INT64 microsecond column exactly as it was written, down
+/// to its UTC marker.
+///
+/// Coercion keys off a column's own physical type, so neither column's
+/// treatment depends on the other. Spark leaves a file in this shape when it
+/// rewrites some timestamp columns and not others.
+#[test]
+fn parquet_input_mixed_timestamp_columns_in_one_file() {
+    let test_data = timestamp_test_data();
+    let temp_file = NamedTempFile::new().unwrap();
+    write_mixed_column_parquet(temp_file.path(), &test_data);
+
+    let data = Bytes::from(std::fs::read(temp_file.path()).unwrap());
+    let batches: Vec<RecordBatch> = open_parquet_reader(data, 1024)
+        .unwrap()
+        .map(|batch| batch.unwrap())
+        .collect();
+    let batch = &batches[0];
+
+    // INT96 carries no time zone, so coercion lands on a naive microsecond
+    // timestamp; the INT64 column keeps the UTC marker it was written with.
+    let schema = batch.schema();
+    assert_eq!(
+        schema.field_with_name("ts_int96").unwrap().data_type(),
+        &DataType::Timestamp(TimeUnit::Microsecond, None),
+    );
+    assert_eq!(
+        schema.field_with_name("ts_micros").unwrap().data_type(),
+        &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+    );
+
+    let expected: Vec<Option<i64>> = test_data
+        .iter()
+        .map(|row| row.ts.map(|ts| ts.microseconds()))
+        .collect();
+    for name in ["ts_int96", "ts_micros"] {
+        let column = batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap_or_else(|| panic!("{name} must decode at microsecond resolution"));
+        let read_back: Vec<Option<i64>> = column.iter().collect();
+        assert_eq!(read_back, expected, "column {name}");
+    }
+}
+
+/// An INT96 timestamp inside a struct field and inside a list element decodes
+/// at microsecond resolution, the same as one at the top level.
+///
+/// Delta permits timestamps at any depth and Spark writes those as INT96 too.
+/// Coercion reaches them by walking struct, list and map paths, including the
+/// `.list.element` name Parquet gives a list's elements.
+#[test]
+fn parquet_input_nested_int96_timestamps() {
+    let test_data = timestamp_test_data();
+    let temp_file = NamedTempFile::new().unwrap();
+    write_nested_int96_parquet(temp_file.path(), &test_data);
+
+    let data = Bytes::from(std::fs::read(temp_file.path()).unwrap());
+    let batches: Vec<RecordBatch> = open_parquet_reader(data, 1024)
+        .unwrap()
+        .map(|batch| batch.unwrap())
+        .collect();
+    let batch = &batches[0];
+
+    // The fixture skips rows without a timestamp.
+    let expected: Vec<i64> = test_data
+        .iter()
+        .filter_map(|row| row.ts)
+        .map(|ts| ts.microseconds())
+        .collect();
+
+    let in_struct = batch
+        .column_by_name("nested")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap()
+        .column_by_name("ts")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .expect("INT96 inside a struct must decode at microsecond resolution")
+        .values()
+        .to_vec();
+    assert_eq!(in_struct, expected, "struct field");
+
+    let in_list = batch
+        .column_by_name("ts_list")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .values()
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .expect("INT96 inside a list must decode at microsecond resolution")
+        .values()
+        .to_vec();
+    assert_eq!(in_list, expected, "list element");
 }
 
 #[test]

--- a/crates/adapters/src/integrated/delta_table/deletion_vector.rs
+++ b/crates/adapters/src/integrated/delta_table/deletion_vector.rs
@@ -31,12 +31,16 @@ use deltalake::logstore::LogStore;
 use deltalake::{DeltaTable, ObjectStore, Path};
 use futures_util::StreamExt;
 use parquet::arrow::ProjectionMask;
-use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector,
+};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use roaring::RoaringTreemap;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
+
+use crate::format::parquet::int96_as_micros;
 
 /// Convert the delta-rs descriptor into its `delta_kernel` equivalent, which
 /// owns the decoding logic. The fields are identical; only the storage-type
@@ -393,11 +397,18 @@ impl PartitionStream for MaskedParquetPartition {
         let mode = self.mode;
 
         let stream = try_stream! {
-            let reader = ParquetObjectReader::new(store, path.clone());
-            let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            let mut reader = ParquetObjectReader::new(store, path.clone());
+            let options = ArrowReaderOptions::default();
+            let mut metadata = ArrowReaderMetadata::load_async(&mut reader, options.clone())
                 .await
                 .map_err(|e| DataFusionError::External(
                     format!("failed to open Parquet file '{path}': {e}").into()))?;
+            if let Some(coerced) = int96_as_micros(&metadata, &options)
+                .map_err(|e| DataFusionError::External(
+                    format!("failed to read INT96 timestamps in Parquet file '{path}': {e}").into()))? {
+                metadata = coerced;
+            }
+            let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata);
             // `num_rows()` is `i64` because Parquet's metadata is signed
             // throughout; it is non-negative for any file whose footer parsed
             // (which it did, just above).

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1,5 +1,6 @@
 use crate::catalog::{ArrowStream, InputCollectionHandle};
 use crate::format::InputBuffer;
+use crate::format::parquet::INT96_TIME_UNIT_NAME;
 use crate::integrated::delta_table::deletion_vector::{
     ReadMode, filtered_parquet_table, read_deletion_vector,
 };
@@ -15,6 +16,7 @@ use chrono::{DateTime, Utc};
 use datafusion::catalog::TableProvider;
 use datafusion::common::DataFusionError;
 use datafusion::common::arrow::array::RecordBatch;
+use datafusion::config::TableParquetOptions;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
@@ -513,19 +515,25 @@ impl DeltaTableInputEndpoint {
         };
 
         // Configure datafusion not to generate Utf8View arrow types, which are
-        // not yet supported by the `serde_arrow` crate. The `SessionContext`
-        // shares the pipeline-wide `RuntimeEnv` so that the CDC-mode ORDER BY
-        // query spills to the same bounded memory pool and on-disk scratch
-        // dir as every other datafusion user in the pipeline.
+        // not yet supported by the `serde_arrow` crate, and to decode INT96
+        // timestamps at `INT96_TIME_UNIT`. The `SessionContext` shares the
+        // pipeline-wide `RuntimeEnv` so that the CDC-mode ORDER BY query spills
+        // to the same bounded memory pool and on-disk scratch dir as every
+        // other datafusion user in the pipeline.
         //
         // `target_partitions` inherits `create_session_context_with`'s
         // worker-derived default; only override if `DELTA_DF_TARGET_PARTITIONS`
         // was set explicitly. Same for `batch_size`.
         let datafusion = create_session_context_with(pipeline_config, runtime_env, |cfg| {
-            let mut cfg = cfg.set_bool(
-                "datafusion.execution.parquet.schema_force_view_types",
-                false,
-            );
+            let mut cfg = cfg
+                .set_bool(
+                    "datafusion.execution.parquet.schema_force_view_types",
+                    false,
+                )
+                .set_str(
+                    "datafusion.execution.parquet.coerce_int96",
+                    INT96_TIME_UNIT_NAME,
+                );
             if let Some(n) = env_target_partitions {
                 cfg = cfg.set_usize("datafusion.execution.target_partitions", n);
             }
@@ -3327,8 +3335,23 @@ impl DeltaTableInputEndpointInner {
             urls.push(ListingTableUrl::parse(file).map_err(|e| anyhow!("internal error processing {description}; {REPORT_ERROR}; error converting file path '{file}' to table URL: {e}"))?);
         }
 
-        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
-            .with_file_extension_opt(Some(".parquet"));
+        // `ParquetFormat` keeps its own copy of the Parquet settings, so hand it
+        // the session's: the snapshot scan and this read must decode a file the
+        // same way.
+        let parquet_options = TableParquetOptions {
+            global: self
+                .datafusion
+                .copied_config()
+                .options()
+                .execution
+                .parquet
+                .clone(),
+            ..Default::default()
+        };
+        let listing_options = ListingOptions::new(Arc::new(
+            ParquetFormat::default().with_options(parquet_options),
+        ))
+        .with_file_extension_opt(Some(".parquet"));
 
         let table_config = ListingTableConfig::new_with_multi_paths(urls)
             .with_listing_options(listing_options)

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4,9 +4,13 @@ use crate::format::parquet::relation_to_arrow_fields;
 use crate::format::parquet::test::load_parquet_file;
 use crate::integrated::delta_table::delta_input_serde_config;
 use crate::test::data::DeltaTestKey;
+use crate::test::parquet_timestamps::{
+    TimestampEncoding, append_delta_version, create_delta_table, timestamp_test_data,
+    write_timestamp_parquet,
+};
 use crate::test::{
-    DeltaTestStruct, file_to_zset, list_files_recursive, test_circuit, test_circuit_with_index,
-    wait,
+    DEFAULT_TIMEOUT_MS, DeltaTestStruct, TimestampTestStruct, file_to_zset, list_files_recursive,
+    test_circuit, test_circuit_with_index, wait,
 };
 use crate::{Catalog, CircuitCatalog};
 use arrow::datatypes::Schema as ArrowSchema;
@@ -102,6 +106,27 @@ where
     info!("Read delta snapshot in {:?}", start.elapsed());
 
     json_file
+}
+
+/// Number of complete (newline-terminated) JSON records in `path`.
+///
+/// Counting only terminated lines means the count never includes a record the
+/// connector is still writing, so a caller that waits on it can then parse the
+/// whole file safely.
+fn complete_json_lines(path: &Path) -> usize {
+    std::fs::read(path)
+        .map(|bytes| bytes.iter().filter(|byte| **byte == b'\n').count())
+        .unwrap_or(0)
+}
+
+/// `data` as the Z-set the pipeline is expected to emit.
+fn timestamp_zset(data: &[TimestampTestStruct]) -> OrdZSet<TimestampTestStruct> {
+    OrdZSet::from_tuples(
+        (),
+        data.iter()
+            .map(|record| Tup2(Tup2(record.clone(), ()), 1))
+            .collect(),
+    )
 }
 
 const DELTA_TEST_INPUT_ENDPOINT: &str = "test_input1";
@@ -4399,5 +4424,156 @@ async fn follow_filter_before_projection_prunes_scan() {
         plan.contains("projection=") && !plan.contains("junk"),
         "the scan must read only the projected columns plus the filter's, so \
          'junk' must be pruned; plan was:\n{plan}"
+    );
+}
+
+/// A Delta table whose data file stores timestamps as INT96 ingests them
+/// intact, dates outside the nanosecond range included. Covers the snapshot
+/// scan; see [`crate::format::parquet::INT96_TIME_UNIT`].
+#[test]
+fn delta_table_input_int96_snapshot_test() {
+    let table_dir = TempDir::new().unwrap();
+    let data = timestamp_test_data();
+    create_delta_table(table_dir.path(), &data, TimestampEncoding::Int96);
+
+    let mut json_file = delta_table_snapshot_to_json::<TimestampTestStruct>(
+        &table_dir.path().display().to_string(),
+        &TimestampTestStruct::schema(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(
+        file_to_zset::<TimestampTestStruct>(json_file.as_file_mut()),
+        timestamp_zset(&data)
+    );
+}
+
+/// Follow mode reads each new version's data files itself rather than through
+/// the snapshot scan, so it carries its own copy of the setting.
+#[test]
+fn delta_table_input_int96_follow_test() {
+    let table_dir = TempDir::new().unwrap();
+    let data = timestamp_test_data();
+    let (snapshot, appended) = data.split_at(2);
+    create_delta_table(table_dir.path(), snapshot, TimestampEncoding::Int96);
+
+    let json_file = NamedTempFile::new().unwrap();
+    let pipeline = delta_table_input_pipeline::<TimestampTestStruct>(
+        &table_dir.path().display().to_string(),
+        &TimestampTestStruct::schema(),
+        &HashMap::from([("mode".to_string(), "snapshot_and_follow".to_string())]),
+        &json_file.path().display().to_string(),
+    );
+    pipeline.start();
+    wait(
+        || complete_json_lines(json_file.path()) == snapshot.len(),
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("timeout waiting for the initial snapshot");
+
+    append_delta_version(table_dir.path(), 1, appended, TimestampEncoding::Int96);
+    wait(
+        || complete_json_lines(json_file.path()) == data.len(),
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("timeout waiting for the appended version");
+    pipeline.stop().unwrap();
+
+    assert_eq!(
+        file_to_zset::<TimestampTestStruct>(&mut File::open(json_file.path()).unwrap()),
+        timestamp_zset(&data)
+    );
+}
+
+/// Applying a deletion vector opens the data file directly, past both the
+/// snapshot scan and the follow path, so it is a third reader to set up.
+#[tokio::test]
+async fn delta_table_input_int96_deletion_vector_test() {
+    use crate::integrated::delta_table::deletion_vector::{ReadMode, filtered_parquet_table};
+    use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use deltalake::{ObjectStore, Path as ObjectStorePath};
+    use roaring::RoaringTreemap;
+
+    let table_dir = TempDir::new().unwrap();
+    let data = timestamp_test_data();
+    let file_name = "data.parquet";
+    write_timestamp_parquet(
+        &table_dir.path().join(file_name),
+        &data,
+        TimestampEncoding::Int96,
+    );
+
+    // The deletion vector marks row 0; the connector must return the rest.
+    let mut deleted = RoaringTreemap::new();
+    deleted.insert(0);
+
+    let logical_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, false),
+        ArrowField::new(
+            "ts",
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            true,
+        ),
+    ]));
+    let store: Arc<dyn ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(table_dir.path()).unwrap());
+    let provider = filtered_parquet_table(
+        store,
+        ObjectStorePath::from(file_name),
+        deleted,
+        logical_schema,
+        ReadMode::NotInBitmap,
+    )
+    .await
+    .unwrap();
+
+    let batches = SessionContext::new()
+        .read_table(provider)
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut records = Vec::new();
+    for batch in &batches {
+        let deserializer = serde_arrow::Deserializer::from_record_batch(batch).unwrap();
+        records.append(
+            &mut Vec::<TimestampTestStruct>::deserialize_with_context(
+                deserializer,
+                &delta_input_serde_config(),
+            )
+            .unwrap(),
+        );
+    }
+
+    assert_eq!(records, data[1..]);
+}
+
+/// A table whose files mix the two physical encodings ingests both intact:
+/// INT96, which Spark writes by default, and INT64 microseconds, which
+/// delta-rs writes. Each file is decoded on its own schema, so the INT64 half
+/// never goes near the coercion.
+#[test]
+fn delta_table_input_mixed_timestamp_encodings_test() {
+    let table_dir = TempDir::new().unwrap();
+    let data = timestamp_test_data();
+    let (int96_rows, micros_rows) = data.split_at(2);
+    create_delta_table(table_dir.path(), int96_rows, TimestampEncoding::Int96);
+    append_delta_version(
+        table_dir.path(),
+        1,
+        micros_rows,
+        TimestampEncoding::Int64Micros,
+    );
+
+    let mut json_file = delta_table_snapshot_to_json::<TimestampTestStruct>(
+        &table_dir.path().display().to_string(),
+        &TimestampTestStruct::schema(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(
+        file_to_zset::<TimestampTestStruct>(json_file.as_file_mut()),
+        timestamp_zset(&data)
     );
 }

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4577,3 +4577,127 @@ fn delta_table_input_mixed_timestamp_encodings_test() {
         timestamp_zset(&data)
     );
 }
+
+/// Guards the datafusion pin in the workspace `Cargo.toml`.
+///
+/// A `columnMapping` table pairs its data file's columns with the read schema
+/// by Parquet field id. Coercing an INT96 column strips that id from every
+/// struct, list and map field in the file, so a struct column pairs with
+/// nothing and reads back as NULL, silently, on exactly the Databricks tables
+/// that write INT96 (<https://github.com/apache/datafusion/issues/24786>).
+///
+/// The snapshot scan coerces inside datafusion's Parquet opener, past any hook
+/// of ours, so only the patched datafusion keeps this passing. Drop the
+/// `[patch.crates-io]` section and this test fails; that is what it is for.
+#[tokio::test]
+async fn delta_table_input_int96_column_mapping_snapshot_test() {
+    use crate::test::parquet_timestamps::write_column_mapped_int96_parquet;
+    use arrow::array::{Array, StringArray, StructArray};
+
+    let table_dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(table_dir.path().join("_delta_log")).unwrap();
+    let ts = timestamp_test_data()[1].ts.unwrap();
+    write_column_mapped_int96_parquet(&table_dir.path().join("data.parquet"), "hello", ts);
+    let size = std::fs::metadata(table_dir.path().join("data.parquet"))
+        .unwrap()
+        .len();
+
+    // Logical names in the Delta schema, physical `col-<id>` names in the
+    // file, paired by id: an ordinary column-mapped table.
+    let schema = json!({"type":"struct","fields":[
+        {"name":"row_id","type":"long","nullable":false,
+         "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"col-1"}},
+        {"name":"info","type":{"type":"struct","fields":[
+            {"name":"inner","type":{"type":"struct","fields":[
+                {"name":"label","type":"string","nullable":true,
+                 "metadata":{"delta.columnMapping.id":4,"delta.columnMapping.physicalName":"col-4"}}]},
+             "nullable":true,
+             "metadata":{"delta.columnMapping.id":3,"delta.columnMapping.physicalName":"col-3"}}]},
+         "nullable":true,
+         "metadata":{"delta.columnMapping.id":2,"delta.columnMapping.physicalName":"col-2"}},
+        {"name":"ts","type":"timestamp","nullable":true,
+         "metadata":{"delta.columnMapping.id":5,"delta.columnMapping.physicalName":"col-5"}}]});
+    let actions = [
+        json!({"protocol":{"minReaderVersion":2,"minWriterVersion":5}}),
+        json!({"metaData":{
+            "id":"3f2b1c00-0000-0000-0000-000000000001",
+            "format":{"provider":"parquet","options":{}},
+            "schemaString": schema.to_string(),
+            "partitionColumns":[],
+            "configuration":{"delta.columnMapping.mode":"id","delta.columnMapping.maxColumnId":"5"},
+            "createdTime":0}}),
+        json!({"add":{"path":"data.parquet","partitionValues":{},
+            "size":size,"modificationTime":0,"dataChange":true}}),
+    ];
+    let mut log = File::create(
+        table_dir
+            .path()
+            .join("_delta_log/00000000000000000000.json"),
+    )
+    .unwrap();
+    for action in &actions {
+        writeln!(log, "{action}").unwrap();
+    }
+    drop(log);
+
+    let table = deltalake::open_table(url::Url::from_file_path(table_dir.path()).unwrap())
+        .await
+        .unwrap();
+    let log_store = table.log_store();
+
+    // The settings the connector gives its own session.
+    let config = datafusion::prelude::SessionConfig::new()
+        .set_bool(
+            "datafusion.execution.parquet.schema_force_view_types",
+            false,
+        )
+        .set_str(
+            "datafusion.execution.parquet.coerce_int96",
+            crate::format::parquet::INT96_TIME_UNIT_NAME,
+        );
+    let datafusion = SessionContext::new_with_config(config);
+    datafusion
+        .runtime_env()
+        .register_object_store(log_store.root_url(), log_store.root_object_store(None));
+
+    let batches = datafusion
+        .read_table(table.table_provider().await.unwrap())
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let batch = &batches[0];
+
+    let info = batch
+        .column_by_name("info")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    assert!(
+        !info.is_null(0),
+        "the struct column lost its field id and was null-filled"
+    );
+    // Cast rather than downcast: delta-rs may hand back `Utf8` or `Utf8View`
+    // depending on its view-type setting, and the point here is the value.
+    let label = arrow::compute::cast(
+        info.column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0),
+        &arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let label = label.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(label.value(0), "hello");
+
+    // The timestamp that triggers the coercion still arrives intact.
+    let timestamps = batch
+        .column_by_name("ts")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
+        .unwrap();
+    assert_eq!(timestamps.value(0), ts.microseconds());
+}

--- a/crates/adapters/src/test.rs
+++ b/crates/adapters/src/test.rs
@@ -43,6 +43,7 @@ mod mock_input_consumer;
 mod mock_output_consumer;
 
 mod datagen;
+pub mod parquet_timestamps;
 mod soft_delete;
 
 #[cfg(all(
@@ -63,7 +64,8 @@ use crate::transport::input_transport_config_to_endpoint;
 pub use data::{
     DatabricksPeople, DeltaTestStruct, EmbeddedStruct, IcebergSubsetTestStruct, IcebergTestStruct,
     KeyStruct, S3TablesTestStruct, TestStruct, TestStruct2, TestStructSoftDelete,
-    generate_test_batch, generate_test_batches, generate_test_batches_with_weights,
+    TimestampTestStruct, generate_test_batch, generate_test_batches,
+    generate_test_batches_with_weights,
 };
 use dbsp::circuit::{CircuitConfig, NodeId};
 use dbsp::utils::Tup2;

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -1105,6 +1105,49 @@ deserialize_table_record!(S3TablesTestStruct["S3TablesTestStruct", Variant, 3] {
     (created_at, "created_at", true, Option<Timestamp>, |_| Some(None))
 });
 
+/// Records in the Parquet timestamp-encoding fixtures built by
+/// [`crate::test::parquet_timestamps`]: `id BIGINT NOT NULL`, `ts TIMESTAMP`.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+pub struct TimestampTestStruct {
+    pub id: i64,
+    pub ts: Option<Timestamp>,
+}
+
+impl TimestampTestStruct {
+    pub fn schema() -> Vec<Field> {
+        vec![
+            Field::new("id".into(), ColumnType::bigint(false)),
+            Field::new("ts".into(), ColumnType::timestamp(true)),
+        ]
+    }
+}
+
+serialize_table_record!(TimestampTestStruct[2]{
+    id["id"]: i64,
+    ts["ts"]: Option<Timestamp>
+});
+
+deserialize_table_record!(TimestampTestStruct["TimestampTestStruct", Variant, 2] {
+    (id, "id", false, i64, |_| None),
+    (ts, "ts", true, Option<Timestamp>, |_| Some(None))
+});
+
 /// SQL table that declares a subset of [`IcebergTestStruct`]'s columns, for
 /// testing that the Iceberg connector only reads declared columns.
 ///

--- a/crates/adapters/src/test/parquet_timestamps.rs
+++ b/crates/adapters/src/test/parquet_timestamps.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use parquet::data_type::{Int64Type, Int96, Int96Type};
+use parquet::data_type::{ByteArray, ByteArrayType, Int64Type, Int96, Int96Type};
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::parser::parse_message_type;
@@ -401,4 +401,54 @@ pub fn timestamp_test_data() -> Vec<TimestampTestStruct> {
         },
         TimestampTestStruct { id: 4, ts: None },
     ]
+}
+
+/// Write a data file of a `columnMapping.mode = id` table: physical
+/// `col-<id>` names, a Parquet field id on every field, a struct nested in a
+/// struct, and an INT96 timestamp.
+///
+/// Coercing the INT96 column is what strips the ids from the struct fields, so
+/// the timestamp has to share the file with them.
+pub fn write_column_mapped_int96_parquet(path: &Path, label: &str, ts: Timestamp) {
+    const MESSAGE_TYPE: &str = r#"
+        message spark_schema {
+            REQUIRED INT64 "col-1" = 1;
+            OPTIONAL group "col-2" = 2 {
+                OPTIONAL group "col-3" = 3 {
+                    OPTIONAL BYTE_ARRAY "col-4" (STRING) = 4;
+                }
+            }
+            OPTIONAL INT96 "col-5" = 5;
+        }
+    "#;
+
+    let schema = Arc::new(parse_message_type(MESSAGE_TYPE).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let mut writer = SerializedFileWriter::new(File::create(path).unwrap(), schema, props).unwrap();
+    let mut row_group = writer.next_row_group().unwrap();
+
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int64Type>()
+        .write_batch(&[1], None, None)
+        .unwrap();
+    column.close().unwrap();
+
+    // All three levels are present, so definition level 3.
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<ByteArrayType>()
+        .write_batch(&[ByteArray::from(label)], Some(&[3]), None)
+        .unwrap();
+    column.close().unwrap();
+
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int96Type>()
+        .write_batch(&[to_int96(ts, 0)], Some(&[1]), None)
+        .unwrap();
+    column.close().unwrap();
+
+    row_group.close().unwrap();
+    writer.close().unwrap();
 }

--- a/crates/adapters/src/test/parquet_timestamps.rs
+++ b/crates/adapters/src/test/parquet_timestamps.rs
@@ -1,0 +1,404 @@
+//! Parquet and Delta fixtures covering the physical encodings Delta writers use
+//! for timestamps.
+//!
+//! Delta pins the logical `timestamp` type at microsecond precision but leaves
+//! the physical encoding to the writer, so one table's files can mix Spark's
+//! deprecated INT96 with INT64 microseconds. See
+//! [`crate::format::parquet::INT96_TIME_UNIT`] for why the two differ.
+//!
+//! The fixtures use Parquet's low-level writer rather than `ArrowWriter`, which
+//! cannot emit INT96 and which records an `ARROW:schema` key that would steer
+//! the reader away from its default INT96 mapping, the mapping these fixtures
+//! exist to exercise.
+
+use std::fs::{File, create_dir_all};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use parquet::data_type::{Int64Type, Int96, Int96Type};
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::parser::parse_message_type;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::test::TimestampTestStruct;
+use feldera_sqllib::Timestamp;
+
+/// Julian day number of 1970-01-01, the epoch INT96 counts days from.
+const JULIAN_DAY_OF_EPOCH: i64 = 2_440_588;
+
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Delta schema of the fixtures. `timestamp` is Delta's microsecond-precision,
+/// UTC-adjusted type, whichever physical encoding a file happens to use.
+const DELTA_SCHEMA: &str = r#"{"type":"struct","fields":[
+    {"name":"id","type":"long","nullable":false,"metadata":{}},
+    {"name":"ts","type":"timestamp","nullable":true,"metadata":{}}]}"#;
+
+/// Physical Parquet encoding of a fixture's `ts` column.
+#[derive(Clone, Copy, Debug)]
+pub enum TimestampEncoding {
+    /// Spark's deprecated INT96, still written by Databricks and Photon.
+    Int96,
+    /// INT64 microseconds since the epoch, what delta-rs and Spark's
+    /// `TIMESTAMP_MICROS` setting write.
+    Int64Micros,
+}
+
+impl TimestampEncoding {
+    /// Physical schema, spelled the way Spark spells it.
+    fn message_type(self) -> &'static str {
+        match self {
+            Self::Int96 => {
+                "message spark_schema {
+                    REQUIRED INT64 id;
+                    OPTIONAL INT96 ts;
+                }"
+            }
+            Self::Int64Micros => {
+                "message spark_schema {
+                    REQUIRED INT64 id;
+                    OPTIONAL INT64 ts (TIMESTAMP(MICROS,true));
+                }"
+            }
+        }
+    }
+}
+
+/// Encode `timestamp` plus `sub_micro_nanos` as Parquet does INT96:
+/// nanoseconds within the day in the low 8 bytes, Julian day number in the
+/// high 4.
+fn to_int96(timestamp: Timestamp, sub_micro_nanos: u32) -> Int96 {
+    let date_time = timestamp.to_dateTime();
+    let seconds = date_time.timestamp();
+    // Euclidean division keeps the nanosecond part non-negative for dates
+    // before the epoch, which is what Parquet readers expect.
+    let day = seconds.div_euclid(SECONDS_PER_DAY) + JULIAN_DAY_OF_EPOCH;
+    let nanos = seconds.rem_euclid(SECONDS_PER_DAY) * 1_000_000_000
+        + i64::from(date_time.timestamp_subsec_nanos())
+        + i64::from(sub_micro_nanos);
+
+    let mut value = Int96::new();
+    value.set_data(nanos as u32, (nanos >> 32) as u32, day as u32);
+    value
+}
+
+/// Write `rows` to `path`, storing `ts` in `encoding`.
+pub fn write_timestamp_parquet(
+    path: &Path,
+    rows: &[TimestampTestStruct],
+    encoding: TimestampEncoding,
+) {
+    let schema = Arc::new(parse_message_type(encoding.message_type()).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let mut writer = SerializedFileWriter::new(File::create(path).unwrap(), schema, props).unwrap();
+    let mut row_group = writer.next_row_group().unwrap();
+
+    let ids: Vec<i64> = rows.iter().map(|row| row.id).collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int64Type>()
+        .write_batch(&ids, None, None)
+        .unwrap();
+    column.close().unwrap();
+
+    // A definition level of 1 marks an optional value as present, 0 as null,
+    // so nulls contribute a level but no value.
+    let definition_levels: Vec<i16> = rows.iter().map(|row| i16::from(row.ts.is_some())).collect();
+    let present = rows.iter().filter_map(|row| row.ts);
+    let mut column = row_group.next_column().unwrap().unwrap();
+    match encoding {
+        TimestampEncoding::Int96 => {
+            let values: Vec<Int96> = present.map(|ts| to_int96(ts, 0)).collect();
+            column
+                .typed::<Int96Type>()
+                .write_batch(&values, Some(&definition_levels), None)
+                .unwrap();
+        }
+        TimestampEncoding::Int64Micros => {
+            let values: Vec<i64> = present.map(|ts| ts.microseconds()).collect();
+            column
+                .typed::<Int64Type>()
+                .write_batch(&values, Some(&definition_levels), None)
+                .unwrap();
+        }
+    }
+    column.close().unwrap();
+
+    row_group.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Write a single INT96 column holding each `ts` plus `sub_micro_nanos`.
+///
+/// Keeping every `sub_micro_nanos` under 1000 makes the reader's rounding mode
+/// observable: truncating returns `ts` unchanged, rounding returns the next
+/// microsecond.
+pub fn write_sub_microsecond_int96_parquet(path: &Path, rows: &[(Timestamp, u32)]) {
+    const MESSAGE_TYPE: &str = "message spark_schema { REQUIRED INT96 ts; }";
+
+    let schema = Arc::new(parse_message_type(MESSAGE_TYPE).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let mut writer = SerializedFileWriter::new(File::create(path).unwrap(), schema, props).unwrap();
+    let mut row_group = writer.next_row_group().unwrap();
+
+    let values: Vec<Int96> = rows
+        .iter()
+        .map(|(ts, sub_micro_nanos)| {
+            assert!(
+                *sub_micro_nanos < 1_000,
+                "remainder must be sub-microsecond"
+            );
+            to_int96(*ts, *sub_micro_nanos)
+        })
+        .collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int96Type>()
+        .write_batch(&values, None, None)
+        .unwrap();
+    column.close().unwrap();
+
+    row_group.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Write `rows` with the timestamp in both encodings side by side, the shape a
+/// Spark job leaves when it rewrites some timestamp columns but not others.
+pub fn write_mixed_column_parquet(path: &Path, rows: &[TimestampTestStruct]) {
+    const MESSAGE_TYPE: &str = "
+        message spark_schema {
+            REQUIRED INT64 id;
+            OPTIONAL INT96 ts_int96;
+            OPTIONAL INT64 ts_micros (TIMESTAMP(MICROS,true));
+        }
+    ";
+
+    let schema = Arc::new(parse_message_type(MESSAGE_TYPE).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let mut writer = SerializedFileWriter::new(File::create(path).unwrap(), schema, props).unwrap();
+    let mut row_group = writer.next_row_group().unwrap();
+
+    let ids: Vec<i64> = rows.iter().map(|row| row.id).collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int64Type>()
+        .write_batch(&ids, None, None)
+        .unwrap();
+    column.close().unwrap();
+
+    let definition_levels: Vec<i16> = rows.iter().map(|row| i16::from(row.ts.is_some())).collect();
+
+    let int96: Vec<Int96> = rows
+        .iter()
+        .filter_map(|row| row.ts)
+        .map(|ts| to_int96(ts, 0))
+        .collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int96Type>()
+        .write_batch(&int96, Some(&definition_levels), None)
+        .unwrap();
+    column.close().unwrap();
+
+    let micros: Vec<i64> = rows
+        .iter()
+        .filter_map(|row| row.ts)
+        .map(|ts| ts.microseconds())
+        .collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int64Type>()
+        .write_batch(&micros, Some(&definition_levels), None)
+        .unwrap();
+    column.close().unwrap();
+
+    row_group.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Write `rows` with the timestamp nested inside a struct and inside a list,
+/// both as INT96.
+///
+/// Rows without a timestamp are skipped and every row gets exactly one list
+/// element, which keeps the definition and repetition levels uniform; nesting,
+/// not nullability, is what this fixture is for.
+pub fn write_nested_int96_parquet(path: &Path, rows: &[TimestampTestStruct]) {
+    const MESSAGE_TYPE: &str = "
+        message spark_schema {
+            REQUIRED INT64 id;
+            OPTIONAL group nested {
+                OPTIONAL INT96 ts;
+            }
+            OPTIONAL group ts_list (LIST) {
+                REPEATED group list {
+                    OPTIONAL INT96 element;
+                }
+            }
+        }
+    ";
+
+    let rows: Vec<&TimestampTestStruct> = rows.iter().filter(|row| row.ts.is_some()).collect();
+    let timestamps: Vec<Int96> = rows
+        .iter()
+        .map(|row| to_int96(row.ts.unwrap(), 0))
+        .collect();
+
+    let schema = Arc::new(parse_message_type(MESSAGE_TYPE).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let mut writer = SerializedFileWriter::new(File::create(path).unwrap(), schema, props).unwrap();
+    let mut row_group = writer.next_row_group().unwrap();
+
+    let ids: Vec<i64> = rows.iter().map(|row| row.id).collect();
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int64Type>()
+        .write_batch(&ids, None, None)
+        .unwrap();
+    column.close().unwrap();
+
+    // `nested` and `nested.ts` are both optional, so a value present at both
+    // levels is definition level 2. Nothing along the path repeats.
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int96Type>()
+        .write_batch(&timestamps, Some(&vec![2; rows.len()]), None)
+        .unwrap();
+    column.close().unwrap();
+
+    // `ts_list`, its repeated `list` group and `element` give definition level
+    // 3; repetition level 0 starts a new list, so one element per row.
+    let mut column = row_group.next_column().unwrap().unwrap();
+    column
+        .typed::<Int96Type>()
+        .write_batch(
+            &timestamps,
+            Some(&vec![3; rows.len()]),
+            Some(&vec![0; rows.len()]),
+        )
+        .unwrap();
+    column.close().unwrap();
+
+    row_group.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Write one data file into `table_dir` and return its `add` action.
+fn add_data_file(
+    table_dir: &Path,
+    rows: &[TimestampTestStruct],
+    encoding: TimestampEncoding,
+) -> serde_json::Value {
+    let name = format!("part-00000-{}.parquet", Uuid::new_v4());
+    let path = PathBuf::from(table_dir).join(&name);
+    write_timestamp_parquet(&path, rows, encoding);
+
+    json!({"add": {
+        "path": name,
+        "partitionValues": {},
+        "size": path.metadata().unwrap().len(),
+        "modificationTime": SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64,
+        "dataChange": true,
+    }})
+}
+
+/// Commit `actions` as Delta table version `version`.
+///
+/// Staged elsewhere and renamed in, the way real Delta writers commit. Written
+/// in place the file is published empty and filled over dozens of `write`
+/// syscalls, so a connector polling the log can read an empty commit, whose
+/// rows are then never ingested, or a truncated one, which fails to parse.
+///
+/// The staging path sits in the table directory rather than `_delta_log`, so
+/// the log listing never has to classify it, and on the same filesystem, so
+/// the rename is atomic.
+fn commit(table_dir: &Path, version: u64, actions: &[serde_json::Value]) {
+    let name = format!("{version:020}.json");
+    let staged = table_dir.join(format!(".staged-{name}"));
+
+    let mut file = File::create(&staged).unwrap();
+    for action in actions {
+        writeln!(file, "{action}").unwrap();
+    }
+    drop(file);
+
+    std::fs::rename(staged, table_dir.join("_delta_log").join(name)).unwrap();
+}
+
+/// Create a Delta table at `table_dir` holding `rows` as version 0.
+///
+/// The log is written by hand because delta-rs writes exclusively through
+/// arrow-rs's `ArrowWriter`, which cannot emit INT96.
+pub fn create_delta_table(
+    table_dir: &Path,
+    rows: &[TimestampTestStruct],
+    encoding: TimestampEncoding,
+) {
+    create_dir_all(table_dir.join("_delta_log")).unwrap();
+    commit(
+        table_dir,
+        0,
+        &[
+            json!({"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}),
+            json!({"metaData": {
+                "id": Uuid::new_v4().to_string(),
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": DELTA_SCHEMA,
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 0,
+            }}),
+            add_data_file(table_dir, rows, encoding),
+        ],
+    );
+}
+
+/// Append `rows` to the Delta table at `table_dir` as `version`.
+pub fn append_delta_version(
+    table_dir: &Path,
+    version: u64,
+    rows: &[TimestampTestStruct],
+    encoding: TimestampEncoding,
+) {
+    commit(
+        table_dir,
+        version,
+        &[add_data_file(table_dir, rows, encoding)],
+    );
+}
+
+/// Rows spanning the INT96 range: one inside the nanosecond window, one past
+/// its 2262-04-11 upper bound, one before its 1677-09-21 lower bound, and a
+/// null. The far-future value is the one a customer hit in a Databricks-written
+/// table; decoded as nanoseconds it wraps to 2247-05-04T01:16:18.871345.
+pub fn timestamp_test_data() -> Vec<TimestampTestStruct> {
+    fn at(rfc3339: &str) -> Option<Timestamp> {
+        Some(Timestamp::from_dateTime(
+            chrono::DateTime::parse_from_rfc3339(rfc3339)
+                .unwrap()
+                .to_utc(),
+        ))
+    }
+
+    vec![
+        TimestampTestStruct {
+            id: 1,
+            ts: at("2024-06-01T12:00:00Z"),
+        },
+        TimestampTestStruct {
+            id: 2,
+            ts: at("4000-12-31T00:00:00Z"),
+        },
+        TimestampTestStruct {
+            id: 3,
+            ts: at("1600-01-01T00:00:00Z"),
+        },
+        TimestampTestStruct { id: 4, ts: None },
+    ]
+}

--- a/docs.feldera.com/docs/connectors/sources/delta.md
+++ b/docs.feldera.com/docs/connectors/sources/delta.md
@@ -196,7 +196,7 @@ The following table lists supported Delta Lake data types and corresponding Feld
 | `SMALLINT`                  | `SMALLINT`       |               |
 | `STRING`                    | `STRING`         |               |
 | `DECIMAL(P,S)`              | `DECIMAL(P,S)`   | The largest supported precision `P` is 28.|
-| `TIMESTAMP`, `TIMESTAMP_NTZ`| `TIMESTAMP`      | Timestamp values are rounded to the nearest millisecond.  Feldera currently does not support timestamps with time zones.  When using the `TIMESTAMP` DeltaLake type, time zone information gets discarded. |
+| `TIMESTAMP`, `TIMESTAMP_NTZ`| `TIMESTAMP`      | Timestamp values are kept to microsecond precision.  Feldera currently does not support timestamps with time zones.  When using the `TIMESTAMP` DeltaLake type, time zone information gets discarded. |
 | `TINYINT`                   | `TINYINT`        |               |
 | `MAP<K,V>`                  | `MAP<K,V>`       |               |
 | `ARRAY<T>`                  | `T ARRAY`        |               |

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/MultiCratesWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/MultiCratesWriter.java
@@ -140,6 +140,48 @@ public final class MultiCratesWriter extends RustWriter {
                 metrics-util = { version = "0.17.0" }""");
         }
 
+        // The pipeline workspace resolves its own dependency graph, so the
+        // [patch] section in the platform's Cargo.toml does not reach it. A
+        // pipeline links dbsp_adapters, and therefore datafusion, so the same
+        // patch has to be repeated here or pipelines build against the
+        // unpatched crate. Keep this in step with the platform Cargo.toml;
+        // drop both once the fix is released upstream.
+        // https://github.com/apache/datafusion/issues/24786
+        cargoStream.println("""
+                [patch.crates-io]
+                datafusion = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-catalog = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-catalog-listing = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-common-runtime = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-datasource = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-datasource-arrow = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-datasource-csv = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-datasource-json = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-doc = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-execution = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-aggregate = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-aggregate-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-nested = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-table = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-window = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-functions-window-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-macros = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-physical-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-physical-expr-adapter = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-physical-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-physical-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-physical-plan = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-proto = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-proto-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-pruning = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-session = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+                datafusion-sql = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }""");
+
         cargoStream.close();
     }
 

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -53,3 +53,57 @@ doctest = false
 # type names; line tables keep panic backtraces useful at a fraction of the size.
 [profile.dev]
 debug = "line-tables-only"
+
+# Feldera fork of datafusion: release 53.1.0 + 1 patch, on branch
+# `int96-preserve-field-metadata-53.1.0`.
+#
+#   - Preserve field metadata when coercing INT96 timestamps.
+#     `Int96Coercer` rebuilds struct, list and map fields with `Field::new_*`,
+#     which start from empty metadata, so reading a file that holds an INT96
+#     column strips `PARQUET:field_id` from every container field. A Delta
+#     table with column mapping pairs its columns to the read schema by that
+#     id, so a struct column silently reads as NULL.
+#     Upstream issue:  https://github.com/apache/datafusion/issues/24786
+#     Upstream branch: https://github.com/ryzhyk/datafusion/tree/int96-preserve-field-metadata
+#     Repro:           https://github.com/ryzhyk/coerce_int96_bug
+#
+# Patching one crate pulls its siblings in from the fork, so every datafusion
+# crate in the graph must be patched or the same crate resolves twice, once
+# from the fork and once from crates.io, and the build fails on mismatched
+# types. `datafusion-functions-json` is a third-party crate, not part of the
+# datafusion workspace, so it stays on crates.io.
+#
+# Drop this section once the fix is released upstream.
+[patch.crates-io]
+datafusion = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-catalog = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-catalog-listing = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-common-runtime = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-arrow = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-csv = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-datasource-json = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-doc = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-execution = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-aggregate = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-aggregate-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-nested = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-table = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-window = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-functions-window-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-macros = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr-adapter = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-expr-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-optimizer = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-physical-plan = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-proto = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-proto-common = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-pruning = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-session = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }
+datafusion-sql = { git = "https://github.com/feldera/datafusion.git", rev = "bee5811ee4c1cfea159bc2e6ece0309c59a66b9f" }


### PR DESCRIPTION
Spark and Databricks still write Delta timestamps as the deprecated INT96 type, which holds a Julian day plus nanoseconds within the day and so spans a wider date range than a 64-bit nanosecond count. arrow-rs decodes INT96 as nanoseconds by default, and `Int96::to_nanos` (in the parquet crate) wraps on overflow, so any date outside 1677-09-21 .. 2262-04-11 was ingested corrupte.

Datafusion has a setting to convert INT96 timestamps to micros. Three reader paths need the setting separately:

  - the snapshot scan, via the connector's datafusion session, whose parquet options delta-rs copies into its own;
  - the per-file reads follow and CDC mode perform, whose `ParquetFormat` ignores the session settings and must be handed them;
  - the deletion-vector reader and the `parquet` input format, which drive arrow-rs directly.

Delta pins the logical `timestamp` type at microsecond precision but leaves the physical encoding to the writer, so one table's files can mix INT96 with INT64 microseconds. Coercion is decided per file from that file's own Parquet schema, so INT64 files are left untouched.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
