### PR TITLE
[profiler] Highlight the current metric for the current node

### DIFF
--- a/js-packages/profiler-layout/package.json
+++ b/js-packages/profiler-layout/package.json
@@ -14,7 +14,7 @@
     "check:watch": "svelte-kit sync && svelte-check --threshold error --watch",
     "test": "vitest --run",
     "test-watch": "vitest",
-    "test-unit": "vitest --run --project component --project unit",
+    "test-unit": "vitest --run --project unit --project component --project browser",
     "test-component": "vitest --run --project component",
     "format": "biome check --write ."
   },

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte
@@ -59,6 +59,7 @@
         metricId={entry.row.metric}
         cells={entry.row.cells}
         total={entry.row.total}
+        current={entry.row.isCurrentMetric}
         expanded={isExpanded(entry)}
         onToggle={() => toggle(entry)}
       />
@@ -82,6 +83,7 @@
     --skew-low: var(--color-surface-600);
     --skew-high: var(--color-error-500);
     --header-bg: white;
+    --current-bg: var(--color-tertiary-50);
   }
   :global(.dark) .metrics-block,
   :global(body.dark) .metrics-block {
@@ -89,5 +91,6 @@
     --bar-high: var(--color-error-700);
     --skew-low: var(--color-surface-400);
     --header-bg: var(--color-dark);
+    --current-bg: var(--color-tertiary-950);
   }
 </style>

--- a/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/blocks/MetricsDistributionBlock.svelte.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { CountValue, PercentValue, type TooltipRow } from 'profiler-lib'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import type { RenderableMetric } from '../dispatch'
 import MetricsDistributionBlock from './MetricsDistributionBlock.svelte'
@@ -170,5 +170,100 @@ describe('MetricsDistributionBlock total column', () => {
     })
     // The rate's Avg is the pooled 2/6, not the mean of the two rates.
     expect(texts(container)).toEqual(['20', '10', '30', '40', '33.3%', '25.0%', '50.0%', ''])
+  })
+})
+
+// Issue 6990: the diagram is colored by one metric, and reading its value meant hunting for the
+// row. That row is banded so it stands out; `dispatch` also floats it to the top.
+//
+// The band's color comes from a theme token through a custom property. Asserting the class
+// string cannot catch a typo in the property name or a token leaving the theme, so these tests
+// load the real stylesheets and read the color the browser resolved.
+describe('MetricsDistributionBlock selected metric', () => {
+  const rows = [
+    entry('records', { cells: cells([new CountValue(10)]), isCurrentMetric: true }),
+    entry('bytes', { cells: cells([new CountValue(20)]) })
+  ]
+
+  const themed = async (theme: 'light' | 'dark') => {
+    await import('../../../../routes/layout.css')
+    await import('feldera-theme/feldera-modern.css')
+    document.documentElement.dataset.theme = 'feldera-modern-theme'
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    return render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: rows }
+    })
+  }
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark')
+    delete document.documentElement.dataset.theme
+  })
+
+  // One subgrid element per row, marked for assistive technology as the current one.
+  const rowElements = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.metrics-block > div > div > div')).filter((el) =>
+      el.className.includes('grid-cols-subgrid')
+    ) as HTMLElement[]
+
+  it('marks the current metric and no other', async () => {
+    const { container } = await themed('light')
+    expect(
+      rowElements(container).map((row) => [
+        row.textContent?.trim().startsWith('records') ? 'records' : 'bytes',
+        row.getAttribute('aria-current')
+      ])
+    ).toEqual([
+      ['records', 'true'],
+      ['bytes', null]
+    ])
+  })
+
+  it('paints the current row in the theme blue and leaves the rest unpainted', async () => {
+    const { container } = await themed('light')
+    const [selected, other] = rowElements(container)
+    // tertiary-50, the palette's palest blue; primary is pink in this theme.
+    expect(getComputedStyle(selected!).backgroundColor).toBe('oklch(0.9535 0.02 274.08)')
+    expect(getComputedStyle(other!).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('paints it a dark blue in dark mode', async () => {
+    const { container } = await themed('dark')
+    const [selected] = rowElements(container)
+    expect(getComputedStyle(selected!).backgroundColor).toBe('oklch(0.3449 0.13 266.38)')
+  })
+
+  it('bands the row in one piece, its columns lining up with the header', async () => {
+    const { container } = await themed('light')
+    const [selected] = rowElements(container)
+    // A subgrid row borrows the block's columns, so one background covers the cells and the gaps
+    // between them, and the cells stay under their headers.
+    expect(getComputedStyle(selected!).display).toBe('grid')
+    const header = Array.from(container.querySelectorAll('.sticky')).find(
+      (h) => h.textContent?.trim() === 'Total'
+    ) as HTMLElement
+    const totalCell = selected!.querySelectorAll('.value-cell')[3] as HTMLElement
+    expect(totalCell.getBoundingClientRect().left).toBeCloseTo(
+      header.getBoundingClientRect().left,
+      0
+    )
+  })
+
+  it('leaves the histogram under the current row uncolored', async () => {
+    const { container } = await themed('light')
+    // The bars carry their own scale; a band behind them would compete with it.
+    for (const chart of container.querySelectorAll('.bar-chart')) {
+      expect(getComputedStyle(chart).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    }
+  })
+
+  it('paints nothing when no metric is current', async () => {
+    document.documentElement.dataset.theme = 'feldera-modern-theme'
+    const { container } = render(MetricsDistributionBlock, {
+      props: { id: 'b', title: 'State', entries: [rows[1]!] }
+    })
+    const [only] = rowElements(container)
+    expect(only!.getAttribute('aria-current')).toBeNull()
+    expect(getComputedStyle(only!).backgroundColor).toBe('rgba(0, 0, 0, 0)')
   })
 })

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.test.ts
@@ -2,19 +2,19 @@ import type { NodeAttributes, TooltipRow } from 'profiler-lib'
 import { describe, expect, it } from 'vitest'
 import { buildBlocks } from './dispatch.js'
 
-function row(metric: string): TooltipRow {
-  return { metric, isCurrentMetric: false, cells: [] }
+function row(metric: string, isCurrentMetric = false): TooltipRow {
+  return { metric, isCurrentMetric, cells: [] }
 }
 
 // Minimal NodeAttributes carrying only a list of metric rows; all other fields
 // are empty since these tests exercise just the ordering of metrics.
-function makeAttrs(metrics: string[]): NodeAttributes {
+function makeAttrs(metrics: string[], current?: string): NodeAttributes {
   return {
     title: 'n op',
     isRegion: false,
     nodeId: 'n',
     columns: [],
-    rows: metrics.map(row),
+    rows: metrics.map((metric) => row(metric, metric === current)),
     attributes: new Map()
   }
 }
@@ -42,5 +42,35 @@ describe('buildBlocks', () => {
     const blocks = buildBlocks(attrs, true)
     const labels = blocks.flatMap((b) => b.entries.map((e) => e.label))
     expect(labels).toEqual(['Slot 1 loose', 'Slot 2 loose', 'Slot 10 loose'])
+  })
+})
+
+// Issue 6990: the metric the diagram is colored by was buried in an alphabetical list
+describe('buildBlocks puts the selected metric first', () => {
+  it('leads its block, ahead of labels that sort before it', () => {
+    const attrs = makeAttrs(['alpha_count', 'beta_count', 'zeta_count'], 'zeta_count')
+    const [block] = buildBlocks(attrs, true)
+    expect(block!.entries.map((e) => e.row.metric)).toEqual([
+      'zeta_count',
+      'alpha_count',
+      'beta_count'
+    ])
+  })
+
+  it('leads the panel, whichever category it belongs to', () => {
+    // 'total size' is a memory metric and 'time' a CPU one, so they land in different blocks;
+    // the selected one decides which block comes first.
+    const metrics = ['total size', 'time']
+    const first = (current: string) => buildBlocks(makeAttrs(metrics, current), true)[0]!
+    expect(first('time').entries[0]!.row.metric).toBe('time')
+    expect(first('total size').entries[0]!.row.metric).toBe('total size')
+    // Two blocks either way: the selected metric moves to the front, stays in its category.
+    expect(buildBlocks(makeAttrs(metrics, 'time'), true)).toHaveLength(2)
+  })
+
+  it('leaves the order alone when no metric is selected', () => {
+    const attrs = makeAttrs(['alpha_count', 'beta_count'])
+    const [block] = buildBlocks(attrs, true)
+    expect(block!.entries.map((e) => e.row.metric)).toEqual(['alpha_count', 'beta_count'])
   })
 })

--- a/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
+++ b/js-packages/profiler-layout/src/lib/components/metrics/dispatch.ts
@@ -45,21 +45,27 @@ export function buildBlocks(attrs: NodeAttributes, showAdvanced: boolean): Rende
     })
   }
 
-  // Sort metrics inside each block by their displayed label so users can scan a long block
-  // without re-reading the whole thing. `compareMetrics` is the order the metric selector uses
-  // as well, so a metric sits in the same relative position in both.
+  // Sort metrics inside each block by their displayed label, placing the current metric first.
+  // `compareMetrics` is the order the metric selector uses as well, so a metric sits in the same
+  // relative position in both.
   for (const entries of byCategory.values()) {
-    entries.sort((a, b) =>
-      compareMetrics(
-        { id: a.row.metric, label: a.label },
-        { id: b.row.metric, label: b.label }
-      )
+    entries.sort(
+      (a, b) =>
+        Number(b.row.isCurrentMetric) - Number(a.row.isCurrentMetric) ||
+        compareMetrics({ id: a.row.metric, label: a.label }, { id: b.row.metric, label: b.label })
     )
   }
 
   const out: RenderableBlock[] = []
   for (const [category, entries] of byCategory) {
     out.push({ id: `category-${slugify(category)}`, title: category, entries })
+  }
+  // Its block leads the panel, so the current metric's value is the first on screen.
+  const holdsCurrent = out.findIndex((block) =>
+    block.entries.some((entry) => entry.row.isCurrentMetric)
+  )
+  if (holdsCurrent > 0) {
+    out.unshift(...out.splice(holdsCurrent, 1))
   }
   return out
 }

--- a/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
+++ b/js-packages/profiler-layout/src/lib/components/metrics/parts/BarChartMetric.svelte
@@ -14,10 +14,17 @@
      * maxima, flags and settings, whose column stays blank. `percentile` is where the total
      * stands, which `profiler-lib` computes; it drives the cell's heat-map background. */
     total?: TooltipCell | undefined
+    /** True for the current metric. */
+    current?: boolean
     expanded: boolean
     onToggle: () => void
   }
-  const { label, metricId, cells, total, expanded, onToggle }: Props = $props()
+  const { label, metricId, cells, total, current = false, expanded, onToggle }: Props = $props()
+
+  // The cells of a row are placed by the block's grid. To paint one unbroken band behind
+  // them, gaps included, they sit in a subgrid row that borrows the block's columns and
+  // carries the background itself. The per-worker histogram drawn below keeps the card's own background.
+  const band = $derived(current ? 'bg-[var(--current-bg)]' : '')
 
   /**
    * Collapsed-view preview style (avg/min/max numbers show in both):
@@ -112,52 +119,56 @@
   const showValues = true
 </script>
 
-<!-- Col 1: label -->
-<div class="col-span-1 flex min-w-0 items-baseline gap-3 pt-1">
-  <span class="truncate text-sm font-medium text-surface-900-100">{label}</span>
-  <Popover>
-    <div>{label}</div>
-    <div class="text-sm text-surface-700-300">{metricId}</div>
-  </Popover>
-</div>
-<!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
-     collapse/expand doesn't reflow the grid mid-transition. -->
-{#each [display.avg, display.min, display.max] as stat}
-<div
-  class="value-cell text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
-  aria-hidden={!showValues}
->
-  {stat.toString()}
-</div>
-{/each}
-<!-- Col 5: total, blank for metrics that do not add up. Its background is a heat map over the
-     standing `profiler-lib` computed: the largest saturates to `--bar-high`, the smallest stays
-     at `--bar-low`. Past the top of that range the fill is dark enough that the text turns
-     white to stay readable. -->
-<div
-  class="value-cell rounded-sm px-1 text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
-  style:background-color={total ? heatColor(total.percentile / 100) : 'transparent'}
-  style:color={total ? heatTextColor(total.percentile / 100) : undefined}
-  aria-hidden={!showValues}
->
-  {total ? total.value.toString() : ''}
-</div>
-<!-- Col 5: skew toggle — always present, always pinned to the top-right -->
-<div class="flex items-center justify-end">
-  <button
-    type="button"
-    onclick={onToggle}
-    class="flex items-center gap-1 text-sm"
+<!-- One grid row: the six cells, on a subgrid so the band behind them is unbroken. -->
+<div class="col-span-6 grid grid-cols-subgrid items-baseline {band}" aria-current={current ? 'true' : undefined}>
+  <!-- Col 1: label -->
+  <div class="col-span-1 flex min-w-0 items-baseline gap-3 pt-1">
+    <span class="truncate text-sm text-surface-900-100 {current ? 'font-semibold' : 'font-medium'}"
+    >{label}</span>
+    <Popover>
+      <div>{label}</div>
+      <div class="text-sm text-surface-700-300">{metricId}</div>
+    </Popover>
+  </div>
+  <!-- Cols 2-4: avg / min / max. Always rendered (same grid slots), opacity-driven visibility so
+       collapse/expand doesn't reflow the grid mid-transition. -->
+  {#each [display.avg, display.min, display.max] as stat}
+  <div
+    class="value-cell text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
+    aria-hidden={!showValues}
   >
-    <span class="tabular-nums text-nowrap" style:color={skewTextColor(skew)}>
-      Skew {skew.toFixed(0)}%
-    </span>
-    <span
-      class="fd fd-chevron-down text-[16px] chevron text-surface-600-400"
-      class:rotate-180={expanded}
-      aria-hidden="true"
-    ></span>
-  </button>
+    {stat.toString()}
+  </div>
+  {/each}
+  <!-- Col 5: total, blank for metrics that do not add up. Its background is a heat map over the
+       standing `profiler-lib` computed: the largest saturates to `--bar-high`, the smallest stays
+       at `--bar-low`. Past the top of that range the fill is dark enough that the text turns
+       white to stay readable. -->
+  <div
+    class="value-cell rounded-sm px-1 text-right text-sm tabular-nums text-surface-900-100 {showValues ? 'opacity-100' : 'opacity-0'}"
+    style:background-color={total ? heatColor(total.percentile / 100) : 'transparent'}
+    style:color={total ? heatTextColor(total.percentile / 100) : undefined}
+    aria-hidden={!showValues}
+  >
+    {total ? total.value.toString() : ''}
+  </div>
+  <!-- Col 5: skew toggle — always present, always pinned to the top-right -->
+  <div class="flex items-center justify-end">
+    <button
+      type="button"
+      onclick={onToggle}
+      class="flex items-center gap-1 text-sm"
+    >
+      <span class="tabular-nums text-nowrap" style:color={skewTextColor(skew)}>
+        Skew {skew.toFixed(0)}%
+      </span>
+      <span
+        class="fd fd-chevron-down text-[16px] chevron text-surface-600-400"
+        class:rotate-180={expanded}
+        aria-hidden="true"
+      ></span>
+    </button>
+  </div>
 </div>
 
 <!-- Bar chart row spans full block width; container height + each bar height animate.


### PR DESCRIPTION
Fixes #6990 

When you choose a metric to highlight for all nodes, the metric is also highlighted in the table for the CURRENT node (if the node has a value for that metric). The metric is also always displayed first, so one does not need to scroll. In this picture the current metric is "invocations count"

### Describe Manual Test Plan

<img width="1494" height="400" alt="image" src="https://github.com/user-attachments/assets/f0cbc63b-53a6-477f-aec4-362cac014fa2" />

## Checklist

- [x] Unit tests added/updated
