### PR TITLE
[DOC][SQL] Cleanup and document the list of reserved keywords

### DIFF
--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -10,8 +10,8 @@ form.
 - Parentheses `()` are used for grouping productions together.
 - The vertical bar `|` indicates choice between two constructs.
 
-SQL reserved keywords cannot be used as table and view names.  In
-addition, the following keywords are reserved: `USER`, `NOW`.
+SQL [reserved keywords](#reserved-keywords) cannot be used as table and
+view names.
 Identifiers starting with "Feldera" (in any case combination) are used
 for system objects, such as the error view, and should not be used for
 user-defined objects.
@@ -837,3 +837,62 @@ a single copy of the data.  This settings is the number of temporal
 filters that are required to share a source in order to enable sharing.
 The default is 10; setting the option to 0
 disables the optimization.  This option is currently experimental.
+
+## Reserved keywords
+
+A reserved keyword can name a table, view, column, function, or alias
+only when it is written as a [quoted identifier](identifiers.md), as in
+`"select"`.  The following words are reserved:
+
+| Initial | Reserved keywords |
+|---|---|
+| A | `ANY`, `ASOF` |
+| C | `CALL`, `CASE`, `CREATE`, `CROSS`, `CURRENT`, `CURSOR` |
+| D | `DATE`, `DATEADD`, `DATEDIFF`, `DATEPART`, `DATETIME`, `DATE_PART`, `DEFAULT`, `DEFINE`, `DELETE`, `DESCRIBE`, `DISTINCT`, `DROP` |
+| E | `END-EXEC`, `EXCEPT`, `EXPLAIN` |
+| F | `FETCH`, `FOREIGN`, `FRIDAY`, `FROM`, `FULL` |
+| G | `GROUP`, `GROUPING` |
+| H | `HAVING` |
+| I | `IN`, `INDEX`, `INNER`, `INSERT`, `INTERNED`, `INTERSECT`, `INTERVAL`, `INTO` |
+| J | `JOIN` |
+| L | `LATENESS`, `LATERAL`, `LEFT`, `LIMIT` |
+| M | `MATCH_CONDITION`, `MATCH_RECOGNIZE`, `MATERIALIZED`, `MEASURE`, `MERGE`, `MINUS`, `MONDAY` |
+| N | `NATURAL`, `NEW`, `NEXT`, `NULL` |
+| O | `OFFSET`, `ON`, `ORDER`, `ORDINAL`, `OUTER`, `OVER` |
+| P | `PARTITION`, `PATTERN`, `PRIMARY` |
+| Q | `QUALIFY` |
+| R | `RANGE`, `REMOVE`, `RIGHT`, `ROLLUP`, `ROW`, `ROWS` |
+| S | `SAFE_CAST`, `SAFE_OFFSET`, `SAFE_ORDINAL`, `SATURDAY`, `SELECT`, `SEMI`, `SET`, `SKIP`, `SOME`, `STREAM`, `SUNDAY` |
+| T | `TABLE`, `TABLESAMPLE`, `THEN`, `THURSDAY`, `TIME`, `TIMESTAMP`, `TRY_CAST`, `TUESDAY` |
+| U | `UNION`, `UNNEST`, `UNSIGNED`, `UPDATE`, `USING`, `UUID` |
+| V | `VALUES`, `VARIANT` |
+| W | `WATERMARK`, `WEDNESDAY`, `WHEN`, `WHERE`, `WINDOW`, `WITH` |
+
+Feldera reserves far fewer words than the SQL standard does; `AND`,
+`CAST`, `COUNT`, `SUM`, `VARCHAR`, and several hundred other standard
+keywords are legal unquoted identifiers.  A few of these words are
+still unusable as unquoted column references:
+
+- `ALL`, `EXISTS`, `NOT`, and `UNIQUE` begin an expression, so the
+  parser rejects them where it expects an identifier.
+
+- `FALSE`, `TRUE`, and `UNKNOWN` are literals, and `CURRENT_CATALOG`,
+  `CURRENT_DATE`, `CURRENT_PATH`, `CURRENT_ROLE`, `CURRENT_SCHEMA`,
+  `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `CURRENT_USER`, `LOCALTIME`,
+  `LOCALTIMESTAMP`, `SESSION_USER`, `SYSTEM_USER`, and `USER` are
+  functions that SQL calls without parentheses.  A column can carry
+  such a name, but a bare reference to it is the literal or the
+  function call.  Qualify the column with the name of its table, as in
+  `t.user`, or quote it, as in `"user"`.
+
+  Feldera does not support any of the functions in this list.
+  Each such name is therefore unusable on its own, although none of them
+  is a reserved keyword.  For the date and time functions use
+  [`NOW()`](datetime.md#now), as in `CAST(NOW() AS DATE)` for `CURRENT_DATE`.
+
+### Names of predefined objects
+
+A table cannot take the name of a predefined function:
+`CREATE TABLE abs(...)`, `CREATE TABLE now(...)`,
+and `CREATE TABLE user(...)` are rejected.  Quoting the name does not
+help; `CREATE TABLE "abs"(...)` is rejected too.  Choose a different name.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -28,11 +28,25 @@ data: {
       "org.dbsp.sqlCompiler.compiler.frontend.parser.SqlForeignKey"
     ]
 
+    # Every keyword token is reserved unless one of the two lists below mentions
+    # it:
+    #
+    #   reserved = keyword tokens - (nonReservedKeywords + nonReservedKeywordsToAdd)
+    #
+    # Calcite's Parser.jj template declares most of the tokens and the 'keywords'
+    # list adds the rest.  The parser concatenates the two non-reserved lists, so
+    # a live entry in either one un-reserves the word and commenting it out in
+    # the other changes nothing.  Commenting out is the only way to reserve a
+    # word, which is why every commented entry records a decision, with its
+    # reason.
+    #
+    # Both lists are copies of Calcite lists: core's default_config.fmpp and
+    # babel's config.fmpp.
+
     # List of new keywords. Example: "DATABASES", "TABLES". If the keyword is
     # not a reserved keyword, add it to the 'nonReservedKeywords' section.
     keywords: [
       "INDEX"
-      "DISCARD"
       "IF"
       "INTERNED"
       "LATENESS"
@@ -40,12 +54,8 @@ data: {
       "LINEAR"
       "MATERIALIZED"
       "WATERMARK"
-      "PLANS"
       "REMOVE"
-      "SEED"
       "SEMI"
-      "SEQUENCES"
-      "TEMP"
       #"VOLATILE"
     ]
 
@@ -180,7 +190,6 @@ data: {
       "JAVA"
       "JSON"
       "K"
-#      "KEY"
       "KEY_MEMBER"
       "KEY_TYPE"
       "LABEL"
@@ -398,13 +407,8 @@ data: {
       "TYPE"
 
       # not in core, added in babel
-      # "DISCARD"
       "IF"
-      # "PLANS"
-      # "SEED"
-      # "SEMI"
-      # "SEQUENCES"
-      # "TEMP"
+#     "SEMI" # reserved: the LEFT SEMI JOIN production consumes it
 
       # The following keywords are reserved in core Calcite,
       # are reserved in some version of SQL,
@@ -432,7 +436,6 @@ data: {
 #     "ANY"
       "ARE"
       "ARRAY"
-#     "ARRAY_AGG" # not a keyword in Calcite
       "ARRAY_MAX_CARDINALITY"
       "AS"
       "ASC"
@@ -488,6 +491,7 @@ data: {
       "CONSTRAINTS"
       "CONSTRUCTOR"
       "CONTAINS"
+      "CONTAINS_SUBSTR"
       "CONTINUE"
       "CONVERT"
       "CORR"
@@ -590,7 +594,7 @@ data: {
       "GLOBAL"
       "GO"
       "GOTO"
-#     "GRANT"
+      "GRANT"
 #     "GROUP"
 #     "GROUPING"
       "GROUPS"
@@ -628,6 +632,7 @@ data: {
       "JSON_OBJECT"
       "JSON_OBJECTAGG"
       "JSON_QUERY"
+      "JSON_SCOPE"
       "JSON_VALUE"
 #     "KEEP" # not a keyword in Calcite
       "KEY"
@@ -789,7 +794,6 @@ data: {
       "SESSION"
       "SESSION_USER"
 #     "SET"
-#     "SETS"
       "SHOW"
 #     "SIGNAL" # not a keyword in Calcite
       "SIMILAR"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
@@ -145,6 +146,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -152,6 +154,15 @@ import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.*;
 
 public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         implements IWritesLogs, ICompilerComponent {
+    /** Supported replacements for the date and time functions that SQL calls without
+     * parentheses; the other such functions, CURRENT_USER e.g., have none. */
+    static final Map<String, String> NILADIC_REPLACEMENTS = Map.of(
+            "CURRENT_TIMESTAMP", "NOW()",
+            "LOCALTIMESTAMP", "NOW()",
+            "CURRENT_DATE", "CAST(NOW() AS DATE)",
+            "CURRENT_TIME", "CAST(NOW() AS TIME)",
+            "LOCALTIME", "CAST(NOW() AS TIME)");
+
     private final TypeCompiler typeCompiler;
     @Nullable
     public final DBSPVariablePath inputRow;
@@ -2476,8 +2487,19 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         }
 
         ExternalFunction ef = this.compiler.getCustomFunctions().getUDF(function);
-        if (ef == null)
+        if (ef == null) {
+            if (call.op.getSyntax() == SqlSyntax.FUNCTION_ID) {
+                // SQL spells these functions without parentheses, so a bare name that
+                // looks like a column reference is in fact a call to one of them
+                String replacement = NILADIC_REPLACEMENTS.get(function.name().toUpperCase(Locale.ENGLISH));
+                String column = function.name().toLowerCase(Locale.ENGLISH);
+                throw new CompilationError("Function " + function.singleQuote() + " is not supported" +
+                        (replacement == null ? "." : "; use " + replacement + " instead.") +
+                        "  If you meant a column with this name, qualify it with a table name or " +
+                        "quote it: \"" + column + "\"", node);
+            }
             throw new CompilationError("Function " + function.singleQuote() + " is unknown", node);
+        }
         List<DBSPType> operandTypes = Linq.map(ef.parameterList,
                 p -> this.typeCompiler.convertType(node.getPositionRange(), p.getType(), false));
         // Give warnings if we have to insert casts that cast away nullability,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -64,6 +64,9 @@ public class MetadataTests extends BaseSQLTests {
         // Create a view named like a system view
         this.statementsFailingInCompilation("CREATE VIEW ERROR_VIEW AS SELECT 2;",
                 "'error_view' already defined");
+        // 'now' is a system table, so no view can carry that name either
+        this.statementsFailingInCompilation("CREATE VIEW now AS SELECT 2;",
+                "'now' already defined");
     }
 
     @Test
@@ -2048,6 +2051,19 @@ public class MetadataTests extends BaseSQLTests {
         Assert.assertEquals(text, c.text);
         Assert.assertEquals(line, c.pos.getLineNum());
         Assert.assertEquals(col, c.pos.getColumnNum());
+    }
+
+    @Test
+    public void predefinedNameColumnTest() {
+        // A column can carry the name of a predefined function.  A reference to a
+        // function that SQL calls without parentheses (e.g. current_date) is parsed as
+        // a function call, so such a column has to be qualified or quoted.
+        // In contrast, 'now' always needs parentheses, so `now` is parsed as a column.
+        this.assertCompilesWithoutError("""
+                CREATE TABLE T(user INT, current_date INT, now INT);
+                CREATE VIEW V AS SELECT t.user AS a, "user" AS b,
+                    t.current_date AS c, "current_date" AS d, now AS e
+                FROM T AS t;""");
     }
 
     /** Verify that {@code sql} is accepted by the SQL compiler without errors. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -233,4 +233,33 @@ public class NegativeParserTests extends BaseSQLTests {
         Assert.assertTrue(error.message.contains("Table 't' is not used"));
         Assert.assertTrue(messages.toString().contains("CREATE TABLE T"));
     }
+
+    @Test
+    public void predefinedFunctionNameTest() {
+        // The rule holds for every predefined function, not just for the 'user' of
+        // RegressionTests.issue3006, and quoting the name does not evade it
+        String message = "has the same name as a predefined function";
+        this.statementsFailingInCompilation("CREATE TABLE abs(x INT);", message);
+        this.statementsFailingInCompilation("CREATE TABLE \"now\"(x INT);", message);
+    }
+
+    @Test
+    public void niladicFunctionColumnTest() {
+        // SQL calls USER without parentheses, so a bare 'user' is that call and not the
+        // column; MetadataTests.predefinedNameColumnTest shows how to reach the column
+        this.statementsFailingInCompilation("""
+                CREATE TABLE T(user INT);
+                CREATE VIEW V AS SELECT user FROM T;""",
+                "Function 'USER' is not supported.  If you meant a column with this name, "
+                + "qualify it with a table name or quote it: \"user\"");
+    }
+
+    @Test
+    public void niladicDateFunctionTest() {
+        // The date and time functions have a supported replacement, named first
+        this.statementsFailingInCompilation("""
+                CREATE TABLE T(x INT);
+                CREATE VIEW V AS SELECT current_date FROM T;""",
+                "Function 'CURRENT_DATE' is not supported; use CAST(NOW() AS DATE) instead.");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
@@ -29,7 +29,9 @@ import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSetOption;
+import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.StderrErrorReporter;
 import org.dbsp.sqlCompiler.compiler.errors.SourceFileContents;
@@ -45,10 +47,20 @@ import org.dbsp.sqlCompiler.compiler.frontend.parser.SqlCreateTable;
 import org.dbsp.sqlCompiler.compiler.frontend.parser.SqlForeignKey;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateViewStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.RelStatement;
+import org.dbsp.generated.parser.DbspParserImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Locale;
 
 /** Test SQL parser extensions. */
 public class ParserTests {
@@ -540,5 +552,118 @@ public class ParserTests {
         SqlToRelCompiler calcite = this.getCompiler();
         List<ParsedStatement> node = calcite.parseStatements(query);
         Assert.assertNotNull(node);
+    }
+
+    /** Use `keyword` as a column name, both in a table declaration and in a query.
+     * Check that the resulting program compiles. */
+    void columnNamed(String keyword) throws SqlParseException {
+        SqlToRelCompiler compiler = this.getCompiler();
+        List<ParsedStatement> statements = compiler.parseStatements(
+                "CREATE TABLE T(" + keyword + " INT);\n" +
+                "CREATE VIEW V AS SELECT " + keyword + " FROM T WHERE " + keyword + " > 0");
+        Assert.assertEquals(keyword, 2, statements.size());
+        SourceFileContents sources = new SourceFileContents();
+        compiler.compile(statements.get(0), sources);
+        RelStatement view = compiler.compile(statements.get(1), sources);
+        RelNode rel = view.to(CreateViewStatement.class).getRel();
+        Assert.assertEquals(keyword,
+                List.of(keyword.toLowerCase(Locale.ENGLISH)), rel.getRowType().getFieldNames());
+    }
+
+    @Test
+    public void unusedKeywordTest() throws SqlParseException {
+        // Calcite's grammar declares these keywords but Feldera does not reserve them:
+        for (String keyword: new String[] {
+                "CONTAINS_SUBSTR", "DISCARD", "GRANT", "JSON_SCOPE",
+                "PLANS", "SEED", "SEQUENCES", "TEMP" })
+            this.columnNamed(keyword);
+
+        // The function call parses without either of its keywords being reserved
+        SqlToRelCompiler compiler = this.getCompiler();
+        Assert.assertNotNull(compiler.parse(
+                "SELECT contains_substr(s, 'cd', json_scope => 'JSON_KEYS') FROM T"));
+    }
+
+    /** Words that need double quotes to serve as identifiers, extracted from the parser implementation. */
+    static Set<String> reservedKeywords() {
+        SqlAbstractParserImpl.Metadata metadata =
+                new DbspParserImpl(new StringReader("")).getMetadata();
+        Set<String> reserved = new TreeSet<>();
+        for (String token: metadata.getTokens()) {
+            // The token list also holds operators such as "(" and ">="
+            if (token.matches("[A-Z][A-Z0-9_-]*")
+                    && metadata.isKeyword(token) && !metadata.isNonReservedKeyword(token))
+                reserved.add(token);
+        }
+        return reserved;
+    }
+
+    /** Checks that the documentation for reserved keywords matches the implementation. */
+    @Test
+    public void documentedReservedKeywordsTest() throws IOException {
+        Path grammar = Path.of("..", "..", "docs.feldera.com", "docs", "sql", "grammar.md");
+        Assert.assertTrue("Cannot find " + grammar.toAbsolutePath(), Files.exists(grammar));
+
+        // The table in the section "Reserved keywords": | S | `SELECT`, `SET`, ... |
+        String text = Files.readString(grammar);
+        int section = text.indexOf("\n## Reserved keywords");
+        Assert.assertTrue(grammar + " has no section 'Reserved keywords'", section >= 0);
+        int nextSection = text.indexOf("\n## ", section + 1);
+        String table = text.substring(section, nextSection < 0 ? text.length() : nextSection);
+        Set<String> documented = new TreeSet<>();
+        Matcher row = Pattern.compile("^\\| ([A-Z]) \\| (.*) \\|$", Pattern.MULTILINE).matcher(table);
+        while (row.find())
+            for (String word: row.group(2).split(","))
+                documented.add(word.replace("`", "").trim());
+
+        Set<String> reserved = reservedKeywords();
+        Set<String> undocumented = new TreeSet<>(reserved);
+        undocumented.removeAll(documented);
+        Set<String> stale = new TreeSet<>(documented);
+        stale.removeAll(reserved);
+        Assert.assertTrue("The reserved keyword table in " + grammar + " no longer matches the parser"
+                        + "\nreserved but not documented: " + undocumented
+                        + "\ndocumented but not reserved: " + stale,
+                undocumented.isEmpty() && stale.isEmpty());
+    }
+
+    @Test
+    public void keyColumnTest() throws SqlParseException {
+        // KEY is not a reserved keyword
+        SqlToRelCompiler compiler = this.getCompiler();
+        List<ParsedStatement> statements = compiler.parseStatements("""
+                CREATE TABLE T(key INT NOT NULL PRIMARY KEY);
+                CREATE VIEW V AS SELECT key FROM T;""");
+        Assert.assertEquals(2, statements.size());
+        SourceFileContents sources = new SourceFileContents();
+        compiler.compile(statements.get(0), sources);
+        RelStatement view = compiler.compile(statements.get(1), sources);
+        RelNode rel = view.to(CreateViewStatement.class).getRel();
+        Assert.assertEquals(List.of("key"), rel.getRowType().getFieldNames());
+    }
+
+    @Test
+    public void calciteReservedKeywordTest() throws SqlParseException {
+        // A sample of words that core Calcite reserves and Feldera does not.  One word
+        // per grammar rule that competes with an identifier: a function name, a type
+        // name, an infix operator, and a clause word.
+        for (String keyword: new String[] { "ABS", "CAST", "DOUBLE", "VARCHAR", "AND", "AS" })
+            this.columnNamed(keyword);
+    }
+
+    @Test
+    public void literalKeywordColumnTest() throws SqlParseException {
+        // TRUE is not reserved, so it can be used as a column name, but a bare true
+        // is the boolean literal rather than the INTEGER column
+        SqlToRelCompiler compiler = this.getCompiler();
+        List<ParsedStatement> statements = compiler.parseStatements("""
+                CREATE TABLE T(true INT);
+                CREATE VIEW V AS SELECT true FROM T;""");
+        SourceFileContents sources = new SourceFileContents();
+        compiler.compile(statements.get(0), sources);
+        RelStatement view = compiler.compile(statements.get(1), sources);
+        RelNode rel = view.to(CreateViewStatement.class).getRel();
+        Assert.assertEquals(SqlTypeName.BOOLEAN,
+                rel.getRowType().getFieldList().get(0).getType().getSqlTypeName());
     }
 }

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -86,4 +86,14 @@ else
     update_pom "${CALCITE_CURRENT}"
 fi
 
+# Check if the list of reserved keywords is up-to-date
+# Fail if the SQL compiler reserves a keyword that Calcite does not reserve
+if [ ! -d "${CALCITE_BUILD_DIR}" ]; then
+    echo "keyword check: skipped, no Calcite source in ${CALCITE_BUILD_DIR}"
+elif ! command -v python3 >/dev/null; then
+    echo "keyword check: skipped, python3 is not installed"
+else
+    "${SCRIPT_DIR}/check-keyword-drift.py" "${CALCITE_BUILD_DIR}"
+fi
+
 mvn package -DskipTests --no-transfer-progress -DargLine="-ea" -q -B "$@"

--- a/sql-to-dbsp-compiler/check-keyword-drift.py
+++ b/sql-to-dbsp-compiler/check-keyword-drift.py
@@ -27,15 +27,21 @@ WORD = re.compile(r'"([A-Z_0-9-]+)"')
 KEYWORD_MARKER = "KEYWORDS:  anything in this list"
 
 # Four token names differ from the SQL text.  The lists use the text.
-TOKEN_TEXT = {"DEFAULT_": "DEFAULT", "SKIP_": "SKIP",
-              "SET_MINUS": "MINUS", "END_EXEC": "END-EXEC"}
+TOKEN_TEXT = {
+    "DEFAULT_": "DEFAULT",
+    "SKIP_": "SKIP",
+    "SET_MINUS": "MINUS",
+    "END_EXEC": "END-EXEC",
+}
 
 
 def fail(message: str) -> NoReturn:
     """Report a file that does not have the expected shape, and give up."""
     print(f"keyword check: {message}", file=sys.stderr)
-    print("The file format probably changed; this script needs an update.",
-          file=sys.stderr)
+    print(
+        "The file format probably changed; this script needs an update.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
@@ -92,7 +98,9 @@ def main() -> int:
         print(__doc__)
         return 0
     if len(sys.argv) != 2:
-        print(f"usage: {program} [-h][--help] CALCITE_SOURCE_DIRECTORY", file=sys.stderr)
+        print(
+            f"usage: {program} [-h][--help] CALCITE_SOURCE_DIRECTORY", file=sys.stderr
+        )
         return 1
 
     calcite = Path(sys.argv[1])
@@ -126,8 +134,10 @@ def main() -> int:
 
     for list_name, words in forgotten.items():
         print(f"{CONFIG}:")
-        print(f"    the list '{list_name}' is missing {len(words)} word(s) that "
-              f"{sources[list_name]} does not reserve:")
+        print(
+            f"    the list '{list_name}' is missing {len(words)} word(s) that "
+            f"{sources[list_name]} does not reserve:"
+        )
         print("    " + " ".join(words))
     print("The SQL compiler reserves each word above.  Add it to the list to allow it")
     print("as a name.  Comment it out to reserve it on purpose.")

--- a/sql-to-dbsp-compiler/check-keyword-drift.py
+++ b/sql-to-dbsp-compiler/check-keyword-drift.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Find keywords that the SQL compiler reserves and Calcite does not.
+
+The SQL compiler reserves every keyword that does not appear in one of the 2
+lists below in config.fmpp.  Both lists are copies of lists in Calcite:
+
+    nonReservedKeywords       copied from core/src/main/codegen/default_config.fmpp
+    nonReservedKeywordsToAdd  copied from babel/src/main/codegen/config.fmpp
+
+A reserved keyword cannot be used as the name of a table, view, or column.
+Calcite adds words to its lists over time.  A word that is missing from the
+copies in config.fmpp becomes incorrectly reserved.
+This script detects such words and fails the build.
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+HERE = Path(__file__).resolve().parent
+CONFIG = HERE / "SQL-compiler/src/main/codegen/config.fmpp"
+
+WORD = re.compile(r'"([A-Z_0-9-]+)"')
+
+# The comment that precedes the keyword declarations in Calcite's template
+KEYWORD_MARKER = "KEYWORDS:  anything in this list"
+
+# Four token names differ from the SQL text.  The lists use the text.
+TOKEN_TEXT = {"DEFAULT_": "DEFAULT", "SKIP_": "SKIP",
+              "SET_MINUS": "MINUS", "END_EXEC": "END-EXEC"}
+
+
+def fail(message: str) -> NoReturn:
+    """Report a file that does not have the expected shape, and give up."""
+    print(f"keyword check: {message}", file=sys.stderr)
+    print("The file format probably changed; this script needs an update.",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def words_in_list(path: Path, list_name: str, include_commented: bool) -> set[str]:
+    """Return the words in the list called list_name in a configuration file.
+
+    Includes commented-out words only if include_commented is true.
+    """
+    text = path.read_text()
+    start = text.find(list_name + ":")
+    if start < 0:
+        fail(f"{path} has no list called {list_name}")
+
+    depth, end = 0, -1
+    for i in range(start, len(text)):
+        if text[i] == "[":
+            depth += 1
+        elif text[i] == "]":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    if end < 0:
+        fail(f"the list {list_name} in {path} has no closing bracket")
+
+    words = set()
+    for line in text[start:end].split("\n")[1:]:
+        if include_commented or not line.lstrip().startswith("#"):
+            words.update(WORD.findall(line))
+    if not words:
+        fail(f"the list {list_name} in {path} has no words")
+    return words
+
+
+def declared_keywords(template: Path) -> set[str]:
+    """Return every keyword that Calcite's parser template declares."""
+    text = template.read_text()
+    start = text.find(KEYWORD_MARKER)
+    if start < 0:
+        fail(f"{template} has no comment reading '{KEYWORD_MARKER}'")
+    end = text.find("\n}", start)
+    if end < 0:
+        fail(f"the keyword declarations in {template} have no closing brace")
+
+    names = re.findall(r"<\s*([A-Z_0-9]+)\s*:", text[start:end])
+    if not names:
+        fail(f"{template} declares no keywords")
+    return {TOKEN_TEXT.get(name, name) for name in names}
+
+
+def main() -> int:
+    program = Path(sys.argv[0]).name
+    if len(sys.argv) == 2 and sys.argv[1] in ("-h", "--help"):
+        print(__doc__)
+        return 0
+    if len(sys.argv) != 2:
+        print(f"usage: {program} [-h][--help] CALCITE_SOURCE_DIRECTORY", file=sys.stderr)
+        return 1
+
+    calcite = Path(sys.argv[1])
+    template = calcite / "core/src/main/codegen/templates/Parser.jj"
+    # Each list has the same name as the Calcite list it was copied from
+    sources = {
+        "nonReservedKeywords": calcite / "core/src/main/codegen/default_config.fmpp",
+        "nonReservedKeywordsToAdd": calcite / "babel/src/main/codegen/config.fmpp",
+    }
+
+    for path in [CONFIG, template, *sources.values()]:
+        if not path.is_file():
+            print(f"keyword check: skipped, {path} is missing")
+            return 0
+
+    # Only keywords can be reserved.  A word in either list is free.
+    keywords = declared_keywords(template) | words_in_list(CONFIG, "keywords", False)
+    appears = set()
+    for list_name in sources:
+        appears |= words_in_list(CONFIG, list_name, True)
+
+    forgotten = {}
+    for list_name, source in sources.items():
+        missing = words_in_list(source, list_name, False) & keywords - appears
+        if missing:
+            forgotten[list_name] = sorted(missing)
+
+    if not forgotten:
+        print("keyword check: the lists in config.fmpp match Calcite's")
+        return 0
+
+    for list_name, words in forgotten.items():
+        print(f"{CONFIG}:")
+        print(f"    the list '{list_name}' is missing {len(words)} word(s) that "
+              f"{sources[list_name]} does not reserve:")
+        print("    " + " ".join(words))
+    print("The SQL compiler reserves each word above.  Add it to the list to allow it")
+    print("as a name.  Comment it out to reserve it on purpose.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This commit adds a list of reserved keywords to the SQL documentation.

This is actually much harder than it looks, since what is "reserved" is decided by a complicated build process which processes some Calcite lists and some of our customizations. We reserve many fewer keywords than Calcite or the SQL standard. The commit adds a scripts that checks whether Calcite changed in this respect and fails the build until we reconcile the keywords lists.

Fixes #7020

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated
