### PR TITLE
[docs] Add usage and docs for delta output threads

### DIFF
--- a/crates/feldera-types/src/transport/delta_table.rs
+++ b/crates/feldera-types/src/transport/delta_table.rs
@@ -96,7 +96,11 @@ pub struct DeltaTableWriterConfig {
     /// Number of parallel threads used by the connector.
     ///
     /// Increasing this value can improve Delta Lake write throughput
-    /// by enabling concurrent writes.
+    /// by enabling concurrent writes. Increasing this value can improve Delta Lake write throughput by enabling concurrent writes.
+    /// Values above 1 require the view to have a unique key, so that the connector can order inserts and deletes correctly.
+    /// Define the key with `CREATE INDEX` and set the connector's `index` property to that index;
+    /// see [views with unique keys](https://docs.feldera.com/connectors/sinks/delta/#views-with-unique-keys) and
+    /// [writing in parallel](https://docs.feldera.com/connectors/sinks/delta/#writing-in-parallel).
     ///
     /// Default: 1.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/docs.feldera.com/docs/connectors/sinks/delta.md
+++ b/docs.feldera.com/docs/connectors/sinks/delta.md
@@ -80,7 +80,7 @@ MERGE INTO {target_table} AS target
 | `log_retention_duration` | <p>Log retention duration for newly created Delta tables.</p><p>Configures the `delta.logRetentionDuration` table property, which controls how long the table's transaction-log history is kept.  Each time a checkpoint is written, Delta Lake automatically cleans up log entries older than this interval (subject to `enable_expired_log_cleanup`).</p><p>The option is only available when creating the Delta table (`mode = append` and there is no existing table at the target location, or `mode = truncate`).</p><p>The value follows the Delta Lake interval syntax `"interval <N> <unit>"`, where `<unit>` is one of `nanosecond[s]`, `microsecond[s]`, `millisecond[s]`, `second[s]`, `minute[s]`, `hour[s]`, `day[s]`, or `week[s]`.  Examples: `"interval 30 days"`, `"interval 6 hours"`.</p><p>Default: `"interval 30 days"` (Delta Lake default).</p>|
 | `enable_expired_log_cleanup` | <p>Whether to clean up expired log entries when a checkpoint is written.</p><p>Configures the `delta.enableExpiredLogCleanup` table property.  When set to `false`, transaction-log entries are retained indefinitely regardless of `log_retention_duration`.</p><p>The option is only available when creating the Delta table (`mode = append` and there is no existing table at the target location, or `mode = truncate`).</p><p>Default: `true` (Delta Lake default).</p>|
 | `max_retries`|<p>Maximum number of retries for failed Delta Lake operations like writing Parquet files and committing transactions.</p><p>The connector performs retries on several levels: individual S3 operations, Delta Lake transaction commits, and overall operation retries. This setting controls the overall operation retries. When a write to the table fails, because of an S3 timeout or any other reason that was not resolved by lower-level retries, the connector will retry the entire operation.</p><p>When not specified, the connector performs infinite retries. When set to 0, the connector doesn't retry failed operations.</p>|
-| `threads` | Number of parallel threads used by the connector. Increasing this value can improve Delta Lake write throughput by enabling concurrent writes. Default: `1`. |
+| `threads` | <p>Number of parallel threads used by the connector. Increasing this value can improve Delta Lake write throughput by enabling concurrent writes.</p><p>Values above 1 require the view to have a unique key, so that the connector can order inserts and deletes correctly. Define the key with `CREATE INDEX` and set the connector's `index` property to that index; see [views with unique keys](#views-with-unique-keys) and [writing in parallel](#writing-in-parallel).</p><p>Default: `1`.</p>|
 
 [*]: Required fields
 
@@ -188,3 +188,37 @@ WITH (
 AS SELECT * FROM my_table;
 ```
 
+### Writing in parallel
+
+Set `threads` above 1 to have the connector write Parquet files concurrently. Parallel writes require the view to have a
+unique key, so that the connector can order inserts and deletes correctly; without one the pipeline fails to start.
+Define the key with `CREATE INDEX` and set the connector's `index` property to that index. See
+[views with unique keys](#views-with-unique-keys) for additional details.
+
+```sql
+CREATE VIEW v
+WITH (
+ 'connectors' = '[{
+    "index": "v_idx",
+    "transport": {
+      "name": "delta_table_output",
+      "config": {
+        "uri": "s3://feldera-fraud-detection-demo/feature_train",
+        "threads": 4,
+        "mode": "append",
+        "aws_access_key_id": <AWS_ACCESS_KEY_ID>,
+        "aws_secret_access_key": <AWS_SECRET_ACCESS_KEY>,
+        "aws_region": "us-east-1"
+      }
+    },
+    "enable_output_buffer": true,
+    "max_output_buffer_time_millis": 10000
+ }]'
+)
+AS SELECT * FROM my_table;
+
+-- Unique key required by "threads": 4.
+CREATE INDEX v_idx ON v(id);
+```
+
+Note where each option goes: `threads` is a transport option, while `index` is a connector option.

--- a/openapi.json
+++ b/openapi.json
@@ -10129,7 +10129,7 @@
           },
           "threads": {
             "type": "integer",
-            "description": "Number of parallel threads used by the connector.\n\nIncreasing this value can improve Delta Lake write throughput\nby enabling concurrent writes.\n\nDefault: 1.",
+            "description": "Number of parallel threads used by the connector.\n\nIncreasing this value can improve Delta Lake write throughput\nby enabling concurrent writes. Increasing this value can improve Delta Lake write throughput by enabling concurrent writes.\nValues above 1 require the view to have a unique key, so that the connector can order inserts and deletes correctly.\nDefine the key with `CREATE INDEX` and set the connector's `index` property to that index;\nsee [views with unique keys](https://docs.feldera.com/connectors/sinks/delta/#views-with-unique-keys) and\n[writing in parallel](https://docs.feldera.com/connectors/sinks/delta/#writing-in-parallel).\n\nDefault: 1.",
             "nullable": true,
             "minimum": 1
           },


### PR DESCRIPTION
The delta output connector will fail if threads are set to > 1 and no index is set. Added example usage and a usage note to the config option that provides the required info to use threads

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
