### PR TITLE
[dbsp] Estimate join input key counts by sampling

### DIFF
--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -37,6 +37,7 @@ use crate::{
 };
 use crate::{DynZWeight, NestedCircuit, Position, Runtime};
 use async_stream::stream;
+use rand::thread_rng;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::{
@@ -1469,6 +1470,55 @@ where
     }
 }
 
+/// Number of keys sampled when estimating a join input's key count.
+const KEY_COUNT_SAMPLE_SIZE: usize = 100;
+
+/// Inputs smaller than this are not sampled, since the cost of sampling can be high
+/// relative to the gain from it.
+const MIN_KEYS_TO_SAMPLE: usize = 10_000;
+
+/// Estimates the number of keys a cursor over `input` will surface.
+///
+/// [`BatchReader::sample_keys`] returns only keys that are present with a
+/// non-zero weight, so the fraction of the sample that survives estimates the
+/// fraction of `key_count` the cursor will yield.
+fn sampled_key_count<B>(input: &B, key_count: usize) -> usize
+where
+    B: BatchReader,
+{
+    let mut sample = input.factories().keys_factory().default_box();
+    input.sample_keys(&mut thread_rng(), KEY_COUNT_SAMPLE_SIZE, sample.as_mut());
+
+    (key_count as u128 * sample.len() as u128 / KEY_COUNT_SAMPLE_SIZE as u128) as usize
+}
+
+/// Estimates the key counts used to choose which side the joint cursor drives.
+///
+/// [`BatchReader::key_count`] reports the sum of key counts across all batches.
+/// The same key that occurs in multiple batches is counted multiple times even
+/// if its weight adds up to 0. Sampling is used to estimate the number of distinct
+/// keys with non-zero weights without actually enumerating them.
+///
+/// Sampling is skipped when the smaller input is below [`MIN_KEYS_TO_SAMPLE`]:
+/// at that size neither side is expensive to drive.
+fn estimate_input_key_counts<D, T>(delta: &D, trace: &T) -> (usize, usize)
+where
+    D: BatchReader,
+    T: BatchReader,
+{
+    let delta_key_count = delta.key_count();
+    let trace_key_count = trace.key_count();
+
+    if min(delta_key_count, trace_key_count) < MIN_KEYS_TO_SAMPLE {
+        return (delta_key_count, trace_key_count);
+    }
+
+    (
+        sampled_key_count(delta, delta_key_count),
+        sampled_key_count(trace, trace_key_count),
+    )
+}
+
 /// A cursor that iterates over matching keys in two cursors.
 /// It enumerates all keys in one cursor, and for each key
 /// checks if the other cursor has a matching key.
@@ -1592,10 +1642,15 @@ where
             }
 
             let delta = self.delta.borrow_mut().take().expect("no input delta provided before flush");
-            let delta_key_count = delta.key_count();
-
             let trace = trace.unwrap();
-            let trace_key_count = if self.saturate { usize::MAX } else { trace.key_count() };
+
+            // Key counts decide which side the joint cursor drives. Driving a
+            // side costs a full pass over it, so getting this wrong can be expensive.
+            let (delta_key_count, trace_key_count) = if self.saturate {
+                (0, usize::MAX)
+            } else {
+                estimate_input_key_counts(&delta, &trace)
+            };
 
             self.empty_input.set(delta.is_empty());
             self.empty_output.set(true);
@@ -1798,6 +1853,108 @@ where
 
             yield (batch, true, joint_cursor.position())
         }
+    }
+}
+
+#[cfg(test)]
+mod key_count_estimate_test {
+    use super::{MIN_KEYS_TO_SAMPLE, estimate_input_key_counts};
+    use crate::{
+        ZWeight,
+        dynamic::DynData,
+        trace::{BatchReader, BatchReaderFactories, SpineSnapshot},
+        typed_batch::{DynOrdIndexedZSet, OrdIndexedZSet},
+        utils::Tup2,
+    };
+    use std::sync::Arc;
+
+    type Batch = DynOrdIndexedZSet<DynData, DynData>;
+
+    /// Builds a snapshot over `batches`, each a list of (key, value, weight).
+    fn snapshot(batches: Vec<Vec<(u64, u64, ZWeight)>>) -> SpineSnapshot<Batch> {
+        let factories: <Batch as BatchReader>::Factories =
+            BatchReaderFactories::new::<u64, u64, ZWeight>();
+        let batches = batches
+            .into_iter()
+            .map(|rows| {
+                let tuples = rows
+                    .into_iter()
+                    .map(|(k, v, w)| Tup2(Tup2(k, v), w))
+                    .collect();
+                Arc::new(OrdIndexedZSet::<u64, u64>::from_tuples((), tuples).into_inner())
+            })
+            .collect();
+
+        SpineSnapshot::with_batches(&factories, batches)
+    }
+
+    fn rows(keys: std::ops::Range<u64>, weight: ZWeight) -> Vec<(u64, u64, ZWeight)> {
+        keys.map(|k| (k, k, weight)).collect()
+    }
+
+    /// The estimate is a sample, so it is checked against a band rather than an
+    /// exact value.
+    #[track_caller]
+    fn assert_within(actual: usize, expected: usize, tolerance_percent: usize) {
+        let tolerance = expected * tolerance_percent / 100;
+        assert!(
+            actual.abs_diff(expected) <= tolerance,
+            "estimate {actual} is not within {tolerance} of {expected}"
+        );
+    }
+
+    const N: u64 = MIN_KEYS_TO_SAMPLE as u64 * 2;
+
+    /// An input that fully retracts and re-inserts the same rows stores twice
+    /// the row count and yields nothing. `key_count()` reports the stored count,
+    /// which is the error that makes the join drive the wrong side.
+    #[test]
+    fn cancelling_keys_are_not_counted() {
+        let delta = snapshot(vec![rows(0..N, -1), rows(0..N, 1)]);
+        let trace = snapshot(vec![rows(0..N, 1)]);
+
+        assert_eq!(delta.key_count(), 2 * N as usize);
+
+        let (delta_keys, _) = estimate_input_key_counts(&delta, &trace);
+        assert_eq!(delta_keys, 0);
+    }
+
+    /// Keys that survive are counted, whether or not the input also holds
+    /// cancelling ones.
+    ///
+    /// Only a third of this input's key slots survive, which is the regime where
+    /// a 100-key sample is noisiest: single draws were measured spanning 6,900
+    /// to 13,500 around a mean of 9,955. The test averages draws rather than
+    /// widening the band, so it still fails if the mean moves. Do not replace it
+    /// with a single draw.
+    #[test]
+    fn surviving_share_of_a_mixed_input_is_counted() {
+        // Keys 0..N/2 cancel; keys N/2..N are inserted once and survive.
+        let delta = snapshot(vec![rows(0..N / 2, -1), rows(0..N, 1)]);
+        let trace = snapshot(vec![rows(0..N, 1)]);
+
+        // Two thirds of the stored key slots belong to keys that cancel.
+        assert_eq!(delta.key_count(), (N + N / 2) as usize);
+
+        const DRAWS: usize = 50;
+        let mean = (0..DRAWS)
+            .map(|_| estimate_input_key_counts(&delta, &trace).0)
+            .sum::<usize>()
+            / DRAWS;
+
+        assert_within(mean, (N / 2) as usize, 10);
+    }
+
+    /// A trace whose records are spread thinly over many keys keeps its count:
+    /// the estimate must not shrink an input that has nothing to cancel.
+    #[test]
+    fn insert_only_input_keeps_its_count() {
+        let delta = snapshot(vec![rows(0..N, 1)]);
+        let trace = snapshot(vec![rows(0..N, 1)]);
+
+        let (delta_keys, trace_keys) = estimate_input_key_counts(&delta, &trace);
+        assert_within(delta_keys, N as usize, 0);
+        assert_within(trace_keys, N as usize, 0);
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1481,7 +1481,9 @@ const MIN_KEYS_TO_SAMPLE: usize = 10_000;
 ///
 /// [`BatchReader::sample_keys`] returns only keys that are present with a
 /// non-zero weight, so the fraction of the sample that survives estimates the
-/// fraction of `key_count` the cursor will yield.
+/// fraction of `key_count` the cursor will yield. The draws are apportioned
+/// across the input's batches so that they sum to exactly
+/// [`KEY_COUNT_SAMPLE_SIZE`], which is what makes it the right denominator.
 fn sampled_key_count<B>(input: &B, key_count: usize) -> usize
 where
     B: BatchReader,
@@ -1494,10 +1496,17 @@ where
 
 /// Estimates the key counts used to choose which side the joint cursor drives.
 ///
-/// [`BatchReader::key_count`] reports the sum of key counts across all batches.
-/// The same key that occurs in multiple batches is counted multiple times even
-/// if its weight adds up to 0. Sampling is used to estimate the number of distinct
-/// keys with non-zero weights without actually enumerating them.
+/// [`BatchReader::key_count`] reports the sum of key counts across all batches,
+/// which overstates what a cursor yields in two ways: a key held by several
+/// batches is counted once per batch, and keys whose weights add up to zero are
+/// counted even though the cursor skips them.
+///
+/// Sampling corrects the second of those. It does not correct the first: a
+/// duplicated key collapses only when two draws happen to land on it, which
+/// needs a sample near the square root of the distinct key count rather than
+/// [`KEY_COUNT_SAMPLE_SIZE`]. Such a key is still counted once per batch that
+/// holds it, so the estimate remains an upper bound on what the cursor will
+/// yield, overstated by at most the number of batches.
 ///
 /// Sampling is skipped when the smaller input is below [`MIN_KEYS_TO_SAMPLE`]:
 /// at that size neither side is expensive to drive.
@@ -1644,14 +1653,6 @@ where
             let delta = self.delta.borrow_mut().take().expect("no input delta provided before flush");
             let trace = trace.unwrap();
 
-            // Key counts decide which side the joint cursor drives. Driving a
-            // side costs a full pass over it, so getting this wrong can be expensive.
-            let (delta_key_count, trace_key_count) = if self.saturate {
-                (0, usize::MAX)
-            } else {
-                estimate_input_key_counts(&delta, &trace)
-            };
-
             self.empty_input.set(delta.is_empty());
             self.empty_output.set(true);
             self.stats.borrow_mut().lhs_tuples += delta.len();
@@ -1661,6 +1662,21 @@ where
                 trace.fetch(&delta).await
             } else {
                 None
+            };
+
+            // Which side the joint cursor drives. Driving a side costs a full
+            // pass over it, so getting this wrong can be expensive. Estimating
+            // the key counts is not free either: it samples both inputs, which
+            // seeks into a spilled trace. `fetch` has already narrowed the trace
+            // to the delta's keys, and a saturating join synthesizes values for
+            // trace keys the delta does not hold, so both force the delta to
+            // drive and neither needs the estimate.
+            let swap = if fetched.is_some() || self.saturate {
+                false
+            } else {
+                let (delta_key_count, trace_key_count) =
+                    estimate_input_key_counts(&delta, &trace);
+                delta_key_count > trace_key_count
             };
 
             let delta_cursor = delta.cursor();
@@ -1680,8 +1696,7 @@ where
 
             let mut val = self.right_factories.val_factory().default_box();
 
-            let mut joint_cursor =
-                JointKeyCursor::new(delta_cursor, trace_cursor, fetched.is_none() && (delta_key_count > trace_key_count));
+            let mut joint_cursor = JointKeyCursor::new(delta_cursor, trace_cursor, swap);
 
             let batch = if size_of::<T::Time>() != 0 {
                 let time = self.clock.time();
@@ -1892,10 +1907,13 @@ mod key_count_estimate_test {
         keys.map(|k| (k, k, weight)).collect()
     }
 
-    /// The estimate is a sample, so it is checked against a band rather than an
-    /// exact value.
+    /// Asserts a sampled estimate against a band. Cases whose draw count and
+    /// survival are both fixed are deterministic; assert those with `assert_eq!`
+    /// rather than a zero-width band.
     #[track_caller]
     fn assert_within(actual: usize, expected: usize, tolerance_percent: usize) {
+        assert!(tolerance_percent > 0, "use assert_eq! for exact cases");
+
         let tolerance = expected * tolerance_percent / 100;
         assert!(
             actual.abs_diff(expected) <= tolerance,
@@ -1945,16 +1963,65 @@ mod key_count_estimate_test {
         assert_within(mean, (N / 2) as usize, 10);
     }
 
-    /// A trace whose records are spread thinly over many keys keeps its count:
-    /// the estimate must not shrink an input that has nothing to cancel.
+    /// The estimate must not depend on how the spine happens to be split into
+    /// batches. Flooring each batch's share of the sample independently used to
+    /// make it collapse as the batch count grew (40 batches read 16,000 of
+    /// 20,000 keys, 200 batches read none at all), and the trace is normally the
+    /// side with more batches, so the bias drove the join onto it.
+    #[test]
+    fn many_batches_do_not_shrink_the_estimate() {
+        let trace = snapshot(vec![rows(0..N, 1)]);
+
+        for batch_count in [1u64, 10, 40, 200] {
+            let per_batch = N / batch_count;
+            let delta = snapshot(
+                (0..batch_count)
+                    .map(|batch| rows(batch * per_batch..(batch + 1) * per_batch, 1))
+                    .collect(),
+            );
+
+            assert_eq!(delta.key_count(), N as usize);
+
+            let (delta_keys, _) = estimate_input_key_counts(&delta, &trace);
+            assert_eq!(delta_keys, N as usize, "batch_count={batch_count}");
+        }
+    }
+
+    /// Sampling corrects for cancellation, not for duplication. A key held by
+    /// several batches with a non-zero net weight is collapsed only when two
+    /// draws land on it, which a 100-key sample almost never does, so it still
+    /// counts once per batch.
+    ///
+    /// This pins the limitation rather than the behavior we would want. Replace
+    /// it if the estimator ever learns to count distinct keys.
+    #[test]
+    fn duplication_across_batches_is_not_corrected() {
+        let trace = snapshot(vec![rows(0..N, 1)]);
+
+        for batch_count in [2usize, 20, 200] {
+            // Every batch holds the same live keys, so the cursor yields N / 2.
+            let delta = snapshot(vec![rows(0..N / 2, 1); batch_count]);
+
+            let key_count = delta.key_count();
+            assert_eq!(key_count, batch_count * (N / 2) as usize);
+
+            let (delta_keys, _) = estimate_input_key_counts(&delta, &trace);
+            assert_within(delta_keys, key_count, 5);
+        }
+    }
+
+    /// The estimate must not shrink an input that has nothing to cancel.
+    ///
+    /// One batch of distinct live keys draws the whole sample and every draw
+    /// survives, so both counts come back exactly.
     #[test]
     fn insert_only_input_keeps_its_count() {
         let delta = snapshot(vec![rows(0..N, 1)]);
         let trace = snapshot(vec![rows(0..N, 1)]);
 
         let (delta_keys, trace_keys) = estimate_input_key_counts(&delta, &trace);
-        assert_within(delta_keys, N as usize, 0);
-        assert_within(trace_keys, N as usize, 0);
+        assert_eq!(delta_keys, N as usize);
+        assert_eq!(trace_keys, N as usize);
     }
 }
 

--- a/crates/dbsp/src/trace/sampling.rs
+++ b/crates/dbsp/src/trace/sampling.rs
@@ -4,32 +4,69 @@ use crate::{
 };
 use rand::Rng;
 
+/// Splits `sample_size` draws among `batches` in proportion to their key counts.
+///
+/// Walks the batches from largest to smallest, giving each its share of the
+/// draws that are left, and stops once the draws run out.
+///
+/// Every batch draws at least once while draws are left, so keys held only by
+/// small batches can still reach the sample. A batch is never asked for more
+/// keys than it holds, so asking for at least as many keys as the spine holds
+/// draws every one of them.
+fn apportion_draws(counts: &[usize], sample_size: usize) -> Vec<usize> {
+    let mut largest_first: Vec<usize> = (0..counts.len())
+        .filter(|&index| counts[index] > 0)
+        .collect();
+    largest_first
+        .sort_unstable_by(|&left, &right| counts[right].cmp(&counts[left]).then(left.cmp(&right)));
+
+    let mut draws = vec![0usize; counts.len()];
+    let mut remaining_draws = sample_size;
+    let mut remaining_keys: usize = counts.iter().sum();
+
+    for index in largest_first {
+        if remaining_draws == 0 {
+            break;
+        }
+
+        let count = counts[index];
+        let fair_share =
+            (count as u128 * remaining_draws as u128 / remaining_keys as u128) as usize;
+
+        draws[index] = fair_share.max(1).min(count).min(remaining_draws);
+        remaining_draws -= draws[index];
+        remaining_keys -= count;
+    }
+
+    draws
+}
+
 /// Samples keys from a set of batches by invoking each batch's
 /// [`BatchReader::sample_keys`] implementation and merging the results.
 ///
-/// `sample_size_for` decides how many keys to request from each batch. The
-/// helper deduplicates keys across batches before appending them to `sample`,
-/// which keeps it usable for overlapping inputs such as merge planning.
-pub(crate) fn sample_keys_from_batches<B, RG, F>(
+/// `sample_size` is split across the batches in proportion to their key counts.
+/// The helper deduplicates keys across batches and drops keys whose weights sum
+/// to zero, which keeps it usable for overlapping inputs such as merge planning.
+/// Both of those shrink the result, so the sample can hold fewer than
+/// `sample_size` keys.
+pub(crate) fn sample_keys_from_batches<B, RG>(
     factories: &B::Factories,
     batches: &[&B],
     rng: &mut RG,
-    sample_size_for: F,
+    sample_size: usize,
     sample: &mut DynVec<B::Key>,
 ) where
     B: BatchReader,
     RG: Rng,
-    F: Fn(&B) -> usize,
 {
     if batches.is_empty() {
         return;
     }
 
-    let total_sample_size = batches
-        .iter()
-        .map(|batch| sample_size_for(*batch))
-        .sum::<usize>();
-    if total_sample_size == 0 {
+    let counts: Vec<usize> = batches.iter().map(|batch| batch.key_count()).collect();
+    let draws = apportion_draws(&counts, sample_size);
+    let total_draws = draws.iter().sum::<usize>();
+    if total_draws == 0 {
         return;
     }
 
@@ -38,14 +75,13 @@ pub(crate) fn sample_keys_from_batches<B, RG, F>(
         factories.weight_factory(),
         batches.iter().map(|batch| batch.cursor()).collect(),
     );
-    intermediate.reserve(total_sample_size);
+    intermediate.reserve(total_draws);
 
-    for batch in batches {
-        let sample_size = sample_size_for(*batch);
-        if sample_size == 0 {
+    for (batch, &draws) in batches.iter().zip(draws.iter()) {
+        if draws == 0 {
             continue;
         }
-        batch.sample_keys(rng, sample_size, intermediate.as_mut());
+        batch.sample_keys(rng, draws, intermediate.as_mut());
     }
 
     intermediate.as_mut().sort_unstable();
@@ -57,5 +93,149 @@ pub(crate) fn sample_keys_from_batches<B, RG, F>(
         {
             sample.push_ref(key);
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::apportion_draws;
+
+    fn shapes() -> Vec<Vec<usize>> {
+        let mut shapes: Vec<Vec<usize>> = vec![
+            vec![20_000],
+            vec![500; 40],
+            vec![100; 200],
+            vec![1; 1_000],
+            vec![1_000_000, 1, 1, 1],
+            vec![7, 0, 13, 0, 5],
+            vec![3, 5],
+        ];
+
+        // Every small spine of three batches, empty ones included.
+        for first in 0..6 {
+            for second in 0..6 {
+                for third in 0..6 {
+                    shapes.push(vec![first, second, third]);
+                }
+            }
+        }
+
+        // Larger spines with uneven batches, from a fixed seed so a failure
+        // reproduces.
+        let mut state = 0x9e37_79b9_7f4a_7c15u64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..2_000 {
+            let batches = (next() % 60) as usize + 1;
+            shapes.push((0..batches).map(|_| (next() % 5_000) as usize).collect());
+        }
+
+        shapes
+    }
+
+    const SAMPLE_SIZES: [usize; 9] = [0, 1, 2, 3, 7, 17, 100, 999, 100_000];
+
+    /// The two invariants callers depend on, over a few thousand spine shapes.
+    ///
+    /// The total is what makes the sample size a usable denominator for a caller
+    /// estimating a proportion; flooring a share computed once against the whole
+    /// spine used to lose up to one draw per batch. No batch is asked for more
+    /// keys than it holds, so every apportioned draw is one that can be taken.
+    #[test]
+    fn draws_sum_to_the_sample_size_and_fit_their_batches() {
+        for counts in shapes() {
+            let total_keys: usize = counts.iter().sum();
+
+            for sample_size in SAMPLE_SIZES {
+                let draws = apportion_draws(&counts, sample_size);
+
+                assert_eq!(
+                    draws.iter().sum::<usize>(),
+                    sample_size.min(total_keys),
+                    "counts={counts:?} sample_size={sample_size}"
+                );
+                for (index, (&draw, &count)) in draws.iter().zip(counts.iter()).enumerate() {
+                    assert!(
+                        draw <= count,
+                        "counts={counts:?} sample_size={sample_size} \
+                         batch {index} drew {draw} of {count}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Asking for at least as many keys as the spine holds draws every key.
+    /// `BatchReader::sample_keys` promises an exhaustive sample in that case.
+    #[test]
+    fn a_full_sample_draws_every_key() {
+        for counts in shapes() {
+            let total_keys: usize = counts.iter().sum();
+
+            for sample_size in [total_keys, total_keys + 1, total_keys * 2] {
+                assert_eq!(
+                    apportion_draws(&counts, sample_size),
+                    counts,
+                    "counts={counts:?} sample_size={sample_size}"
+                );
+            }
+        }
+    }
+
+    /// A batch holding half the keys draws about half the sample.
+    #[test]
+    fn draws_track_key_counts() {
+        assert_eq!(
+            apportion_draws(&[10_000, 5_000, 5_000], 100),
+            vec![50, 25, 25]
+        );
+    }
+
+    /// A batch whose fair share rounds down to nothing still draws once, so keys
+    /// held only by small batches can reach the sample.
+    #[test]
+    fn small_batches_draw_at_least_once() {
+        assert_eq!(
+            apportion_draws(&[1_000, 10, 10, 10], 100),
+            vec![97, 1, 1, 1]
+        );
+    }
+
+    /// The draws are spent largest batch first and stop when they run out, so a
+    /// batch that dominates the spine can leave the smallest ones with nothing.
+    #[test]
+    fn a_dominant_batch_can_exhaust_the_draws() {
+        assert_eq!(
+            apportion_draws(&[1_000_000, 1, 1, 1], 100),
+            vec![99, 1, 0, 0]
+        );
+    }
+
+    /// Empty batches never draw, and they do not consume anyone else's draw.
+    #[test]
+    fn empty_batches_do_not_draw() {
+        assert_eq!(apportion_draws(&[50, 0, 50, 0], 10), vec![5, 0, 5, 0]);
+    }
+
+    /// With more non-empty batches than draws, the largest batches take one each
+    /// and the rest get nothing.
+    #[test]
+    fn more_batches_than_draws_still_sums_to_the_sample_size() {
+        let draws = apportion_draws(&vec![1; 200], 100);
+
+        assert_eq!(draws.iter().sum::<usize>(), 100);
+        assert!(draws.iter().all(|&draw| draw <= 1));
+    }
+
+    /// A sample size of zero, and a spine holding no keys at all, draw nothing.
+    #[test]
+    fn degenerate_inputs_draw_nothing() {
+        assert_eq!(apportion_draws(&[10, 20], 0), vec![0, 0]);
+        assert_eq!(apportion_draws(&[0, 0], 100), vec![0, 0]);
+        assert_eq!(apportion_draws(&[], 100), Vec::<usize>::new());
     }
 }

--- a/crates/dbsp/src/trace/spine_async.rs
+++ b/crates/dbsp/src/trace/spine_async.rs
@@ -1809,22 +1809,8 @@ where
         RG: Rng,
     {
         let batches = self.merger.get_batches();
-        let total_keys = batches.iter().map(|batch| batch.key_count()).sum::<usize>();
         let batch_refs: Vec<_> = batches.iter().map(Arc::as_ref).collect();
-        sample_keys_from_batches(
-            &self.factories,
-            &batch_refs,
-            rng,
-            |batch| {
-                if sample_size == 0 || total_keys == 0 {
-                    0
-                } else {
-                    ((batch.key_count() as u128) * (sample_size as u128) / (total_keys as u128))
-                        as usize
-                }
-            },
-            sample,
-        );
+        sample_keys_from_batches(&self.factories, &batch_refs, rng, sample_size, sample);
     }
 
     async fn fetch<KR>(

--- a/crates/dbsp/src/trace/spine_async/snapshot.rs
+++ b/crates/dbsp/src/trace/spine_async/snapshot.rs
@@ -245,26 +245,8 @@ where
     where
         RG: Rng,
     {
-        let total_keys = self
-            .batches
-            .iter()
-            .map(|batch| batch.key_count())
-            .sum::<usize>();
         let batch_refs: Vec<_> = self.batches.iter().map(Arc::as_ref).collect();
-        sample_keys_from_batches(
-            &self.factories,
-            &batch_refs,
-            rng,
-            |batch| {
-                if sample_size == 0 || total_keys == 0 {
-                    0
-                } else {
-                    ((batch.key_count() as u128) * (sample_size as u128) / (total_keys as u128))
-                        as usize
-                }
-            },
-            sample,
-        );
+        sample_keys_from_batches(&self.factories, &batch_refs, rng, sample_size, sample);
     }
 
     async fn fetch<K>(


### PR DESCRIPTION
When evaluating a join we choose the side with fewer keys to drive the join. We step through every key on that side and lookup the key on the other side. Picking the wrong side can be expensive, especially in pathological cases where a side has many duplicate or mutually canceling keys. BatchReader::key_count() doesn't account for this. We use sampling to more accurately estimate the number of distinct keys in a spine: we sample N keys, K<=N unique keys come back => estimated distinct key count is key_count() * K / N.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
