### PR TITLE
[python] close the model-scoring test's race on re-predictions

### DIFF
--- a/python/tests/runtime/test_model_scoring.py
+++ b/python/tests/runtime/test_model_scoring.py
@@ -104,8 +104,11 @@ class ModelServer(threading.Thread):
         # Ignore deleted requests
         writes = [self._prediction(i["insert"]) for i in items if "insert" in i]
         if writes:
-            self.predictions_written += len(writes)
+            # `input_json` blocks until the pipeline has processed the batch, so a
+            # test that waits on this counter waits for the predictions to be
+            # visible to a query, not merely for the write to be issued.
             self.pipeline.input_json("model_prediction", writes, update_format="raw")
+            self.predictions_written += len(writes)
 
     def _prediction(self, request: Mapping[str, Any]) -> dict:
         probability = predict(float(request["pct_of_limit"]))
@@ -227,12 +230,13 @@ class TestModelScoring(PipelineTestCase):
             [{"cc_num": 1001, "ts": DAY_2, "zip": 94105, "credit_limit": "20000.00"}],
             update_format="raw",
         )
-        # Wait for the server to receive the new prediction (one delete and one insert)
+        # Wait for the two re-predictions to be written and processed. `scored`
+        # cannot serve as the barrier here: a re-prediction upserts on
+        # (event_time, trans_id), so it stays at SEED_TRANSACTIONS throughout.
         self.wait_until(
             lambda: server.predictions_written >= before + 2,
             "the corrected transactions to be re-predicted",
         )
-        self.wait_for_predictions(SEED_TRANSACTIONS)
         repredicted = server.predictions_written - before
         log(f"cardholder correction triggered {repredicted} new predictions")
 


### PR DESCRIPTION
Fix for this CI flake: https://github.com/feldera/feldera/actions/runs/33321716698/job/99285235785

ModelServer._apply bumped predictions_written before issuing the write, so wait_until(predictions_written >= before + 2) returned while the two re-predictions were still in flight. The follow-up wait_for_predictions(SEED_TRANSACTIONS) could not cover the gap: a re-prediction upserts on the (event_time, trans_id) primary key, so scored holds at SEED_TRANSACTIONS from phase 1 onward and never observes step 2.

The window it left open is wide. Between the cardholder correction and the re-predictions landing, transactions 2 and 3 carry fingerprints that no prediction matches, so predicted_transaction holds 4 rows, and the test raced the server's two HTTP round trips against its own three ad-hoc queries. CI lost that race on run 33321716698:

    assert self.scalar("SELECT COUNT(*) FROM predicted_transaction") == 6
    AssertionError: assert 4 == 6

input_json blocks on the completion token, so counting after the write turns the existing wait_until into a real barrier and leaves every assertion strict. Drop the wait_for_predictions call that read like synchronization but was not.

Verified by injecting time.sleep(8) ahead of the write: the old order fails with assert 4 == 6, the new order passes.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
