### PR TITLE
[SQL] Do not build TopK operators that carry duplicate columns

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -175,7 +175,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPDirectComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPEqualityComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
-import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPNoComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
@@ -1328,173 +1327,6 @@ public class CalciteToDBSPCompiler extends RelVisitor
         return filter;
     }
 
-    /** Keeps track of the fields of a tuple that are used as key fields.
-     * Note that key fields may be duplicated.
-     * E.g., a key may contain fields 1, 3, and 1 of a tuple of size 5, in this order.
-     * [_, 0 and 2, _, 1, _]. */
-    static class KeyFields {
-        /** Indexes of fields that belong to the key, in the order they appear in the key: [1, 3, 1] */
-        private final List<Integer> keyFields;
-        private final Set<Integer> keyFieldSet;
-
-        public KeyFields() {
-            this.keyFieldSet = new HashSet<>();
-            this.keyFields = new ArrayList<>();
-        }
-
-        public KeyFields(KeyFields other) {
-            this.keyFieldSet = new HashSet<>(other.keyFieldSet);
-            this.keyFields = new ArrayList<>(other.keyFields);
-        }
-
-        public boolean isKeyField(int i) {
-            return this.keyFieldSet.contains(i);
-        }
-
-        /** Call this function to add key fields in the order they appear in the key */
-        public void add(int index) {
-            this.keyFieldSet.add(index);
-            this.keyFields.add(index);
-        }
-
-        public void addAll(List<Integer> indexes) {
-            for (int i: indexes)
-                this.add(i);
-        }
-
-        public void addAllUsed(@Nullable FieldUseMap map) {
-            if (map == null)
-                return;
-            if (map.isRef())
-                map = map.deref();
-            this.addAll(map.getUsedFields());
-        }
-
-        /** Extract the non-key fields from a value into a tuple, in the order they appear in the tuple.
-         * For our example, the result will be [e.0, e.2, e.4]
-         *
-         * @param e Expression that is a reference to a tuple.
-         * @return  A tuple containing just the non-key fields, in order.
-         */
-        DBSPTupleExpression nonKeyFields(DBSPExpression e) {
-            // Almost like nonKeyFields with 3 arguments, except we don't insert casts ever
-            // return this.nonKeyFields(var, e.getType().to(DBSPTypeTupleBase.class), 0);
-            List<DBSPExpression> fields = new ArrayList<>();
-            DBSPTypeTupleBase tuple = e.getType().to(DBSPTypeTupleBase.class);
-            for (int i = 0; i < tuple.size(); i++) {
-                if (this.isKeyField(i))
-                    continue;
-                fields.add(e.field(i).applyCloneIfNeeded());
-            }
-            return new DBSPTupleExpression(fields, false);
-        }
-
-        /** Extract the non-key fields from a value into a tuple, and insert casts if needed.
-         * For our example, the result will be [(desiredType[0])e.0, (desiredType[1])e.2, (desiredType[2])e.4]
-         *
-         * @param e        Expression that is a reference to a tuple.
-         * @param desiredType Type to cast resulting tuple to.
-         * @return          A tuple containing just the non-key fields, in order.
-         */
-        DBSPTupleExpression nonKeyFields(DBSPExpression e, DBSPTypeTupleBase desiredType) {
-            List<DBSPExpression> fields = new ArrayList<>();
-            Utilities.enforce(e.getType().getToplevelFieldCount() >= desiredType.size());
-            for (int i = 0; i < desiredType.size(); i++) {
-                if (this.isKeyField(i))
-                    continue;
-                fields.add(e.field(i)
-                        .applyCloneIfNeeded()
-                        .nullabilityCast(desiredType.getFieldType(i), DBSPCastExpression.CastType.SqlUnsafe));
-            }
-            return new DBSPTupleExpression(fields, false);
-        }
-
-        /** Extract the key fields from a value (e), in the order they have to appear in the key.
-         * For our example the result will be [(keyType[0])e.1, (keyType[1])e.3, (keyType[2])e.1]
-         *
-         * @param e       Expression that is a reference to a tuple.
-         * @param keyType Type for the key fields in the result; may introduce nullability casts.
-         * @return A tuple containing just the key fields, in order.
-         */
-        DBSPTupleExpression keyFields(DBSPExpression e, DBSPTypeTupleBase keyType) {
-            List<DBSPExpression> fields = new ArrayList<>();
-            Utilities.enforce(keyType.size() == this.size());
-            int index = 0;
-            for (int kf: this.keyFields) {
-                fields.add(e.field(kf)
-                        .applyCloneIfNeeded()
-                        .nullabilityCast(keyType.getFieldType(index), DBSPCastExpression.CastType.SqlUnsafe));
-                index++;
-            }
-            return new DBSPTupleExpression(fields, false);
-        }
-
-        /** Given a type for the row, return the type for the key */
-        DBSPTypeTuple keyType(DBSPTypeTupleBase row) {
-            List<DBSPType> fields = new ArrayList<>();
-            for (int kf: this.keyFields) {
-                fields.add(row.getFieldType(kf));
-            }
-            return new DBSPTypeTuple(fields);
-        }
-
-        /**
-         * Produce a list with original fields from two values: the key value, and the data value.
-         *
-         * @param key       Expression containing the key fields, in order.
-         * @param data      Expression containing the data fields, in order.
-         * @param result    A list of the unshuffled fields.  The result is
-         *                  [data.0, key.0, data.1, key.1, data.2]
-         *                  (In this case we expect key.0 == key.2 always)
-         */
-        void unshuffleKeyAndDataFields(DBSPExpression key, DBSPExpression data, List<DBSPExpression> result) {
-            Utilities.enforce(key.getType().getToplevelFieldCount() == this.size());
-            int size = this.keyFieldSet.size() + data.getType().getToplevelFieldCount();
-            int skipped = 0;
-            boolean nullableData = data.getType().deref().mayBeNull;
-            for (int i = 0; i < size; i++) {
-                @Nullable DBSPExpression checkNull = nullableData ? data.deref().is_null() : null;
-                if (this.isKeyField(i)) {
-                    int index = 0;
-                    for (int ki: this.keyFields) {
-                        // There could be multiple positions, stop at the first one
-                        if (ki == i)
-                            break;
-                        index++;
-                    }
-                    DBSPExpression keyField = key.deref().field(index).applyCloneIfNeeded();
-                    if (nullableData) {
-                        if (!keyField.getType().mayBeNull)
-                            keyField = keyField.some();
-                        keyField = new DBSPIfExpression(key.getNode(),
-                                checkNull, keyField.getType().none(), keyField);
-                    }
-                    result.add(keyField);
-                    skipped++;
-                } else {
-                    DBSPExpression dataField;
-                    dataField = data.deref().field(i - skipped).applyCloneIfNeeded();
-                    if (nullableData) {
-                        if (!dataField.getType().mayBeNull)
-                            dataField = dataField.some();
-                        dataField = new DBSPIfExpression(key.getNode(),
-                                checkNull, dataField.getType().none(), dataField);
-                    }
-                    result.add(dataField);
-                }
-            }
-        }
-
-        private int size() {
-            return this.keyFields.size();
-        }
-
-        @Override
-        public String toString() {
-            return "KeyFields: " + this.keyFields;
-        }
-    }
-
     /** Create the AND of a list of boolean expressions */
     DBSPExpression makeAnd(List<DBSPExpression> predicates) {
         DBSPExpression result = predicates.get(0);
@@ -2029,8 +1861,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 // The following loop is an adapted version of extendedRight.keyFields
                 final DBSPVariablePath joinRightVar = joinVar.getType().var();
                 final List<DBSPExpression> rightKeyFields = new ArrayList<>();
-                for (int i = 0; i < extendedRight.size(); i++) {
-                    int index = extendedRight.keyFields.get(i);
+                for (int index : extendedRight.keyFieldIndexes()) {
                     rightKeyFields.add(joinRightVar.deref().field(leftColumns + index)
                             .applyCloneIfNeeded()
                             .cast(node, rightResultType.getFieldType(index), DBSPCastExpression.CastType.SqlUnsafe));
@@ -2768,7 +2599,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
             shuffle.add(inputRowType.size() + elementIndex);
             elementIndex++;
             index++;
-            previousPartitionKeys = ga.partitionKeys;
+            previousPartitionKeys = ga.partitionKeyIndexes();
         }
 
         shuffle.addAll(later);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/KeyFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/KeyFields.java
@@ -1,0 +1,190 @@
+package org.dbsp.sqlCompiler.compiler.frontend;
+
+import org.dbsp.sqlCompiler.compiler.visitors.unusedFields.FieldUseMap;
+import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Keeps track of the fields of a tuple that are used as key fields.
+ * Note that key fields may be duplicated.
+ * E.g., a key may contain fields 1, 3, and 1 of a tuple of size 5, in this order.
+ * [_, 0 and 2, _, 1, _]. */
+public class KeyFields {
+    /** Indexes of fields that belong to the key, in the order they appear in the key: [1, 3, 1] */
+    private final List<Integer> keyFields;
+    private final Set<Integer> keyFieldSet;
+
+    public KeyFields() {
+        this.keyFieldSet = new HashSet<>();
+        this.keyFields = new ArrayList<>();
+    }
+
+    public KeyFields(KeyFields other) {
+        this.keyFieldSet = new HashSet<>(other.keyFieldSet);
+        this.keyFields = new ArrayList<>(other.keyFields);
+    }
+
+    public boolean isKeyField(int i) {
+        return this.keyFieldSet.contains(i);
+    }
+
+    /** Indexes of the key fields, in the order they appear in the key. */
+    public List<Integer> keyFieldIndexes() {
+        return Collections.unmodifiableList(this.keyFields);
+    }
+
+    /** Call this function to add key fields in the order they appear in the key */
+    public void add(int index) {
+        this.keyFieldSet.add(index);
+        this.keyFields.add(index);
+    }
+
+    public void addAll(List<Integer> indexes) {
+        for (int i: indexes)
+            this.add(i);
+    }
+
+    public void addAllUsed(@Nullable FieldUseMap map) {
+        if (map == null)
+            return;
+        if (map.isRef())
+            map = map.deref();
+        this.addAll(map.getUsedFields());
+    }
+
+    /** Extract the non-key fields from a value into a tuple, in the order they appear in the tuple.
+     * For our example, the result will be [e.0, e.2, e.4]
+     *
+     * @param e Expression that is a reference to a tuple.
+     * @return  A tuple containing just the non-key fields, in order.
+     */
+    public DBSPTupleExpression nonKeyFields(DBSPExpression e) {
+        // Almost like nonKeyFields with 3 arguments, except we don't insert casts ever
+        // return this.nonKeyFields(var, e.getType().to(DBSPTypeTupleBase.class), 0);
+        List<DBSPExpression> fields = new ArrayList<>();
+        DBSPTypeTupleBase tuple = e.getType().to(DBSPTypeTupleBase.class);
+        for (int i = 0; i < tuple.size(); i++) {
+            if (this.isKeyField(i))
+                continue;
+            fields.add(e.field(i).applyCloneIfNeeded());
+        }
+        return new DBSPTupleExpression(fields, false);
+    }
+
+    /** Extract the non-key fields from a value into a tuple, and insert casts if needed.
+     * For our example, the result will be [(desiredType[0])e.0, (desiredType[1])e.2, (desiredType[2])e.4]
+     *
+     * @param e        Expression that is a reference to a tuple.
+     * @param desiredType Type to cast resulting tuple to.
+     * @return          A tuple containing just the non-key fields, in order.
+     */
+    public DBSPTupleExpression nonKeyFields(DBSPExpression e, DBSPTypeTupleBase desiredType) {
+        List<DBSPExpression> fields = new ArrayList<>();
+        Utilities.enforce(e.getType().getToplevelFieldCount() >= desiredType.size());
+        for (int i = 0; i < desiredType.size(); i++) {
+            if (this.isKeyField(i))
+                continue;
+            fields.add(e.field(i)
+                    .applyCloneIfNeeded()
+                    .nullabilityCast(desiredType.getFieldType(i), DBSPCastExpression.CastType.SqlUnsafe));
+        }
+        return new DBSPTupleExpression(fields, false);
+    }
+
+    /** Extract the key fields from a value (e), in the order they have to appear in the key.
+     * For our example the result will be [(keyType[0])e.1, (keyType[1])e.3, (keyType[2])e.1]
+     *
+     * @param e       Expression that is a reference to a tuple.
+     * @param keyType Type for the key fields in the result; may introduce nullability casts.
+     * @return A tuple containing just the key fields, in order.
+     */
+    public DBSPTupleExpression keyFields(DBSPExpression e, DBSPTypeTupleBase keyType) {
+        List<DBSPExpression> fields = new ArrayList<>();
+        Utilities.enforce(keyType.size() == this.size());
+        int index = 0;
+        for (int kf: this.keyFields) {
+            fields.add(e.field(kf)
+                    .applyCloneIfNeeded()
+                    .nullabilityCast(keyType.getFieldType(index), DBSPCastExpression.CastType.SqlUnsafe));
+            index++;
+        }
+        return new DBSPTupleExpression(fields, false);
+    }
+
+    /** Given a type for the row, return the type for the key */
+    public DBSPTypeTuple keyType(DBSPTypeTupleBase row) {
+        List<DBSPType> fields = new ArrayList<>();
+        for (int kf: this.keyFields) {
+            fields.add(row.getFieldType(kf));
+        }
+        return new DBSPTypeTuple(fields);
+    }
+
+    /**
+     * Produce a list with original fields from two values: the key value, and the data value.
+     *
+     * @param key       Expression containing the key fields, in order.
+     * @param data      Expression containing the data fields, in order.
+     * @param result    A list of the unshuffled fields.  The result is
+     *                  [data.0, key.0, data.1, key.1, data.2]
+     *                  (In this case we expect key.0 == key.2 always)
+     */
+    public void unshuffleKeyAndDataFields(DBSPExpression key, DBSPExpression data, List<DBSPExpression> result) {
+        Utilities.enforce(key.getType().getToplevelFieldCount() == this.size());
+        int size = this.keyFieldSet.size() + data.getType().getToplevelFieldCount();
+        int skipped = 0;
+        boolean nullableData = data.getType().deref().mayBeNull;
+        for (int i = 0; i < size; i++) {
+            @Nullable DBSPExpression checkNull = nullableData ? data.deref().is_null() : null;
+            if (this.isKeyField(i)) {
+                int index = 0;
+                for (int ki: this.keyFields) {
+                    // There could be multiple positions, stop at the first one
+                    if (ki == i)
+                        break;
+                    index++;
+                }
+                DBSPExpression keyField = key.deref().field(index).applyCloneIfNeeded();
+                if (nullableData) {
+                    if (!keyField.getType().mayBeNull)
+                        keyField = keyField.some();
+                    keyField = new DBSPIfExpression(key.getNode(),
+                            checkNull, keyField.getType().none(), keyField);
+                }
+                result.add(keyField);
+                skipped++;
+            } else {
+                DBSPExpression dataField;
+                dataField = data.deref().field(i - skipped).applyCloneIfNeeded();
+                if (nullableData) {
+                    if (!dataField.getType().mayBeNull)
+                        dataField = dataField.some();
+                    dataField = new DBSPIfExpression(key.getNode(),
+                            checkNull, dataField.getType().none(), dataField);
+                }
+                result.add(dataField);
+            }
+        }
+    }
+
+    private int size() {
+        return this.keyFields.size();
+    }
+
+    @Override
+    public String toString() {
+        return "KeyFields: " + this.keyFields;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/FirstLastAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/FirstLastAggregate.java
@@ -147,7 +147,7 @@ public class FirstLastAggregate extends WindowAggregates {
         DBSPClosureExpression makeKeys =
                 new DBSPRawTupleExpression(
                         new DBSPTupleExpression(
-                                Linq.map(this.partitionKeys,
+                                Linq.map(this.partition.keyFieldIndexes(),
                                         p -> rowVar.deref().field(p).applyCloneIfNeeded()), false),
                         new DBSPTupleExpression(this.node,
                                 lastOperator.getOutputZSetElementType().to(DBSPTypeTuple.class),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
@@ -377,12 +377,13 @@ public class RangeAggregates extends WindowAggregates {
 
         // Join the previous result with the aggregate
         DBSPSimpleOperator indexInput;
+        List<Integer> partitionKeyIndexes = this.partition.keyFieldIndexes();
         DBSPType lastPartAndOrderType;
         DBSPType lastCopiedFieldsType;
         {
             // Index the lastOperator
             DBSPVariablePath previousRowRefVar = lastTupleType.ref().var();
-            List<DBSPExpression> expressions = Linq.map(partitionKeys,
+            List<DBSPExpression> expressions = Linq.map(partitionKeyIndexes,
                     f -> previousRowRefVar.deref().field(f).applyCloneIfNeeded());
 
             DBSPExpression orderField = previousRowRefVar.deref().field(orderColumnIndex);
@@ -392,7 +393,7 @@ public class RangeAggregates extends WindowAggregates {
             // Copy all the fields from the previousRowRefVar except the partition fields.
             List<DBSPExpression> fields = new ArrayList<>();
             for (int i = 0; i < lastTupleType.size(); i++) {
-                if (partitionKeys.contains(i))
+                if (partitionKeyIndexes.contains(i))
                     continue;
                 if (orderColumnIndex == i)
                     continue;
@@ -418,8 +419,8 @@ public class RangeAggregates extends WindowAggregates {
                     lastTupleType.size() + aggResultType.size()];
             int indexField = 0;
             for (int i = 0; i < lastTupleType.size(); i++) {
-                if (partitionKeys.contains(i)) {
-                    int keyIndex = partitionKeys.indexOf(i);
+                if (partitionKeyIndexes.contains(i)) {
+                    int keyIndex = partitionKeyIndexes.indexOf(i);
                     // If the field is in the index, use it from the index
                     allFields[i] = key
                             .deref()
@@ -430,7 +431,7 @@ public class RangeAggregates extends WindowAggregates {
                     // If the field is the order key, use it from the index too; it's the last one
                     allFields[i] = key
                             .deref()
-                            .field(this.partitionKeys.size())
+                            .field(partitionKeyIndexes.size())
                             .applyCloneIfNeeded();
                     indexField++;
                 } else {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RankAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RankAggregate.java
@@ -28,6 +28,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.util.Linq;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -148,12 +149,14 @@ public class RankAggregate extends WindowAggregates {
         DBSPComparatorExpression comparator = CalciteToDBSPCompiler.generateComparator(
                 node, this.group.orderKeys.getFieldCollations(), inputRowType, false);
 
-        // The rank must be added at the end of the input collection (that's how Calcite expects it).
+        // The partition fields already live in the key, so the value holds only the other row fields.
+        // The rank must be added at the end of the row (that's how Calcite expects it).
         DBSPVariablePath left = DBSPTypeInteger.getType(node, INT64, false).var();
         DBSPVariablePath right = inputRowType.ref().var();
-        List<DBSPExpression> flattened = DBSPTypeTupleBase.flatten(right.deref());
-        flattened.add(left);
-        DBSPTupleExpression tuple = new DBSPTupleExpression(flattened, false);
+        DBSPTupleExpression nonPartitionFields = this.partition.nonKeyFields(right.deref());
+        List<DBSPExpression> valueFields = Linq.list(nonPartitionFields.fields);
+        valueFields.add(left);
+        DBSPTupleExpression tuple = new DBSPTupleExpression(valueFields, false);
         DBSPClosureExpression outputProducer = tuple.closure(left, right);
 
         // TopK operator.
@@ -167,8 +170,7 @@ public class RankAggregate extends WindowAggregates {
         this.compiler.addOperator(topK);
         DBSPIntegrateOperator integral = new DBSPIntegrateOperator(node, topK.outputPort());
         this.compiler.addOperator(integral);
-        // We must drop the index we built.
-        return new DBSPDeindexOperator(node.maybeFinal(isLast), node, integral.outputPort());
+        return this.reassembleFields(node.maybeFinal(isLast), integral.outputPort());
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/WindowAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/WindowAggregates.java
@@ -5,12 +5,15 @@ import org.apache.calcite.rel.core.Window;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteToDBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.KeyFields;
 import org.dbsp.sqlCompiler.compiler.frontend.TypeCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.IntermediateRel;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -19,6 +22,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.util.ICastable;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
@@ -43,7 +47,8 @@ public abstract class WindowAggregates implements ICastable {
     public final int windowFieldIndex;
     final DBSPTypeTuple windowResultType;
     final DBSPTypeTuple inputRowType;
-    public final List<Integer> partitionKeys;
+    /** The row fields that form the partition key, in key order. */
+    final KeyFields partition;
     final DBSPVariablePath inputRowRefVar;
     final ExpressionCompiler eComp;
 
@@ -67,7 +72,8 @@ public abstract class WindowAggregates implements ICastable {
                 window.getRowType(), false).to(DBSPTypeTuple.class);
         this.inputRowType = this.compiler.convertType(node.getPositionRange(),
                 window.getInput().getRowType(), false).to(DBSPTypeTuple.class);
-        this.partitionKeys = this.group.keys.toList();
+        this.partition = new KeyFields();
+        this.partition.addAll(this.group.keys.toList());
         this.inputRowRefVar = this.inputRowType.ref().var();
         this.eComp = new ExpressionCompiler(window, this.inputRowRefVar, window.constants, this.compiler.compiler());
     }
@@ -76,11 +82,16 @@ public abstract class WindowAggregates implements ICastable {
         return CalciteObject.create(this.window);
     }
 
+    /** Indexes of the row fields that form the partition key, in key order. */
+    public List<Integer> partitionKeyIndexes() {
+        return this.partition.keyFieldIndexes();
+    }
+
     OutputPort indexInput(DBSPSimpleOperator lastOperator, @Nullable List<Integer> previousPartitionKeys) {
-        if (!lastOperator.is(DBSPDeindexOperator.class) || !this.partitionKeys.equals(previousPartitionKeys)) {
+        if (!lastOperator.is(DBSPDeindexOperator.class) || !this.partition.keyFieldIndexes().equals(previousPartitionKeys)) {
             DBSPType inputRowType = lastOperator.getOutputZSetElementType();
             DBSPVariablePath firstInputVar = inputRowType.ref().var();
-            List<DBSPExpression> expressions = Linq.map(this.partitionKeys,
+            List<DBSPExpression> expressions = Linq.map(this.partition.keyFieldIndexes(),
                     f -> firstInputVar.deref().field(f).applyCloneIfNeeded());
             DBSPTupleExpression partition = new DBSPTupleExpression(this.node, expressions);
             DBSPExpression row = DBSPTupleExpression.flatten(firstInputVar.deref());
@@ -97,6 +108,24 @@ public abstract class WindowAggregates implements ICastable {
         }
     }
 
+    /** Put the fields of each row back in row order.  The input is an indexed collection whose key
+     * holds the partition fields and whose value holds the remaining fields, in row order, followed
+     * by any extra fields.  The result is a Map operator that emits the row followed by the extra fields.
+     * The map is not inserted in the circuit.
+     *
+     * <p>The key is the one {@link #indexInput} builds from the partition fields.
+     *
+     * @param node     Calcite node that the resulting operator implements.
+     * @param indexed  Indexed collection to rebuild the rows from. */
+    DBSPSimpleOperator reassembleFields(CalciteRelNode node, OutputPort indexed) {
+        DBSPTypeIndexedZSet indexedType = indexed.getOutputIndexedZSetType();
+        DBSPVariablePath keyValue = indexedType.getKVRefType().var();
+        List<DBSPExpression> fields = new ArrayList<>();
+        this.partition.unshuffleKeyAndDataFields(keyValue.field(0), keyValue.field(1), fields);
+        DBSPClosureExpression rebuild = new DBSPTupleExpression(fields, false).closure(keyValue);
+        return new DBSPMapOperator(node, rebuild, indexed);
+    }
+
     public abstract DBSPSimpleOperator implement(
             DBSPSimpleOperator input, DBSPSimpleOperator lastOperator,
             @Nullable List<Integer> previousPartitionKeys, boolean isLast);
@@ -106,7 +135,7 @@ public abstract class WindowAggregates implements ICastable {
     }
 
     public DBSPTupleExpression partitionKeys() {
-        List<DBSPExpression> expressions = Linq.map(this.partitionKeys,
+        List<DBSPExpression> expressions = Linq.map(this.partition.keyFieldIndexes(),
                 f -> this.inputRowRefVar.deref().field(f).applyCloneIfNeeded());
         return new DBSPTupleExpression(node, expressions);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
@@ -67,6 +67,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.keys.LosslessCastKeyAnalysis
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
@@ -180,15 +181,29 @@ public class FindUnboundedState extends Passes {
     /** A group-by key has a bounded number of values when it has at most this many */
     static final long MAX_KEY_VALUES = 1024;
 
-    /** True if the tuple type has a bounded number of values: it has no fields, or all its
-     * fields are booleans and they admit at most {@link #MAX_KEY_VALUES} combinations
-     * (2 values for a boolean and 3 for a nullable one). */
+    /** Number of values a field of this type can hold, or 0 when they are too many to
+     * enumerate: 2 for a boolean and 256 for an 8-bit integer, one more when nullable. */
+    static long domainSize(DBSPType type) {
+        final long values;
+        if (type.is(DBSPTypeBool.class))
+            values = 2;
+        else if (type.code == DBSPTypeCode.INT8 || type.code == DBSPTypeCode.UINT8)
+            values = 256;
+        else
+            return 0;
+        return type.mayBeNull ? values + 1 : values;
+    }
+
+    /** True if the tuple type has a bounded number of values: it has no fields, or every
+     * field has a countable domain and together they admit at most
+     * {@link #MAX_KEY_VALUES} combinations. */
     static boolean hasBoundedDomain(DBSPTypeTupleBase tuple) {
         long values = 1;
         for (DBSPType field : tuple.tupFields) {
-            if (!field.is(DBSPTypeBool.class))
+            long size = domainSize(field);
+            if (size == 0)
                 return false;
-            values *= field.mayBeNull ? 3 : 2;
+            values *= size;
             if (values > MAX_KEY_VALUES)
                 return false;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TopKTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TopKTests.java
@@ -1,7 +1,11 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -274,5 +278,116 @@ public class TopKTests extends SqlIoTest {
                  2          | S2     | 2011-07-30  | 2
                  3          | S1     | 2011-08-02  | 1
                 (5 rows)""");
+    }
+
+    /** Compile a query with one TopK operator and check the arities of its output key and value. */
+    void checkTopKShape(String query, int keyArity, int valueArity) {
+        var cc = this.getCC("CREATE VIEW V AS " + query);
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            int topKs = 0;
+
+            @Override
+            public void postorder(DBSPIndexedTopKOperator node) {
+                DBSPTypeIndexedZSet output = node.getOutputIndexedZSetType();
+                Assert.assertEquals(keyArity, output.keyType.to(DBSPTypeTuple.class).size());
+                Assert.assertEquals(valueArity, output.elementType.to(DBSPTypeTuple.class).size());
+                this.topKs++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(1, this.topKs);
+                super.endVisit();
+            }
+        });
+    }
+
+    /** The partition fields live in the TopK key, so the value holds only the other fields and the rank.
+     * Every query selects all columns, so the optimizer trims nothing. */
+    @Test
+    public void topKValueOmitsPartitionFields() {
+        String select = "SELECT ID, DocumentId, Status, DateCreated, rn FROM (SELECT *, ROW_NUMBER() OVER (";
+        String from = ") AS rn FROM DocumentStatusLog) WHERE rn <= 2;";
+        // Partition fields in the middle of the row
+        this.checkTopKShape(select + "PARTITION BY Status, DocumentId ORDER BY DateCreated DESC" + from, 2, 3);
+        // No partition: the whole row and the rank are in the value
+        this.checkTopKShape(select + "ORDER BY DateCreated" + from, 0, 5);
+        // Partition on the first field
+        this.checkTopKShape(select + "PARTITION BY ID ORDER BY DateCreated" + from, 1, 4);
+        // Partition on every field: only the rank is in the value
+        this.checkTopKShape(select + "PARTITION BY ID, DocumentId, Status, DateCreated ORDER BY ID" + from, 4, 1);
+        // Partition field that is also an ORDER BY field
+        this.checkTopKShape(select + "PARTITION BY DocumentId ORDER BY DocumentId, DateCreated" + from, 1, 4);
+        // TopK after another window aggregate over the same partition; its result is one more input field
+        this.checkTopKShape("""
+                SELECT ID, DocumentId, Status, DateCreated, r, rn FROM (
+                    SELECT *, RANK() OVER (PARTITION BY DocumentId ORDER BY ID) AS r,
+                              ROW_NUMBER() OVER (PARTITION BY DocumentId ORDER BY DateCreated) AS rn
+                    FROM DocumentStatusLog)
+                WHERE rn <= 1;""", 1, 5);
+        // TopK after a window aggregate over a different partition, so the TopK builds its own index
+        this.checkTopKShape("""
+                SELECT ID, DocumentId, Status, DateCreated, r, rn FROM (
+                    SELECT *, RANK() OVER (PARTITION BY Status ORDER BY ID) AS r,
+                              ROW_NUMBER() OVER (PARTITION BY DocumentId ORDER BY DateCreated) AS rn
+                    FROM DocumentStatusLog)
+                WHERE rn <= 1;""", 1, 5);
+    }
+
+    /** NULL partition keys form one partition and come back as NULL once the fields are reassembled. */
+    @Test
+    public void nullPartitionKey() {
+        var ccs = this.getCCS("""
+                CREATE TABLE T(a INT, b INT NOT NULL);
+                CREATE VIEW V AS
+                SELECT a, b, rn FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rn FROM T)
+                WHERE rn <= 1;""");
+        // Validated on Postgres
+        ccs.step("INSERT INTO T VALUES (NULL, 1), (NULL, 2), (1, 3), (1, 4), (2, 5);", """
+                 a | b | rn | weight
+                --------------------
+                   | 1 | 1  | 1
+                 1 | 3 | 1  | 1
+                 2 | 5 | 1  | 1""");
+    }
+
+    /** Partition fields in the middle and at the end of the row, with every column and the rank selected. */
+    @Test
+    public void partitionFieldsInsideRow() {
+        // Validated on Postgres
+        String paramQuery = """
+                SELECT ID, DocumentId, Status, DateCreated, rn FROM (
+                    SELECT *, ?() OVER (PARTITION BY Status, DocumentId ORDER BY DateCreated DESC) AS rn
+                    FROM DocumentStatusLog)
+                WHERE rn <= 2;
+                 ID | DocumentId | Status | DateCreated | rn
+                --------------------------------------------
+                 6  | 1          | S1     | 2011-09-02  | 1
+                 2  | 1          | S1     | 2011-07-29  | 2
+                 3  | 1          | S2     | 2011-07-30  | 1
+                 1  | 2          | S1     | 2011-07-28  | 1
+                 4  | 2          | S2     | 2011-07-30  | 1
+                 5  | 2          | S3     | 2011-08-01  | 1
+                 6  | 3          | S1     | 2011-08-02  | 1
+                (7 rows)
+
+                SELECT ID, DocumentId, Status, DateCreated, rn FROM (
+                    SELECT *, ?() OVER (PARTITION BY DateCreated ORDER BY ID) AS rn
+                    FROM DocumentStatusLog)
+                WHERE rn <= 1;
+                 ID | DocumentId | Status | DateCreated | rn
+                --------------------------------------------
+                 1  | 2          | S1     | 2011-07-28  | 1
+                 2  | 1          | S1     | 2011-07-29  | 1
+                 3  | 1          | S2     | 2011-07-30  | 1
+                 5  | 2          | S3     | 2011-08-01  | 1
+                 6  | 3          | S1     | 2011-08-02  | 1
+                 6  | 1          | S1     | 2011-09-02  | 1
+                (6 rows)""";
+        for (String function : new String[]{"RANK", "DENSE_RANK", "ROW_NUMBER"}) {
+            // No ties within any partition, so the three functions agree
+            this.qst(paramQuery.replace("?", function));
+        }
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
@@ -154,6 +154,22 @@ public class IncrementalUnboundedStateTests extends StreamingTestBase {
     }
 
     @Test
+    public void groupByTinyint() {
+        // A TINYINT key admits 256 values, and 257 when it is nullable
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(code TINYINT, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT code, COUNT(*) AS cnt FROM input GROUP BY code;""");
+    }
+
+    @Test
+    public void groupByTinyintAndBoolean() {
+        // 256 times 2 is within MAX_KEY_VALUES = 1024
+        this.assertNoUnboundedStateWarnings("""
+                CREATE TABLE input(code TINYINT NOT NULL, paid BOOLEAN NOT NULL, ts TIMESTAMP LATENESS INTERVAL 10 DAYS);
+                CREATE VIEW output AS SELECT code, paid, COUNT(*) AS cnt FROM input GROUP BY code, paid;""");
+    }
+
+    @Test
     public void chainAggregateByBoolean() {
         // Over an append-only table MAX keeps one running value per group, a chain aggregate,
         // and a boolean key allows a bounded number of groups

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysisTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/keys/KeyAnalysisTests.java
@@ -1,7 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer.keys;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
@@ -226,22 +225,18 @@ public class KeyAnalysisTests extends SqlIoTest {
                 QUALIFY row_number() OVER (PARTITION BY a + b ORDER BY c) = 1;""");
     }
 
-    /** The TOP-1 output is indexed by the seven partition columns and repeats them in its
-     * value tuple.  Each value of the key is named by both its columns. */
+    /** Each of the seven key columns is selected twice, so each value of the key is named
+     * by two columns.  Enumerating the namings would produce 2^7 keys, more than
+     * {@code Keys.MAX_KEYS}, so the equivalence sets must stay within one key. */
     @Test
     public void wideKeyOfDuplicatedColumnsStaysOneKey() {
-        String view = """
+        this.assertKeys("""
                 CREATE TABLE w(c1 INT NOT NULL, c2 INT NOT NULL, c3 INT NOT NULL, c4 INT NOT NULL,
-                               c5 INT NOT NULL, c6 INT NOT NULL, c7 INT NOT NULL, x INT);
-                CREATE VIEW v AS SELECT c1, c2, c3, c4, c5, c6, c7, x FROM w
-                QUALIFY row_number() OVER (PARTITION BY c1, c2, c3, c4, c5, c6, c7 ORDER BY x) = 1;""";
-        // The TOP-1 partition columns are its index, and its value tuple repeats them, so
-        // each of the seven values of the key is named by an index and a value column
-        // This is an approximation of the true key, which has 2^7 members
-        Analyzed analyzed = this.analyze(view);
-        Assert.assertEquals("[[i0=v0, i1=v1, i2=v2, i3=v3, i4=v4, i5=v5, i6=v6]]",
-                analyzed.keysOf(DBSPIndexedTopKOperator.class));
-        Assert.assertEquals("[[0, 1, 2, 3, 4, 5, 6]]", analyzed.viewKeys());
+                               c5 INT NOT NULL, c6 INT NOT NULL, c7 INT NOT NULL, x INT,
+                               PRIMARY KEY (c1, c2, c3, c4, c5, c6, c7));
+                CREATE VIEW v AS SELECT c1, c1 AS d1, c2, c2 AS d2, c3, c3 AS d3, c4, c4 AS d4,
+                                        c5, c5 AS d5, c6, c6 AS d6, c7, c7 AS d7 FROM w;""",
+                "[[0=1, 2=3, 4=5, 6=7, 8=9, 10=11, 12=13]]");
     }
 
     /** Two independent keys: the primary key of the table, and the partition column of a

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/TopKUnusedFieldsIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/TopKUnusedFieldsIncrementalTests.java
@@ -18,7 +18,7 @@ public class TopKUnusedFieldsIncrementalTests extends StreamingTestBase {
                 SELECT id, a FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn = 1;""");
-        Assert.assertEquals(new TopKUnusedFieldsTests.Shape(3, 2, false), shape(ccs));
+        Assert.assertEquals(new TopKUnusedFieldsTests.Shape(2, 1, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 20, 200, 0, 0), (2, 5, 500, 0, 0);",
                 """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/TopKUnusedFieldsTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/TopKUnusedFieldsTests.java
@@ -17,7 +17,8 @@ import java.util.List;
 /** Tests for the removing unused fields in {@link DBSPIndexedTopKOperator}. */
 public class TopKUnusedFieldsTests extends SqlIoTest {
     /** Field count of the value part of a TopK's input and output,
-     * and whether the TopK reports its output as a multiset. */
+     * and whether the TopK reports its output as a multiset.
+     * The partition columns are the TopK's index, so neither count includes them. */
     record Shape(int inputFields, int outputFields, boolean isMultiset) {}
 
     static class TopKShapes extends CircuitVisitor {
@@ -77,7 +78,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn = 1;""");
-        Assert.assertEquals(new Shape(3, 2, false), shape(ccs));
+        Assert.assertEquals(new Shape(2, 1, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 20, 200, 0, 0), (2, 5, 500, 0, 0);",
                 """
@@ -95,7 +96,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a, rn FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 2;""");
-        Assert.assertEquals(new Shape(3, 3, false), shape(ccs));
+        Assert.assertEquals(new Shape(2, 2, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 20, 200, 0, 0), (1, 30, 300, 0, 0), (2, 5, 500, 0, 0);",
                 """
@@ -114,7 +115,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT rn, id FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 2;""");
-        Assert.assertEquals(new Shape(2, 2, false), shape(ccs));
+        Assert.assertEquals(new Shape(1, 1, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 20, 200, 0, 0), (1, 30, 300, 0, 0), (2, 5, 500, 0, 0);",
                 """
@@ -134,7 +135,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 3 AND MOD(rn, 2) = 1;""");
-        Assert.assertEquals(new Shape(3, 3, false), shape(ccs));
+        Assert.assertEquals(new Shape(2, 2, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 20, 200, 0, 0), (1, 30, 300, 0, 0), (2, 5, 500, 0, 0);",
                 """
@@ -155,7 +156,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT DISTINCT id, a FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 2;""");
-        Assert.assertEquals(new Shape(3, 2, true), shape(ccs));
+        Assert.assertEquals(new Shape(2, 1, true), shape(ccs));
         CountDistinct distinct = new CountDistinct(ccs.compiler);
         ccs.visit(distinct);
         Assert.assertEquals(1, distinct.count);
@@ -175,7 +176,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a + b AS s FROM (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn = 1;""");
-        Assert.assertEquals(new Shape(4, 3, false), shape(ccs));
+        Assert.assertEquals(new Shape(3, 2, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 1, 0), (1, 20, 200, 2, 0);",
                 """
@@ -193,7 +194,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a FROM (
                     SELECT *, RANK() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 1;""");
-        Assert.assertEquals(new Shape(3, 2, true), shape(ccs));
+        Assert.assertEquals(new Shape(2, 1, true), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 10, 200, 0, 0), (1, 5, 300, 0, 0);",
                 """
@@ -234,8 +235,8 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a AS v FROM L
                 UNION ALL
                 SELECT id, c AS v FROM L;""");
-        // Stored: id, ts, a, c.  Emitted: id, a, c.
-        Assert.assertEquals(new Shape(4, 3, false), shape(ccs));
+        // Stored: ts, a, c.  Emitted: a, c.  id survives only in the index.
+        Assert.assertEquals(new Shape(3, 2, false), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 7), (1, 20, 200, 0, 8), (2, 5, 500, 0, 9);",
                 """
@@ -255,7 +256,7 @@ public class TopKUnusedFieldsTests extends SqlIoTest {
                 SELECT id, a FROM (
                     SELECT *, DENSE_RANK() OVER (PARTITION BY id ORDER BY ts DESC) AS rn FROM T)
                 WHERE rn <= 2;""");
-        Assert.assertEquals(new Shape(3, 2, true), shape(ccs));
+        Assert.assertEquals(new Shape(2, 1, true), shape(ccs));
         // Expected output validated with Postgres 14.
         ccs.stepWeightOne("INSERT INTO T VALUES (1, 10, 100, 0, 0), (1, 10, 200, 0, 0), (1, 5, 300, 0, 0), (1, 1, 400, 0, 0);",
                 """


### PR DESCRIPTION
Some operators that produce indexed-Zsets as outputs can produce two copies of the same column: as a key, and as a value. This is wasteful. We have eliminated this duplication for JOINs a while ago, but it still exists for TopK operators. This PR removes the duplication for TopK operators. 

This deduplication not only reduces storage, but also improves the precision of other analyses, like key analyses and waterlines, which couldn't know that the columns carry the same values.

Part of #7027

## Checklist

- [x] Unit tests added/updated
