### PR TITLE
[SQL] The maximum number of iterations executed before convergence should depend also on the size of the largest nested component

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -24,6 +24,7 @@
 package org.dbsp.sqlCompiler.circuit;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewDeclarationOperator;
@@ -272,6 +273,15 @@ public final class DBSPCircuit extends DBSPNode
     /** Number of operators in the circuit. */
     public int size() {
         return this.allOperators.size();
+    }
+
+    /** The number of operators in the largest nested operator or in this circuit */
+    public int largestComponentSize() {
+        int result = this.allOperators.size();
+        for (DBSPOperator operator : this.allOperators)
+            if (operator.is(DBSPNestedOperator.class))
+                result = Math.max(result, operator.to(DBSPNestedOperator.class).size());
+        return result;
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNestedOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNestedOperator.java
@@ -123,6 +123,11 @@ public class DBSPNestedOperator extends DBSPOperator implements ICircuit {
         return this.viewByName.get(name);
     }
 
+    /** The number of operators in this nested circuit. */
+    public int size() {
+        return this.allOperators.size();
+    }
+
     @Override
     public Iterable<DBSPOperator> getAllOperators() {
         return this.allOperators;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Repeat.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Repeat.java
@@ -35,8 +35,8 @@ public class Repeat implements IWritesLogs, CircuitTransform, ICompilerComponent
         // In some cases more repeats are needed.
         // Some optimizations may require a number of iterations given by the size of the circuit
         // but some may require a number of iterations that depends on the complexity of the
-        // inner expressions.  ConvertCasts is such an example */
-        int maxRepeats = Math.max(circuit.size(), 10);
+        // inner expressions.  ConvertCasts is such an example.
+        int maxRepeats = Math.max(circuit.largestComponentSize(), 10);
         int repeats = 0;
         while (true) {
             Logger.INSTANCE.belowLevel(this, 1)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -423,6 +423,40 @@ public class RecursiveTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue7038() {
+        // Removing unused fields needs one round per operator around the recursion
+        var ccs = this.getCCS("""
+                CREATE TABLE l1(k INT NOT NULL, v1 VARCHAR);
+                CREATE TABLE edge(src INT NOT NULL, dst INT NOT NULL);
+                DECLARE RECURSIVE VIEW reach(src INT NOT NULL, dst INT NOT NULL, v1 VARCHAR);
+                CREATE VIEW reach AS
+                SELECT src, dst, CAST(NULL AS VARCHAR) AS v1 FROM edge
+                UNION
+                SELECT r.src, e.dst, l1.v1 FROM reach r
+                LEFT JOIN l1 ON r.dst = l1.k
+                JOIN edge e ON r.dst = e.src;""");
+        // Results validated using postgres:
+        // WITH RECURSIVE edge(src, dst) AS (VALUES (1, 2), (2, 3), (3, 4)),
+        //   l1(k, v1) AS (VALUES (2, 'A'), (3, 'B')),
+        //   reach(src, dst, v1) AS (
+        //     SELECT src, dst, NULL::text FROM edge
+        //     UNION
+        //     SELECT r.src, e.dst, l1.v1 FROM reach r LEFT JOIN l1 ON r.dst = l1.k JOIN edge e ON r.dst = e.src)
+        // SELECT * FROM reach ORDER BY src, dst, v1;
+        ccs.stepWeightOne("""
+                INSERT INTO edge VALUES (1, 2), (2, 3), (3, 4);
+                INSERT INTO l1 VALUES (2, 'A'), (3, 'B');""", """
+                 src | dst | v1
+                ----------------
+                 1   | 2   |NULL
+                 1   | 3   | A
+                 1   | 4   | B
+                 2   | 3   |NULL
+                 2   | 4   | B
+                 3   | 4   |NULL""");
+    }
+
+    @Test
     public void issue7039() {
         var ccs = this.getCCS("""
                 CREATE TABLE l1(k INT NOT NULL, v1 VARCHAR);


### PR DESCRIPTION
Fixes #7038 

The compiler executes some optimizations until the result converges. In order to guard against bugs which would cause infinite iterations, the compiler also puts as a bound for the number of iterations the size of its circuit. The reasoning is that most iterative optimizations have to actually make progress by rewriting at least one operator at a time. However, this bound failed to take into account the fact that nested (recursive) components can be large. Now it does: the number of iterations is capped by the max(circuit size, max(largest nested node size))

- [x] Unit tests added/updated
