### PR TITLE
[dbsp] Sample more keys to partition output batches evenly.

### DIFF
--- a/crates/dbsp/src/trace.rs
+++ b/crates/dbsp/src/trace.rs
@@ -395,31 +395,34 @@ pub enum BatchLocation {
 //     }
 // }
 
-/// Number of keys [`BatchReader::partition_keys`] to sample in order to place
+/// Number of keys [`BatchReader::partition_keys`] samples in order to place
 /// `num_partitions - 1` boundaries.
 ///
 /// More samples lead to more accurate bounds (with less imbalance between the
-/// resulting ranges), but make sampling more expensive. We choos sample size
+/// resulting ranges), but make sampling more expensive. We choose a sample size
 /// that keeps the expected largest range within 10% of an even split.
 ///
 /// Each boundary is a sample quantile, so a range ends up holding a
 /// Beta-distributed share of the batch with `sample_size / num_partitions`
 /// draws in it and a relative error near the inverse square root of that count.
 ///
-/// Three terms, in order:
+/// The smallest of these three terms wins:
 ///
-/// * `DRAWS_PER_PARTITION` per partition, the accuracy the boundaries need.
+/// * `DRAWS_PER_PARTITION` draws per partition. This is the term that buys the
+///   accuracy: the relative error above falls as the draws per partition rise.
 /// * A budget that keeps the sample small against one range's scan. The sample
 ///   is drawn once on one thread and the ranges are then scanned in parallel,
 ///   so a draw competes with `key_count / num_partitions` keys, not with the
 ///   whole batch. A draw seeks to a random row in every batch of a spine
-///   snapshot, which is dearer than the sequential step per key that the scan
-///   pays, hence the charge of several hundred keys per draw.
-/// * Never fewer than `num_partitions.pow(2)`, because on a batch that small
-///   the sample costs nothing in absolute terms whatever the budget says.
+///   snapshot, which is more expensive than the sequential step per key that
+///   the scan pays, hence the charge of several hundred keys per draw.
+/// * `key_count`, beyond which [`BatchReader::sample_keys`] has no more keys to
+///   give. A sample that large is exhaustive and the split is exact.
 ///
-/// Capped at `key_count`, where [`BatchReader::sample_keys`] returns every key
-/// and the split is exact.
+/// Raised afterwards to `num_partitions.pow(2)` if the budget put it lower,
+/// since on a batch that small the sample costs nothing in absolute terms
+/// whatever the budget says. The `key_count` cap outranks that floor: a batch
+/// holding fewer keys than the floor is still drawn whole.
 pub(crate) fn partition_sample_size(key_count: usize, num_partitions: usize) -> usize {
     /// Draws per partition. 256 keeps the expected largest range within ~10% of
     /// an even split (~20% at the 99th percentile) for partition counts from 4

--- a/crates/dbsp/src/trace.rs
+++ b/crates/dbsp/src/trace.rs
@@ -395,6 +395,46 @@ pub enum BatchLocation {
 //     }
 // }
 
+/// Number of keys [`BatchReader::partition_keys`] to sample in order to place
+/// `num_partitions - 1` boundaries.
+///
+/// More samples lead to more accurate bounds (with less imbalance between the
+/// resulting ranges), but make sampling more expensive. We choos sample size
+/// that keeps the expected largest range within 10% of an even split.
+///
+/// Each boundary is a sample quantile, so a range ends up holding a
+/// Beta-distributed share of the batch with `sample_size / num_partitions`
+/// draws in it and a relative error near the inverse square root of that count.
+///
+/// Three terms, in order:
+///
+/// * `DRAWS_PER_PARTITION` per partition, the accuracy the boundaries need.
+/// * A budget that keeps the sample small against one range's scan. The sample
+///   is drawn once on one thread and the ranges are then scanned in parallel,
+///   so a draw competes with `key_count / num_partitions` keys, not with the
+///   whole batch. A draw seeks to a random row in every batch of a spine
+///   snapshot, which is dearer than the sequential step per key that the scan
+///   pays, hence the charge of several hundred keys per draw.
+/// * Never fewer than `num_partitions.pow(2)`, because on a batch that small
+///   the sample costs nothing in absolute terms whatever the budget says.
+///
+/// Capped at `key_count`, where [`BatchReader::sample_keys`] returns every key
+/// and the split is exact.
+pub(crate) fn partition_sample_size(key_count: usize, num_partitions: usize) -> usize {
+    /// Draws per partition. 256 keeps the expected largest range within ~10% of
+    /// an even split (~20% at the 99th percentile) for partition counts from 4
+    /// to 32; doubling it halves what is left of the gap.
+    const DRAWS_PER_PARTITION: usize = 256;
+
+    /// Scanned keys a draw is charged against the budget.
+    const KEYS_CHARGED_PER_DRAW: usize = 512;
+
+    (num_partitions * DRAWS_PER_PARTITION)
+        .min(key_count / (num_partitions * KEYS_CHARGED_PER_DRAW))
+        .max(num_partitions * num_partitions)
+        .min(key_count)
+}
+
 /// A set of `(key, value, time, diff)` tuples whose contents may be read in
 /// order by key and value.
 ///
@@ -614,8 +654,11 @@ where
     /// Returns num_partitions-1 keys from the batch that partition the batch into num_partitions
     /// approximately equal size ranges 0..key1, key1..key2, ... , key_num_partitions-1..last_key_in_the_batch.
     ///
-    /// The default implementation uses the sample_keys method to sample num_partitions^2 keys and
-    /// picks keys num_partitions, 2*num_partitions, ..,num_partitions-1*num_partitions as boundaries.
+    /// The default implementation samples keys with [`BatchReader::sample_keys`]
+    /// and cuts the sorted sample into `num_partitions` equal runs, so each
+    /// boundary is a sample quantile. `partition_sample_size` decides how many
+    /// keys it draws, from the imbalance a caller reading the ranges in
+    /// parallel can afford.
     ///
     /// # Arguments
     ///
@@ -630,7 +673,7 @@ where
             return;
         }
 
-        let sample_size = num_partitions * num_partitions;
+        let sample_size = partition_sample_size(self.key_count(), num_partitions);
 
         let mut sample = self.factories().keys_factory().default_box();
         self.sample_keys(&mut thread_rng(), sample_size, sample.as_mut());
@@ -1799,6 +1842,65 @@ mod serialize_test {
             assert_eq!(archived.len(), table.len());
             for (index, offset) in table.iter().enumerate() {
                 assert_eq!(archived[index] as usize, *offset, "offset {index}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod partition_sample_size_test {
+    use super::partition_sample_size;
+
+    const P: usize = 12;
+
+    /// A batch large enough for the budget to clear the accuracy target draws
+    /// that target, whatever the partition count.
+    #[test]
+    fn a_large_batch_draws_the_accuracy_target() {
+        assert_eq!(partition_sample_size(10_000_000_000, P), P * 256);
+        assert_eq!(partition_sample_size(10_000_000_000, 32), 32 * 256);
+    }
+
+    /// Sampling runs on one thread before the ranges are scanned in parallel,
+    /// so a mid-sized batch trades some accuracy to keep the serial phase short.
+    #[test]
+    fn a_mid_sized_batch_is_held_to_its_budget() {
+        assert_eq!(partition_sample_size(4_000_000, P), 4_000_000 / (P * 512));
+    }
+
+    /// Below the budget the sample costs nothing in absolute terms, so the
+    /// floor decides.
+    #[test]
+    fn a_small_batch_falls_back_to_the_floor() {
+        assert_eq!(partition_sample_size(100_000, P), P * P);
+        assert_eq!(partition_sample_size(P * P, P), P * P);
+    }
+
+    /// `sample_keys` returns every key when asked for at least as many as the
+    /// batch holds, which makes the split exact.
+    #[test]
+    fn a_batch_smaller_than_the_sample_is_drawn_whole() {
+        for key_count in 0..P * P {
+            assert_eq!(partition_sample_size(key_count, P), key_count);
+        }
+    }
+
+    /// A bigger batch never asks for a smaller sample.
+    #[test]
+    fn the_sample_size_never_shrinks_as_the_batch_grows() {
+        for partitions in [2, 4, P, 32, 64] {
+            let mut previous = 0;
+            let mut key_count = 0;
+            while key_count < 100_000_000 {
+                let sample_size = partition_sample_size(key_count, partitions);
+                assert!(
+                    sample_size >= previous,
+                    "{partitions} partitions: {key_count} keys drew {sample_size} \
+                     after a smaller batch drew {previous}"
+                );
+                assert!(sample_size <= key_count.max(partitions * partitions));
+                previous = sample_size;
+                key_count = (key_count + 1) * 3 / 2;
             }
         }
     }

--- a/crates/dbsp/src/trace/sampling.rs
+++ b/crates/dbsp/src/trace/sampling.rs
@@ -231,6 +231,45 @@ mod test {
         assert!(draws.iter().all(|&draw| draw <= 1));
     }
 
+    /// A spine where every batch falls below one share still spends the whole
+    /// sample, over enough batches to place a full set of partition boundaries.
+    ///
+    /// `BatchReader::partition_keys` samples `partitions.pow(2)` keys and cuts
+    /// them into `partitions` runs, so it needs draws to reach at least
+    /// `partitions` batches. A spine holds far more batches than that, each a
+    /// small fraction of the keys.
+    #[test]
+    fn a_spine_of_many_small_batches_still_draws_the_whole_sample() {
+        const PARTITIONS: usize = 12;
+        const SAMPLE_SIZE: usize = PARTITIONS * PARTITIONS;
+
+        // Batch counts and sizes spanning four orders of magnitude, as a spine's
+        // levels do.
+        const TIERS: [(usize, usize); 4] = [
+            // (batches, keys per batch)
+            (1_000, 10_000),
+            (500, 100_000),
+            (200, 1_000_000),
+            (100, 5_000_000),
+        ];
+        let counts: Vec<usize> = TIERS
+            .iter()
+            .flat_map(|&(batches, keys)| std::iter::repeat_n(keys, batches))
+            .collect();
+
+        let total_keys: usize = counts.iter().sum();
+        assert!(counts.len() > SAMPLE_SIZE);
+        assert!(
+            counts.iter().all(|&count| count < total_keys / SAMPLE_SIZE),
+            "the shape under test is one where no batch reaches a full share"
+        );
+
+        let draws = apportion_draws(&counts, SAMPLE_SIZE);
+
+        assert_eq!(draws.iter().sum::<usize>(), SAMPLE_SIZE);
+        assert!(draws.iter().filter(|&&draw| draw > 0).count() >= PARTITIONS);
+    }
+
     /// A sample size of zero, and a spine holding no keys at all, draw nothing.
     #[test]
     fn degenerate_inputs_draw_nothing() {

--- a/crates/dbsp/src/trace/sampling.rs
+++ b/crates/dbsp/src/trace/sampling.rs
@@ -232,16 +232,18 @@ mod test {
     }
 
     /// A spine where every batch falls below one share still spends the whole
-    /// sample, over enough batches to place a full set of partition boundaries.
+    /// sample, over enough batches for a caller to cut it into runs.
     ///
-    /// `BatchReader::partition_keys` samples `partitions.pow(2)` keys and cuts
-    /// them into `partitions` runs, so it needs draws to reach at least
-    /// `partitions` batches. A spine holds far more batches than that, each a
-    /// small fraction of the keys.
+    /// `BatchReader::partition_keys` cuts its sample into one run per partition
+    /// and takes a boundary from each, so a sample that reaches fewer batches
+    /// than that yields fewer boundaries. A spine holds far more batches than
+    /// the sample holds draws, each batch a small fraction of the keys.
     #[test]
     fn a_spine_of_many_small_batches_still_draws_the_whole_sample() {
-        const PARTITIONS: usize = 12;
-        const SAMPLE_SIZE: usize = PARTITIONS * PARTITIONS;
+        /// Runs the sample is to be cut into, standing in for a caller's
+        /// partition count.
+        const RUNS: usize = 12;
+        const SAMPLE_SIZE: usize = 144;
 
         // Batch counts and sizes spanning four orders of magnitude, as a spine's
         // levels do.
@@ -267,7 +269,7 @@ mod test {
         let draws = apportion_draws(&counts, SAMPLE_SIZE);
 
         assert_eq!(draws.iter().sum::<usize>(), SAMPLE_SIZE);
-        assert!(draws.iter().filter(|&&draw| draw > 0).count() >= PARTITIONS);
+        assert!(draws.iter().filter(|&&draw| draw > 0).count() >= RUNS);
     }
 
     /// A sample size of zero, and a spine holding no keys at all, draw nothing.

--- a/crates/dbsp/src/trace/sampling.rs
+++ b/crates/dbsp/src/trace/sampling.rs
@@ -6,37 +6,60 @@ use rand::Rng;
 
 /// Splits `sample_size` draws among `batches` in proportion to their key counts.
 ///
-/// Walks the batches from largest to smallest, giving each its share of the
-/// draws that are left, and stops once the draws run out.
+/// Lays the batches' keys end to end and places a draw every
+/// `total_keys / sample_size` positions, from a random offset into the first
+/// interval. A batch holding some fraction of the keys draws that fraction of
+/// the sample, rounded up or down by where the offset falls, and the shares sum
+/// to `sample_size` exactly.
 ///
-/// Every batch draws at least once while draws are left, so keys held only by
-/// small batches can still reach the sample. A batch is never asked for more
-/// keys than it holds, so asking for at least as many keys as the spine holds
-/// draws every one of them.
-fn apportion_draws(counts: &[usize], sample_size: usize) -> Vec<usize> {
-    let mut largest_first: Vec<usize> = (0..counts.len())
-        .filter(|&index| counts[index] > 0)
-        .collect();
-    largest_first
-        .sort_unstable_by(|&left, &right| counts[right].cmp(&counts[left]).then(left.cmp(&right)));
+/// A batch is never asked for more keys than it holds, so asking for at least
+/// as many keys as the batches hold draws every one of them.
+fn apportion_draws<RG>(counts: &[usize], sample_size: usize, rng: &mut RG) -> Vec<usize>
+where
+    RG: Rng,
+{
+    let total_keys: usize = counts.iter().sum();
+    let offset = if 0 < sample_size && sample_size < total_keys {
+        rng.gen_range(0..total_keys)
+    } else {
+        // Every other case draws all of the keys or none of them, and the
+        // offset does not come into it.
+        0
+    };
+
+    apportion_draws_from(counts, sample_size, offset)
+}
+
+/// [`apportion_draws`] with the offset picked by the caller rather than at
+/// random, so that a test can sweep every offset the generator could produce.
+fn apportion_draws_from(counts: &[usize], sample_size: usize, offset: usize) -> Vec<usize> {
+    let total_keys: usize = counts.iter().sum();
+    if sample_size >= total_keys {
+        return counts.to_vec();
+    }
 
     let mut draws = vec![0usize; counts.len()];
-    let mut remaining_draws = sample_size;
-    let mut remaining_keys: usize = counts.iter().sum();
-
-    for index in largest_first {
-        if remaining_draws == 0 {
-            break;
-        }
-
-        let count = counts[index];
-        let fair_share =
-            (count as u128 * remaining_draws as u128 / remaining_keys as u128) as usize;
-
-        draws[index] = fair_share.max(1).min(count).min(remaining_draws);
-        remaining_draws -= draws[index];
-        remaining_keys -= count;
+    if sample_size == 0 {
+        return draws;
     }
+    debug_assert!(offset < total_keys);
+
+    // Position of each draw among the combined keys. The product reaches
+    // `total_keys` squared, so it needs more room than a `usize`.
+    let position = |draw: usize| {
+        ((offset as u128 + (draw as u128) * (total_keys as u128)) / (sample_size as u128)) as usize
+    };
+
+    let mut next = 0;
+    let mut keys_before_next_batch = 0;
+    for (batch, &count) in counts.iter().enumerate() {
+        keys_before_next_batch += count;
+        while next < sample_size && position(next) < keys_before_next_batch {
+            draws[batch] += 1;
+            next += 1;
+        }
+    }
+    debug_assert_eq!(next, sample_size);
 
     draws
 }
@@ -64,7 +87,7 @@ pub(crate) fn sample_keys_from_batches<B, RG>(
     }
 
     let counts: Vec<usize> = batches.iter().map(|batch| batch.key_count()).collect();
-    let draws = apportion_draws(&counts, sample_size);
+    let draws = apportion_draws(&counts, sample_size, rng);
     let total_draws = draws.iter().sum::<usize>();
     if total_draws == 0 {
         return;
@@ -98,7 +121,14 @@ pub(crate) fn sample_keys_from_batches<B, RG>(
 
 #[cfg(test)]
 mod test {
-    use super::apportion_draws;
+    use super::{apportion_draws, apportion_draws_from};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    /// A generator seeded per call, so a failure reproduces.
+    fn rng() -> ChaCha8Rng {
+        ChaCha8Rng::seed_from_u64(0x5eed)
+    }
 
     fn shapes() -> Vec<Vec<usize>> {
         let mut shapes: Vec<Vec<usize>> = vec![
@@ -139,31 +169,187 @@ mod test {
 
     const SAMPLE_SIZES: [usize; 9] = [0, 1, 2, 3, 7, 17, 100, 999, 100_000];
 
-    /// The two invariants callers depend on, over a few thousand spine shapes.
+    /// Every offset `apportion_draws` could pick for a spine small enough to
+    /// sweep, and a spread over the range for one that is not.
+    fn offsets(total_keys: usize) -> Vec<usize> {
+        if total_keys <= 512 {
+            (0..total_keys.max(1)).collect()
+        } else {
+            vec![
+                0,
+                total_keys / 4,
+                total_keys / 2,
+                total_keys - total_keys / 4,
+                total_keys - 1,
+            ]
+        }
+    }
+
+    /// Everything `apportion_draws` could return for these arguments, one entry
+    /// per offset, so that an invariant asserted over them holds whatever the
+    /// generator picks.
+    fn apportionments(counts: &[usize], sample_size: usize) -> Vec<Vec<usize>> {
+        offsets(counts.iter().sum())
+            .into_iter()
+            .map(|offset| apportion_draws_from(counts, sample_size, offset))
+            .collect()
+    }
+
+    /// The two invariants a caller depends on, over a few thousand spine shapes
+    /// and every offset each of them can be drawn at.
     ///
-    /// The total is what makes the sample size a usable denominator for a caller
-    /// estimating a proportion; flooring a share computed once against the whole
-    /// spine used to lose up to one draw per batch. No batch is asked for more
-    /// keys than it holds, so every apportioned draw is one that can be taken.
+    /// * The draws total `sample_size`, or every key the spine holds if it
+    ///   holds fewer than that.
+    /// * No batch draws more keys than it holds, so every draw apportioned to a
+    ///   batch is one that batch can take.
     #[test]
     fn draws_sum_to_the_sample_size_and_fit_their_batches() {
         for counts in shapes() {
             let total_keys: usize = counts.iter().sum();
 
             for sample_size in SAMPLE_SIZES {
-                let draws = apportion_draws(&counts, sample_size);
-
-                assert_eq!(
-                    draws.iter().sum::<usize>(),
-                    sample_size.min(total_keys),
-                    "counts={counts:?} sample_size={sample_size}"
-                );
-                for (index, (&draw, &count)) in draws.iter().zip(counts.iter()).enumerate() {
-                    assert!(
-                        draw <= count,
-                        "counts={counts:?} sample_size={sample_size} \
-                         batch {index} drew {draw} of {count}"
+                for draws in apportionments(&counts, sample_size) {
+                    assert_eq!(
+                        draws.iter().sum::<usize>(),
+                        sample_size.min(total_keys),
+                        "counts={counts:?} sample_size={sample_size} draws={draws:?}"
                     );
+                    for (index, (&draw, &count)) in draws.iter().zip(counts.iter()).enumerate() {
+                        assert!(
+                            draw <= count,
+                            "counts={counts:?} sample_size={sample_size} \
+                             batch {index} drew {draw} of {count}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// The invariants over every small spine and every offset, exhaustively:
+    /// each batch count from none to five, up to four batches, every sample size
+    /// up to a dozen. These are the sizes where a rounding slip has nowhere to
+    /// hide, and where the two early returns meet the general case.
+    #[test]
+    fn small_spines_hold_the_invariants_at_every_offset() {
+        fn check(counts: &[usize]) {
+            let total_keys: usize = counts.iter().sum();
+
+            for sample_size in 0..=12 {
+                for offset in 0..total_keys.max(1) {
+                    let draws = apportion_draws_from(counts, sample_size, offset);
+                    let context = format!(
+                        "counts={counts:?} sample_size={sample_size} \
+                         offset={offset} draws={draws:?}"
+                    );
+
+                    assert_eq!(
+                        draws.iter().sum::<usize>(),
+                        sample_size.min(total_keys),
+                        "{context}"
+                    );
+                    for (&draw, &count) in draws.iter().zip(counts.iter()) {
+                        assert!(draw <= count, "{context}");
+                        // A batch with no keys has none to give.
+                        assert!(count > 0 || draw == 0, "{context}");
+                        if sample_size < total_keys {
+                            // Within one of the share the batch's keys are worth.
+                            let share = count * sample_size;
+                            assert!(
+                                (share / total_keys..=share.div_ceil(total_keys)).contains(&draw),
+                                "{context}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut counts = Vec::new();
+        for batches in 0..=4 {
+            counts.clear();
+            counts.resize(batches, 0);
+            loop {
+                check(&counts);
+
+                // Odometer over every combination of counts in 0..=5.
+                let Some(carry) = counts.iter().position(|&count| count < 5) else {
+                    break;
+                };
+                counts[carry] += 1;
+                counts[..carry].fill(0);
+            }
+        }
+    }
+
+    /// Summed over every offset the generator could pick, a batch draws exactly
+    /// the share its keys are worth.
+    #[test]
+    fn draws_are_unbiased_over_the_offsets() {
+        for counts in [
+            vec![3, 5],
+            vec![7, 0, 13, 0, 5],
+            vec![1; 20],
+            vec![1_000, 10, 10, 10],
+            vec![500; 40],
+        ] {
+            let total_keys: usize = counts.iter().sum();
+
+            for sample_size in [1, 2, 3, 7, 17, 100] {
+                if sample_size >= total_keys {
+                    continue;
+                }
+
+                let mut totals = vec![0usize; counts.len()];
+                for offset in 0..total_keys {
+                    for (total, draw) in
+                        totals
+                            .iter_mut()
+                            .zip(apportion_draws_from(&counts, sample_size, offset))
+                    {
+                        *total += draw;
+                    }
+                }
+
+                for (&total, &count) in totals.iter().zip(counts.iter()) {
+                    assert_eq!(
+                        total,
+                        count * sample_size,
+                        "counts={counts:?} sample_size={sample_size} totals={totals:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Batches large enough that a draw's position outgrows a `usize` on the way
+    /// to being computed.
+    #[test]
+    fn a_huge_spine_does_not_overflow() {
+        let counts = vec![usize::MAX / 4; 3];
+        let total_keys: usize = counts.iter().sum();
+
+        for offset in [0, total_keys / 2, total_keys - 1] {
+            let draws = apportion_draws_from(&counts, 100, offset);
+
+            assert_eq!(draws.iter().sum::<usize>(), 100);
+            for &draw in &draws {
+                assert!((33..=34).contains(&draw), "draws={draws:?}");
+            }
+        }
+    }
+
+    /// The offset `apportion_draws` picks is always one `apportion_draws_from`
+    /// accepts, over a spread of generator states.
+    #[test]
+    fn the_offset_stays_in_range() {
+        for seed in 0..256 {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            for counts in [vec![1, 1], vec![3, 5], vec![7, 0, 13, 0, 5], vec![500; 40]] {
+                let total_keys: usize = counts.iter().sum();
+                for sample_size in [0, 1, 2, 7, 100, 100_000] {
+                    let draws = apportion_draws(&counts, sample_size, &mut rng);
+                    assert_eq!(draws.iter().sum::<usize>(), sample_size.min(total_keys));
                 }
             }
         }
@@ -178,7 +364,7 @@ mod test {
 
             for sample_size in [total_keys, total_keys + 1, total_keys * 2] {
                 assert_eq!(
-                    apportion_draws(&counts, sample_size),
+                    apportion_draws(&counts, sample_size, &mut rng()),
                     counts,
                     "counts={counts:?} sample_size={sample_size}"
                 );
@@ -190,42 +376,70 @@ mod test {
     #[test]
     fn draws_track_key_counts() {
         assert_eq!(
-            apportion_draws(&[10_000, 5_000, 5_000], 100),
+            apportion_draws(&[10_000, 5_000, 5_000], 100, &mut rng()),
             vec![50, 25, 25]
         );
     }
 
-    /// A batch whose fair share rounds down to nothing still draws once, so keys
-    /// held only by small batches can reach the sample.
+    /// Sizes spanning orders of magnitude draw in proportion all the same, so
+    /// the sample stays representative of the keys rather than of the batches.
     #[test]
-    fn small_batches_draw_at_least_once() {
-        assert_eq!(
-            apportion_draws(&[1_000, 10, 10, 10], 100),
-            vec![97, 1, 1, 1]
+    fn draws_track_key_counts_across_orders_of_magnitude() {
+        let mut counts = vec![25_000_000; 10];
+        counts.extend(std::iter::repeat_n(13_332, 190));
+        let total_keys: usize = counts.iter().sum();
+
+        let draws = apportion_draws(&counts, 1_000, &mut rng());
+
+        assert_eq!(draws.iter().sum::<usize>(), 1_000);
+        let large: usize = draws[..10].iter().sum();
+        let large_share = 250_000_000 * 1_000 / total_keys;
+        assert!(
+            large.abs_diff(large_share) <= 10,
+            "the ten large batches hold {large_share} draws' worth of keys and drew {large}"
         );
     }
 
-    /// The draws are spent largest batch first and stop when they run out, so a
-    /// batch that dominates the spine can leave the smallest ones with nothing.
+    /// The draws reach across the whole run of batches.
     #[test]
-    fn a_dominant_batch_can_exhaust_the_draws() {
-        assert_eq!(
-            apportion_draws(&[1_000_000, 1, 1, 1], 100),
-            vec![99, 1, 0, 0]
+    fn draws_reach_across_the_whole_spine() {
+        const BATCHES: usize = 200;
+        const SAMPLE_SIZE: usize = 144;
+
+        let draws = apportion_draws(&vec![500; BATCHES], SAMPLE_SIZE, &mut rng());
+        assert_eq!(draws.iter().sum::<usize>(), SAMPLE_SIZE);
+
+        let drawn: Vec<usize> = draws
+            .iter()
+            .enumerate()
+            .filter(|&(_, &draw)| draw > 0)
+            .map(|(batch, _)| batch)
+            .collect();
+        let widest_gap = drawn
+            .windows(2)
+            .map(|pair| pair[1] - pair[0])
+            .chain([drawn[0] + 1, BATCHES - drawn[drawn.len() - 1]])
+            .max()
+            .unwrap();
+        assert!(
+            widest_gap <= 3,
+            "{widest_gap} batches in a row drew nothing: {drawn:?}"
         );
     }
 
     /// Empty batches never draw, and they do not consume anyone else's draw.
     #[test]
     fn empty_batches_do_not_draw() {
-        assert_eq!(apportion_draws(&[50, 0, 50, 0], 10), vec![5, 0, 5, 0]);
+        assert_eq!(
+            apportion_draws(&[50, 0, 50, 0], 10, &mut rng()),
+            vec![5, 0, 5, 0]
+        );
     }
 
-    /// With more non-empty batches than draws, the largest batches take one each
-    /// and the rest get nothing.
+    /// With more non-empty batches than draws, no batch draws more than once.
     #[test]
     fn more_batches_than_draws_still_sums_to_the_sample_size() {
-        let draws = apportion_draws(&vec![1; 200], 100);
+        let draws = apportion_draws(&vec![1; 200], 100, &mut rng());
 
         assert_eq!(draws.iter().sum::<usize>(), 100);
         assert!(draws.iter().all(|&draw| draw <= 1));
@@ -233,11 +447,6 @@ mod test {
 
     /// A spine where every batch falls below one share still spends the whole
     /// sample, over enough batches for a caller to cut it into runs.
-    ///
-    /// `BatchReader::partition_keys` cuts its sample into one run per partition
-    /// and takes a boundary from each, so a sample that reaches fewer batches
-    /// than that yields fewer boundaries. A spine holds far more batches than
-    /// the sample holds draws, each batch a small fraction of the keys.
     #[test]
     fn a_spine_of_many_small_batches_still_draws_the_whole_sample() {
         /// Runs the sample is to be cut into, standing in for a caller's
@@ -266,7 +475,7 @@ mod test {
             "the shape under test is one where no batch reaches a full share"
         );
 
-        let draws = apportion_draws(&counts, SAMPLE_SIZE);
+        let draws = apportion_draws(&counts, SAMPLE_SIZE, &mut rng());
 
         assert_eq!(draws.iter().sum::<usize>(), SAMPLE_SIZE);
         assert!(draws.iter().filter(|&&draw| draw > 0).count() >= RUNS);
@@ -275,8 +484,8 @@ mod test {
     /// A sample size of zero, and a spine holding no keys at all, draw nothing.
     #[test]
     fn degenerate_inputs_draw_nothing() {
-        assert_eq!(apportion_draws(&[10, 20], 0), vec![0, 0]);
-        assert_eq!(apportion_draws(&[0, 0], 100), vec![0, 0]);
-        assert_eq!(apportion_draws(&[], 100), Vec::<usize>::new());
+        assert_eq!(apportion_draws(&[10, 20], 0, &mut rng()), vec![0, 0]);
+        assert_eq!(apportion_draws(&[0, 0], 100, &mut rng()), vec![0, 0]);
+        assert_eq!(apportion_draws(&[], 100, &mut rng()), Vec::<usize>::new());
     }
 }

--- a/crates/dbsp/src/trace/spine_async/snapshot.rs
+++ b/crates/dbsp/src/trace/spine_async/snapshot.rs
@@ -351,3 +351,77 @@ where
         unimplemented!();
     }
 }
+
+#[cfg(test)]
+mod partition_keys_test {
+    use crate::{
+        ZWeight,
+        dynamic::{DowncastTrait, DynData},
+        trace::{BatchReader, BatchReaderFactories, Cursor, SpineSnapshot},
+        typed_batch::{DynOrdIndexedZSet, OrdIndexedZSet},
+        utils::Tup2,
+    };
+    use std::sync::Arc;
+
+    type Batch = DynOrdIndexedZSet<DynData, DynData>;
+
+    const BATCHES: u64 = 200;
+    const KEYS_PER_BATCH: u64 = 500;
+    const PARTITIONS: usize = 12;
+
+    /// A snapshot with many batches.
+    fn interleaved_snapshot() -> SpineSnapshot<Batch> {
+        let factories: <Batch as BatchReader>::Factories =
+            BatchReaderFactories::new::<u64, u64, ZWeight>();
+        let batches = (0..BATCHES)
+            .map(|batch| {
+                let tuples = (0..KEYS_PER_BATCH)
+                    .map(|i| {
+                        let key = i * BATCHES + batch;
+                        Tup2(Tup2(key, key), 1)
+                    })
+                    .collect();
+                Arc::new(OrdIndexedZSet::<u64, u64>::from_tuples((), tuples).into_inner())
+            })
+            .collect();
+
+        SpineSnapshot::with_batches(&factories, batches)
+    }
+
+    /// `partition_keys` returns a full set of boundaries, cutting ranges of
+    /// comparable size, over a snapshot of many small batches.
+    ///
+    /// The snapshot holds more batches than the sample holds draws and no batch
+    /// reaches a full share of it, so each batch contributes at most one key.
+    #[test]
+    fn a_snapshot_of_many_small_batches_yields_every_boundary() {
+        let snapshot = interleaved_snapshot();
+        let total_keys = BATCHES * KEYS_PER_BATCH;
+        assert_eq!(snapshot.key_count() as u64, total_keys);
+        assert!(KEYS_PER_BATCH < total_keys / PARTITIONS.pow(2) as u64);
+
+        let mut bounds = snapshot.factories().keys_factory().default_box();
+        snapshot.partition_keys(PARTITIONS, bounds.as_mut());
+
+        assert_eq!(bounds.len(), PARTITIONS - 1);
+
+        // Sizes of the ranges the boundaries cut the snapshot into.
+        let mut sizes = vec![0u64; PARTITIONS];
+        let mut cursor = snapshot.cursor();
+        while cursor.key_valid() {
+            let key = *cursor.key().downcast_checked::<u64>();
+            let partition = (0..PARTITIONS - 1)
+                .find(|&i| key < *bounds.index(i).downcast_checked::<u64>())
+                .unwrap_or(PARTITIONS - 1);
+            sizes[partition] += 1;
+            cursor.step_key();
+        }
+
+        assert_eq!(sizes.iter().sum::<u64>(), total_keys);
+        let largest = *sizes.iter().max().unwrap();
+        assert!(
+            largest * PARTITIONS as u64 <= total_keys * 3,
+            "largest range holds {largest} of {total_keys} keys: {sizes:?}"
+        );
+    }
+}

--- a/crates/dbsp/src/trace/spine_async/snapshot.rs
+++ b/crates/dbsp/src/trace/spine_async/snapshot.rs
@@ -396,6 +396,12 @@ mod partition_keys_test {
         move |batch, i| i * batches + batch
     }
 
+    /// Each batch holding one contiguous run of keys, as they are when the key
+    /// grows with arrival: a timestamp, or a sequence number.
+    fn contiguous(keys_per_batch: u64) -> impl Fn(u64, u64) -> u64 {
+        move |batch, i| batch * keys_per_batch + i
+    }
+
     /// Partitions `snapshot` and returns the size of each range.
     fn partition(snapshot: &SpineSnapshot<Batch>, partitions: usize) -> Vec<u64> {
         let mut bounds = snapshot.factories().keys_factory().default_box();
@@ -458,6 +464,29 @@ mod partition_keys_test {
         assert!(
             sample_size > PARTITIONS.pow(2),
             "fixture is meant to be sampled above the floor, drew {sample_size}"
+        );
+
+        assert_within(&partition(&snapshot, PARTITIONS), 3);
+    }
+
+    /// A snapshot whose batches each hold one contiguous run of keys partitions
+    /// as evenly as one whose batches are spread over the key range.
+    ///
+    /// The sample is smaller than the batch count here, so most batches draw
+    /// nothing. Which ones matters: where the batches divide the key range
+    /// between them, a run of undrawn batches at one end of that range leaves
+    /// its keys with no boundary to fall between, and they all land in one
+    /// partition.
+    #[test]
+    fn a_snapshot_of_contiguous_batches_partitions_evenly() {
+        const BATCHES: u64 = 200;
+        const KEYS_PER_BATCH: u64 = 500;
+        const PARTITIONS: usize = 12;
+
+        let snapshot = snapshot(BATCHES, KEYS_PER_BATCH, contiguous(KEYS_PER_BATCH));
+        assert!(
+            partition_sample_size(snapshot.key_count(), PARTITIONS) < BATCHES as usize,
+            "the sample is meant to be too small to reach every batch"
         );
 
         assert_within(&partition(&snapshot, PARTITIONS), 3);

--- a/crates/dbsp/src/trace/spine_async/snapshot.rs
+++ b/crates/dbsp/src/trace/spine_async/snapshot.rs
@@ -357,7 +357,7 @@ mod partition_keys_test {
     use crate::{
         ZWeight,
         dynamic::{DowncastTrait, DynData},
-        trace::{BatchReader, BatchReaderFactories, Cursor, SpineSnapshot},
+        trace::{BatchReader, BatchReaderFactories, Cursor, SpineSnapshot, partition_sample_size},
         typed_batch::{DynOrdIndexedZSet, OrdIndexedZSet},
         utils::Tup2,
     };
@@ -365,20 +365,21 @@ mod partition_keys_test {
 
     type Batch = DynOrdIndexedZSet<DynData, DynData>;
 
-    const BATCHES: u64 = 200;
-    const KEYS_PER_BATCH: u64 = 500;
-    const PARTITIONS: usize = 12;
-
-    /// A snapshot with many batches.
-    fn interleaved_snapshot() -> SpineSnapshot<Batch> {
+    /// A snapshot of `batches` batches of `keys_per_batch` keys each, laid out
+    /// by `key`, which maps a batch index and an offset within it to a key.
+    fn snapshot(
+        batches: u64,
+        keys_per_batch: u64,
+        key: impl Fn(u64, u64) -> u64,
+    ) -> SpineSnapshot<Batch> {
         let factories: <Batch as BatchReader>::Factories =
             BatchReaderFactories::new::<u64, u64, ZWeight>();
-        let batches = (0..BATCHES)
+        let batches = (0..batches)
             .map(|batch| {
-                let tuples = (0..KEYS_PER_BATCH)
+                let tuples = (0..keys_per_batch)
                     .map(|i| {
-                        let key = i * BATCHES + batch;
-                        Tup2(Tup2(key, key), 1)
+                        let k = key(batch, i);
+                        Tup2(Tup2(k, k), 1)
                     })
                     .collect();
                 Arc::new(OrdIndexedZSet::<u64, u64>::from_tuples((), tuples).into_inner())
@@ -388,6 +389,43 @@ mod partition_keys_test {
         SpineSnapshot::with_batches(&factories, batches)
     }
 
+    /// Keys of every batch spread over the whole key range, as they are when a
+    /// spine groups its batches by arrival time and the keys do not correlate
+    /// with arrival.
+    fn interleaved(batches: u64) -> impl Fn(u64, u64) -> u64 {
+        move |batch, i| i * batches + batch
+    }
+
+    /// Partitions `snapshot` and returns the size of each range.
+    fn partition(snapshot: &SpineSnapshot<Batch>, partitions: usize) -> Vec<u64> {
+        let mut bounds = snapshot.factories().keys_factory().default_box();
+        snapshot.partition_keys(partitions, bounds.as_mut());
+        assert_eq!(bounds.len(), partitions - 1);
+
+        let mut sizes = vec![0u64; partitions];
+        let mut cursor = snapshot.cursor();
+        while cursor.key_valid() {
+            let key = *cursor.key().downcast_checked::<u64>();
+            let range = (0..partitions - 1)
+                .find(|&i| key < *bounds.index(i).downcast_checked::<u64>())
+                .unwrap_or(partitions - 1);
+            sizes[range] += 1;
+            cursor.step_key();
+        }
+        assert_eq!(sizes.iter().sum::<u64>(), snapshot.key_count() as u64);
+        sizes
+    }
+
+    #[track_caller]
+    fn assert_within(sizes: &[u64], multiple_of_an_even_split: u64) {
+        let total: u64 = sizes.iter().sum();
+        let largest = *sizes.iter().max().unwrap();
+        assert!(
+            largest * sizes.len() as u64 <= total * multiple_of_an_even_split,
+            "largest range holds {largest} of {total} keys: {sizes:?}"
+        );
+    }
+
     /// `partition_keys` returns a full set of boundaries, cutting ranges of
     /// comparable size, over a snapshot of many small batches.
     ///
@@ -395,33 +433,33 @@ mod partition_keys_test {
     /// reaches a full share of it, so each batch contributes at most one key.
     #[test]
     fn a_snapshot_of_many_small_batches_yields_every_boundary() {
-        let snapshot = interleaved_snapshot();
-        let total_keys = BATCHES * KEYS_PER_BATCH;
-        assert_eq!(snapshot.key_count() as u64, total_keys);
-        assert!(KEYS_PER_BATCH < total_keys / PARTITIONS.pow(2) as u64);
+        const BATCHES: u64 = 200;
+        const KEYS_PER_BATCH: u64 = 500;
+        const PARTITIONS: usize = 12;
 
-        let mut bounds = snapshot.factories().keys_factory().default_box();
-        snapshot.partition_keys(PARTITIONS, bounds.as_mut());
+        let snapshot = snapshot(BATCHES, KEYS_PER_BATCH, interleaved(BATCHES));
+        assert_eq!(snapshot.key_count() as u64, BATCHES * KEYS_PER_BATCH);
+        assert!(KEYS_PER_BATCH < snapshot.key_count() as u64 / PARTITIONS.pow(2) as u64);
 
-        assert_eq!(bounds.len(), PARTITIONS - 1);
+        assert_within(&partition(&snapshot, PARTITIONS), 3);
+    }
 
-        // Sizes of the ranges the boundaries cut the snapshot into.
-        let mut sizes = vec![0u64; PARTITIONS];
-        let mut cursor = snapshot.cursor();
-        while cursor.key_valid() {
-            let key = *cursor.key().downcast_checked::<u64>();
-            let partition = (0..PARTITIONS - 1)
-                .find(|&i| key < *bounds.index(i).downcast_checked::<u64>())
-                .unwrap_or(PARTITIONS - 1);
-            sizes[partition] += 1;
-            cursor.step_key();
-        }
+    /// A batch large enough for the sample size to come from the accuracy term
+    /// rather than the floor still partitions evenly, so the split does not
+    /// depend on `partition_keys` happening to fall back to its floor.
+    #[test]
+    fn a_snapshot_sampled_above_the_floor_partitions_evenly() {
+        const BATCHES: u64 = 50;
+        const KEYS_PER_BATCH: u64 = 4_000;
+        const PARTITIONS: usize = 6;
 
-        assert_eq!(sizes.iter().sum::<u64>(), total_keys);
-        let largest = *sizes.iter().max().unwrap();
+        let snapshot = snapshot(BATCHES, KEYS_PER_BATCH, interleaved(BATCHES));
+        let sample_size = partition_sample_size(snapshot.key_count(), PARTITIONS);
         assert!(
-            largest * PARTITIONS as u64 <= total_keys * 3,
-            "largest range holds {largest} of {total_keys} keys: {sizes:?}"
+            sample_size > PARTITIONS.pow(2),
+            "fixture is meant to be sampled above the floor, drew {sample_size}"
         );
+
+        assert_within(&partition(&snapshot, PARTITIONS), 3);
     }
 }


### PR DESCRIPTION
Claude claimed that drawing N^2 samples is not sufficient to produce
an even N-way partitioning of a spine key range. This can cost a lot
of extra time in a parallel output connector, with one of the threads
being busy long after all other threads have completed.

I didn't fully understand the math, but it also came up with experimental
evidence, so it must be right.

We increase the number of samples to 256 per partition, which
should keep the imbalance within 10%.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
