### PR TITLE
Claim Rust compilation before cleanup

### DIFF
--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -83,6 +83,10 @@ const THRESHOLD_COMPILATION_TARGET_WARNING: f64 = 0.7;
 const THRESHOLD_COMPILATION_TARGET_CLEAR: f64 = 0.9;
 
 /// Rust compilation task that wakes up periodically.
+///
+/// Each tick claims work before cleaning the target directory. Cleanup of a
+/// large or full volume can take minutes or hang; running it first left
+/// `SqlCompiled` pipelines sitting while SQL kept finishing (#6496).
 /// Sleeps inbetween ticks which affects the response time of Rust compilation.
 /// This task only returns if the Rust compiler wants to be restarted to have any precompilation
 /// reapplied because it cleared the target directory. Otherwise, this task cannot fail, and any
@@ -99,40 +103,9 @@ pub async fn rust_compiler_task(
     loop {
         let mut unexpected_error = false;
 
-        // Clean up
-        if last_cleanup.is_none_or(|ts| ts.elapsed() >= CLEANUP_INTERVAL) {
-            if let Err(e) = cleanup_rust_compilation(&config, db.clone()).await {
-                match e {
-                    RustCompilationCleanupError::Database(e) => {
-                        error!(
-                            "Rust worker {worker_id}: compilation cleanup failed: database error occurred: {e}"
-                        );
-                    }
-                    RustCompilationCleanupError::Utility(e) => {
-                        error!(
-                            "Rust worker {worker_id}: compilation cleanup failed: utility error occurred: {e}"
-                        );
-                    }
-                    RustCompilationCleanupError::TargetCleared => {
-                        if allow_exit_upon_target_cleared {
-                            // This restart behavior only occurs for a standalone compiler server
-                            warn!(
-                                "Rust worker {worker_id}: target directory has been cleared due to lack of space -- restarting to have any precompilation re-applied"
-                            );
-                            return Err(());
-                        } else {
-                            warn!(
-                                "Rust worker {worker_id}: target directory has been cleared due to lack of space -- the next compilation will be slow"
-                            );
-                        }
-                    }
-                }
-                unexpected_error = true;
-            }
-            last_cleanup = Some(Instant::now());
-        }
-
-        // Compile
+        // Compile before cleanup. A large or full target directory can make
+        // cleanup take minutes or hang (#6742); doing it first left
+        // SqlCompiled pipelines untouched while SQL kept finishing work (#6496).
         let result = attempt_end_to_end_rust_compilation(
             worker_id,
             total_workers,
@@ -167,6 +140,38 @@ pub async fn rust_compiler_task(
             }
         }
 
+        if last_cleanup.is_none_or(|ts| ts.elapsed() >= CLEANUP_INTERVAL) {
+            if let Err(e) = cleanup_rust_compilation(&config, db.clone()).await {
+                match e {
+                    RustCompilationCleanupError::Database(e) => {
+                        error!(
+                            "Rust worker {worker_id}: compilation cleanup failed: database error occurred: {e}"
+                        );
+                    }
+                    RustCompilationCleanupError::Utility(e) => {
+                        error!(
+                            "Rust worker {worker_id}: compilation cleanup failed: utility error occurred: {e}"
+                        );
+                    }
+                    RustCompilationCleanupError::TargetCleared => {
+                        if allow_exit_upon_target_cleared {
+                            // This restart behavior only occurs for a standalone compiler server
+                            warn!(
+                                "Rust worker {worker_id}: target directory has been cleared due to lack of space -- restarting to have any precompilation re-applied"
+                            );
+                            return Err(());
+                        } else {
+                            warn!(
+                                "Rust worker {worker_id}: target directory has been cleared due to lack of space -- the next compilation will be slow"
+                            );
+                        }
+                    }
+                }
+                unexpected_error = true;
+            }
+            last_cleanup = Some(Instant::now());
+        }
+
         // Wait
         if unexpected_error {
             // Unexpected error occurred
@@ -187,8 +192,8 @@ pub async fn rust_compiler_task(
 ///    `SqlCompiled` if they are of the current `platform_version`. Any pipeline with
 ///    `program_status` of `SqlCompiled` or `CompilingRust` with a non-current `platform_version`
 ///    will have it updated to current and its `program_status` set back to `Pending`.
-/// 2. Queries the database for a pipeline which has `program_status` of `SqlCompiled` the longest
-/// 3. Updates pipeline database `program_status` to `CompilingRust`
+/// 2. Claims the pipeline that has been `SqlCompiled` the longest
+/// 3. Marks it `CompilingRust` in the same transaction as the claim
 /// 4. Performs Rust compilation on `program_info.main`, `udf_rust` and `udf_toml`, configured
 ///    with `program_config`
 /// 5. Upon completion, the compilation status is set to `Success`
@@ -226,23 +231,18 @@ async fn attempt_end_to_end_rust_compilation(
         )
         .await?;
 
-    // (2) Find pipeline which needs Rust compilation
-    // Atomically claim the next pipeline for Rust compilation using modulo sharding
+    // (2)+(3) Claim the next SqlCompiled pipeline and mark CompilingRust in
+    // one transaction. A separate select then update let a second compiler
+    // server miss the row or reset it mid-compile (#6496).
     let Some((tenant_id, pipeline)) = db
         .lock()
         .await
-        .get_next_rust_compilation(&common_config.platform_version, worker_id, total_workers)
+        .claim_next_rust_compilation(&common_config.platform_version, worker_id, total_workers)
         .await?
     else {
         trace!("No pipeline found which needs Rust compilation");
         return Ok(false);
     };
-
-    // (3) Update database that Rust compilation is ongoing
-    db.lock()
-        .await
-        .transit_program_status_to_compiling_rust(tenant_id, pipeline.id, pipeline.program_version)
-        .await?;
 
     // (4) Perform Rust compilation
     let compilation_result = perform_rust_compilation(

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -1995,6 +1995,10 @@ pub(crate) async fn get_next_sql_compilation(
 
 /// Retrieves the pipeline which is stopped, whose program status has been SqlCompiled
 /// for the longest, and is of the current platform version. Returns `None` if none is found.
+///
+/// `FOR UPDATE SKIP LOCKED` lets a second compiler server take the next row
+/// instead of waiting on, or double-claiming, a row another worker already
+/// holds (#6496).
 pub(crate) async fn get_next_rust_compilation(
     txn: &Transaction<'_>,
     platform_version: &str,
@@ -2012,6 +2016,7 @@ pub(crate) async fn get_next_rust_compilation(
                    AND ({PIPELINE_ID_SQL_HASH_FUNCTION_CALL} % $2) = $3
              ORDER BY p.program_status_since ASC, p.id ASC
              LIMIT 1
+             FOR UPDATE SKIP LOCKED
             "
         ))
         .await?;
@@ -2032,6 +2037,39 @@ pub(crate) async fn get_next_rust_compilation(
             parse_pipeline_row_all(&row)?,
         ))),
     }
+}
+
+/// Lock the next `SqlCompiled` pipeline and mark it `CompilingRust` in the
+/// same transaction so the rust worker actually starts work (#6496).
+pub(crate) async fn claim_next_rust_compilation(
+    txn: &Transaction<'_>,
+    platform_version: &str,
+    worker_id: usize,
+    total_workers: usize,
+) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+    let Some((tenant_id, pipeline)) =
+        get_next_rust_compilation(txn, platform_version, worker_id, total_workers).await?
+    else {
+        return Ok(None);
+    };
+
+    set_program_status(
+        txn,
+        tenant_id,
+        pipeline.id,
+        pipeline.program_version,
+        &ProgramStatus::CompilingRust,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    )
+    .await?;
+
+    Ok(Some((tenant_id, pipeline)))
 }
 
 /// Counts pipelines with outstanding compilation work.

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -470,6 +470,10 @@ pub(crate) trait Storage {
     ) -> Result<(), DBError>;
 
     /// Transitions program status to `CompilingRust`.
+    ///
+    /// Production claims go through [`Storage::claim_next_rust_compilation`].
+    /// Tests and the behavioral model still drive this step on its own.
+    #[allow(dead_code)]
     async fn transit_program_status_to_compiling_rust(
         &self,
         tenant_id: TenantId,
@@ -725,7 +729,22 @@ pub(crate) trait Storage {
 
     /// Retrieves the pipeline which is stopped, whose program status has been SqlCompiled
     /// for the longest, and is of the current platform version. Returns `None` if none is found.
+    ///
+    /// Production claims go through [`Storage::claim_next_rust_compilation`].
+    /// Tests and the behavioral model still read without claiming.
+    #[allow(dead_code)]
     async fn get_next_rust_compilation(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError>;
+
+    /// Atomically claim the next `SqlCompiled` pipeline for Rust compilation.
+    ///
+    /// Picks and marks `CompilingRust` in one transaction. A separate select
+    /// then update let a second compiler server miss or steal the row (#6496).
+    async fn claim_next_rust_compilation(
         &self,
         platform_version: &str,
         worker_id: usize,

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -1665,6 +1665,25 @@ impl Storage for StoragePostgres {
         Ok(next_pipeline_program)
     }
 
+    async fn claim_next_rust_compilation(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+        let mut client = self.pool.get().await?;
+        let txn = transaction::begin(&mut client).await?;
+        let claimed = operations::pipeline::claim_next_rust_compilation(
+            &txn,
+            platform_version,
+            worker_id,
+            total_workers,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(claimed)
+    }
+
     async fn count_pipelines_needing_compilation(&self) -> Result<u64, DBError> {
         let mut client = self.pool.get().await?;
         let txn = transaction::begin(&mut client).await?;

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2754,6 +2754,152 @@ async fn pipeline_program_compilation() {
     );
 }
 
+fn empty_program_info() -> serde_json::Value {
+    serde_json::to_value(ProgramInfo {
+        schema: serde_json::to_value(ProgramSchema {
+            inputs: vec![],
+            outputs: vec![],
+        })
+        .unwrap(),
+        main_rust: "".to_string(),
+        udf_stubs: "".to_string(),
+        input_connectors: BTreeMap::new(),
+        output_connectors: BTreeMap::new(),
+        circuit_ir: None,
+        dataflow: None,
+    })
+    .unwrap()
+}
+
+async fn new_sql_compiled_pipeline(
+    db: &StoragePostgres,
+    tenant_id: TenantId,
+    name: &str,
+    program_config: serde_json::Value,
+) -> ExtendedPipelineDescr {
+    let pipeline = db
+        .new_pipeline(
+            tenant_id,
+            Uuid::now_v7(),
+            "v0",
+            PipelineDescr {
+                name: name.to_string(),
+                description: "".to_string(),
+                tags: vec![],
+                runtime_config: json!({}),
+                program_code: "".to_string(),
+                udf_rust: "".to_string(),
+                udf_toml: "".to_string(),
+                program_config,
+            },
+        )
+        .await
+        .unwrap();
+    db.transit_program_status_to_compiling_sql(tenant_id, pipeline.id, Version(1))
+        .await
+        .unwrap();
+    db.transit_program_status_to_sql_compiled(
+        tenant_id,
+        pipeline.id,
+        Version(1),
+        &SqlCompilationInfo {
+            exit_code: 0,
+            messages: vec![],
+        },
+        &empty_program_info(),
+    )
+    .await
+    .unwrap();
+    db.get_pipeline_by_id(tenant_id, pipeline.id)
+        .await
+        .unwrap()
+}
+
+/// A program with no `runtime_version` (the default) must enter the Rust
+/// queue after SQL, and the owner worker must claim it (#6496).
+#[tokio::test]
+async fn rust_claim_picks_sql_compiled_when_runtime_version_is_unset() {
+    let handle = test_setup().await;
+    let tenant_id = TenantRecord::default().id;
+    let pipeline =
+        new_sql_compiled_pipeline(&handle.db, tenant_id, "unset-runtime", json!({})).await;
+
+    assert_eq!(pipeline.program_status, ProgramStatus::SqlCompiled);
+    assert!(
+        pipeline.program_config.get("runtime_version").is_none()
+            || pipeline.program_config["runtime_version"].is_null()
+    );
+
+    let claimed = handle
+        .db
+        .claim_next_rust_compilation("v0", 0, 1)
+        .await
+        .unwrap()
+        .expect("SqlCompiled with an empty program_config must be claimable");
+    assert_eq!(claimed.1.id, pipeline.id);
+
+    let after = handle
+        .db
+        .get_pipeline_by_id(tenant_id, pipeline.id)
+        .await
+        .unwrap();
+    assert_eq!(after.program_status, ProgramStatus::CompilingRust);
+    assert!(handle
+        .db
+        .claim_next_rust_compilation("v0", 0, 1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+/// Two compiler servers must not both claim the same row, and a worker
+/// must not compile another worker's shard (#6496).
+#[tokio::test]
+async fn rust_claim_is_exclusive_and_respects_worker_shards() {
+    let handle = test_setup().await;
+    let tenant_id = TenantRecord::default().id;
+
+    let mut have_shard0 = false;
+    let mut have_shard1 = false;
+    for i in 0..32 {
+        let pipeline =
+            new_sql_compiled_pipeline(&handle.db, tenant_id, &format!("shard-{i}"), json!({}))
+                .await;
+        have_shard0 |= is_pipeline_assigned_to_worker(pipeline.id, 0, 2);
+        have_shard1 |= is_pipeline_assigned_to_worker(pipeline.id, 1, 2);
+        if have_shard0 && have_shard1 {
+            break;
+        }
+    }
+    assert!(have_shard0 && have_shard1, "need a pipeline on each shard");
+
+    let claimed0 = handle
+        .db
+        .claim_next_rust_compilation("v0", 0, 2)
+        .await
+        .unwrap()
+        .expect("worker 0 must claim its shard");
+    assert!(is_pipeline_assigned_to_worker(claimed0.1.id, 0, 2));
+    assert_eq!(
+        handle
+            .db
+            .get_pipeline_by_id(tenant_id, claimed0.1.id)
+            .await
+            .unwrap()
+            .program_status,
+        ProgramStatus::CompilingRust
+    );
+
+    let claimed1 = handle
+        .db
+        .claim_next_rust_compilation("v0", 1, 2)
+        .await
+        .unwrap()
+        .expect("worker 1 must claim its shard");
+    assert!(is_pipeline_assigned_to_worker(claimed1.1.id, 1, 2));
+    assert_ne!(claimed0.1.id, claimed1.1.id);
+}
+
 /// Checks that `count_pipelines_needing_compilation` counts exactly the stopped
 /// pipelines whose program status is pending, compiling_sql, sql_compiled or
 /// compiling_rust.
@@ -8963,6 +9109,29 @@ impl Storage for Mutex<DbModel> {
         });
         let chosen = pipelines.first().unwrap().clone(); // Already checked for empty
         Ok(Some((chosen.0, chosen.1)))
+    }
+
+    async fn claim_next_rust_compilation(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+        let Some((tenant_id, pipeline)) = self
+            .get_next_rust_compilation(platform_version, worker_id, total_workers)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        self.transit_program_status_to_compiling_rust(
+            tenant_id,
+            pipeline.id,
+            pipeline.program_version,
+        )
+        .await?;
+
+        Ok(Some((tenant_id, pipeline)))
     }
 
     async fn count_pipelines_needing_compilation(&self) -> Result<u64, DBError> {


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/6496

## Summary
- The rust worker cleaned the target directory before claiming `SqlCompiled` work. A slow or stuck cleanup left pipelines sitting after SQL success while the SQL worker kept going (#6496).
- Claiming was a select then a separate update, so a second compiler server could miss or steal the row.
- Claim is now one transaction with `FOR UPDATE SKIP LOCKED`, the rust loop compiles first, and local database tests cover an unset `runtime_version` and two-worker sharding.

## Test plan
- [x] `cargo test -p pipeline-manager --lib -- rust_claim_picks_sql_compiled rust_claim_is_exclusive pipeline_program_compilation`
- [x] `cargo clippy -p pipeline-manager --lib -- -D warnings` (pre-existing `collapsible_match` / `useless_conversion` on `main` only)
- [ ] Confirm a pipeline with empty `program_config` still reaches Rust after SQL on a two-compiler setup
