### PR TITLE
[SQL] An operator that does not produce the same output stream type as the input type cannot be an identity function

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RemoveIdentityOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RemoveIdentityOperators.java
@@ -95,6 +95,11 @@ public class RemoveIdentityOperators extends Passes {
                 return false;
             if (!expression.getResultType().is(DBSPTypeRawTuple.class))
                 return false;
+            DBSPTypeRawTuple result = expression.getResultType().to(DBSPTypeRawTuple.class);
+            if (result.size() != 2 ||
+                    !raw.tupFields[0].deref().sameType(result.tupFields[0]) ||
+                    !raw.tupFields[1].deref().sameType(result.tupFields[1]))
+                return false;
             DBSPVariablePath var = paramType.var();
             DBSPClosureExpression id = new DBSPRawTupleExpression(
                     new DBSPTupleExpression(DBSPTypeTupleBase.flatten(var.field(0).deref()), false),
@@ -112,6 +117,9 @@ public class RemoveIdentityOperators extends Passes {
             return false;
         DBSPSimpleOperator simple = operator.to(DBSPSimpleOperator.class);
         if (simple.function == null || !simple.function.is(DBSPClosureExpression.class))
+            return false;
+        DBSPUnaryOperator unary = operator.to(DBSPUnaryOperator.class);
+        if (!unary.input().outputType().sameType(unary.outputType()))
             return false;
         return isIdentityFunction(simple.getClosureFunction());
     }
@@ -171,7 +179,7 @@ public class RemoveIdentityOperators extends Passes {
                 return;
             OutputPort input = operator.input();
             this.candidates.add(new Candidate(operator, input,
-                    this.getGCKinds(operator.outputPort()), 
+                    this.getGCKinds(operator.outputPort()),
                     this.getGCKinds(input)));
         }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -423,6 +423,39 @@ public class RecursiveTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue7039() {
+        var ccs = this.getCCS("""
+                CREATE TABLE l1(k INT NOT NULL, v1 VARCHAR);
+                CREATE TABLE edge(src INT NOT NULL, dst INT NOT NULL);
+                DECLARE RECURSIVE VIEW reach(src INT NOT NULL, dst INT NOT NULL);
+                CREATE VIEW reach AS
+                SELECT src, dst FROM edge
+                UNION
+                SELECT r.src, e.dst FROM reach r
+                LEFT JOIN l1 ON r.dst = l1.k
+                JOIN edge e ON r.dst = e.src;""");
+        // Results validated using postgres:
+        // WITH RECURSIVE edge(src, dst) AS (VALUES (1, 2), (2, 3), (3, 4)),
+        //   l1(k, v1) AS (VALUES (2, 'A')),
+        //   reach(src, dst) AS (
+        //     SELECT src, dst FROM edge
+        //     UNION
+        //     SELECT r.src, e.dst FROM reach r LEFT JOIN l1 ON r.dst = l1.k JOIN edge e ON r.dst = e.src)
+        // SELECT * FROM reach ORDER BY src, dst;
+        ccs.stepWeightOne("""
+                INSERT INTO edge VALUES (1, 2), (2, 3), (3, 4);
+                INSERT INTO l1 VALUES (2, 'A');""", """
+                 src | dst
+                -----------
+                 1   | 2
+                 1   | 3
+                 1   | 4
+                 2   | 3
+                 2   | 4
+                 3   | 4""");
+    }
+
+    @Test
     public void testRecursive() {
         String sql = """
                 DECLARE RECURSIVE VIEW V(v INT);


### PR DESCRIPTION
Fixes #7039 

- [x] Unit tests added/updated

This was just a silly bug.