### PR TITLE
Fix empty steps during connector transaction

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -111,7 +111,7 @@ use nonzero_ext::nonzero;
 use rmpv::Value as RmpValue;
 use serde_json::Value as JsonValue;
 use size_of::HumanBytes;
-use stats::{BufferedInput, StepResults};
+use stats::StepResults;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -8699,19 +8699,17 @@ impl ControllerInner {
         // circuit thread, and the circuit thread reads the endpoint metrics.
         // Updating in the wrong order can cause the circuit thread to park
         // itself indefinitely.
-        let buffered_input = if let Some(endpoint_id) = endpoint_id {
+        if let Some(endpoint_id) = endpoint_id {
             self.status.input_batch_from_endpoint(
                 endpoint_id,
                 amt,
                 &self.backpressure_thread_unparker,
-            )
-        } else {
-            BufferedInput::Normal
-        };
+            );
+        }
 
         if !amt.is_empty() {
             self.status
-                .input_batch_global(amt, buffered_input, &self.circuit_thread_unparker);
+                .input_batch_global(amt, &self.circuit_thread_unparker);
         }
     }
 

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3389,6 +3389,7 @@ impl CircuitThread {
             output_backpressure_warning = None;
 
             let coordination_request = self.controller.coordination_request.lock().unwrap().clone();
+            let step_selection = self.next_step_selection(coordination_request.as_ref());
             match trigger.trigger(
                 self.last_checkpoint(),
                 self.last_checkpoint_sync(),
@@ -3406,7 +3407,7 @@ impl CircuitThread {
                 self.concurrent_phase != ConcurrentPhase::Inactive,
                 self.checkpoint_requested(),
                 self.sync_checkpoint_requested(),
-                self.next_step_inputs(coordination_request.as_ref()),
+                &step_selection,
                 coordination_request,
                 self.step,
             ) {
@@ -4213,8 +4214,10 @@ impl CircuitThread {
         }
     }
 
-    fn next_step_inputs(&self, coordination_request: Option<&StepRequest>) -> StepInputs {
-        if let Some(coordination_request) = coordination_request {
+    /// The endpoints that the next step polls, used both to decide whether to
+    /// take a step and to execute it. See [StepSelection].
+    fn next_step_selection(&self, coordination_request: Option<&StepRequest>) -> StepSelection {
+        let inputs = if let Some(coordination_request) = coordination_request {
             coordination_request.inputs
         } else if self.checkpoint_requested()
             && self.ft.is_none()
@@ -4231,7 +4234,21 @@ impl CircuitThread {
             StepInputs::CheckpointBarriers
         } else {
             StepInputs::All
-        }
+        };
+
+        let committed = if coordination_request.is_none() {
+            self.controller
+                .transaction_info
+                .lock()
+                .unwrap()
+                .committed_connectors()
+        } else {
+            // When there is a coordinator, the coordinator decides which input
+            // connectors to use.
+            HashSet::new()
+        };
+
+        StepSelection { inputs, committed }
     }
 
     /// Requests all of the input adapters to flush their input to the circuit,
@@ -4329,7 +4346,7 @@ impl CircuitThread {
         // in the future is to remove the notion of barriers altogether, making input
         // connectors always checkpointable.
         let coordination_request = self.controller.coordination_request.lock().unwrap().clone();
-        let inputs = self.next_step_inputs(coordination_request.as_ref());
+        let selection = self.next_step_selection(coordination_request.as_ref());
 
         // Collect the ids of the endpoints that we'll flush to the circuit.
         //
@@ -4341,34 +4358,8 @@ impl CircuitThread {
         let statuses = self.controller.status.input_status();
         let mut waiting = HashMap::with_capacity(statuses.len());
 
-        // Connectors that have committed the transaction and should not be queried
-        // until the transaction is committed. This is necessary to ensure liveness, i.e.,
-        // the transaction does not continue indefinitely because connectors keep reinitiating
-        // it.
-        let committing = if coordination_request.is_none() {
-            self.controller
-                .transaction_info
-                .lock()
-                .unwrap()
-                .committed_connectors()
-        } else {
-            // When there is a coordinator, the coordinator decides which input
-            // connectors to use.
-            Default::default()
-        };
-
         for (&endpoint_id, status) in statuses.iter() {
-            let poll_endpoint = if committing.contains(&status.endpoint_name) {
-                // Do not include connectors that have requested commit.
-                false
-            } else {
-                match inputs {
-                    StepInputs::All => true,
-                    StepInputs::CheckpointBarriers => status.is_barrier(),
-                    StepInputs::None => false,
-                }
-            };
-            if !poll_endpoint {
+            if !selection.polls(status) {
                 if let Some(resume) = self.input_metadata.remove(&status.endpoint_name) {
                     step_metadata.insert(
                         endpoint_id,
@@ -5397,6 +5388,49 @@ impl FtState {
     }
 }
 
+/// Determines the input endpoints that the next step will poll.
+///
+/// [StepTrigger] and [CircuitThread::input_step] must agree on this set. The
+/// trigger decides to step from the amount of input those endpoints have
+/// buffered, and `input_step` then consumes exactly those endpoints. Counting
+/// an endpoint that `input_step` will not poll sends the circuit in a busy
+/// loop, stepping on empty inputs.
+struct StepSelection {
+    /// Which endpoints the coordinator, or a pending checkpoint, allows.
+    inputs: StepInputs,
+
+    /// Connectors that have committed the in-progress transaction.
+    ///
+    /// They are not polled until the transaction commits.
+    committed: HashSet<String>,
+}
+
+impl StepSelection {
+    /// True if the next step polls `status`.
+    fn polls(&self, status: &InputEndpointStatus) -> bool {
+        if self.committed.contains(&status.endpoint_name) {
+            return false;
+        }
+        match self.inputs {
+            StepInputs::All => true,
+            StepInputs::CheckpointBarriers => status.is_barrier(),
+            StepInputs::None => false,
+        }
+    }
+
+    /// Records buffered by the endpoints that the next step polls.
+    ///
+    /// Input buffered by any other endpoint stays buffered across the step, so
+    /// it must not enter the decision to take one.
+    fn buffered_records(&self, statuses: &BTreeMap<EndpointId, InputEndpointStatus>) -> u64 {
+        statuses
+            .values()
+            .filter(|status| self.polls(status))
+            .map(|status| status.metrics.buffered_records.load(Ordering::Relaxed))
+            .sum()
+    }
+}
+
 /// Decides when to trigger a step.
 struct StepTrigger {
     /// Time when `max_buffering_delay` expires.
@@ -5481,7 +5515,7 @@ impl StepTrigger {
         concurrent_active: bool,
         checkpoint_requested: bool,
         sync_checkpoint_requested: bool,
-        step_inputs: StepInputs,
+        step_selection: &StepSelection,
         coordination_request: Option<StepRequest>,
         step: Step,
     ) -> Action {
@@ -5549,27 +5583,12 @@ impl StepTrigger {
         let result = if let Some(result) = result {
             result
         } else {
-            // Count buffered records.
-            //
-            // Count only the inputs that the next input step is allowed to poll.
-            // During checkpoint barrier handling, non-barrier inputs are
-            // deliberately ignored; counting them would trigger empty steps
-            // because input_step() will not consume them.
-            //
-            // `step_inputs` matches the input selection that input_step() will
-            // use if this trigger decides to run a step.
-            let buffered_records = self
-                .controller
-                .status
-                .input_status()
-                .values()
-                .filter(|status| match step_inputs {
-                    StepInputs::All => true,
-                    StepInputs::CheckpointBarriers => status.is_barrier(),
-                    StepInputs::None => false,
-                })
-                .map(|status| status.metrics.buffered_records.load(Ordering::Relaxed))
-                .sum::<u64>();
+            // Count buffered records, over exactly the endpoints that
+            // `input_step()` will poll if this trigger decides to run a step.
+            // Counting any other endpoint spins the circuit thread on empty
+            // steps; see [StepSelection].
+            let buffered_records =
+                step_selection.buffered_records(&self.controller.status.input_status());
 
             if buffered_records > self.min_batch_size_records
                 || timer_expired(self.buffer_timeout, now)

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -105,20 +105,6 @@ pub(crate) const MAX_CONNECTOR_ERRORS: usize = 100;
 /// error chain and a backtrace survives intact.
 pub(crate) const MAX_CONNECTOR_ERROR_LEN: usize = 8 * 1024;
 
-/// Kind of input buffered by an endpoint.
-///
-/// Used by [ControllerStatus::input_batch_global] to decide whether input
-/// buffering should wake the circuit thread.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) enum BufferedInput {
-    /// Regular input buffering, with no special wakeup reason.
-    Normal,
-
-    /// Input was buffered for an endpoint currently blocking checkpoint or
-    /// suspend on a barrier.
-    Barrier,
-}
-
 /// Completion token.
 ///
 /// A completion token associated with an endpoint identifies a position in the endpoint's
@@ -1171,24 +1157,17 @@ impl ControllerStatus {
     ///
     /// This method is used for all input batches, including inserts that don't
     /// belong to an endpoint, e.g., happen by executing an ad-hoc INSERT query.
-    pub(super) fn input_batch_global(
-        &self,
-        amt: BufferSize,
-        buffered_input: BufferedInput,
-        circuit_thread_unparker: &Unparker,
-    ) {
-        let num_records = amt.records as u64;
-        // Increment buffered_records; unpark circuit thread once
-        // `min_batch_size_records` is exceeded.
-        let old = self.global_metrics.input_batch(amt);
+    pub(super) fn input_batch_global(&self, amt: BufferSize, circuit_thread_unparker: &Unparker) {
+        self.global_metrics.input_batch(amt);
 
-        if old == 0
-            || (old <= self.pipeline_config.global.min_batch_size_records
-                && old + num_records > self.pipeline_config.global.min_batch_size_records)
-            || buffered_input == BufferedInput::Barrier
-        {
-            circuit_thread_unparker.unpark();
-        }
+        // Wake the circuit thread for every batch and let [StepTrigger] decide
+        // whether to step.  A wake rule of its own has to know which endpoints
+        // the next step polls, and gets it wrong every time that set narrows:
+        // input buffered by an endpoint the step skips stays buffered, so a
+        // rule reading the global count sleeps through input it could consume.
+        // `min_batch_size_records` and `max_buffering_delay` still batch input,
+        // because they gate the step, not the wakeup.
+        circuit_thread_unparker.unpark();
     }
 
     /// Update counters after receiving a new input batch.
@@ -1199,30 +1178,18 @@ impl ControllerStatus {
     /// * `amt` - number of bytes and records in the batch.
     /// * `backpressure_thread_unparker` - unparker used to wake up the
     ///   backpressure thread if the endpoint is full.
-    ///
-    /// Returns the kind of input that was buffered, used by
-    /// [Self::input_batch_global] to decide whether to wake the circuit thread.
     pub(super) fn input_batch_from_endpoint(
         &self,
         endpoint_id: EndpointId,
         amt: BufferSize,
         backpressure_thread_unparker: &Unparker,
-    ) -> BufferedInput {
+    ) {
         // There is a potential race condition if the endpoint is currently
         // being removed. In this case, it's safe to ignore this operation.
         if !amt.is_empty() {
             let inputs = self.input_status();
             if let Some(endpoint_stats) = inputs.get(&endpoint_id) {
                 let old = endpoint_stats.add_buffered(amt);
-                // Barrier endpoints must wake the circuit thread even if they
-                // already had buffered input. Otherwise the generic wake rules
-                // can ignore an old > 0 batch, leaving a suspend request parked
-                // even though this batch may make the endpoint checkpointable.
-                let buffered_input = if endpoint_stats.is_barrier() {
-                    BufferedInput::Barrier
-                } else {
-                    BufferedInput::Normal
-                };
                 let threshold = BufferSize {
                     records: endpoint_stats.config.connector_config.max_queued_records() as usize,
                     bytes: endpoint_stats.config.connector_config.max_queued_bytes() as usize,
@@ -1237,11 +1204,8 @@ impl ControllerStatus {
                 {
                     backpressure_thread_unparker.unpark();
                 }
-                return buffered_input;
             }
         }
-
-        BufferedInput::Normal
     }
 
     /// Update counters after receiving an end-of-input event on an input

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -1161,12 +1161,7 @@ impl ControllerStatus {
         self.global_metrics.input_batch(amt);
 
         // Wake the circuit thread for every batch and let [StepTrigger] decide
-        // whether to step.  A wake rule of its own has to know which endpoints
-        // the next step polls, and gets it wrong every time that set narrows:
-        // input buffered by an endpoint the step skips stays buffered, so a
-        // rule reading the global count sleeps through input it could consume.
-        // `min_batch_size_records` and `max_buffering_delay` still batch input,
-        // because they gate the step, not the wakeup.
+        // whether to step.
         circuit_thread_unparker.unpark();
     }
 

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -9,15 +9,15 @@ use crate::{
         test_circuit_with_aggregate, wait,
     },
     transport::{
-        InputQueue, InputReader, InputReaderCommand, input_transport_config_to_endpoint,
-        set_barrier,
+        InputQueue, InputQueueEntry, InputReader, InputReaderCommand,
+        input_transport_config_to_endpoint, set_barrier,
     },
 };
 use anyhow::anyhow;
 use chrono::Utc;
 use crossbeam::sync::Parker;
 use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
-use feldera_adapterlib::format::{BufferSize, Parser};
+use feldera_adapterlib::format::{BufferSize, InputBuffer, Parser};
 use feldera_types::{
     adapter_stats::ExternalOutputEndpointMetrics,
     config::{FtModel, InputEndpointConfig, OutputEndpointConfig},
@@ -1063,6 +1063,247 @@ fn fault_tolerance_mismatch_unregisters_the_endpoint() {
         "the rejected endpoint stayed registered"
     );
     assert!(controller.status().input_status().is_empty());
+
+    controller.stop().unwrap();
+}
+
+/// An input endpoint that opens and commits Feldera transactions, the way a
+/// connector configured with a `transaction_mode` does.
+///
+/// It hands over whatever it has queued in reply to a `Queue` command, like an
+/// ordinary connector, so an endpoint that keeps input buffered across steps is
+/// one the controller chose not to poll.
+#[derive(Clone)]
+struct TransactionalInputEndpoint {
+    details: Arc<Mutex<Option<TransactionalInputEndpointDetails>>>,
+}
+
+struct TransactionalInputEndpointDetails {
+    parser: Box<dyn Parser>,
+    queue: InputQueue,
+}
+
+impl TransactionalInputEndpoint {
+    fn new() -> Self {
+        Self {
+            details: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Opens the transaction labeled `label`, or joins it if another connector
+    /// has already opened it, ahead of the input queued next.
+    fn start_transaction(&self, label: &str) {
+        self.push_entry(
+            InputQueueEntry::new_with_aux(Utc::now(), ())
+                .with_start_transaction(Some(Some(label.to_string()))),
+        );
+    }
+
+    /// Commits this connector's part of the transaction, after the input
+    /// queued so far.  The transaction itself commits once every participant
+    /// has done this.
+    fn commit_transaction(&self) {
+        self.push_entry(
+            InputQueueEntry::new_with_aux(Utc::now(), ()).with_commit_transaction(true),
+        );
+    }
+
+    /// Parses `data` and queues it, reporting the records as buffered.
+    fn push(&self, data: &str) {
+        let mut guard = self.details.lock().unwrap();
+        let details = guard.as_mut().unwrap();
+        let parsed = details.parser.parse(data.as_bytes(), None);
+        details.queue.push(parsed, Utc::now());
+    }
+
+    fn push_entry(&self, entry: InputQueueEntry<(), Box<dyn InputBuffer>>) {
+        self.details
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .queue
+            .push_entry(entry, Vec::new());
+    }
+}
+
+impl InputEndpoint for TransactionalInputEndpoint {
+    fn fault_tolerance(&self) -> Option<FtModel> {
+        None
+    }
+}
+
+impl TransportInputEndpoint for TransactionalInputEndpoint {
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        _schema: Relation,
+        _resume_info: Option<serde_json::Value>,
+    ) -> anyhow::Result<Box<dyn InputReader>> {
+        *self.details.lock().unwrap() = Some(TransactionalInputEndpointDetails {
+            parser,
+            queue: InputQueue::new(consumer),
+        });
+        Ok(Box::new(self.clone()))
+    }
+}
+
+impl InputReader for TransactionalInputEndpoint {
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+        self
+    }
+
+    fn request(&self, command: InputReaderCommand) {
+        match command {
+            InputReaderCommand::Queue { .. } => {
+                self.details.lock().unwrap().as_ref().unwrap().queue.queue()
+            }
+            InputReaderCommand::Extend
+            | InputReaderCommand::Pause
+            | InputReaderCommand::Disconnect => (),
+            InputReaderCommand::Replay { .. } => {
+                unreachable!("this endpoint is not fault tolerant")
+            }
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        false
+    }
+}
+
+/// Input buffered by a connector that has committed the in-progress
+/// transaction must not keep the circuit thread stepping.
+///
+/// Such a connector is not polled until the transaction commits, so that a
+/// participant cannot extend forever the transaction it just committed.  Its
+/// input therefore stays buffered across every step.  A step trigger that
+/// counts it decides to step, takes a step that consumes nothing, finds the
+/// same input still buffered, and steps again: the circuit thread spins on
+/// empty steps for the rest of the transaction, evaluating the whole circuit
+/// each time.
+#[test]
+fn committed_connector_input_does_not_spin_the_circuit() {
+    init_test_logger();
+
+    // Step as soon as anything is buffered, with no clock connector and no
+    // checkpoint timer to ask for a step of its own.  Any step the test
+    // observes is then one the trigger decided to take on buffered input.
+    let config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 4,
+        "min_batch_size_records": 0,
+        "max_buffering_delay_usecs": 0,
+        "clock_resolution_usecs": null,
+    }))
+    .unwrap();
+
+    let controller = Controller::with_test_config(
+        |circuit_config| {
+            Ok(test_circuit::<TestStruct>(
+                circuit_config,
+                &TestStruct::schema(),
+                &[None, None],
+            ))
+        },
+        &config,
+        Box::new(|e, _| panic!("error: {e}")),
+    )
+    .unwrap();
+    controller.start();
+
+    let add_endpoint = |name: &str, stream: &str| {
+        let endpoint = TransactionalInputEndpoint::new();
+        let endpoint_config: InputEndpointConfig = serde_json::from_value(json!({
+            "stream": stream,
+            "transport": { "name": "file_input", "config": { "path": "unused" } },
+            "format": { "name": "csv" }
+        }))
+        .unwrap();
+        controller
+            .add_input_endpoint(name, endpoint_config, Box::new(endpoint.clone()), None)
+            .unwrap();
+        endpoint
+    };
+    let committer = add_endpoint("committer", "test_input1");
+    let holder = add_endpoint("holder", "test_input2");
+
+    let committed = |name: &str| {
+        controller
+            .inner
+            .transaction_info
+            .lock()
+            .unwrap()
+            .committed_connectors()
+            .contains(name)
+    };
+    let participates = |name: &str| {
+        controller
+            .inner
+            .transaction_info
+            .lock()
+            .unwrap()
+            .initiators
+            .initiated_by_connectors
+            .contains_key(name)
+    };
+
+    // Both connectors open the same transaction. `holder` never commits, so
+    // the transaction stays open for the rest of the test.
+    holder.start_transaction("t");
+    committer.start_transaction("t");
+    committer.push("1,true,,foo\n");
+    wait(
+        || participates("holder") && participates("committer"),
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("the connectors never opened a transaction");
+
+    // `committer` commits its part. From here the controller stops polling it.
+    committer.commit_transaction();
+    wait(|| committed("committer"), DEFAULT_TIMEOUT_MS)
+        .expect("the connector never committed its part of the transaction");
+
+    // Input it buffers now cannot be consumed until the transaction commits.
+    committer.push(&"2,true,,foo\n".repeat(100));
+    wait(
+        || controller.status().num_buffered_input_records() == 100,
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("the committed connector's input was consumed after all");
+
+    // Nothing the next step can consume is buffered, so the circuit thread
+    // must stay parked.
+    let before = controller.status().global_metrics.total_initiated_steps();
+    sleep(Duration::from_secs(1));
+    let steps = controller.status().global_metrics.total_initiated_steps() - before;
+    assert!(
+        steps < 10,
+        "the circuit thread took {steps} steps in a second with nothing to consume"
+    );
+
+    // The pipeline is parked, not wedged: input on the connector that is still
+    // polled gets processed.
+    let processed = controller.status().num_total_processed_records();
+    holder.push("3,true,,foo\n");
+    wait(
+        || controller.status().num_total_processed_records() > processed,
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("input on a polled connector was never processed");
+
+    // Committing the transaction releases the backlog.
+    holder.commit_transaction();
+    wait(
+        || controller.status().num_buffered_input_records() == 0,
+        DEFAULT_TIMEOUT_MS,
+    )
+    .expect("the backlog was never consumed after the transaction committed");
+    assert_eq!(
+        controller.inner.get_transaction_state(),
+        TransactionState::None
+    );
 
     controller.stop().unwrap();
 }

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -1,4 +1,4 @@
-use super::{OutputEndpointControl, stats::BufferedInput};
+use super::OutputEndpointControl;
 use crate::{
     Controller, InputConsumer, InputEndpoint, OutputEndpoint, PipelineConfig,
     TransportInputEndpoint,
@@ -2850,52 +2850,74 @@ fn output_path(storage_dir: &Path, i: usize) -> PathBuf {
     storage_dir.join(format!("output{}.csv", i + 1))
 }
 
+/// Buffering input wakes the circuit thread, whatever else is buffered.
+///
+/// A wake rule that reasons about how much is buffered has to know which
+/// endpoints the next step polls, and gets it wrong every time that set
+/// narrows: input buffered by an endpoint the step skips stays buffered, so
+/// the global count never falls back and every other endpoint's wakeup is
+/// swallowed.  Waking unconditionally and leaving the decision to
+/// [`StepTrigger`] costs one trigger evaluation and cannot go stale.
+///
+/// A missed wakeup here is a hang, not a slowdown:
+/// [`committed_connector_input_does_not_spin_the_circuit`] covers the case
+/// end to end.
 #[test]
-fn barrier_input_batch_wakes_when_endpoint_already_has_buffered_input() {
+fn input_batch_wakes_the_circuit_thread() {
     init_test_logger();
 
-    // During suspend, every new batch from a barrier endpoint can be the batch
-    // that clears the barrier.
-    //
-    // https://github.com/feldera/feldera/actions/runs/26535433930/job/78166265316
-    // That test likely failed because the endpoint already had buffered
-    // barrier input, so the old > 0 condition was not enough to wake the
-    // circuit thread.
-    let tempdir = TempDir::new().unwrap();
-    let storage_dir = tempdir.path().join("storage");
-    create_dir(&storage_dir).unwrap();
-    File::create(input_path(&storage_dir, 0)).unwrap();
+    let config: PipelineConfig = serde_json::from_value(json!({
+        "name": "test",
+        "workers": 4,
+        // High enough that a wake rule reading the buffered count would
+        // suppress the wakeup below.
+        "min_batch_size_records": 1_000_000,
+        "clock_resolution_usecs": null,
+    }))
+    .unwrap();
 
-    let controller = start_controller(&storage_dir, &[0]);
-
-    let endpoint_id = {
-        let input_status = controller.status().input_status();
-        *input_status.keys().next().unwrap()
-    };
-    {
-        let input_status = controller.status().input_status();
-        let endpoint = input_status.get(&endpoint_id).unwrap();
-        endpoint.set_barrier(true);
-        endpoint
-            .metrics
-            .buffered_records
-            .store(1, Ordering::Relaxed);
-    }
+    let controller = Controller::with_test_config(
+        |circuit_config| {
+            Ok(test_circuit::<TestStruct>(
+                circuit_config,
+                &TestStruct::schema(),
+                &[None],
+            ))
+        },
+        &config,
+        Box::new(|e, _| panic!("error: {e}")),
+    )
+    .unwrap();
+    let status = controller.status();
 
     let parker = Parker::new();
-    let unparker = parker.unparker().clone();
-    let buffered_input = controller.status().input_batch_from_endpoint(
-        endpoint_id,
+    let batch = BufferSize {
+        records: 1,
+        bytes: 1,
+    };
+    // A backlog no step will consume, of the kind a connector that has
+    // committed the in-progress transaction leaves behind.
+    status.input_batch_global(
         BufferSize {
-            records: 1,
-            bytes: 1,
+            records: 1_000,
+            bytes: 1_000,
         },
-        &unparker,
+        parker.unparker(),
     );
+    parker.park_timeout(Duration::ZERO);
+
+    status.input_batch_global(batch, parker.unparker());
 
     controller.stop().unwrap();
 
-    assert_eq!(buffered_input, BufferedInput::Barrier);
+    // Set, so `park` returns without blocking. Unset, this waits the full
+    // timeout and the assertion fails.
+    let start = Instant::now();
+    parker.park_timeout(Duration::from_secs(10));
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "buffering input did not wake the circuit thread"
+    );
 }
 
 fn start_controller(storage_dir: &Path, barriers: &[usize]) -> Controller {


### PR DESCRIPTION
The circuit was spinning in a busy loop when only a subset of connectors have committed a transaction.

This commit makes the controller slightly simpler for a change.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
