### PR TITLE
[profiler] Display profile metric names consistently in all UI elements

### DIFF
--- a/js-packages/profiler-layout/src/lib/components/ProfilerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ProfilerLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Select } from 'common-ui'
+  import { measurementLabel } from 'profiler-lib'
   import type {
     Dataflow,
     JsonProfiles,
@@ -65,7 +66,9 @@
       tooltipData = data.match({
         some: (topNodes) => ({
           genericTable: {
-            header: `Nodes with highest values for the metric "${selectedMetricId}"`,
+            header: `Nodes with highest values for the metric "${measurementLabel(
+              selectedMetricId
+            )}"`,
             columns: ['Node', 'Value', 'Operation'],
             rows: topNodes.map((n) => ({
               stub: { text: n.nodeId, onclick: () => profilerDiagram?.search(n.nodeId) },

--- a/js-packages/profiler-layout/src/lib/components/ProfilerTooltip.svelte
+++ b/js-packages/profiler-layout/src/lib/components/ProfilerTooltip.svelte
@@ -1,6 +1,11 @@
 <script lang="ts" module>
   import type { NodeAttributes, TooltipRow } from 'profiler-lib'
-  import { measurementCategory, measurementDescription, shadeOfRed } from 'profiler-lib'
+  import {
+    measurementCategory,
+    measurementDescription,
+    measurementLabel,
+    shadeOfRed
+  } from 'profiler-lib'
   import { SvelteSet } from 'svelte/reactivity'
   import { groupBy } from '$lib/functions/array'
 
@@ -116,7 +121,9 @@
                                                 class:current-metric={row.isCurrentMetric}
                                                 title={measurementDescription(
                                                     row.metric,
-                                                ).description}>{row.metric}</td
+                                                ).description}>{measurementLabel(
+                                                    row.metric,
+                                                )}</td
                                             >
                                             {#each row.cells as cell}
                                                 {@const percent =

--- a/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
+++ b/js-packages/profiler-layout/src/lib/components/SupportBundleViewerLayout.svelte
@@ -14,6 +14,7 @@
     useShortcut
   } from 'common-ui'
   import { Pane, PaneGroup, PaneResizer } from 'paneforge'
+  import { measurementLabel } from 'profiler-lib'
   import type {
     Dataflow,
     JsonProfiles,
@@ -184,7 +185,7 @@
       tooltipData = data.match({
         some: (topNodes) => ({
           genericTable: {
-            header: `Nodes with highest values for "${selectedMetricId}"`,
+            header: `Nodes with highest values for "${measurementLabel(selectedMetricId)}"`,
             columns: ['Node', 'Value', 'Operation'],
             rows: topNodes.map((n) => ({
               stub: { text: n.nodeId, onclick: () => profilerDiagram?.search(n.nodeId) },

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
@@ -4,7 +4,12 @@
 // (`ProfileMetricDescription::category`). Every block renders as a distribution.
 
 import type { NodeAttributes, TooltipRow } from 'profiler-lib'
-import { measurementCategory, measurementDescription } from 'profiler-lib'
+import {
+  compareMetrics,
+  measurementCategory,
+  measurementDescription,
+  measurementLabel
+} from 'profiler-lib'
 
 export type RenderableMetric = {
   row: TooltipRow
@@ -18,15 +23,6 @@ export type RenderableBlock = {
 }
 
 const UNCATEGORIZED = 'Other'
-
-const labelFor = (id: string): string => {
-  // Humanize id: replace separators with spaces, capitalize first letter.
-  const cleaned = id.replace(/[_.]/g, ' ').replace(/\s+/g, ' ').trim()
-  if (cleaned.length === 0) {
-    return id
-  }
-  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
-}
 
 const slugify = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, '-')
 
@@ -45,17 +41,19 @@ export function buildBlocks(attrs: NodeAttributes, showAdvanced: boolean): Rende
     }
     bucket.push({
       row,
-      label: labelFor(row.metric)
+      label: measurementLabel(row.metric)
     })
   }
 
   // Sort metrics inside each block by their displayed label so users can scan a long block
-  // without re-reading the whole thing. Locale-aware compare with `numeric: true`
-  // keeps numbered labels like "slot 2 ..." / "slot 10 ..." in their natural sequence.
-  const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true })
+  // without re-reading the whole thing. `compareMetrics` is the order the metric selector uses
+  // as well, so a metric sits in the same relative position in both.
   for (const entries of byCategory.values()) {
-    entries.sort(
-      (a, b) => collator.compare(a.label, b.label) || collator.compare(a.row.metric, b.row.metric)
+    entries.sort((a, b) =>
+      compareMetrics(
+        { id: a.row.metric, label: a.label },
+        { id: b.row.metric, label: b.label }
+      )
     )
   }
 

--- a/js-packages/profiler-lib/src/index.ts
+++ b/js-packages/profiler-lib/src/index.ts
@@ -15,6 +15,8 @@ export {
 export {
     measurementCategory,
     measurementDescription,
+    measurementLabel,
+    compareMetrics,
     CircuitProfile,
     PropertyValue,
     MissingValue,

--- a/js-packages/profiler-lib/src/metadataSelection.test.ts
+++ b/js-packages/profiler-lib/src/metadataSelection.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The metric selector lists the metrics a profile carries. Issue 6991: it listed the raw ids
+ * (`spine_storage_size_bytes`) while the table of values spelled them out ("Spine storage size
+ * bytes"), so the same metric appeared under two names. Both now go through `measurementLabel`.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { MetadataSelector } from './metadataSelection.js'
+import { CircuitProfile, compareMetrics, type JsonProfiles } from './profile.js'
+import type { MetricOption, ProfilerCallbacks } from './profiler.js'
+
+// One operator carrying a byte metric, a percentage, and a composite batch-size summary.
+const profile = (() => {
+    const metadata = {
+        nn1: [
+            { metric_id: 'spine_storage_size_bytes', value: { type: 'bytes', value: 2048 } },
+            { metric_id: 'runtime_percent', value: { type: 'percent', value: { numerator: 1, denominator: 4 } } },
+            {
+                metric_id: 'input_batches_stats',
+                value: {
+                    batches_count: { type: 'count', value: 2 },
+                    min_records_count: { type: 'count', value: 1 },
+                    max_records_count: { type: 'count', value: 9 },
+                    avg_records_count: { type: 'count', value: 5 },
+                    total_records_count: { type: 'count', value: 10 }
+                }
+            }
+        ]
+    }
+    const json = {
+        metrics: [],
+        worker_profiles: [{ metadata }],
+        graph: {
+            nodes: { id: 'n', label: 'root', nodes: [{ Simple: { id: 'nn1', label: 'op' } }] },
+            edges: []
+        }
+    }
+    return CircuitProfile.fromJson(json as unknown as JsonProfiles).profile
+})()
+
+const options = (): MetricOption[] => {
+    let listed: MetricOption[] = []
+    const callbacks = {
+        onMetricsChanged: (metrics: MetricOption[]) => {
+            listed = metrics
+        }
+    } as unknown as ProfilerCallbacks
+    new MetadataSelector(profile, callbacks).initialize()
+    return listed
+}
+
+describe('MetadataSelector metric options', () => {
+    it('labels each metric the way the tables spell it', () => {
+        const byId = new Map(options().map((o) => [o.id, o.label]))
+        expect(byId.get('spine_storage_size_bytes')).toBe('Spine storage size bytes')
+        expect(byId.get('runtime_percent')).toBe('Runtime percent')
+        expect(byId.get('input_batches_stats.min_size')).toBe('Input batches stats min size')
+    })
+
+    it('keeps the id as the value the selector reports back', () => {
+        // The label is for reading; selection still travels by id.
+        for (const option of options()) {
+            expect(profile.simpleNodes.get('nn1').unwrap().getMeasurements(option.id).length)
+                .toBeGreaterThan(0)
+        }
+    })
+
+    it('lists the metrics in the order the tables use', () => {
+        const listed = options().map((o) => ({ id: o.id, label: o.label }))
+        expect(listed).toEqual([...listed].sort(compareMetrics))
+    })
+})

--- a/js-packages/profiler-lib/src/metadataSelection.ts
+++ b/js-packages/profiler-lib/src/metadataSelection.ts
@@ -1,7 +1,7 @@
 // Selector tool to decide which circuit metadata to use for visualizations
 
 import { SubList } from "./util.js";
-import { CircuitProfile } from "./profile.js";
+import { CircuitProfile, compareMetrics, measurementLabel } from "./profile.js";
 import type { ProfilerCallbacks, MetricOption, WorkerOption } from "./profiler.js";
 
 /** Describes which metadata from a circuit to display. */
@@ -63,10 +63,11 @@ export class MetadataSelector {
     }
 
     notifyMetricsChanged() {
-        const metrics: MetricOption[] = Array.from(this.allMetrics).sort().map(metric => ({
-            id: metric,
-            label: metric
-        }));
+        // Ordered the way the metrics tables order their rows: by the name shown, and by id
+        // where two ids spell the same name.
+        const metrics: MetricOption[] = Array.from(this.allMetrics)
+            .map(metric => ({ id: metric, label: measurementLabel(metric) }))
+            .sort(compareMetrics);
         this.callbacks.onMetricsChanged(metrics, this.selectedMetric);
     }
 

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -16,11 +16,83 @@ import {
     SimpleNode,
     StringValue,
     TimeValue,
+    compareMetrics,
+    measurementLabel,
     totalShare,
     type JsonProfiles
 } from './profile.js'
 import type { Dataflow } from './dataflow.js'
 import { NumericRange, Option } from './util.js'
+
+// Issue 6991: the metric selector showed `spine_storage_size_bytes` while the table of values
+// showed "Spine storage size bytes". One helper now names a metric for every place on screen.
+describe('measurementLabel', () => {
+    it('spells out a metric id', () => {
+        expect(measurementLabel('spine_storage_size_bytes')).toBe('Spine storage size bytes')
+        expect(measurementLabel('runtime_percent')).toBe('Runtime percent')
+    })
+
+    it('spells out the parts of a composite metric', () => {
+        // Suffixes are joined with a dot, and labels the runtime attaches carry a colon.
+        expect(measurementLabel('input_batches_stats.min_size')).toBe('Input batches stats min size')
+        expect(measurementLabel('completed_merges.slot:0.steps')).toBe('Completed merges slot:0 steps')
+    })
+
+    it('leaves a legacy name readable', () => {
+        // Legacy ids are spelled with spaces and slashes already.
+        expect(measurementLabel('input batches/min size')).toBe('Input batches/min size')
+        expect(measurementLabel('time%')).toBe('Time%')
+    })
+
+    it('returns the id when there is nothing to spell out', () => {
+        expect(measurementLabel('')).toBe('')
+        expect(measurementLabel('_')).toBe('_')
+    })
+})
+
+// What the transformation cannot know, pinned so a change to it is deliberate. The runtime
+// attaches labels as `key:value` pairs joined with dots (`slot` and `input` today, both numeric),
+// and the label spells every `_` and `.` as a space.
+describe('measurementLabel on names it cannot parse', () => {
+    it('spells out an underscore inside a label value too', () => {
+        // Nothing in the id says which underscores separate words and which belong to a value.
+        expect(measurementLabel('completed_merges.endpoint:kafka_input.steps'))
+            .toBe('Completed merges endpoint:kafka input steps')
+    })
+
+    it('spells two different ids the same way', () => {
+        // `_` and `.` both become spaces, so ids that differ only in their separator collide.
+        // Selection travels by id, so the two stay distinct everywhere but on screen.
+        expect(measurementLabel('a_b')).toBe(measurementLabel('a.b'))
+    })
+})
+
+describe('compareMetrics', () => {
+    const metric = (id: string) => ({ id, label: measurementLabel(id) })
+    const order = (ids: string[]) => ids.map(metric).sort(compareMetrics).map((m) => m.id)
+
+    it('reads digit runs as numbers', () => {
+        expect(order([
+            'loose_batches_count.slot:10',
+            'loose_batches_count.slot:2',
+            'loose_batches_count.slot:1'
+        ])).toEqual([
+            'loose_batches_count.slot:1',
+            'loose_batches_count.slot:2',
+            'loose_batches_count.slot:10'
+        ])
+    })
+
+    it('breaks a tie on the id, so ids that spell one label still have a fixed order', () => {
+        // Which of the two leads is the collator's business; that the answer does not depend on
+        // the order they arrived in is what a list needs.
+        expect(order(['a.b', 'a_b'])).toEqual(order(['a_b', 'a.b']))
+    })
+
+    it('ignores case, as the tables do', () => {
+        expect(order(['beta_count', 'Alpha_count'])).toEqual(['Alpha_count', 'beta_count'])
+    })
+})
 
 describe('CircuitProfile.isTop', () => {
     it('recognises the toplevel node by the parsed root id', () => {

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -1006,6 +1006,30 @@ export function measurementCategory(prop: string): string {
     return legacyMeasurementCategory(prop);
 }
 
+/** The name of a measurement as shown to a user: the metric id with its separators turned into
+ * spaces and the first letter capitalized, so `spine_storage_size_bytes` reads "Spine storage
+ * size bytes".  Every place that names a metric on screen uses this, so the metric selector and
+ * the tables agree. */
+export function measurementLabel(prop: string): string {
+    const spelled = prop.replace(/[_.]/g, " ").replace(/\s+/g, " ").trim();
+    if (spelled.length === 0) {
+        return prop;
+    }
+    return spelled.charAt(0).toUpperCase() + spelled.slice(1);
+}
+
+/** Compares the names a reader sees, with digit runs read as numbers so "Slot 2" comes before
+ * "Slot 10", and case ignored. */
+const metricCollator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true });
+
+/** Order two metrics the way every list of them is ordered.  The id breaks a tie: two ids can
+ * spell one label, since `measurementLabel` turns both `_` and `.` into spaces. */
+export function compareMetrics(
+    a: { id: string, label: string },
+    b: { id: string, label: string }): number {
+    return metricCollator.compare(a.label, b.label) || metricCollator.compare(a.id, b.id);
+}
+
 /** Return a description of the measurement and a boolean indicating whether the measurements is "advanced" */
 export function measurementDescription(prop: string): { description: string, advanced: boolean } {
     let info = MetricDescriptions.getMetricInfo(stripSuffix(prop));


### PR DESCRIPTION
### Describe Manual Test Plan

<img width="529" height="323" alt="image" src="https://github.com/user-attachments/assets/6c3528c0-b268-4c42-ad48-a4a01ad6b97f" />

## Checklist

- [x] Unit tests added/updated

Fixes #6991 

Some ui elements would display "input_records", some would display "Input records". Now they all go through the same function.