### PR TITLE
[SQL] Surface unbounded state analysis results as warnings

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -33,6 +33,16 @@ import TabItem from '@theme/TabItem';
           certificates a private CA signs. See
           [NATS input connector](/connectors/sources/nats).
 
+        - Behavior change (SQL compiler): a program that declares `LATENESS`,
+          declares an `append_only` table, or filters with `NOW()` now gets an
+          `Unbounded state` warning for each join, aggregate, `DISTINCT`,
+          window function, or primary-key index whose state may grow without
+          bound. Existing pipelines of this kind compile with warnings, and a
+          program that sets `FELDERA_WARNINGS_ARE_ERRORS = ON` fails to compile
+          until the state is bounded or the warning is silenced with
+          `SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON`. See
+          [Unbounded state warnings](/sql/streaming#unbounded-state-warnings).
+
         ## v0.344.0
 
         - The Delta Lake and Iceberg input connectors read a `VARIANT` column

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,44 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        - The Kafka connector's `sasl.mechanism = OAUTHBEARER` authentication can now
+          target GCP Managed Service for Apache Kafka, in addition to AWS MSK. Set the
+          new `oauth_provider` field to `gcp` to mint tokens from Google Application
+          Default Credentials, including the GKE metadata server under Workload
+          Identity. See
+          [Kafka input connector](/connectors/sources/kafka#how-to-write-connector-config) (#6886).
+
+        - The NATS input connector implements the authentication methods its
+          schema already declared: a bare `nkey` seed (Ed25519
+          challenge-response), `jwt` with the seed that signs the connection
+          nonce (decentralized/operator-mode auth with the JWT and seed as two
+          secrets rather than one `.creds` file), `token`, and
+          `user_and_password`. Previously only `credentials` took effect and
+          the rest were silently ignored; configuring more than one method is
+          now rejected. A new `tls` section in `connection_config` sets
+          `require_tls` and `root_certificates_file` for servers whose
+          certificates a private CA signs. See
+          [NATS input connector](/connectors/sources/nats).
+
+        ## v0.344.0
+
+        - The Delta Lake and Iceberg input connectors read a `VARIANT` column
+          stored in the Parquet variant binary encoding, which is how Delta
+          Lake's `variant` type stores one. Values keep the types the writer
+          encoded, so a date inside a `VARIANT` arrives as a date rather than
+          as a string. A `VARIANT` column stored as JSON text still reads as
+          before, and the two can sit side by side in one table.
+
+        - Breaking change (Delta Lake output connector): a `VARIANT` column is
+          now written as the Delta `variant` type rather than as JSON text in a
+          `string` column, so values keep the types they have in Feldera. Set
+          `variant_encoding` to `json_string` for the previous encoding, which
+          is also what appending to a table whose `VARIANT` column is already a
+          `string` requires. See
+          [VARIANT](/connectors/sinks/delta#variant).
+
+        ## v0.343.0
+
         - The `bloom_false_positive_rate` storage setting now applies when a
           Bloom filter is read as well as when it is written.  Lowering it and
           restarting a pipeline reduces Bloom filter memory without rewriting
@@ -24,6 +62,8 @@ import TabItem from '@theme/TabItem';
           a checkpoint written by this or a later version cannot be resumed by
           an earlier version.  Checkpoints written by earlier versions continue
           to be read.
+
+        ## v0.340.0
 
         - Output connectors can be paused, like input connectors: a paused
           output connector discards the output of its view instead of writing it
@@ -49,40 +89,6 @@ import TabItem from '@theme/TabItem';
           token, which `fda` reads once per invocation; `feldera/oidc-auth-action`
           v3.0.1 and later export that variable. For a command that prints a
           token, pass its output as `--auth "$(...)"`.
-
-        - The Delta Lake and Iceberg input connectors read a `VARIANT` column
-          stored in the Parquet variant binary encoding, which is how Delta
-          Lake's `variant` type stores one. Values keep the types the writer
-          encoded, so a date inside a `VARIANT` arrives as a date rather than
-          as a string. A `VARIANT` column stored as JSON text still reads as
-          before, and the two can sit side by side in one table.
-
-        - Breaking change (Delta Lake output connector): a `VARIANT` column is
-          now written as the Delta `variant` type rather than as JSON text in a
-          `string` column, so values keep the types they have in Feldera. Set
-          `variant_encoding` to `json_string` for the previous encoding, which
-          is also what appending to a table whose `VARIANT` column is already a
-          `string` requires. See
-          [VARIANT](/connectors/sinks/delta#variant).
-
-        - The Kafka connector's `sasl.mechanism = OAUTHBEARER` authentication can now
-          target GCP Managed Service for Apache Kafka, in addition to AWS MSK. Set the
-          new `oauth_provider` field to `gcp` to mint tokens from Google Application
-          Default Credentials, including the GKE metadata server under Workload
-          Identity. See
-          [Kafka input connector](/connectors/sources/kafka#how-to-write-connector-config) (#6886).
-
-        - The NATS input connector implements the authentication methods its
-          schema already declared: a bare `nkey` seed (Ed25519
-          challenge-response), `jwt` with the seed that signs the connection
-          nonce (decentralized/operator-mode auth with the JWT and seed as two
-          secrets rather than one `.creds` file), `token`, and
-          `user_and_password`. Previously only `credentials` took effect and
-          the rest were silently ignored; configuring more than one method is
-          now rejected. A new `tls` section in `connection_config` sets
-          `require_tls` and `root_certificates_file` for servers whose
-          certificates a private CA signs. See
-          [NATS input connector](/connectors/sources/nats).
 
         ## v0.337.0
 

--- a/docs.feldera.com/docs/sql/streaming.md
+++ b/docs.feldera.com/docs/sql/streaming.md
@@ -165,3 +165,62 @@ Two details of the query matter for correctness:
 * The polarity filter `is_delete IS NOT TRUE` must be outside the subquery
   that ranks the changes. Filtering out the deletions before ranking would
   "resurrect" the previous insertion of a deleted key.
+
+## Unbounded state warnings
+
+The compiler analyzes programs to find operators whose state is
+likely to grow without bound: joins, aggregates, `DISTINCT`, window functions,
+and the indexes of tables with a `PRIMARY KEY`.  This is a static analysis,
+not based on actual data.  In consequence the analysis is
+best effort, and can err in both directions:
+it can report as unbounded an operator whose state stays small in
+practice, and it can miss state that grows very large, such as a
+chain of joins that can produce an output exponentially larger than the inputs.
+
+The compiler performs this analysis only if it infers that the compiled
+program performs stream processing, i.e., when one of the following holds:
+
+- a table or view column has a [`LATENESS`](#lateness-expressions) annotation,
+- a table is declared [`append_only`](#append_only-tables),
+- a [temporal filter](/tutorials/time-series#now-and-temporal-filters)
+  compares a column with `NOW()`.
+
+For streaming programs the compiler assumes that every table can grow without bound,
+even a table that is not part of a stream, such as a dimension table.  The
+[`expected_size`](/sql/grammar#size-hints) table property can be used to inform the
+compiler that the size of the table is bounded.  Operators downstream
+of such tables are generally considered bounded too, so they are not
+reported (even if the table size is actually very large).
+
+### Annotating dimension tables
+
+A common streaming pattern joins a stream of events, kept bounded by a
+temporal filter or by lateness, with a dimension table, such as a list
+of products or customers.  The compiler cannot tell a dimension table
+from a table that grows without bound, so without further information
+it reports the join and every operator downstream of the join.  Declare
+the expected size of each dimension table:
+
+```sql
+CREATE TABLE products (
+    sku VARCHAR NOT NULL PRIMARY KEY,
+    name VARCHAR
+) WITH ('expected_size' = '100000');
+```
+
+With this annotation the join with `products` and the operators
+downstream of the join are no longer reported, and the remaining
+warnings point at state that really grows with the stream, such as the
+index of an event table that has a `PRIMARY KEY` but no `LATENESS`.
+The analysis treats [recursive views](/sql/recursion) conservatively
+and is likely to report false positives for them.
+
+Sometimes the warnings cannot point precisely to the SQL construct that
+is responsible for the actual state, and then they will provide only
+an approximate position.
+
+You can silence these warnings with `SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON`.
+
+The [time series guide](/tutorials/time-series) explains how lateness,
+`append_only`, and temporal filters let the compiler garbage-collect
+state.

--- a/docs.feldera.com/docs/sql/streaming.md
+++ b/docs.feldera.com/docs/sql/streaming.md
@@ -198,8 +198,17 @@ A common streaming pattern joins a stream of events, kept bounded by a
 temporal filter or by lateness, with a dimension table, such as a list
 of products or customers.  The compiler cannot tell a dimension table
 from a table that grows without bound, so without further information
-it reports the join and every operator downstream of the join.  Declare
-the expected size of each dimension table:
+it reports the join, which retains the whole table.  When the join is
+on a key of the dimension table, such as its `PRIMARY KEY`, each event
+matches at most one row, so the output of the join is as bounded as the
+stream of events and the operators downstream of the join are not
+reported; a join on other columns reports them too.  The join columns
+must have the type of the key columns, or a lossless widening of it: a
+`VARCHAR` event column matched against a `VARCHAR(255)` key, or a
+`BIGINT` column against an `INT` key, is recognized, while a key of
+type `CHAR(n)`, whose comparison ignores trailing spaces, or a join
+column narrower than the key is not.  Declare the expected size of
+each dimension table:
 
 ```sql
 CREATE TABLE products (

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -156,6 +156,8 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     public final SourceFileContents sources;
     public InputSource inputSources = InputSource.None;
     public final ProgramMetadata metadata;
+    /** The view that each Calcite relational operator was compiled for */
+    public final ViewOrigins viewOrigins = new ViewOrigins();
 
     public final TypeCompiler typeCompiler;
     public boolean hasWarnings;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -102,6 +102,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -318,9 +319,13 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         return this.metadata.hasValue(WARNINGS_ARE_ERRORS) && !this.metadata.isFalsy(WARNINGS_ARE_ERRORS);
     }
 
+    /** Name of the SET variable that silences all warnings with the given error type */
+    public static String silencingVariable(String errorType) {
+        return "FELDERA_IGNORE_WARNING_" + errorType.toUpperCase(Locale.ENGLISH).replace(" ", "_");
+    }
+
     boolean warningIsSilenced(String warning) {
-        String variable = warning.replace(" ", "_");
-        variable = "FELDERA_IGNORE_WARNING_" + variable;
+        String variable = silencingVariable(warning);
         return this.metadata.hasValue(variable) && !this.metadata.isFalsy(variable);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -106,6 +106,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.function.Consumer;
 
 /**
  * This class compiles SQL statements into DBSP circuits.
@@ -159,6 +160,10 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     public final ProgramMetadata metadata;
     /** The view that each Calcite relational operator was compiled for */
     public final ViewOrigins viewOrigins = new ViewOrigins();
+    /** Receives the optimizer before it runs and may insert passes into it.
+     * Testing hook, for observing intermediate circuits: production code must leave it null. */
+    @Nullable
+    public Consumer<CircuitOptimizer> optimizerHook = null;
 
     public final TypeCompiler typeCompiler;
     public boolean hasWarnings;
@@ -896,6 +901,8 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     @Nullable DBSPCircuit optimize(@Nullable DBSPCircuit circuit) {
         if (circuit == null) return null;
         CircuitOptimizer optimizer = new CircuitOptimizer(this);
+        if (this.optimizerHook != null)
+            this.optimizerHook.accept(optimizer);
         return optimizer.optimize(circuit);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ViewOrigins.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ViewOrigins.java
@@ -1,0 +1,48 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import org.apache.calcite.rel.RelNode;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/** Records, for every Calcite relational operator, the view whose definition it belongs to. */
+public class ViewOrigins {
+    /** The view whose definition contains an operator, and the position of the view's statement */
+    public record ViewSourcePosition(ProgramIdentifier view, SourcePositionRange position) { }
+
+    /** Maps each Calcite relational operator of a view's plan to that view and the
+     * position of the view's statement; operators are compared by identity */
+    final Map<RelNode, ViewSourcePosition> origins = new IdentityHashMap<>();
+    /** Maps the name of each view to the root of the view's plan */
+    final Map<ProgramIdentifier, RelNode> plans = new HashMap<>();
+
+    /** Record every operator of the plan rooted at {@code plan} as belonging to {@code view} */
+    public void add(RelNode plan, ProgramIdentifier view, SourcePositionRange position) {
+        this.plans.putIfAbsent(view, plan);
+        this.add(plan, new ViewSourcePosition(view, position));
+    }
+
+    private void add(RelNode rel, ViewSourcePosition origin) {
+        // Plans are trees; a node reached twice keeps its first origin
+        if (this.origins.putIfAbsent(rel, origin) != null)
+            return;
+        for (RelNode input : rel.getInputs())
+            this.add(input, origin);
+    }
+
+    /** The view whose definition contains {@code rel}, or null if the compiler synthesized it */
+    @Nullable
+    public ViewSourcePosition get(RelNode rel) {
+        return this.origins.get(rel);
+    }
+
+    /** The root of the plan of {@code view}, or null for a view the compiler did not plan */
+    @Nullable
+    public RelNode getPlan(ProgramIdentifier view) {
+        return this.plans.get(view);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -3085,6 +3085,8 @@ public class CalciteToDBSPCompiler extends RelVisitor
 
     private DBSPNode compileCreateView(CreateViewStatement view) {
         RelNode rel = view.getRel();
+        SourcePositionRange viewPosition = new SourcePositionRange(view.getParserPosition());
+        this.compiler().viewOrigins.add(rel, view.relationName, viewPosition);
         this.go(rel);
         DBSPSimpleOperator op = this.getOperator(rel);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteEmptyRel.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteEmptyRel.java
@@ -4,6 +4,7 @@ import org.apache.calcite.rel.RelNode;
 import org.dbsp.util.IIndentStream;
 
 import java.util.Map;
+import java.util.List;
 
 /** Represents a CalciteObject that does not exist.
  * Similar to {@link CalciteObject#EMPTY}, but this is a subclass of {@link CalciteRelNode}. */
@@ -50,5 +51,10 @@ public class CalciteEmptyRel extends CalciteRelNode {
     @Override
     public long getId() {
         return 0;
+    }
+
+    @Override
+    public List<RelNode> getRelNodes() {
+        return List.of();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteRelNode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteRelNode.java
@@ -81,4 +81,7 @@ public abstract class CalciteRelNode extends CalciteObject implements IHasId {
 
     /** Return a version of this node where all final nodes are marked partial */
     public abstract CalciteRelNode intermediate();
+
+    /** The Calcite relational operators that this node stands for, in execution order */
+    public abstract List<RelNode> getRelNodes();
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/IntermediateRel.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/IntermediateRel.java
@@ -114,4 +114,9 @@ public class IntermediateRel extends CalciteRelNode {
     public long getId() {
         return this.relNode.getId();
     }
+
+    @Override
+    public List<RelNode> getRelNodes() {
+        return List.of(this.relNode);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/LastRel.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/LastRel.java
@@ -108,4 +108,9 @@ public class LastRel extends CalciteRelNode {
     public long getId() {
         return this.relNode.getId();
     }
+
+    @Override
+    public List<RelNode> getRelNodes() {
+        return List.of(this.relNode);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/RelAnd.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/RelAnd.java
@@ -107,4 +107,9 @@ public class RelAnd extends CalciteRelNode {
     public long getId() {
         return this.nodes.isEmpty() ? 0 : this.nodes.iterator().next().getId();
     }
+
+    @Override
+    public List<RelNode> getRelNodes() {
+        return Linq.map(this.sort(), last -> last.relNode);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/RelSequence.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/RelSequence.java
@@ -112,4 +112,12 @@ public class RelSequence extends CalciteRelNode {
     public long getId() {
         return this.nodes.isEmpty() ? 0 : Utilities.last(this.nodes).getId();
     }
+
+    @Override
+    public List<RelNode> getRelNodes() {
+        List<RelNode> result = new ArrayList<>();
+        for (CalciteRelNode node : this.nodes)
+            result.addAll(node.getRelNodes());
+        return result;
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraphs.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraphs.java
@@ -1,12 +1,19 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.ICircuit;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.ToIndentableString;
 import org.dbsp.util.Utilities;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 /** Maps each ICircuit to its {@link CircuitGraph} */
 public class CircuitGraphs implements ToIndentableString {
@@ -22,6 +29,27 @@ public class CircuitGraphs implements ToIndentableString {
 
     public void newCircuit(ICircuit circuit) {
         Utilities.putNew(this.graphs, circuit, new CircuitGraph(circuit));
+    }
+
+    /** The graph of the root circuit, which contains the recursive circuits */
+    CircuitGraph rootGraph() {
+        for (CircuitGraph graph : this.graphs.values())
+            if (graph.circuit.is(DBSPCircuit.class))
+                return graph;
+        throw new InternalCompilerError("No graph for the root circuit");
+    }
+
+    /** The operator closest downstream of {@code start}
+     * that satisfies {@code test}; null if none.  When {@code circuit} is a recursive
+     * circuit that contains no such operator, the search continues in the root
+     * circuit from the successors of the recursive circuit. */
+    @Nullable
+    public DBSPOperator closestDownstream(
+        ICircuit circuit, DBSPOperator start, Predicate<DBSPOperator> test) {
+        DBSPOperator found = this.getGraph(circuit).closestSuccessor(start, test);
+        if (found == null && circuit.is(DBSPNestedOperator.class))
+            found = this.rootGraph().closestSuccessor(circuit.to(DBSPNestedOperator.class), test);
+        return found;
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -31,6 +31,7 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.MerkleOuter;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.CanonicalForm;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EliminateDump;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.SimplifyConditionals;
@@ -51,6 +52,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.ImplementNow;
 import org.dbsp.sqlCompiler.compiler.visitors.unusedFields.UnusedFields;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity.MonotoneAnalyzer;
 import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
+import org.dbsp.util.Utilities;
 
 /** All optimizations applied to circuits. */
 public class CircuitOptimizer extends Passes {
@@ -202,5 +204,46 @@ public class CircuitOptimizer extends Passes {
 
     public DBSPCircuit optimize(DBSPCircuit input) {
         return this.apply(input);
+    }
+
+    /** Index of the {@code occurrence}-th pass of class {@code anchor}, counting from 1 */
+    private int indexOf(Class<? extends CircuitTransform> anchor, int occurrence) {
+        Utilities.enforce(occurrence >= 1, () -> "Occurrence " + occurrence + " is not positive");
+        int seen = 0;
+        for (int i = 0; i < this.passes.size(); i++) {
+            if (!anchor.isInstance(this.passes.get(i)))
+                continue;
+            seen++;
+            if (seen == occurrence)
+                return i;
+        }
+        throw new InternalCompilerError("Only " + seen + " passes of class " + anchor.getSimpleName() +
+                " in " + this.name + ", occurrence " + occurrence + " requested");
+    }
+
+    /** Insert {@code pass} before the first pass of class {@code anchor}, which must be present.
+     * Testing hook: production code adds its passes in order and must not use it. */
+    public void insertBefore(Class<? extends CircuitTransform> anchor, CircuitTransform pass) {
+        this.insertBefore(anchor, 1, pass);
+    }
+
+    /** Insert {@code pass} before the {@code occurrence}-th pass of class {@code anchor}, counting
+     * from 1; at least that many must be present.  Testing hook, like
+     * {@link #insertBefore(Class, CircuitTransform)}. */
+    public void insertBefore(Class<? extends CircuitTransform> anchor, int occurrence, CircuitTransform pass) {
+        this.passes.add(this.indexOf(anchor, occurrence), pass);
+    }
+
+    /** Insert {@code pass} after the first pass of class {@code anchor}, which must be present.
+     * Testing hook, like {@link #insertBefore(Class, CircuitTransform)}. */
+    public void insertAfter(Class<? extends CircuitTransform> anchor, CircuitTransform pass) {
+        this.insertAfter(anchor, 1, pass);
+    }
+
+    /** Insert {@code pass} after the {@code occurrence}-th pass of class {@code anchor}, counting
+     * from 1; at least that many must be present.  Testing hook, like
+     * {@link #insertBefore(Class, CircuitTransform)}. */
+    public void insertAfter(Class<? extends CircuitTransform> anchor, int occurrence, CircuitTransform pass) {
+        this.passes.add(this.indexOf(anchor, occurrence) + 1, pass);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -143,6 +143,8 @@ public class CircuitOptimizer extends Passes {
         this.add(new OptimizeWithGraph(compiler, g -> new CloneOperatorsWithFanout(compiler, g)));
         this.add(new LinearPostprocessRetainKeys(compiler));
         this.add(new ExpandIndexedInputs(compiler));
+        // Needs the GC operators of MonotoneAnalyzer and the primary-key indexes of ExpandIndexedInputs
+        this.add(new FindUnboundedState(compiler));
         this.add(new Conditional(compiler, new InsertWeightValidation(compiler),
                 this.compiler.metadata::enforcePositiveInputs));
         this.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
@@ -195,7 +197,6 @@ public class CircuitOptimizer extends Passes {
         this.add(new MerkleOuter(compiler, true));
         this.add(new MerkleOuter(compiler, false));
         this.add(new TagRegions(compiler));
-        this.add(new FindUnboundedState(compiler));
         this.add(new CircuitStatistics(compiler));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
@@ -14,8 +14,11 @@ import org.dbsp.sqlCompiler.circuit.ICircuit;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperatorBase;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPConcreteAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
@@ -25,7 +28,11 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPLagOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
@@ -36,6 +43,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPRowNumberOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUpsertFeedbackOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
@@ -53,6 +61,8 @@ import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.ViewOrigins;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRanges;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.keys.KeyAnalysis;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.keys.LosslessCastKeyAnalysis;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
@@ -76,6 +86,9 @@ import java.util.Set;
  * <li>"bounded state", a property of operators.  An operator may internally
  * contain multiple integrators.</li>
  * </ul>
+ * Note that a join of a bounded stream with an unbounded table over a key of the
+ * table has a bounded output, at most one row per row of the stream, while its state
+ * is unbounded.
  * Stateful operators with unbounded state are collected in {@link #unbounded}.
  *
  * <p>Only stream-processing programs receive a warning for each unbounded operator. */
@@ -105,11 +118,15 @@ public class FindUnboundedState extends Passes {
     public final List<UnboundedOperator> unbounded = new ArrayList<>();
     /** True if the program declares LATENESS or append_only tables, or uses a temporal filter */
     boolean streaming = false;
+    /** The keys of every collection; a join over a key of one input has as many rows as the other */
+    final KeyAnalysis keys;
 
     public FindUnboundedState(DBSPCompiler compiler) {
         super("FindUnboundedState", compiler);
         this.add(new DetectStreamingOperations(compiler));
         this.add(new FindGCedStreams(compiler));
+        this.keys = new LosslessCastKeyAnalysis(compiler);
+        this.add(this.keys);
         FindBounded findBounded = new FindBounded(compiler);
         this.add(findBounded);
         // Second run for recursive circuits
@@ -200,6 +217,12 @@ public class FindUnboundedState extends Passes {
         return true;
     }
 
+    /** True if the index of the indexed collection {@code port} is a key of it: each index
+     * value occurs in at most one row. */
+    boolean indexIsKey(OutputPort port) {
+        return this.keys.getKeys(port).hasKeyWithinIndex();
+    }
+
     /** Detects whether the program declares that it processes unbounded streams.
      * NOW() counts only when it feeds a window operator, i.e., in a temporal filter. */
     class DetectStreamingOperations extends CircuitVisitor {
@@ -258,6 +281,10 @@ public class FindUnboundedState extends Passes {
 
         boolean isBounded(OutputPort port) {
             return FindUnboundedState.this.isBounded(port);
+        }
+
+        boolean indexIsKey(OutputPort port) {
+            return FindUnboundedState.this.indexIsKey(port);
         }
 
         /** Operators without a rule of their own propagate boundedness from all their inputs */
@@ -355,6 +382,77 @@ public class FindUnboundedState extends Passes {
         public void postorder(DBSPIndexedTopKOperator node) {
             boolean perGroup = node.limit.is(DBSPUSizeLiteral.class) && hasBoundedKey(node);
             if (perGroup || this.allInputsBounded(node))
+                this.markBounded(node);
+        }
+
+        /** A join produces at most one row per row of a bounded input when every such row
+         * matches at most one row of the other input */
+        @Override
+        public void postorder(DBSPJoinBaseOperator node) {
+            OutputPort left = node.left();
+            OutputPort right = node.right();
+            if (this.allInputsBounded(node)
+                    || (this.isBounded(left) && this.indexIsKey(right))
+                    || (this.isBounded(right) && this.indexIsKey(left)))
+                this.markBounded(node);
+        }
+
+        /** A left join also outputs every unmatched left row */
+        void leftJoin(DBSPJoinBaseOperator node) {
+            if (this.isBounded(node.left()) && (this.isBounded(node.right()) || this.indexIsKey(node.right())))
+                this.markBounded(node);
+        }
+
+        @Override
+        public void postorder(DBSPLeftJoinOperator node) {
+            this.leftJoin(node);
+        }
+
+        @Override
+        public void postorder(DBSPLeftJoinIndexOperator node) {
+            this.leftJoin(node);
+        }
+
+        @Override
+        public void postorder(DBSPLeftJoinFilterMapOperator node) {
+            this.leftJoin(node);
+        }
+
+        /** An ASOF join outputs at most one row per left row */
+        @Override
+        public void postorder(DBSPAsofJoinOperator node) {
+            if (this.isBounded(node.left()))
+                this.markBounded(node);
+        }
+
+        @Override
+        public void postorder(DBSPConcreteAsofJoinOperator node) {
+            if (this.isBounded(node.left()))
+                this.markBounded(node);
+        }
+
+        /** An anti join outputs a subset of its left input */
+        @Override
+        public void postorder(DBSPAntiJoinOperator node) {
+            if (this.isBounded(node.left()))
+                this.markBounded(node);
+        }
+
+        /** All inputs of a star join share the index.  At most one input may lack a key within
+         * it, and that input must be bounded; if every input has one, any bounded input suffices. */
+        @Override
+        public void postorder(DBSPStarJoinBaseOperator node) {
+            OutputPort unkeyed = null;
+            boolean anyBounded = false;
+            for (OutputPort input : node.inputs) {
+                anyBounded |= this.isBounded(input);
+                if (!this.indexIsKey(input)) {
+                    if (unkeyed != null)
+                        return;
+                    unkeyed = input;
+                }
+            }
+            if (unkeyed == null ? anyBounded : this.isBounded(unkeyed))
                 this.markBounded(node);
         }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
@@ -1,46 +1,70 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.core.Window;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.ICircuit;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
-import org.dbsp.sqlCompiler.circuit.annotation.CompactName;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperatorBase;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPLagOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateWithWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPositiveOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRankOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPRowNumberOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamDistinctOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUpsertFeedbackOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewDeclarationOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.circuit.operator.IGCOperator;
 import org.dbsp.sqlCompiler.circuit.operator.IInputOperator;
 import org.dbsp.sqlCompiler.circuit.operator.IJoin;
+import org.dbsp.sqlCompiler.circuit.operator.ILinearAggregate;
 import org.dbsp.sqlCompiler.circuit.operator.ILinear;
 import org.dbsp.sqlCompiler.circuit.operator.INonLinearAggregate;
 import org.dbsp.sqlCompiler.circuit.operator.IStateful;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.ViewOrigins;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRanges;
-import org.dbsp.sqlCompiler.ir.aggregate.IAggregate;
-import org.dbsp.sqlCompiler.ir.expression.DBSPBaseTupleExpression;
-import org.dbsp.util.Logger;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
+import org.dbsp.util.Linq;
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 /** Find operators whose state may grow without bound.
@@ -54,16 +78,24 @@ import java.util.Set;
  * </ul>
  * Stateful operators with unbounded state are collected in {@link #unbounded}.
  *
- * <p>Currently no one consumes the output produced by this pass, but it can be obtained
- * by turning logging up using the compiler option -TFindUnboundedState=1 */
+ * <p>Only stream-processing programs receive a warning for each unbounded operator. */
 public class FindUnboundedState extends Passes {
+    /** Error type shared by all warnings emitted by this pass */
+    public static final String WARNING = "Unbounded state";
+    /** Continuation of the first warning of a compilation; tells the user how to silence all of them
+     * and where they are documented */
+    public static final String HINT = "Silence these warnings with SET " +
+            DBSPCompiler.silencingVariable(WARNING) + " = ON\n" +
+            "See https://docs.feldera.com/sql/streaming#unbounded-state-warnings";
+
     /**
      * An operator whose state may grow without bound.
      *
      * @param operator        The operator holding the state.
+     * @param circuit         The circuit that contains the operator.
      * @param unboundedInputs Indexes of the operator inputs that are not bounded.
      */
-    public record UnboundedOperator(DBSPOperator operator, List<Integer> unboundedInputs) { }
+    public record UnboundedOperator(DBSPOperator operator, ICircuit circuit, List<Integer> unboundedInputs) { }
 
     /** Streams whose integral is bounded */
     final Set<OutputPort> bounded = new HashSet<>();
@@ -71,15 +103,21 @@ public class FindUnboundedState extends Passes {
     final Set<OutputPort> gcedStreams = new HashSet<>();
     /** Operators whose state may grow without bound */
     public final List<UnboundedOperator> unbounded = new ArrayList<>();
+    /** True if the program declares LATENESS or append_only tables, or uses a temporal filter */
+    boolean streaming = false;
 
     public FindUnboundedState(DBSPCompiler compiler) {
         super("FindUnboundedState", compiler);
+        this.add(new DetectStreamingOperations(compiler));
         this.add(new FindGCedStreams(compiler));
         FindBounded findBounded = new FindBounded(compiler);
         this.add(findBounded);
         // Second run for recursive circuits
         this.add(findBounded);
         this.add(new CollectUnbounded(compiler));
+        Graph graph = new Graph(compiler);
+        this.add(graph);
+        this.add(new ReportUnbounded(graph.getGraphs()));
     }
 
     @Override
@@ -87,6 +125,7 @@ public class FindUnboundedState extends Passes {
         this.bounded.clear();
         this.gcedStreams.clear();
         this.unbounded.clear();
+        this.streaming = false;
         return super.apply(circuit);
     }
 
@@ -119,11 +158,72 @@ public class FindUnboundedState extends Passes {
                 || operator.is(IJoin.class);
     }
 
+    /** A group-by key has a bounded number of values when it has at most this many */
+    static final long MAX_KEY_VALUES = 1024;
+
+    /** True if the tuple type has a bounded number of values: it has no fields, or all its
+     * fields are booleans and they admit at most {@link #MAX_KEY_VALUES} combinations
+     * (2 values for a boolean and 3 for a nullable one). */
+    static boolean hasBoundedDomain(DBSPTypeTupleBase tuple) {
+        long values = 1;
+        for (DBSPType field : tuple.tupFields) {
+            if (!field.is(DBSPTypeBool.class))
+                return false;
+            values *= field.mayBeNull ? 3 : 2;
+            if (values > MAX_KEY_VALUES)
+                return false;
+        }
+        return true;
+    }
+
+    /** True if the group-by aggregate has a bounded number of groups: the key of its
+     * indexed input has a bounded domain. */
+    static boolean hasBoundedKey(DBSPOperator aggregate) {
+        OutputPort input = aggregate.inputs.get(0);
+        if (!input.outputType().is(DBSPTypeIndexedZSet.class))
+            return false;
+        return hasBoundedDomain(input.getOutputIndexedZSetType().keyType.to(DBSPTypeTupleBase.class));
+    }
+
+    /** True if the rows of the Z-set on {@code port} have a bounded domain */
+    static boolean hasBoundedRows(OutputPort port) {
+        if (!port.outputType().is(DBSPTypeZSet.class))
+            return false;
+        DBSPType element = port.getOutputZSetElementType();
+        return element.is(DBSPTypeTupleBase.class) && hasBoundedDomain(element.to(DBSPTypeTupleBase.class));
+    }
+
     boolean allInputsBounded(DBSPOperator operator) {
         for (OutputPort input : operator.inputs)
             if (!this.isBounded(input))
                 return false;
         return true;
+    }
+
+    /** Detects whether the program declares that it processes unbounded streams.
+     * NOW() counts only when it feeds a window operator, i.e., in a temporal filter. */
+    class DetectStreamingOperations extends CircuitVisitor {
+        DetectStreamingOperations(DBSPCompiler compiler) {
+            super(compiler);
+        }
+
+        @Override
+        public void postorder(DBSPSourceTableOperator node) {
+            boolean lateness = Linq.any(node.metadata.getColumns(), column -> column.lateness != null);
+            if (lateness || node.metadata.isAppendOnly())
+                FindUnboundedState.this.streaming = true;
+        }
+
+        @Override
+        public void postorder(DBSPViewBaseOperator node) {
+            if (node.metadata.hasLateness())
+                FindUnboundedState.this.streaming = true;
+        }
+
+        @Override
+        public void postorder(DBSPWindowOperator node) {
+            FindUnboundedState.this.streaming = true;
+        }
     }
 
     /**
@@ -147,63 +247,134 @@ public class FindUnboundedState extends Passes {
             super(compiler);
         }
 
-        /** True if all output streams of the operator are bounded */
-        boolean hasBoundedOutput(DBSPOperator node) {
-            if (node.is(DBSPWindowOperator.class))
-                return !node.to(DBSPWindowOperator.class).lowerUnbounded;
-            // A waterline is a single value
-            if (node.is(DBSPWaterlineOperator.class) || node.is(DBSPConstantOperator.class))
-                return true;
-            // Prunes its state and its output using its waterline input
-            if (node.is(DBSPPartitionedRollingAggregateWithWaterlineOperator.class))
-                return true;
-            // The NOW system table always contains exactly one row
-            if (node.is(IInputOperator.class) &&
-                    node.to(IInputOperator.class).getTableName().equals(DBSPCompiler.NOW_TABLE_NAME))
-                return true;
-            // An aggregate over an empty key always has bounded output
-            if (node.is(IAggregate.class)) {
-                var tuple = node.inputs.get(0).getOutputIndexedZSetType().keyType.to(DBSPBaseTupleExpression.class);
-                if (tuple.size() == 0) {
-                    return true;
-                }
-            }
-
-            return propagatesBounded(node) && FindUnboundedState.this.allInputsBounded(node);
+        void markBounded(DBSPOperator node) {
+            for (int i = 0; i < node.outputCount(); i++)
+                FindUnboundedState.this.bounded.add(node.getOutput(i));
         }
 
+        boolean allInputsBounded(DBSPOperator node) {
+            return FindUnboundedState.this.allInputsBounded(node);
+        }
+
+        boolean isBounded(OutputPort port) {
+            return FindUnboundedState.this.isBounded(port);
+        }
+
+        /** Operators without a rule of their own propagate boundedness from all their inputs */
         @Override
         public void postorder(DBSPOperator node) {
             if (node.is(IGCOperator.class))
                 return;
-            if (this.hasBoundedOutput(node))
-                for (int i = 0; i < node.outputCount(); i++)
-                    FindUnboundedState.this.bounded.add(node.getOutput(i));
+            if (propagatesBounded(node) && this.allInputsBounded(node))
+                this.markBounded(node);
         }
 
+        /** A window with a lower bound retains a bounded interval of its input */
+        @Override
+        public void postorder(DBSPWindowOperator node) {
+            if (!node.lowerUnbounded)
+                this.markBounded(node);
+        }
+
+        /** A waterline is a single value */
+        @Override
+        public void postorder(DBSPWaterlineOperator node) {
+            this.markBounded(node);
+        }
+
+        @Override
+        public void postorder(DBSPConstantOperator node) {
+            this.markBounded(node);
+        }
+
+        /** Prunes its state and its output using its waterline input */
+        @Override
+        public void postorder(DBSPPartitionedRollingAggregateWithWaterlineOperator node) {
+            this.markBounded(node);
+        }
+
+        /** A table is bounded when its declaration says so; the NOW system table holds one row */
+        @Override
+        public void postorder(DBSPSourceTableOperator node) {
+            if (node.metadata.expectedSize != null || node.tableName.equals(DBSPCompiler.NOW_TABLE_NAME))
+                this.markBounded(node);
+        }
+
+        /** A group-by aggregate produces one row per group */
+        void aggregate(DBSPOperator node) {
+            if (hasBoundedKey(node) || this.allInputsBounded(node))
+                this.markBounded(node);
+        }
+
+        @Override
+        public void postorder(DBSPAggregateOperatorBase node) {
+            this.aggregate(node);
+        }
+
+        /** A rolling aggregate produces one row per input row */
+        @Override
+        public void postorder(DBSPPartitionedRollingAggregateOperator node) {
+            this.postorder((DBSPOperator) node);
+        }
+
+        @Override
+        public void postorder(DBSPAggregateLinearPostprocessOperator node) {
+            this.aggregate(node);
+        }
+
+        @Override
+        public void postorder(DBSPAggregateLinearPostprocessRetainKeysOperator node) {
+            this.aggregate(node);
+        }
+
+        @Override
+        public void postorder(DBSPChainAggregateOperator node) {
+            this.aggregate(node);
+        }
+
+        @Override
+        public void postorder(DBSPPrimitiveAggregateOperator node) {
+            this.aggregate(node);
+        }
+
+        /** A distinct produces at most one row per value of its row type */
+        @Override
+        public void postorder(DBSPDistinctOperator node) {
+            if (hasBoundedRows(node.input()) || this.allInputsBounded(node))
+                this.markBounded(node);
+        }
+
+        @Override
+        public void postorder(DBSPBinaryDistinctOperator node) {
+            if (hasBoundedRows(node.left()) || this.allInputsBounded(node))
+                this.markBounded(node);
+        }
+
+        /** A top-k produces at most 'limit' rows per group */
+        @Override
+        public void postorder(DBSPIndexedTopKOperator node) {
+            boolean perGroup = node.limit.is(DBSPUSizeLiteral.class) && hasBoundedKey(node);
+            if (perGroup || this.allInputsBounded(node))
+                this.markBounded(node);
+        }
+
+        /** The declaration of a recursive view is the feedback input of the recursive circuit;
+         * nothing else is assumed about its size. */
         @Override
         public void postorder(DBSPViewDeclarationOperator node) {
             ICircuit parent = this.getParent();
             if (!parent.is(DBSPNestedOperator.class))
                 return;
             OutputPort port = parent.to(DBSPNestedOperator.class).outputForDeclaration(node);
-            if (port != null && FindUnboundedState.this.isBounded(port))
+            if (port != null && this.isBounded(port))
                 FindUnboundedState.this.bounded.add(node.outputPort());
-        }
-
-        @Override
-        public void postorder(DBSPSourceTableOperator node) {
-            if (node.metadata.expectedSize != null)
-                FindUnboundedState.this.bounded.add(node.outputPort());
-            else
-                super.postorder(node);
         }
 
         @Override
         public void postorder(DBSPNestedOperator node) {
             for (int i = 0; i < node.outputCount(); i++) {
                 OutputPort internal = node.internalOutputs.get(i);
-                if (internal != null && FindUnboundedState.this.isBounded(internal))
+                if (internal != null && this.isBounded(internal))
                     FindUnboundedState.this.bounded.add(node.getOutput(i));
             }
         }
@@ -246,6 +417,35 @@ public class FindUnboundedState extends Passes {
                 super.postorder(node);
         }
 
+        /** A distinct keeps one entry per distinct row, so a bounded row domain bounds its state */
+        @Override
+        public void postorder(DBSPDistinctOperator node) {
+            if (!hasBoundedRows(node.input()))
+                super.postorder(node);
+        }
+
+        @Override
+        public void postorder(DBSPBinaryDistinctOperator node) {
+            if (!hasBoundedRows(node.left()))
+                super.postorder(node);
+        }
+
+        /** A linear aggregate keeps one accumulator per group, so a bounded key bounds its state */
+        void linearAggregate(DBSPOperator node) {
+            if (!hasBoundedKey(node))
+                this.postorder((DBSPOperator) node);
+        }
+
+        @Override
+        public void postorder(DBSPAggregateLinearPostprocessOperator node) {
+            this.linearAggregate(node);
+        }
+
+        @Override
+        public void postorder(DBSPChainAggregateOperator node) {
+            this.linearAggregate(node);
+        }
+
         @Override
         public void postorder(DBSPPartitionedRollingAggregateWithWaterlineOperator node) {
             if (this.insideRecursive())
@@ -259,35 +459,14 @@ public class FindUnboundedState extends Passes {
         }
 
         void markUnbounded(DBSPOperator operator, List<Integer> inputs) {
-            var ub = new UnboundedOperator(operator, inputs);
+            var ub = new UnboundedOperator(operator, this.getParent(), inputs);
             FindUnboundedState.this.unbounded.add(ub);
-
-            SourcePositionRanges pos = FindSourcePositions.getPositions(this.compiler, operator);
-            String sources = this.compiler.sources.getFragments(pos);
-            if (!sources.isEmpty())
-                sources += "\n";
-            Logger.INSTANCE.belowLevel(FindUnboundedState.class, 1)
-                    .append("Potentially unbounded memory in operator ")
-                    .append(Objects.requireNonNull(CompactName.getCompactName(operator)))
-                    .append(" ")
-                    .append(operator.getClass().getSimpleName())
-                    .newline()
-                    .append(sources);
         }
 
         @Override
         public void postorder(DBSPOperator node) {
             if (!node.is(IStateful.class))
                 return;
-            // Operators inside recursive circuits store a history of deltas,
-            // which can grow without bound
-            if (this.getParent().is(DBSPNestedOperator.class)) {
-                List<Integer> all = new ArrayList<>();
-                for (int input = 0; input < node.inputs.size(); input++)
-                    all.add(input);
-                this.markUnbounded(node, all);
-                return;
-            }
             // Operators whose output trace is pruned by a GC operator have bounded state
             if (FindUnboundedState.this.hasGCedOutput(node))
                 return;
@@ -296,11 +475,157 @@ public class FindUnboundedState extends Passes {
                 if (!FindUnboundedState.this.isBounded(node.inputs.get(input)))
                     unbounded.add(input);
             }
-            if (node.inputs.isEmpty())
-                // Stateful non-GCed input operator
-                this.markUnbounded(node, unbounded);
+            if (node.inputs.isEmpty()) {
+                // A stateful input operator stores the table; the table is bounded
+                // only when the declaration promises a bounded size
+                if (!FindUnboundedState.this.isBounded(node.getOutput(0)))
+                    this.markUnbounded(node, unbounded);
+                return;
+            }
             if (!unbounded.isEmpty())
                 this.markUnbounded(node, unbounded);
+        }
+    }
+
+    /**
+     * Warn about each unbounded operator of a stream-processing program;
+     * runs after {@link CollectUnbounded} and {@link Graph}.
+     */
+    class ReportUnbounded implements CircuitTransform {
+        final CircuitGraphs graphs;
+
+        ReportUnbounded(CircuitGraphs graphs) {
+            this.graphs = graphs;
+        }
+
+        /** SQL-level name, with its article, of the relational operator {@code rel} when it
+         * holds state; null for stateless relational operators such as projections and filters. */
+        @Nullable
+        static String sqlName(RelNode rel) {
+            if (rel instanceof Join || rel instanceof Correlate)
+                return "a JOIN";
+            if (rel instanceof Aggregate aggregate)
+                return aggregate.getAggCallList().isEmpty() ? "a DISTINCT" : "an aggregate";
+            if (rel instanceof Window)
+                return "a window function";
+            if (rel instanceof Sort sort)
+                return (sort.fetch != null || sort.offset != null) ? "an ORDER BY with LIMIT" : null;
+            if (rel instanceof Intersect intersect)
+                return intersect.all ? "an INTERSECT ALL" : "an INTERSECT";
+            if (rel instanceof Minus minus)
+                return minus.all ? "an EXCEPT ALL" : "an EXCEPT";
+            if (rel instanceof Union union)
+                return union.all ? null : "a UNION";
+            return null;
+        }
+
+        /** SQL-level name, with its article, of the construct whose state the operator holds:
+         * the first stateful relational operator that the operator implements; the kind of
+         * operator decides for operators that the compiler synthesizes without one. */
+        static String sqlName(DBSPOperator operator) {
+            for (RelNode rel : operator.getRelNode().getRelNodes()) {
+                String name = sqlName(rel);
+                if (name != null)
+                    return name;
+            }
+            if (operator.is(IJoin.class))
+                return "a JOIN";
+            if (operator.is(DBSPWindowOperator.class))
+                return "a temporal filter";
+            if (operator.is(DBSPPositiveOperator.class))
+                return "an EXCEPT ALL";
+            if (operator.is(DBSPDistinctOperator.class)
+                    || operator.is(DBSPBinaryDistinctOperator.class)
+                    || operator.is(DBSPStreamDistinctOperator.class))
+                return "a DISTINCT";
+            if (operator.is(DBSPPartitionedRollingAggregateOperator.class)
+                    || operator.is(DBSPPartitionedRollingAggregateWithWaterlineOperator.class)
+                    || operator.is(DBSPRankOperator.class)
+                    || operator.is(DBSPRowNumberOperator.class)
+                    || operator.is(DBSPLagOperator.class))
+                return "a window function";
+            if (operator.is(ILinearAggregate.class)
+                    || operator.is(INonLinearAggregate.class)
+                    || operator.is(DBSPAggregateOperatorBase.class))
+                return "an aggregate";
+            String internal = operator.is(DBSPSimpleOperator.class) ?
+                    operator.to(DBSPSimpleOperator.class).operation :
+                    operator.getClass().getSimpleName();
+            return "the " + internal + " operator";
+        }
+
+        /** The view whose definition contains the operator, obtained by inspecting
+         * the attached Calcite Rel tree. */
+        @Nullable
+        ViewOrigins.ViewSourcePosition viewOf(UnboundedOperator ub) {
+            for (RelNode rel : ub.operator().getRelNode().getRelNodes()) {
+                ViewOrigins.ViewSourcePosition origin = FindUnboundedState.this.compiler.viewOrigins.get(rel);
+                if (origin != null)
+                    return origin;
+            }
+            DBSPOperator sink = this.graphs.closestDownstream(
+                    ub.circuit(), ub.operator(), operator -> operator.is(DBSPSinkOperator.class));
+            if (sink == null)
+                return null;
+            return new ViewOrigins.ViewSourcePosition(sink.to(DBSPSinkOperator.class).viewName, this.ownPosition(sink));
+        }
+
+        /** The SQL construct that produced the operator when known,
+         * otherwise the first expression the operator evaluates. */
+        SourcePositionRange ownPosition(DBSPOperator operator) {
+            SourcePositionRanges own = new SourcePositionRanges(operator.getSourcePositions());
+            if (!own.positions.isEmpty())
+                return own.positions.get(0);
+            SourcePositionRanges all = FindSourcePositions.getPositions(
+                    FindUnboundedState.this.compiler, operator);
+            if (!all.positions.isEmpty())
+                return all.positions.get(0);
+            return SourcePositionRange.INVALID;
+        }
+
+        /** The operator's own position when it has one; the compiler synthesizes
+         * many operators without positions, and the view statement narrows the position. */
+        SourcePositionRange positionOf(DBSPOperator operator, @Nullable ViewOrigins.ViewSourcePosition view) {
+            SourcePositionRange own = this.ownPosition(operator);
+            if (own.isValid() || view == null)
+                return own;
+            return view.position();
+        }
+
+        String describe(DBSPOperator operator, @Nullable ViewOrigins.ViewSourcePosition view) {
+            if (operator.is(IInputOperator.class)) {
+                String table = operator.to(IInputOperator.class).getTableName().singleQuote();
+                return "The index of table " + table + " may grow without bound";
+            }
+            String where = view == null ? "" :
+                    " in the code implementing view " + view.view().singleQuote();
+            return "The state of " + sqlName(operator) + where + " may grow without bound";
+        }
+
+        @Override
+        public DBSPCircuit apply(DBSPCircuit circuit) {
+            if (!FindUnboundedState.this.streaming)
+                return circuit;
+            boolean first = true;
+            for (UnboundedOperator ub : FindUnboundedState.this.unbounded) {
+                ViewOrigins.ViewSourcePosition view = this.viewOf(ub);
+                FindUnboundedState.this.compiler.reportWarning(
+                        this.positionOf(ub.operator(), view), WARNING, this.describe(ub.operator(), view));
+                if (first)
+                    FindUnboundedState.this.compiler.reportWarning(SourcePositionRange.INVALID, WARNING, HINT, true);
+                first = false;
+            }
+            return circuit;
+        }
+
+        @Override
+        public String getName() {
+            return "ReportUnbounded";
+        }
+
+        @Override
+        public String toString() {
+            return this.getName();
         }
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Lineage.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Lineage.java
@@ -84,7 +84,14 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /** Analyze dataflow graph and compute lineage for some output columns.
- * "Lineage" traces a column to a source table. */
+ * "Lineage" traces a column to a source table.
+ *
+ * <p>A value keeps its lineage only through operations that leave it unchanged: field
+ * access, tuple construction, references, and casts that change nothing but the nullability
+ * of the type.  Any other operation, including a cast to another width or precision, yields a
+ * value of unknown lineage.  Two values with the same lineage are therefore equal under the
+ * comparison of their common type.  A subclass of {@link InnerLineage} may relax the rule for
+ * casts. */
 public class Lineage extends CircuitVisitor {
     // Note: this interface has some implementations outside this class as well.
     // We should not assume that all implementations reside here.
@@ -683,7 +690,8 @@ public class Lineage extends CircuitVisitor {
             System.out.println("[Compared:] " + compared);
     }
 
-    /** Computes lineage of an expression by tracking where each field of the expression is coming from. */
+    /** Computes lineage of an expression by tracking where each field of the expression is coming
+     * from.  {@link Lineage} describes which operations preserve lineage. */
     public static class InnerLineage extends SymbolicInterpreter<ValueSource> {
         final ResolveReferences resolver;
         /** Receives the columns compared against literals; null when nobody wants them */
@@ -834,6 +842,11 @@ public class Lineage extends CircuitVisitor {
             return VisitDecision.STOP;
         }
 
+        /** Only a cast that changes nothing but nullability preserves lineage (see the class
+         * comment), because other casts may change the values or their comparison: a cast to
+         * or from {@code CHAR(n)} pads or trims, and {@code CHAR} comparisons ignore trailing
+         * spaces; a cast to a narrower {@code VARCHAR(n)} truncates; {@code DECIMAL} and
+         * {@code TIMESTAMP} casts round or truncate when the scale or precision shrinks. */
         @Override
         public void postorder(DBSPCastExpression expression) {
             DBSPType type = expression.getType();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/ColumnEquivalence.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/ColumnEquivalence.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeSet;
 
 /** The columns of one collection grouped by value: two columns belong to the same

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysis.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysis.java
@@ -6,6 +6,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperatorBase;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateZeroOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConcreteAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
@@ -40,7 +41,6 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.Lineage;
@@ -94,6 +94,11 @@ public class KeyAnalysis extends CircuitVisitor {
 
     public KeyAnalysis(DBSPCompiler compiler) {
         super(compiler);
+    }
+
+    /** The lineage interpreter that decides which output columns copy which input columns */
+    Lineage.InnerLineage interpreter() {
+        return new Lineage.InnerLineage(this.compiler(), null);
     }
 
     public Keys getKeys(OutputPort port) {
@@ -177,7 +182,7 @@ public class KeyAnalysis extends CircuitVisitor {
      * plain copy of a parameter column, that parameter column.
      * @param outputShape shape of the produced rows */
     Provenance provenance(CollectionShape outputShape, DBSPClosureExpression closure) {
-        Lineage.ValueSource result = new Lineage.InnerLineage(this.compiler(), null).analyze(closure, initialValues(closure));
+        Lineage.ValueSource result = this.interpreter().analyze(closure, initialValues(closure));
         List<Lineage.ValueSource> columns = new ArrayList<>();
         if (closure.body.getType().is(DBSPTypeRawTuple.class)) {
             // A (index, value) pair; either part may be unknown to the interpreter, e.g. when empty
@@ -319,9 +324,11 @@ public class KeyAnalysis extends CircuitVisitor {
         return operator.function.to(DBSPClosureExpression.class);
     }
 
-    /** The output carries the same rows as the input. */
-    private void copy(DBSPUnaryOperator operator) {
-        OutputPort input = operator.input();
+    /** The output carries the same rows as the operator's only input. */
+    private void copy(DBSPSimpleOperator operator) {
+        Utilities.enforce(operator.inputs.size() == 1,
+                () -> operator + " has " + operator.inputs.size() + " inputs");
+        OutputPort input = operator.inputs.get(0);
         this.set(operator, this.getKeys(input), this.getEquivalence(input));
     }
 
@@ -363,10 +370,27 @@ public class KeyAnalysis extends CircuitVisitor {
         this.set(node, Keys.of(ColumnEquivalence.NONE.keyOf(key)));
     }
 
-    /** Source maps are created by a later pass. */
+    /** A table with a PRIMARY KEY indexed by that key: the index identifies the row.  The value
+     * is either the whole row, in which case each index column duplicates the row column it was
+     * copied from, or the row without its key columns (--gen2 compiler flag). */
     @Override
     public void postorder(DBSPSourceMapOperator node) {
-        throw new InternalCompilerError("Unexpected operator", node);
+        if (!(node.outputPort().getShape() instanceof IndexedShape shape))
+            return;
+        List<Integer> keyFields = node.getKeyFields();
+        int rowFields = node.metadata.getColumns().size();
+        // This happens when `gen2` is false
+        boolean valueIsRow = shape.valueFields() == rowFields;
+        Utilities.enforce(valueIsRow || shape.valueFields() == rowFields - keyFields.size(),
+                () -> "Value of " + node + " has " + shape.valueFields() + " fields for a row of " + rowFields);
+        ColumnEquivalence equivalence = ColumnEquivalence.NONE;
+        if (valueIsRow) {
+            List<List<Column>> groups = new ArrayList<>();
+            for (int i = 0; i < keyFields.size(); i++)
+                groups.add(List.of(Column.index(i), Column.value(keyFields.get(i))));
+            equivalence = ColumnEquivalence.of(groups);
+        }
+        this.set(node, Keys.of(equivalence.keyOf(shape.indexColumns())), equivalence);
     }
 
     /** A filter keeps the input keys.  A column that a top-level conjunct equates with a
@@ -389,7 +413,7 @@ public class KeyAnalysis extends CircuitVisitor {
         DBSPClosureExpression closure = closureOf(node);
         if (input == null || closure == null)
             return result;
-        Lineage.InnerLineage inner = new Lineage.InnerLineage(this.compiler(), null);
+        Lineage.InnerLineage inner = this.interpreter();
         inner.analyze(closure, initialValues(closure));
         for (DBSPExpression conjunct : closure.body.conjuncts()) {
             conjunct = conjunct.stripWrapBool();
@@ -419,7 +443,7 @@ public class KeyAnalysis extends CircuitVisitor {
      * With one input the operator is the identity. */
     private void rowUnion(DBSPSimpleOperator node) {
         if (node.inputs.size() == 1) {
-            this.copy(node.to(DBSPUnaryOperator.class));
+            this.copy(node);
             return;
         }
         ColumnEquivalence equivalence = this.getEquivalence(node.inputs.get(0));
@@ -430,6 +454,11 @@ public class KeyAnalysis extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPSumOperator node) {
+        this.rowUnion(node);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator node) {
         this.rowUnion(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/LosslessCastKeyAnalysis.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/LosslessCastKeyAnalysis.java
@@ -1,0 +1,18 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.keys;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.Lineage;
+
+/** A key analysis in which a column that is a lossless cast of another column counts as a copy
+ * of it, see {@link LosslessCastLineage}.  A key therefore survives such a cast, and a copy
+ * this analysis reports may be wider than its source. */
+public class LosslessCastKeyAnalysis extends KeyAnalysis {
+    public LosslessCastKeyAnalysis(DBSPCompiler compiler) {
+        super(compiler);
+    }
+
+    @Override
+    Lineage.InnerLineage interpreter() {
+        return new LosslessCastLineage(this.compiler());
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/LosslessCastLineage.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/LosslessCastLineage.java
@@ -1,0 +1,49 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.keys;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.Lineage;
+import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
+import org.dbsp.sqlCompiler.ir.type.primitive.IHasPrecision;
+
+/** A lineage interpreter in which a lossless cast preserves the lineage of its source, in
+ * addition to the casts that {@link Lineage.InnerLineage} accepts.  A cast is lossless when it
+ * changes neither the value nor how it compares: a non-fixed string cast to an equal, larger, or
+ * unlimited precision, or any cast between integer types, which raises an error for a value the
+ * target cannot hold rather than changing it.  Two values with the same lineage are therefore
+ * equal, but need not have the same type: a column with the lineage of another column may be a
+ * wider copy of it.  Every other cast stays opaque, for the reasons {@link Lineage.InnerLineage}
+ * gives. */
+class LosslessCastLineage extends Lineage.InnerLineage {
+    LosslessCastLineage(DBSPCompiler compiler) {
+        super(compiler, null);
+    }
+
+    /** True if casting {@code from} to {@code to} changes neither the value nor its comparison. */
+    static boolean isLosslessCast(DBSPType from, DBSPType to) {
+        if (from.is(DBSPTypeString.class) && to.is(DBSPTypeString.class)) {
+            DBSPTypeString source = from.to(DBSPTypeString.class);
+            DBSPTypeString target = to.to(DBSPTypeString.class);
+            if (source.fixed || target.fixed)
+                return false;
+            if (target.precision == IHasPrecision.UNLIMITED_PRECISION)
+                return true;
+            return source.precision != IHasPrecision.UNLIMITED_PRECISION
+                    && target.precision >= source.precision;
+        }
+        // An integer cast fails on a value the target cannot hold instead of altering it
+        return from.is(DBSPTypeInteger.class) && to.is(DBSPTypeInteger.class);
+    }
+
+    /** A lossless cast carries the lineage of its source; the strict rule decides the rest. */
+    @Override
+    public void postorder(DBSPCastExpression expression) {
+        if (isLosslessCast(expression.source.getType(), expression.getType())) {
+            this.set(expression, this.get(expression.source));
+            return;
+        }
+        super.postorder(expression);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ContainsNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ContainsNow.java
@@ -17,6 +17,7 @@ public class ContainsNow extends InnerVisitor {
     public boolean found;
     /** If true the 'found' is reset for each invocation. */
     public final boolean perExpression;
+    /** The last now() call found */
     @Nullable
     DBSPExpression nowExpression = null;
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
@@ -182,7 +182,10 @@ public class RewriteNow extends CircuitCloneVisitor {
         super(compiler, false);
     }
 
-    DBSPSimpleOperator createJoin(DBSPSimpleOperator input, DBSPUnaryOperator operator) {
+    /** Join {@code input} with the NOW stream; {@code operator} is the operator being rewritten,
+     * and {@code nowCall} the NOW() call that requires the join. */
+    DBSPSimpleOperator createJoin(DBSPSimpleOperator input, DBSPUnaryOperator operator,
+                                  DBSPExpression nowCall) {
         DBSPType inputType = input.getOutputZSetElementType();
         DBSPVariablePath var = inputType.ref().var();
         DBSPExpression indexFunction = new DBSPRawTupleExpression(
@@ -204,7 +207,10 @@ public class RewriteNow extends CircuitCloneVisitor {
         DBSPExpression joinFunction = new DBSPTupleExpression(fields, false)
                 .closure(key, left, right);
         Utilities.enforce(nowIndexed != null);
-        DBSPSimpleOperator result = new DBSPStreamJoinOperator(operator.getRelNode(), joinType,
+        // The join has no SQL counterpart; use the NOW() source code position
+        CalciteRelNode joinNode = operator.getRelNode().copy();
+        joinNode.addSourcePositions(List.of(nowCall.getSourcePosition()));
+        DBSPSimpleOperator result = new DBSPStreamJoinOperator(joinNode, joinType,
                 joinFunction, operator.isMultiset, index.outputPort(), nowIndexed.outputPort(), false);
         this.addOperator(result);
         return result;
@@ -225,7 +231,8 @@ public class RewriteNow extends CircuitCloneVisitor {
         if (cn.found()) {
             OutputPort input = this.mapped(operator.input());
             this.warnExpensive(cn.nowExpression);
-            DBSPSimpleOperator join = this.createJoin(input.simpleNode(), operator);
+            DBSPSimpleOperator join = this.createJoin(
+                    input.simpleNode(), operator, Objects.requireNonNull(cn.nowExpression));
             RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
             function = rn.apply(function).to(DBSPExpression.class);
             DBSPSimpleOperator result = new DBSPMapOperator(
@@ -451,9 +458,12 @@ public class RewriteNow extends CircuitCloneVisitor {
 
         if (leftOver.is(NonTemporalFilter.class)) {
             // Implement leftover as a join
-            DBSPSimpleOperator join = this.createJoin(result, operator);
-            RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
             DBSPExpression filterBody = leftOver.to(NonTemporalFilter.class).expression().wrapBoolIfNeeded();
+            ContainsNow cn = new ContainsNow(this.compiler(), true);
+            cn.apply(filterBody);
+            DBSPSimpleOperator join = this.createJoin(
+                    result, operator, Objects.requireNonNull(cn.nowExpression));
+            RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
             this.warnExpensive(filterBody);
             function = filterBody.closure(function.parameters);
             function = rn.apply(function).to(DBSPClosureExpression.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DiGraph.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DiGraph.java
@@ -1,6 +1,12 @@
 package org.dbsp.util.graph;
 
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /** Abstract representation of a graph. */
 public interface DiGraph<Node> {
@@ -9,6 +15,27 @@ public interface DiGraph<Node> {
 
     /** Returns the successors of a node */
     List<Port<Node>> getSuccessors(Node node);
+
+    /** The node closest downstream of {@code start} that satisfies {@code test}, searching
+     * breadth first; null if none is reachable.  {@code start} is tested only when
+     * a cycle leads back to it. */
+    @Nullable
+    default Node closestSuccessor(Node start, Predicate<Node> test) {
+        Set<Node> visited = new HashSet<>();
+        Deque<Node> queue = new ArrayDeque<>();
+        for (Port<Node> port : this.getSuccessors(start))
+            queue.add(port.node());
+        while (!queue.isEmpty()) {
+            Node current = queue.remove();
+            if (!visited.add(current))
+                continue;
+            if (test.test(current))
+                return current;
+            for (Port<Node> port : this.getSuccessors(current))
+                queue.add(port.node());
+        }
+        return null;
+    }
 
     default int getFanout(Node node) {
         return this.getSuccessors(node).size();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
@@ -1,0 +1,635 @@
+package org.dbsp.sqlCompiler.compiler.sql.streaming;
+
+import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
+import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
+import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.FindUnboundedState;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Tests for the {@link FindUnboundedState#WARNING} warnings.
+ * Only incremental circuits contain the garbage collection operators that bound state,
+ * so these tests compile incrementally, like the pipeline manager does. */
+public class IncrementalUnboundedStateTests extends StreamingTestBase {
+    /** A join over two tables that neither garbage collection nor a size bound keeps small.
+     * Tests prepend the declaration of the 'orders' table to inject stream-processing indicators. */
+    static final String UNBOUNDED_JOIN = """
+            CREATE TABLE customers(id INT, name VARCHAR);
+            CREATE VIEW V AS
+            SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;""";
+
+    /** The warning for {@link #UNBOUNDED_JOIN} when a one-line declaration of 'orders' precedes it */
+    static final String JOIN_WARNING = """
+            (no input file): Unbounded state
+            (no input file):4:61: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                3|CREATE VIEW V AS
+                4|SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;
+                                                                              ^^^^^^^^^^^^^^^^^
+            Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+            See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+            """;
+
+    /** Two tables without lateness; 'append_only' marks the program as stream processing */
+    static final String TABLES = """
+            CREATE TABLE T(x INT, y INT) WITH ('append_only' = 'true');
+            CREATE TABLE S(x INT, y INT);
+            """;
+
+    /** Compile {@code sql} and check that the {@link FindUnboundedState#WARNING} warnings,
+     * rendered as the compiler prints them, are exactly {@code expected}. */
+    void assertUnboundedStateWarnings(String sql, String expected) {
+        var cc = this.getCC(sql);
+        StringBuilder rendered = new StringBuilder();
+        for (CompilerMessages.Message message : cc.compiler.messages.messages)
+            if (message.warning && message.errorType.equals(FindUnboundedState.WARNING))
+                rendered.append(message);
+        Assert.assertEquals(expected, rendered.toString());
+    }
+
+    void assertNoUnboundedStateWarnings(String sql) {
+        this.assertUnboundedStateWarnings(sql, "");
+    }
+
+    /** The anchor that the documentation site generates for a Markdown heading */
+    static String anchor(String heading) {
+        return heading.toLowerCase(Locale.ENGLISH)
+                .replaceAll("[^a-z0-9 ]", "")
+                .trim()
+                .replaceAll(" +", "-");
+    }
+
+    @Test
+    public void documentationLinkIsValid() throws IOException {
+        // Check that the URL in the documentation exists
+        // The hint links to https://docs.feldera.com/<page>#<anchor>, which the site
+        // builds from docs.feldera.com/docs/<page>.md and one of its headings
+        Matcher url = Pattern.compile("https://docs\\.feldera\\.com/([^#\\s]+)#(\\S+)").matcher(FindUnboundedState.HINT);
+        Assert.assertTrue(FindUnboundedState.HINT, url.find());
+        Path page = Path.of(BaseSQLTests.PROJECT_DIRECTORY, "..", "docs.feldera.com", "docs", url.group(1) + ".md");
+        Assert.assertTrue("Documentation page not found: " + page.normalize(), Files.exists(page));
+        List<String> headings = Files.readAllLines(page).stream()
+                .filter(line -> line.startsWith("#"))
+                .map(line -> anchor(line.replaceFirst("^#+", "")))
+                .toList();
+        Assert.assertTrue("No heading for anchor '" + url.group(2) + "' in " + page.normalize() + ": " + headings,
+                headings.contains(url.group(2)));
+    }
+
+    // ---- Programs that must not produce warnings ----
+
+    @Test
+    public void batchProgram() {
+        // Without LATENESS, append_only, or NOW() the program is not a
+        // stream-processing program, so the unbounded join is not reported
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                """ + UNBOUNDED_JOIN);
+    }
+
+    @Test
+    public void silenced() {
+        this.assertNoUnboundedStateWarnings("""
+                SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON;
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR);
+                """ + UNBOUNDED_JOIN);
+    }
+
+    @Test
+    public void boundedProgram() {
+        // Lateness lets the compiler garbage-collect both aggregates and the join
+        // that combines them, so this stream-processing program has no unbounded state
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE T(ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR, x INT);
+                CREATE VIEW V AS
+                SELECT CAST(ts AS DATE) AS d, COUNT(*) AS c, MAX(x) AS m
+                FROM T GROUP BY CAST(ts AS DATE);""");
+    }
+
+    @Test
+    public void countWithoutGroupBy() {
+        // A linear aggregate keeps one accumulator per group, and without
+        // GROUP BY there is a single group, however large the input
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT COUNT(*) AS cnt FROM input;""");
+    }
+
+    @Test
+    public void maxWithoutGroupByAppendOnly() {
+        // Without deletions MAX only has to remember the current maximum
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                CREATE VIEW output AS SELECT MAX(id) AS m FROM input;""");
+    }
+
+    @Test
+    public void nowOutsideTemporalFilter() {
+        // NOW() marks a program as stream processing only inside a temporal filter;
+        // computing the current time in a projection does not, and the compiler
+        // reports that use separately as an inefficient pattern
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id INT, name VARCHAR);
+                CREATE VIEW V AS
+                SELECT o.id, o.ts, c.name, NOW() AS at FROM orders o JOIN customers c ON o.customer = c.id;""");
+    }
+
+    @Test
+    public void groupByBooleans() {
+        // Boolean keys have a bounded number of values, so the linear aggregate
+        // keeps a bounded number of accumulators
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(paid BOOLEAN NOT NULL, shipped BOOLEAN, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT paid, shipped, COUNT(*) AS cnt FROM input GROUP BY paid, shipped;""");
+    }
+
+    @Test
+    public void groupByTenBooleans() {
+        // Ten booleans admit exactly MAX_KEY_VALUES = 1024 groups, which is still bounded
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(b0 BOOLEAN NOT NULL, b1 BOOLEAN NOT NULL, b2 BOOLEAN NOT NULL, b3 BOOLEAN NOT NULL,
+                                   b4 BOOLEAN NOT NULL, b5 BOOLEAN NOT NULL, b6 BOOLEAN NOT NULL, b7 BOOLEAN NOT NULL,
+                                   b8 BOOLEAN NOT NULL, b9 BOOLEAN NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS
+                SELECT b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, COUNT(*) AS cnt
+                FROM input GROUP BY b0, b1, b2, b3, b4, b5, b6, b7, b8, b9;""");
+    }
+
+    @Test
+    public void chainAggregateByBoolean() {
+        // Over an append-only table MAX keeps one running value per group, a chain aggregate,
+        // and a boolean key allows a bounded number of groups
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE T(id INT, x INT, flag BOOLEAN NOT NULL, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                CREATE VIEW V AS SELECT flag, MAX(x) AS m FROM T GROUP BY flag;""");
+    }
+
+    @Test
+    public void distinctOverBooleans() {
+        // A distinct keeps one entry per distinct row, and boolean rows have a bounded domain
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE T(paid BOOLEAN NOT NULL, shipped BOOLEAN, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                CREATE VIEW V AS SELECT DISTINCT paid, shipped FROM T;""");
+    }
+
+    // ---- Programs that must produce warnings ----
+
+    @Test
+    public void tableLateness() {
+        // The only warning carries the silencing hint
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR);
+                """ + UNBOUNDED_JOIN, JOIN_WARNING);
+    }
+
+    @Test
+    public void viewLateness() {
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                """ + UNBOUNDED_JOIN + """
+
+                LATENESS V.ts INTERVAL 1 HOUR;""",
+                """
+                (no input file): Unbounded state
+                (no input file):4:61: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;
+                                                                                  ^^^^^^^^^^^^^^^^^
+                    5|LATENESS V.ts INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void appendOnly() {
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                """ + UNBOUNDED_JOIN, JOIN_WARNING);
+    }
+
+    @Test
+    public void asError() {
+        this.statementsFailingInCompilation("""
+                SET FELDERA_WARNINGS_ARE_ERRORS = ON;
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR);
+                """ + UNBOUNDED_JOIN,
+                """
+                (no input file): Unbounded state
+                (no input file):5:61: error: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;
+                                                                                  ^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void localView() {
+        // The optimizer removes the local view, but the warning still names it, because the
+        // compiler remembers which view each Calcite relational operator was compiled for
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR);
+                CREATE TABLE customers(id INT, name VARCHAR);
+                CREATE LOCAL VIEW joined AS
+                SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;
+                CREATE VIEW V AS SELECT id, name FROM joined WHERE id > 0;""",
+                """
+                (no input file): Unbounded state
+                (no input file):4:61: warning: Unbounded state: The state of a JOIN in the code implementing view 'joined' may grow without bound
+                    4|SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id;
+                                                                                  ^^^^^^^^^^^^^^^^^
+                    5|CREATE VIEW V AS SELECT id, name FROM joined WHERE id > 0;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void temporalFilter() {
+        // The temporal filter bounds the orders side of the join; the customers side stays unbounded
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE orders(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id INT, name VARCHAR);
+                CREATE VIEW V AS
+                SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id
+                WHERE o.ts >= NOW() - INTERVAL 1 HOUR;""",
+                """
+                (no input file): Unbounded state
+                (no input file):4:61: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|SELECT o.id, o.ts, c.name FROM orders o JOIN customers c ON o.customer = c.id
+                                                                                  ^^^^^^^^^^^^^^^^^
+                    5|WHERE o.ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void recursiveView() {
+        // The recursion reads table E directly, so its history of deltas is unbounded.
+        // The compiler synthesizes the operators inside the recursion without source
+        // positions, so the warning points at the statement of the closest output view.
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE E(x INT, ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR);
+                DECLARE RECURSIVE VIEW R(x INT);
+                CREATE VIEW R AS SELECT x FROM E UNION SELECT x + 1 FROM R WHERE x < 10;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of a UNION in the code implementing view 'r' may grow without bound
+                    2|DECLARE RECURSIVE VIEW R(x INT);
+                    3|CREATE VIEW R AS SELECT x FROM E UNION SELECT x + 1 FROM R WHERE x < 10;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void recursiveViewBoundedInput() {
+        // A temporal filter bounds the stream entering the recursion, but not the fixpoint:
+        // the operators on the recursion itself are reported, and only silencing removes them
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE E(x INT, ts TIMESTAMP NOT NULL);
+                CREATE LOCAL VIEW recent AS SELECT x FROM E WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                DECLARE RECURSIVE VIEW R(x INT);
+                CREATE VIEW R AS SELECT x FROM recent UNION SELECT x + 1 FROM R WHERE x < 10;""",
+                """
+                (no input file): Unbounded state
+                (no input file):4:1: warning: Unbounded state: The state of a UNION in the code implementing view 'r' may grow without bound
+                    3|DECLARE RECURSIVE VIEW R(x INT);
+                    4|CREATE VIEW R AS SELECT x FROM recent UNION SELECT x + 1 FROM R WHERE x < 10;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void mutualRecursionBoundedInput() {
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE E(x INT, ts TIMESTAMP NOT NULL);
+                CREATE LOCAL VIEW recent AS SELECT x FROM E WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                DECLARE RECURSIVE VIEW A(x INT);
+                DECLARE RECURSIVE VIEW B(x INT);
+                CREATE VIEW A AS SELECT x FROM recent UNION SELECT x FROM B;
+                CREATE VIEW B AS SELECT x + 1 AS x FROM A WHERE x < 10;""",
+                """
+                (no input file): Unbounded state
+                (no input file):5:1: warning: Unbounded state: The state of a UNION in the code implementing view 'a' may grow without bound
+                    5|CREATE VIEW A AS SELECT x FROM recent UNION SELECT x FROM B;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    6|CREATE VIEW B AS SELECT x + 1 AS x FROM A WHERE x < 10;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void recursiveViewBoundedOperatorsBesideCycle() {
+        // The MIN aggregate and the join depend only on the bounded stream that enters the
+        // recursion, so they are not reported; the UNION on the recursion itself is
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE E(x INT, ts TIMESTAMP NOT NULL);
+                CREATE LOCAL VIEW recent AS SELECT x FROM E WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                DECLARE RECURSIVE VIEW R(x INT);
+                CREATE VIEW R AS
+                SELECT x FROM recent WHERE x > (SELECT MIN(x) FROM recent)
+                UNION SELECT x + 1 FROM R WHERE x < 10;""",
+                """
+                (no input file): Unbounded state
+                (no input file):4:1: warning: Unbounded state: The state of a UNION in the code implementing view 'r' may grow without bound
+                    4|CREATE VIEW R AS
+                    5|SELECT x FROM recent WHERE x > (SELECT MIN(x) FROM recent)
+                    6|UNION SELECT x + 1 FROM R WHERE x < 10;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void recursiveViewJoinsUnboundedTable() {
+        // The join with table G brings an unbounded stream into the recursion and is reported
+        // together with the UNION on the recursion itself
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE E(x INT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE G(x INT, y INT);
+                CREATE LOCAL VIEW recent AS SELECT x FROM E WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                DECLARE RECURSIVE VIEW R(x INT);
+                CREATE VIEW R AS SELECT x FROM recent UNION SELECT G.y FROM R JOIN G ON R.x = G.x;""",
+                """
+                (no input file): Unbounded state
+                (no input file):5:73: warning: Unbounded state: The state of a JOIN in the code implementing view 'r' may grow without bound
+                    4|DECLARE RECURSIVE VIEW R(x INT);
+                    5|CREATE VIEW R AS SELECT x FROM recent UNION SELECT G.y FROM R JOIN G ON R.x = G.x;
+                                                                                              ^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:1: warning: Unbounded state: The state of a UNION in the code implementing view 'r' may grow without bound
+                    4|DECLARE RECURSIVE VIEW R(x INT);
+                    5|CREATE VIEW R AS SELECT x FROM recent UNION SELECT G.y FROM R JOIN G ON R.x = G.x;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    @Test
+    public void primaryKey() {
+        // The index of a table with a PRIMARY KEY grows with the table,
+        // unless the declaration bounds the table size
+        String program = """
+                CREATE TABLE events(id INT, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, name VARCHAR)%s;
+                CREATE VIEW V AS SELECT e.ts, c.name FROM events e JOIN customers c ON e.id = c.id;""";
+        // Only the first warning explains how to silence them
+        this.assertUnboundedStateWarnings(String.format(program, ""),
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, name VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE VIEW V AS SELECT e.ts, c.name FROM events e JOIN customers c ON e.id = c.id;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):3:72: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, name VARCHAR);
+                    3|CREATE VIEW V AS SELECT e.ts, c.name FROM events e JOIN customers c ON e.id = c.id;
+                                                                                             ^^^^^^^^^^^
+                """);
+        this.assertUnboundedStateWarnings(String.format(program, " WITH ('expected_size' = '1000')"),
+                """
+                (no input file): Unbounded state
+                (no input file):3:72: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, name VARCHAR) WITH ('expected_size' = '1000');
+                    3|CREATE VIEW V AS SELECT e.ts, c.name FROM events e JOIN customers c ON e.id = c.id;
+                                                                                             ^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void chainAggregateById() {
+        // One running value per group is still one per distinct id
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE T(id INT, x INT, flag BOOLEAN NOT NULL, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                CREATE VIEW V AS SELECT id, MAX(x) AS m FROM T GROUP BY id;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:29: warning: Unbounded state: The state of an aggregate in the code implementing view 'v' may grow without bound
+                    1|CREATE TABLE T(id INT, x INT, flag BOOLEAN NOT NULL, ts TIMESTAMP NOT NULL) WITH ('append_only' = 'true');
+                    2|CREATE VIEW V AS SELECT id, MAX(x) AS m FROM T GROUP BY id;
+                                                  ^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void maxWithoutGroupBy() {
+        // Unlike COUNT, MAX is not linear: to handle deletions it keeps the whole input
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT MAX(id) AS m FROM input;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:30: warning: Unbounded state: The state of an aggregate in the code implementing view 'output' may grow without bound
+                    1|CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                    2|CREATE VIEW output AS SELECT MAX(id) AS m FROM input;
+                                                   ^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void groupByElevenBooleans() {
+        // Eleven booleans admit 2048 groups, one doubling past MAX_KEY_VALUES
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE input(b0 BOOLEAN NOT NULL, b1 BOOLEAN NOT NULL, b2 BOOLEAN NOT NULL, b3 BOOLEAN NOT NULL,
+                                   b4 BOOLEAN NOT NULL, b5 BOOLEAN NOT NULL, b6 BOOLEAN NOT NULL, b7 BOOLEAN NOT NULL,
+                                   b8 BOOLEAN NOT NULL, b9 BOOLEAN NOT NULL, b10 BOOLEAN NOT NULL,
+                                   ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS
+                SELECT b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, COUNT(*) AS cnt
+                FROM input GROUP BY b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10;""",
+                """
+                (no input file): Unbounded state
+                (no input file):5:1: warning: Unbounded state: The state of an aggregate in the code implementing view 'output' may grow without bound
+                    5|CREATE VIEW output AS
+                    6|SELECT b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, COUNT(*) AS cnt
+                    7|FROM input GROUP BY b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void groupByManyBooleans() {
+        // Seven nullable booleans allow 3^7 = 2187 groups, more than the bound the analysis accepts
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE input(b0 BOOLEAN, b1 BOOLEAN, b2 BOOLEAN, b3 BOOLEAN, b4 BOOLEAN, b5 BOOLEAN, b6 BOOLEAN,
+                                   ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS
+                SELECT b0, b1, b2, b3, b4, b5, b6, COUNT(*) AS cnt FROM input GROUP BY b0, b1, b2, b3, b4, b5, b6;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of an aggregate in the code implementing view 'output' may grow without bound
+                    3|CREATE VIEW output AS
+                    4|SELECT b0, b1, b2, b3, b4, b5, b6, COUNT(*) AS cnt FROM input GROUP BY b0, b1, b2, b3, b4, b5, b6;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void limitThenAggregate() {
+        // ORDER BY x LIMIT 5 outputs at most five rows, so the aggregate over them has a
+        // bounded input and is not reported; the top-k itself still retains the whole input
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE T(x INT, y INT, flag BOOLEAN NOT NULL) WITH ('append_only' = 'true');
+                CREATE LOCAL VIEW top AS SELECT * FROM T ORDER BY x LIMIT 5;
+                CREATE VIEW V AS SELECT x, MAX(y) AS m FROM top GROUP BY x;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:1: warning: Unbounded state: The state of an ORDER BY with LIMIT in the code implementing view 'top' may grow without bound
+                    2|CREATE LOCAL VIEW top AS SELECT * FROM T ORDER BY x LIMIT 5;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    3|CREATE VIEW V AS SELECT x, MAX(y) AS m FROM top GROUP BY x;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void topKPerBoolean() {
+        // Three rows per value of a boolean partition key: a bounded output
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE T(x INT, y INT, flag BOOLEAN NOT NULL) WITH ('append_only' = 'true');
+                CREATE LOCAL VIEW top AS
+                SELECT * FROM (SELECT x, y, flag, ROW_NUMBER() OVER (PARTITION BY flag ORDER BY y) AS rn FROM T) WHERE rn <= 3;
+                CREATE VIEW V AS SELECT x, MAX(y) AS m FROM top GROUP BY x;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:35: warning: Unbounded state: The state of a window function in the code implementing view 'top' may grow without bound
+                    3|SELECT * FROM (SELECT x, y, flag, ROW_NUMBER() OVER (PARTITION BY flag ORDER BY y) AS rn FROM T) WHERE rn <= 3;
+                                                        ^^^^^^^^^^^^
+                    4|CREATE VIEW V AS SELECT x, MAX(y) AS m FROM top GROUP BY x;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void topKPerInteger() {
+        // Three rows per value of an integer partition key: as many rows as there are keys
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE T(x INT, y INT, flag BOOLEAN NOT NULL) WITH ('append_only' = 'true');
+                CREATE LOCAL VIEW top AS
+                SELECT * FROM (SELECT x, y, flag, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM T) WHERE rn <= 3;
+                CREATE VIEW V AS SELECT flag, MAX(y) AS m FROM top GROUP BY flag;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:35: warning: Unbounded state: The state of a window function in the code implementing view 'top' may grow without bound
+                    3|SELECT * FROM (SELECT x, y, flag, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM T) WHERE rn <= 3;
+                                                        ^^^^^^^^^^^^
+                    4|CREATE VIEW V AS SELECT flag, MAX(y) AS m FROM top GROUP BY flag;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):4:31: warning: Unbounded state: The state of an aggregate in the code implementing view 'v' may grow without bound
+                    3|SELECT * FROM (SELECT x, y, flag, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM T) WHERE rn <= 3;
+                    4|CREATE VIEW V AS SELECT flag, MAX(y) AS m FROM top GROUP BY flag;
+                                                    ^^^^^^
+                """);
+    }
+
+    @Test
+    public void orderByLimit() {
+        this.assertUnboundedStateWarnings(TABLES + "CREATE VIEW V AS SELECT * FROM T ORDER BY x LIMIT 5;",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of an ORDER BY with LIMIT in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT, y INT);
+                    3|CREATE VIEW V AS SELECT * FROM T ORDER BY x LIMIT 5;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void distinct() {
+        this.assertUnboundedStateWarnings(TABLES + "CREATE VIEW V AS SELECT DISTINCT x FROM T;",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of a DISTINCT in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT, y INT);
+                    3|CREATE VIEW V AS SELECT DISTINCT x FROM T;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void windowFunction() {
+        this.assertUnboundedStateWarnings(TABLES + """
+                CREATE VIEW V AS SELECT * FROM (SELECT x, y, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM T) WHERE rn <= 2;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:46: warning: Unbounded state: The state of a window function in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT, y INT);
+                    3|CREATE VIEW V AS SELECT * FROM (SELECT x, y, ROW_NUMBER() OVER (PARTITION BY x ORDER BY y) AS rn FROM T) WHERE rn <= 2;
+                                                                   ^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+
+    @Test
+    public void except() {
+        // EXCEPT applies DISTINCT to both inputs; the two identical warnings are reported once
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE T(x INT) WITH ('append_only' = 'true');
+                CREATE TABLE S(x INT);
+                CREATE VIEW V AS SELECT x FROM T EXCEPT SELECT x FROM S;""",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of a DISTINCT in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT);
+                    3|CREATE VIEW V AS SELECT x FROM T EXCEPT SELECT x FROM S;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of an EXCEPT in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT);
+                    3|CREATE VIEW V AS SELECT x FROM T EXCEPT SELECT x FROM S;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    @Test
+    public void exceptAll() {
+        this.assertUnboundedStateWarnings(TABLES + "CREATE VIEW V AS SELECT x FROM T EXCEPT ALL SELECT x FROM S;",
+                """
+                (no input file): Unbounded state
+                (no input file):3:1: warning: Unbounded state: The state of an EXCEPT ALL in the code implementing view 'v' may grow without bound
+                    2|CREATE TABLE S(x INT, y INT);
+                    3|CREATE VIEW V AS SELECT x FROM T EXCEPT ALL SELECT x FROM S;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                """);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
@@ -1,5 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.sql.streaming;
 
+import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
@@ -46,9 +48,23 @@ public class IncrementalUnboundedStateTests extends StreamingTestBase {
     /** Compile {@code sql} and check that the {@link FindUnboundedState#WARNING} warnings,
      * rendered as the compiler prints them, are exactly {@code expected}. */
     void assertUnboundedStateWarnings(String sql, String expected) {
-        var cc = this.getCC(sql);
+        this.assertUnboundedStateWarnings(this.getCC(sql).compiler, expected);
+    }
+
+    /** As {@link #assertUnboundedStateWarnings(String, String)}, compiling for the Gen-2 engine,
+     * whose indexed inputs drop the primary-key columns from the value. */
+    void assertUnboundedStateWarningsGen2(String sql, String expected) {
+        CompilerOptions options = this.testOptions();
+        options.ioOptions.gen2 = true;
+        DBSPCompiler compiler = new DBSPCompiler(options);
+        compiler.submitStatementsForCompilation(sql);
+        compiler.getFinalCircuit(false);
+        this.assertUnboundedStateWarnings(compiler, expected);
+    }
+
+    void assertUnboundedStateWarnings(DBSPCompiler compiler, String expected) {
         StringBuilder rendered = new StringBuilder();
-        for (CompilerMessages.Message message : cc.compiler.messages.messages)
+        for (CompilerMessages.Message message : compiler.messages.messages)
             if (message.warning && message.errorType.equals(FindUnboundedState.WARNING))
                 rendered.append(message);
         Assert.assertEquals(expected, rendered.toString());
@@ -120,6 +136,13 @@ public class IncrementalUnboundedStateTests extends StreamingTestBase {
         this.assertNoUnboundedStateWarnings("""
                 CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
                 CREATE VIEW output AS SELECT COUNT(*) AS cnt FROM input;""");
+    }
+
+    @Test
+    public void aggregateOverEmptyInput() {
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(id BIGINT NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT MIN(id) AS m FROM input WHERE false;""");
     }
 
     @Test
@@ -378,6 +401,179 @@ public class IncrementalUnboundedStateTests extends StreamingTestBase {
                     4|DECLARE RECURSIVE VIEW R(x INT);
                     5|CREATE VIEW R AS SELECT x FROM recent UNION SELECT G.y FROM R JOIN G ON R.x = G.x;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    /** A join of recent events with a table over its PRIMARY KEY, aggregated downstream */
+    static final String JOIN_ON_PRIMARY_KEY = """
+            CREATE TABLE events(id INT, customer INT, ts TIMESTAMP NOT NULL);
+            CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+            CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+            CREATE VIEW V AS
+            SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;""";
+
+    /** The warnings for {@link #JOIN_ON_PRIMARY_KEY}: each recent event matches at most one
+     * customer, so the join output is bounded like its event input and the aggregate downstream
+     * is not reported; the join itself still retains the whole customers table */
+    static final String JOIN_ON_PRIMARY_KEY_WARNINGS = """
+            (no input file): Unbounded state
+            (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+                               ^^^^^^^^^
+                3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+            Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+            See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+            (no input file): Unbounded state
+            (no input file):5:68: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                4|CREATE VIEW V AS
+                5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;
+                                                                                     ^^^^^^^^^^^^^^^^^
+            """;
+
+    @Test
+    public void joinOnPrimaryKey() {
+        this.assertUnboundedStateWarnings(JOIN_ON_PRIMARY_KEY, JOIN_ON_PRIMARY_KEY_WARNINGS);
+    }
+
+    /** The Gen-2 engine keeps the key columns of an indexed input only in its index */
+    @Test
+    public void joinOnPrimaryKeyGen2() {
+        this.assertUnboundedStateWarningsGen2(JOIN_ON_PRIMARY_KEY, JOIN_ON_PRIMARY_KEY_WARNINGS);
+    }
+
+    @Test
+    public void joinOnNonKeyColumn() {
+        // A join on a column that is not a key of customers can multiply the events,
+        // so the aggregate downstream is reported as well
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE events(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+                CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                CREATE VIEW V AS
+                SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.region_id GROUP BY c.region;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:68: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.region_id GROUP BY c.region;
+                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^
+                (no input file): Unbounded state
+                (no input file):4:1: warning: Unbounded state: The state of an aggregate in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.region_id GROUP BY c.region;
+                """);
+    }
+
+    @Test
+    public void leftJoinOnPrimaryKey() {
+        // A left join adds the unmatched left rows, which the bounded left input also bounds
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE events(id INT, customer INT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+                CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                CREATE VIEW V AS
+                SELECT c.region, COUNT(*) AS cnt FROM recent e LEFT JOIN customers c ON e.customer = c.id GROUP BY c.region;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region_id INT, region VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:73: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e LEFT JOIN customers c ON e.customer = c.id GROUP BY c.region;
+                                                                                              ^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    @Test
+    public void joinOnWidenedVarcharKey() {
+        // The join compares the VARCHAR(255) key cast to VARCHAR; the cast loses nothing,
+        // so the key analysis still sees the key and the aggregate is not reported
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE events(id INT, customer VARCHAR, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id VARCHAR(255) NOT NULL PRIMARY KEY, region VARCHAR);
+                CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                CREATE VIEW V AS
+                SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id VARCHAR(255) NOT NULL PRIMARY KEY, region VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:68: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;
+                                                                                         ^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    @Test
+    public void joinOnWidenedIntegerKey() {
+        // An INT key cast to BIGINT keeps its value and its comparison
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE events(id INT, customer BIGINT, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region VARCHAR);
+                CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                CREATE VIEW V AS
+                SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id INT NOT NULL PRIMARY KEY, region VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:68: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;
+                                                                                         ^^^^^^^^^^^^^^^^^
+                """);
+    }
+
+    @Test
+    public void joinOnCharKey() {
+        // CHAR comparisons ignore trailing spaces, so the cast of the CHAR(10) key to VARCHAR
+        // does not preserve the key and the aggregate downstream is reported
+        this.assertUnboundedStateWarnings("""
+                CREATE TABLE events(id INT, customer VARCHAR, ts TIMESTAMP NOT NULL);
+                CREATE TABLE customers(id CHAR(10) NOT NULL PRIMARY KEY, region VARCHAR);
+                CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                CREATE VIEW V AS
+                SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;""",
+                """
+                (no input file): Unbounded state
+                (no input file):2:14: warning: Unbounded state: The index of table 'customers' may grow without bound
+                    2|CREATE TABLE customers(id CHAR(10) NOT NULL PRIMARY KEY, region VARCHAR);
+                                   ^^^^^^^^^
+                    3|CREATE LOCAL VIEW recent AS SELECT * FROM events WHERE ts >= NOW() - INTERVAL 1 HOUR;
+                Silence these warnings with SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON
+                See https://docs.feldera.com/sql/streaming#unbounded-state-warnings
+                (no input file): Unbounded state
+                (no input file):5:68: warning: Unbounded state: The state of a JOIN in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;
+                                                                                         ^^^^^^^^^^^^^^^^^
+                (no input file): Unbounded state
+                (no input file):4:1: warning: Unbounded state: The state of an aggregate in the code implementing view 'v' may grow without bound
+                    4|CREATE VIEW V AS
+                    5|SELECT c.region, COUNT(*) AS cnt FROM recent e JOIN customers c ON e.customer = c.id GROUP BY c.region;
                 """);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraphsTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraphsTests.java
@@ -1,0 +1,59 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDeltaOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
+import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
+import org.dbsp.util.Linq;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/** Tests for the downstream search of {@link CircuitGraphs} */
+public class CircuitGraphsTests extends BaseSQLTests {
+    static final Predicate<DBSPOperator> IS_SINK = operator -> operator.is(DBSPSinkOperator.class);
+
+    /** The only operator of class {@code clazz} among {@code operators} */
+    static <T extends DBSPOperator> T single(Iterable<DBSPOperator> operators, Class<T> clazz) {
+        List<DBSPOperator> found = Linq.where(Linq.list(operators), operator -> operator.is(clazz));
+        Assert.assertEquals(found.toString(), 1, found.size());
+        return found.get(0).to(clazz);
+    }
+
+    @Test
+    public void searchCrossesRecursiveComponent() {
+        var cc = this.getCC("""
+                CREATE TABLE E(x INT);
+                DECLARE RECURSIVE VIEW R(x INT);
+                CREATE VIEW R AS SELECT x FROM E UNION SELECT x + 1 FROM R WHERE x < 10;""");
+        DBSPCircuit circuit = cc.getCircuit();
+        Graph graph = new Graph(cc.compiler);
+        graph.apply(circuit);
+        CircuitGraphs graphs = graph.getGraphs();
+
+        DBSPNestedOperator recursive = single(circuit.getAllOperators(), DBSPNestedOperator.class);
+        DBSPDistinctOperator distinct = single(recursive.getAllOperators(), DBSPDistinctOperator.class);
+        DBSPSinkOperator sink = circuit.getSink(cc.compiler.canonicalName("R", false));
+        Assert.assertNotNull(sink);
+
+        // The recursive circuit contains no sink...
+        Assert.assertNull(graphs.getGraph(recursive).closestSuccessor(distinct, IS_SINK));
+        // ...so the search continues from the recursive circuit in the root circuit
+        Assert.assertSame(sink, graphs.closestDownstream(recursive, distinct, IS_SINK));
+
+        // A match inside the recursive circuit ends the search there
+        DBSPDeltaOperator delta = single(recursive.getAllOperators(), DBSPDeltaOperator.class);
+        Assert.assertSame(distinct, graphs.closestDownstream(
+                recursive, delta, operator -> operator.is(DBSPDistinctOperator.class)));
+
+        // From the root circuit the search passes through the recursive circuit
+        DBSPSourceTableOperator source = single(circuit.getAllOperators(), DBSPSourceTableOperator.class);
+        Assert.assertSame(sink, graphs.closestDownstream(circuit, source, IS_SINK));
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysisTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysisTests.java
@@ -1,15 +1,25 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer.keys;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
-
-import org.dbsp.util.Logger;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitTransform;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Locale;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
 
-/** Tests for {@link KeyAnalysis}, using the logger to capture changes. */
+/** Tests for {@link KeyAnalysis}.  Each test compiles a program with a pass hooked into the
+ * optimizer before {@link LeftJoinChains}. */
 public class KeyAnalysisTests extends SqlIoTest {
     static final String TABLES = """
             CREATE TABLE t(a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY (a, b));
@@ -17,39 +27,57 @@ public class KeyAnalysisTests extends SqlIoTest {
             CREATE TABLE m(a INT NOT NULL, b INT, c INT);
             """;
 
-    /** Compile the program and return the analysis log */
-    private String compileLog(String view) {
-        StringBuilder builder = new StringBuilder();
-        Appendable save = Logger.INSTANCE.setDebugStream(builder);
-        Logger.INSTANCE.setLoggingLevel(KeyAnalysis.class, 1);
-        try {
-            DBSPCompiler compiler = this.testCompiler();
-            compiler.submitStatementsForCompilation(TABLES + view);
-            this.getCCS(compiler);
-        } finally {
-            Logger.INSTANCE.setLoggingLevel(KeyAnalysis.class, 0);
-            Logger.INSTANCE.setDebugStream(save);
+    /** A pass that analyzes the keys of the circuit it receives and keeps the circuit */
+    static class Analyzed implements CircuitTransform {
+        final KeyAnalysis keys;
+        @Nullable
+        DBSPCircuit circuit = null;
+
+        Analyzed(DBSPCompiler compiler) {
+            this.keys = new KeyAnalysis(compiler);
         }
-        return builder.toString();
+
+        @Override
+        public DBSPCircuit apply(DBSPCircuit circuit) {
+            this.keys.apply(circuit);
+            this.circuit = circuit;
+            return circuit;
+        }
+
+        @Override
+        public String getName() {
+            return "AnalyzeKeys";
+        }
+
+        /** The keys of view {@code v}, as printed */
+        String viewKeys() {
+            DBSPSinkOperator sink = Objects.requireNonNull(this.circuit).getSink(new ProgramIdentifier("v"));
+            Assert.assertNotNull("View v not found", sink);
+            return this.keys.getKeys(sink.input()).toString();
+        }
+
+        /** The keys of the only operator of class {@code clazz}, as printed */
+        <T extends DBSPSimpleOperator> String keysOf(Class<T> clazz) {
+            List<DBSPOperator> found = Objects.requireNonNull(this.circuit)
+                    .allOperators.stream().filter(clazz::isInstance).toList();
+            Assert.assertEquals("Operators of class " + clazz.getSimpleName(), 1, found.size());
+            return this.keys.getKeys(clazz.cast(found.get(0)).outputPort()).toString();
+        }
     }
 
-    /** Compile the program and return the keys the analysis reported for view {@code v}. */
-    private String viewKeys(String view) {
-        String log = this.compileLog(view);
-        String marker = "view v keys ";
-        String found = null;
-        for (String line : log.split("\n")) {
-            String lower = line.toLowerCase(Locale.ENGLISH);
-            if (lower.startsWith(marker))
-                found = line.substring(marker.length()).trim();
-        }
-        if (found == null)
-            throw new AssertionError("No keys reported for view v:\n" + log);
-        return found;
+    /** Compile the program and analyze its circuit as {@link LeftJoinChains} sees it */
+    private Analyzed analyze(String view) {
+        DBSPCompiler compiler = this.testCompiler();
+        Analyzed analyzed = new Analyzed(compiler);
+        compiler.optimizerHook = optimizer -> optimizer.insertBefore(LeftJoinChains.class, analyzed);
+        compiler.submitStatementsForCompilation(TABLES + view);
+        Assert.assertNotNull(compiler.getFinalCircuit(false));
+        Assert.assertNotNull("The optimizer did not reach LeftJoinChains", analyzed.circuit);
+        return analyzed;
     }
 
     private void assertKeys(String view, String expected) {
-        Assert.assertEquals(expected, this.viewKeys(view));
+        Assert.assertEquals(expected, this.analyze(view).viewKeys());
     }
 
     private void assertNoKeys(String view) {
@@ -210,9 +238,10 @@ public class KeyAnalysisTests extends SqlIoTest {
         // The TOP-1 partition columns are its index, and its value tuple repeats them, so
         // each of the seven values of the key is named by an index and a value column
         // This is an approximation of the true key, which has 2^7 members
-        String log = this.compileLog(view);
-        Assert.assertTrue(log, log.contains("[i0=v0, i1=v1, i2=v2, i3=v3, i4=v4, i5=v5, i6=v6]"));
-        this.assertKeys(view, "[[0, 1, 2, 3, 4, 5, 6]]");
+        Analyzed analyzed = this.analyze(view);
+        Assert.assertEquals("[[i0=v0, i1=v1, i2=v2, i3=v3, i4=v4, i5=v5, i6=v6]]",
+                analyzed.keysOf(DBSPIndexedTopKOperator.class));
+        Assert.assertEquals("[[0, 1, 2, 3, 4, 5, 6]]", analyzed.viewKeys());
     }
 
     /** Two independent keys: the primary key of the table, and the partition column of a
@@ -279,10 +308,10 @@ public class KeyAnalysisTests extends SqlIoTest {
         String view = """
                 CREATE VIEW v AS SELECT t.a, t.b, g.mx
                 FROM t LEFT JOIN (SELECT MAX(x) AS mx FROM s) g ON t.c < g.mx;""";
-        String log = this.compileLog(view);
-        Assert.assertTrue(log, log.contains("stream_join keys [[0, 1]]"));
-        Assert.assertTrue(log, log.contains("stream_antijoin keys [[v0, v1]]"));
-        this.assertNoKeys(view);
+        Analyzed analyzed = this.analyze(view);
+        Assert.assertEquals("[[0, 1]]", analyzed.keysOf(DBSPStreamJoinOperator.class));
+        Assert.assertEquals("[[v0, v1]]", analyzed.keysOf(DBSPStreamAntiJoinOperator.class));
+        Assert.assertEquals("[]", analyzed.viewKeys());
     }
 
     @Test


### PR DESCRIPTION
Fixes #7015 
Fixes #7045

The compiler will heuristically detect whether a program is a "Stream processing program" and provide warnings when it thinks the program can have "unbounded" state. There's a flag to turn such warnings off: 
`SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON`.

One can also annotate dimension tables with `expected_size` to indicate that they will have bounded sizes.

See the documentation and the test cases for example warnings.

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated
