### PR TITLE
Fix vscode inotify watch exhaustion

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,10 +39,12 @@
 				"files.watcherExclude": {
 					"**/target/**": true,
 					"**/node_modules/**": true,
+					"**/target-check/**": true,
+					"**/cargo_workspace/**": true,
 					"**/build/**": true,
 					"**/.venv/**": true,
 					"**/.svelte-kit/**": true,
-					"**/dist/**": true,
+					"js-packages/**/dist/**": true,
 					"**/__pycache__/**": true
 				},
 				"files.exclude": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,15 @@
 			"settings": {
 				"editor.formatOnSave": false,
 				"terminal.integrated.defaultProfile.linux": "bash",
+				"files.watcherExclude": {
+					"**/target/**": true,
+					"**/node_modules/**": true,
+					"**/build/**": true,
+					"**/.venv/**": true,
+					"**/.svelte-kit/**": true,
+					"**/dist/**": true,
+					"**/__pycache__/**": true
+				},
 				"files.exclude": {
 					"**/CODE_OF_CONDUCT.md": true,
 					"**/LICENSE": true

--- a/scripts/inotify.sh
+++ b/scripts/inotify.sh
@@ -2,8 +2,10 @@
 # Inspect and manage inotify watch usage.
 #
 # Usage:
-#   scripts/inotify.sh          Show per-process watch counts
-#   scripts/inotify.sh --free   Kill the top node.js watcher to free watches
+#   scripts/inotify.sh                    Show per-process watch counts
+#   scripts/inotify.sh --free             Kill the VS Code file watcher
+#   scripts/inotify.sh --free --dry-run   Report what --free would kill
+#   scripts/inotify.sh --free --yes       Kill a non-watcher node process unprompted
 
 set -euo pipefail
 
@@ -11,10 +13,16 @@ MIN_WATCHES_TO_KILL=10000
 
 # Watch counts per PID, summed over every inotify fd the process holds.
 declare -A watches=()
+unreadable=0
 while read -r fd_dir fd; do
   pid=${fd_dir#/proc/}
   pid=${pid%/fd}
-  n=$(grep -c '^inotify' "/proc/$pid/fdinfo/$fd" 2>/dev/null) || n=0
+  if [ -r "/proc/$pid/fdinfo/$fd" ]; then
+    n=$(grep -c '^inotify' "/proc/$pid/fdinfo/$fd" 2>/dev/null) || n=0
+  else
+    n=0
+    unreadable=$((unreadable + 1))
+  fi
   watches[$pid]=$((${watches[$pid]:-0} + n))
 done < <(find /proc/[0-9]*/fd -lname 'anon_inode:inotify' -printf '%h %f\n' 2>/dev/null)
 
@@ -61,8 +69,29 @@ short_cmd() {
       esac
     fi
     out+="$arg "
-  done < "/proc/$pid/cmdline"
-  echo "${out% }" | cut -c1-110
+  done 2>/dev/null < "/proc/$pid/cmdline" || true
+  if [ -z "$out" ]; then
+    if [ -e "/proc/$pid" ]; then
+      out="[$(cat "/proc/$pid/comm" 2>/dev/null || echo unknown)]"
+    else
+      out="(exited)"
+    fi
+  fi
+  # An argv may contain newlines, which would break the table and print past the
+  # width limit, so flatten it before truncating.
+  out=${out% }
+  printf '%.110s\n' "${out//$'\n'/ }"
+}
+
+# VS Code forks one process per watcher type; only the file watcher is safe to
+# kill, because the server respawns it.
+is_file_watcher() {
+  local cmdline
+  cmdline=$(tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null) || return 1
+  case "$cmdline" in
+    *--type=fileWatcher* | *watcherMain*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 show_status() {
@@ -71,6 +100,45 @@ show_status() {
   watchers_by_count | while read -r count pid; do
     printf "%6d  PID %-8s %s\n" "$count" "$pid" "$(short_cmd "$pid")"
   done
+  echo ""
+  echo "Counts cover processes owned by $(id -un) only; the limit is per user."
+  if [ "$unreadable" -gt 0 ]; then
+    echo "$unreadable inotify fds were unreadable and counted as 0."
+  fi
+}
+
+# Kill $1, or report the kill under --dry-run.
+kill_watcher() {
+  local pid=$1 count=$2
+  if [ "$dry_run" = 1 ]; then
+    echo "Would kill PID $pid to free $count watches (--dry-run)."
+    exit 0
+  fi
+  echo "Killing PID $pid to free $count watches..."
+  if ! kill "$pid" 2>/dev/null; then
+    echo "PID $pid is already gone; its watches are free."
+    exit 0
+  fi
+  echo "Done. Freed ~$count inotify watches."
+  exit 0
+}
+
+# A node process other than the file watcher may be the editor server itself, so
+# killing it drops the session. Require the user to say so.
+confirm_kill() {
+  local pid=$1 reply
+  if [ "$assume_yes" = 1 ]; then
+    return 0
+  fi
+  # The caller's stdin is the watcher list, so ask the terminal directly.
+  if ! { exec 3< /dev/tty; } 2>/dev/null; then
+    echo "PID $pid is not the VS Code file watcher; killing it may end your session."
+    echo "Re-run with --yes to kill it anyway, or --dry-run to see this without killing."
+    exit 1
+  fi
+  read -r -u 3 -p "Kill PID $pid? Killing it may end your session. [y/N] " reply
+  exec 3<&-
+  [[ "$reply" =~ ^[Yy]$ ]]
 }
 
 free_watches() {
@@ -79,7 +147,7 @@ free_watches() {
     exit 0
   fi
 
-  # Walk watchers from the heaviest down to the first one we can kill.
+  # Walk watchers from the heaviest down to the first one worth killing.
   while read -r count pid; do
     if ! is_node "$pid"; then
       printf "Skipping PID %s (%d watches), not a node process: %s\n" \
@@ -93,9 +161,14 @@ free_watches() {
 
     echo "Top node watcher: PID $pid using $count of $limit watches"
     echo "  $(short_cmd "$pid")"
-    echo "Killing PID $pid to free $count watches..."
-    kill "$pid"
-    echo "Done. Freed ~$count inotify watches."
+
+    if is_file_watcher "$pid"; then
+      kill_watcher "$pid" "$count"
+    fi
+    if confirm_kill "$pid"; then
+      kill_watcher "$pid" "$count"
+    fi
+    echo "Left PID $pid alone."
     exit 0
   done < <(watchers_by_count)
 
@@ -103,8 +176,23 @@ free_watches() {
   exit 1
 }
 
-case "${1:-}" in
-  --free) free_watches ;;
-  "")     show_status ;;
-  *)      echo "Usage: $0 [--free]"; exit 1 ;;
-esac
+free=0
+dry_run=0
+assume_yes=0
+for arg in "$@"; do
+  case "$arg" in
+    --free)    free=1 ;;
+    --dry-run) dry_run=1 ;;
+    --yes)     assume_yes=1 ;;
+    *)         echo "Usage: $0 [--free [--dry-run] [--yes]]"; exit 1 ;;
+  esac
+done
+
+if [ "$free" = 1 ]; then
+  free_watches
+elif [ "$dry_run" = 1 ] || [ "$assume_yes" = 1 ]; then
+  echo "--dry-run and --yes apply to --free only."
+  exit 1
+else
+  show_status
+fi

--- a/scripts/inotify.sh
+++ b/scripts/inotify.sh
@@ -3,77 +3,104 @@
 #
 # Usage:
 #   scripts/inotify.sh          Show per-process watch counts
-#   scripts/inotify.sh --free   Kill the top node.js process to free watches
+#   scripts/inotify.sh --free   Kill the top node.js watcher to free watches
 
 set -euo pipefail
 
-# Collect per-process inotify watch counts into parallel arrays
-pids=()
-counts=()
-for pid in $(find /proc/*/fd -lname 'anon_inode:inotify' 2>/dev/null | cut -d/ -f3 | sort -u); do
-  total=0
-  for fd in $(ls -la /proc/"$pid"/fd 2>/dev/null | grep inotify | awk '{print $9}'); do
-    n=$(grep -c '^inotify' /proc/"$pid"/fdinfo/"$fd" 2>/dev/null) || true
-    total=$((total + n))
-  done
-  if [ "$total" -gt 0 ]; then
-    pids+=("$pid")
-    counts+=("$total")
-  fi
-done
+MIN_WATCHES_TO_KILL=10000
+
+# Watch counts per PID, summed over every inotify fd the process holds.
+declare -A watches=()
+while read -r fd_dir fd; do
+  pid=${fd_dir#/proc/}
+  pid=${pid%/fd}
+  n=$(grep -c '^inotify' "/proc/$pid/fdinfo/$fd" 2>/dev/null) || n=0
+  watches[$pid]=$((${watches[$pid]:-0} + n))
+done < <(find /proc/[0-9]*/fd -lname 'anon_inode:inotify' -printf '%h %f\n' 2>/dev/null)
 
 limit=$(cat /proc/sys/fs/inotify/max_user_watches)
 used=0
-for c in "${counts[@]}"; do used=$((used + c)); done
+for pid in "${!watches[@]}"; do
+  if [ "${watches[$pid]}" -eq 0 ]; then
+    unset "watches[$pid]"
+  else
+    used=$((used + watches[$pid]))
+  fi
+done
+
+# "count pid" lines, highest count first.
+watchers_by_count() {
+  for pid in "${!watches[@]}"; do
+    echo "${watches[$pid]} $pid"
+  done | sort -rn
+}
+
+argv0() {
+  tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -1
+}
+
+# node renames its main thread, so /proc/PID/comm cannot identify an interpreter.
+is_node() {
+  case "$(basename -- "$(argv0 "$1")")" in
+    node | node[0-9]* | nodejs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Command line with the interpreter reduced to its name and long paths collapsed
+# to their last two components, so the distinguishing arguments survive truncation.
+short_cmd() {
+  local pid=$1 arg out="" first=1
+  while IFS= read -r -d '' arg; do
+    if [ "$first" = 1 ]; then
+      first=0
+      arg=$(basename -- "$arg")
+    else
+      case "$arg" in
+        /*/*/*) arg=".../$(basename -- "$(dirname -- "$arg")")/$(basename -- "$arg")" ;;
+      esac
+    fi
+    out+="$arg "
+  done < "/proc/$pid/cmdline"
+  echo "${out% }" | cut -c1-110
+}
 
 show_status() {
   echo "inotify watches: $used / $limit"
   echo ""
-  # Sort by count descending
-  for i in "${!pids[@]}"; do
-    echo "${counts[$i]} ${pids[$i]}"
-  done | sort -rn | while read -r count pid; do
-    comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "unknown")
-    cmd=$(tr '\0' ' ' < /proc/"$pid"/cmdline 2>/dev/null | cut -c1-120)
-    printf "%6d  PID %-7s %-10s %s\n" "$count" "$pid" "($comm)" "$cmd"
+  watchers_by_count | while read -r count pid; do
+    printf "%6d  PID %-8s %s\n" "$count" "$pid" "$(short_cmd "$pid")"
   done
 }
 
 free_watches() {
-  if [ ${#pids[@]} -eq 0 ]; then
+  if [ ${#watches[@]} -eq 0 ]; then
     echo "No inotify watchers found."
     exit 0
   fi
 
-  # Find top watcher
-  top_idx=0
-  for i in "${!counts[@]}"; do
-    if [ "${counts[$i]}" -gt "${counts[$top_idx]}" ]; then
-      top_idx=$i
+  # Walk watchers from the heaviest down to the first one we can kill.
+  while read -r count pid; do
+    if ! is_node "$pid"; then
+      printf "Skipping PID %s (%d watches), not a node process: %s\n" \
+        "$pid" "$count" "$(short_cmd "$pid")"
+      continue
     fi
-  done
-  top_pid=${pids[$top_idx]}
-  top_count=${counts[$top_idx]}
+    if [ "$count" -lt "$MIN_WATCHES_TO_KILL" ]; then
+      echo "Heaviest node watcher holds only $count watches, nothing worth killing."
+      exit 0
+    fi
 
-  comm=$(cat /proc/"$top_pid"/comm 2>/dev/null || echo "unknown")
-  cmd=$(tr '\0' ' ' < /proc/"$top_pid"/cmdline 2>/dev/null | cut -c1-120)
-
-  echo "Top watcher: PID $top_pid ($comm) using $top_count of $limit watches"
-  echo "  $cmd"
-
-  if [[ "$comm" != "node" ]]; then
-    echo "Not a node process — skipping kill."
-    exit 1
-  fi
-
-  if [ "$top_count" -lt 10000 ]; then
-    echo "Watch count is low ($top_count) — no need to kill."
+    echo "Top node watcher: PID $pid using $count of $limit watches"
+    echo "  $(short_cmd "$pid")"
+    echo "Killing PID $pid to free $count watches..."
+    kill "$pid"
+    echo "Done. Freed ~$count inotify watches."
     exit 0
-  fi
+  done < <(watchers_by_count)
 
-  echo "Killing PID $top_pid to free $top_count watches..."
-  kill "$top_pid"
-  echo "Done. Freed ~$top_count inotify watches."
+  echo "No node watcher found to kill."
+  exit 1
 }
 
 case "${1:-}" in

--- a/scripts/inotify.sh
+++ b/scripts/inotify.sh
@@ -11,22 +11,26 @@ set -euo pipefail
 
 MIN_WATCHES_TO_KILL=10000
 
+# Override with a fixture tree to check the watch accounting and the kill
+# decision on known input; the contents of live /proc change between runs.
+proc=${INOTIFY_PROC_ROOT:-/proc}
+
 # Watch counts per PID, summed over every inotify fd the process holds.
 declare -A watches=()
 unreadable=0
 while read -r fd_dir fd; do
-  pid=${fd_dir#/proc/}
+  pid=${fd_dir#"$proc"/}
   pid=${pid%/fd}
-  if [ -r "/proc/$pid/fdinfo/$fd" ]; then
-    n=$(grep -c '^inotify' "/proc/$pid/fdinfo/$fd" 2>/dev/null) || n=0
+  if [ -r "$proc/$pid/fdinfo/$fd" ]; then
+    n=$(grep -c '^inotify' "$proc/$pid/fdinfo/$fd" 2>/dev/null) || n=0
   else
     n=0
     unreadable=$((unreadable + 1))
   fi
   watches[$pid]=$((${watches[$pid]:-0} + n))
-done < <(find /proc/[0-9]*/fd -lname 'anon_inode:inotify' -printf '%h %f\n' 2>/dev/null)
+done < <(find "$proc"/[0-9]*/fd -lname 'anon_inode:inotify' -printf '%h %f\n' 2>/dev/null)
 
-limit=$(cat /proc/sys/fs/inotify/max_user_watches)
+limit=$(cat "$proc/sys/fs/inotify/max_user_watches")
 used=0
 for pid in "${!watches[@]}"; do
   if [ "${watches[$pid]}" -eq 0 ]; then
@@ -44,7 +48,7 @@ watchers_by_count() {
 }
 
 argv0() {
-  tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -1
+  tr '\0' '\n' < "$proc/$1/cmdline" 2>/dev/null | head -1
 }
 
 # node renames its main thread, so /proc/PID/comm cannot identify an interpreter.
@@ -69,10 +73,10 @@ short_cmd() {
       esac
     fi
     out+="$arg "
-  done 2>/dev/null < "/proc/$pid/cmdline" || true
+  done 2>/dev/null < "$proc/$pid/cmdline" || true
   if [ -z "$out" ]; then
-    if [ -e "/proc/$pid" ]; then
-      out="[$(cat "/proc/$pid/comm" 2>/dev/null || echo unknown)]"
+    if [ -e "$proc/$pid" ]; then
+      out="[$(cat "$proc/$pid/comm" 2>/dev/null || echo unknown)]"
     else
       out="(exited)"
     fi
@@ -87,7 +91,7 @@ short_cmd() {
 # kill, because the server respawns it.
 is_file_watcher() {
   local cmdline
-  cmdline=$(tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null) || return 1
+  cmdline=$(tr '\0' ' ' < "$proc/$1/cmdline" 2>/dev/null) || return 1
   case "$cmdline" in
     *--type=fileWatcher* | *watcherMain*) return 0 ;;
     *) return 1 ;;
@@ -164,6 +168,11 @@ free_watches() {
 
     if is_file_watcher "$pid"; then
       kill_watcher "$pid" "$count"
+    fi
+    # Prompting here would defeat --dry-run, whose caller may have no terminal.
+    if [ "$dry_run" = 1 ]; then
+      echo "Would ask before killing PID $pid: it is not the VS Code file watcher (--dry-run)."
+      exit 0
     fi
     if confirm_kill "$pid"; then
       kill_watcher "$pid" "$count"


### PR DESCRIPTION
Built-in VS Code file watchers touch the various build directories, which exhausts the system's capacity for subscribing new file watchers. This interferes with the JavaScript development server for web-console (cd js-packages/web-console && bun run dev). This change prevents VS Code watching unnecessary directories.

The change in the inotify.sh results in a better recognition of the node process to kill (which bloats the used file watches subscriptions)