### PR TITLE
Validate authentication claims and tenant selectors

### DIFF
--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -54,7 +54,7 @@ use actix_web::http::header::{self, HeaderMap, HeaderName, HeaderValue};
 use actix_web::middleware::Next;
 use actix_web::{
     dev::{ServiceRequest, ServiceResponse},
-    error::ErrorUnauthorized,
+    error::{ErrorBadRequest, ErrorUnauthorized},
     web::Data,
 };
 use actix_web_httpauth::extractors::{
@@ -257,6 +257,11 @@ pub(crate) async fn auth_validator(
     req: ServiceRequest,
     credentials: BearerAuth,
 ) -> Result<ServiceRequest, (actix_web::error::Error, ServiceRequest)> {
+    // Reject ambiguous or malformed selectors before any auth path can treat
+    // one as an absent header and silently choose a different tenant.
+    if let Err(error) = tenant_selector(req.headers()) {
+        return Err((error, req));
+    }
     let token = credentials.token();
     if token.starts_with(API_KEY_PREFIX) {
         return api_key_auth(req, token).await;
@@ -275,6 +280,28 @@ pub(crate) async fn auth_validator(
             ))
         }
     }
+}
+
+/// A tenant selector is one non-empty header value. All credential types use
+/// this parser, including credentials promoted from WebSocket subprotocols.
+fn tenant_selector(headers: &HeaderMap) -> Result<Option<&str>, actix_web::Error> {
+    let invalid = || {
+        ErrorBadRequest(
+            "Invalid Feldera-Tenant header: send exactly one non-empty tenant name or UUID, or omit the header",
+        )
+    };
+    let mut values = headers.get_all(TENANT_HEADER);
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(invalid());
+    }
+    let selector = value.to_str().map_err(|_| invalid())?;
+    if selector.trim().is_empty() {
+        return Err(invalid());
+    }
+    Ok(Some(selector))
 }
 
 /// Decode the JWT payload without verifying the signature and return the
@@ -435,13 +462,6 @@ async fn oidc_trust_auth(
     let label = format!("oidc:{}", token_data.claims.sub);
     let db_err =
         |e: DBError, req: ServiceRequest| Err((crate::error::ManagerError::from(e).into(), req));
-    let header_tenant = |req: &ServiceRequest| {
-        req.headers()
-            .get(TENANT_HEADER)
-            .and_then(|h| h.to_str().ok())
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-    };
 
     // An owner belongs to no tenant of its own, so it acts wherever the
     // Feldera-Tenant header points, and in the default tenant without one, as a
@@ -472,7 +492,11 @@ async fn oidc_trust_auth(
     // that happened to be its only match would let it act on a tenant it never
     // asked for, believing it acted on the one it did.
     let tenant_matches: Vec<(TenantId, Role)> = matches;
-    let (acting_tenant, role) = match header_tenant(&req) {
+    let selector = match tenant_selector(req.headers()) {
+        Ok(selector) => selector.map(str::to_string),
+        Err(e) => return Err((e, req)),
+    };
+    let (acting_tenant, role) = match selector {
         Some(selector) => {
             let selected = {
                 let db = state.db.lock().await;
@@ -517,13 +541,13 @@ async fn resolve_owner_acting_tenant(
     headers: &actix_web::http::header::HeaderMap,
     home: TenantId,
 ) -> Result<TenantId, actix_web::Error> {
-    match headers.get(TENANT_HEADER).and_then(|h| h.to_str().ok()) {
-        Some(selector) if !selector.is_empty() => db
+    match tenant_selector(headers)? {
+        Some(selector) => db
             .resolve_tenant_selector(selector)
             .await
             // DBError::UnknownTenantName maps to HTTP 404 through ResponseError.
             .map_err(|e| crate::error::ManagerError::from(e).into()),
-        _ => Ok(home),
+        None => Ok(home),
     }
 }
 
@@ -842,12 +866,10 @@ async fn bearer_auth(
 
             // Non-owner: the membership table is the authorization authority;
             // the tenancy strategy only provisions (see `provision_login`).
-            let selector = req
-                .headers()
-                .get(TENANT_HEADER)
-                .and_then(|h| h.to_str().ok())
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
+            let selector = match tenant_selector(req.headers()) {
+                Ok(selector) => selector.map(str::to_string),
+                Err(e) => return Err((e, req)),
+            };
 
             if let Err(e) = provision_login(
                 &state,
@@ -942,6 +964,29 @@ async fn api_key_auth(
     };
     match validate {
         Ok((tenant_id, role)) => {
+            let selector = match tenant_selector(req.headers()) {
+                Ok(selector) => selector,
+                Err(e) => return Err((e, req)),
+            };
+            if let Some(selector) = selector {
+                let selected = ad
+                    .unwrap()
+                    .db
+                    .lock()
+                    .await
+                    .resolve_tenant_selector(selector)
+                    .await;
+                match selected {
+                    Ok(selected) if selected == tenant_id => {}
+                    Ok(_) | Err(DBError::UnknownTenantName { .. }) => {
+                        let error = DBError::NotATenantMember {
+                            tenant: selector.to_string(),
+                        };
+                        return Err((crate::error::ManagerError::from(error).into(), req));
+                    }
+                    Err(e) => return Err((crate::error::ManagerError::from(e).into(), req)),
+                }
+            }
             AuthenticatedPrincipal {
                 acting_tenant: tenant_id,
                 role,
@@ -1235,8 +1280,22 @@ impl AuthProvider {
     }
 }
 
-pub(crate) fn aws_auth_config() -> AuthConfiguration {
+/// Shared login JWT checks. Generic OIDC requires an audience; Cognito access
+/// tokens bind to the client through `client_id`, checked after decoding.
+fn login_validation(issuer: &str, audience: Option<&str>) -> Validation {
     let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_issuer(&[issuer]);
+    validation.set_required_spec_claims(&["exp", "iss", "sub"]);
+    validation.validate_nbf = true;
+    if let Some(audience) = audience {
+        validation.set_audience(&[audience]);
+        // set_audience checks a present claim but does not require one.
+        validation.required_spec_claims.insert("aud".to_string());
+    }
+    validation
+}
+
+pub(crate) fn aws_auth_config() -> AuthConfiguration {
     let client_id = env::var("FELDERA_AUTH_CLIENT_ID")
         .expect("Missing environment variable FELDERA_AUTH_CLIENT_ID");
     let iss =
@@ -1245,7 +1304,7 @@ pub(crate) fn aws_auth_config() -> AuthConfiguration {
     // We do not validate with set_audience because it is optional,
     // and AWS Cognito doesn't consistently claim it in JWT (e.g. via Hosted UI
     // auth)
-    validation.set_issuer(&[&iss]);
+    let validation = login_validation(&iss, None);
     AuthConfiguration {
         provider: AuthProvider::AwsCognito(ProviderAwsCognito {
             issuer: iss.clone(),
@@ -1264,7 +1323,6 @@ pub(crate) async fn generic_oidc_auth_config(
     api_config: &crate::config::ApiServerConfig,
     extra_roots: &[Certificate],
 ) -> Result<AuthConfiguration, Box<dyn std::error::Error>> {
-    let mut validation = Validation::new(Algorithm::RS256);
     let client_id = env::var("FELDERA_AUTH_CLIENT_ID")
         .expect("Missing environment variable FELDERA_AUTH_CLIENT_ID");
     let iss =
@@ -1279,9 +1337,7 @@ pub(crate) async fn generic_oidc_auth_config(
     )
     .await?;
 
-    validation.set_issuer(&[&iss]);
-    // Use configurable audience claim from API server configuration
-    validation.set_audience(&[&api_config.auth_audience]);
+    let validation = login_validation(&iss, Some(&api_config.auth_audience));
 
     // Add 'groups' scope if authorized_groups is configured
     let extra_oidc_scopes = if !api_config.authorized_groups.is_empty() {
@@ -1503,18 +1559,22 @@ async fn decode_token_with_validation(
 ) -> Result<TokenData<OidcClaim>, AuthError> {
     let token_data = decode_oidc_token(token, req, configuration).await?;
 
-    // Provider-specific validations based on optional fields
-
-    // Validate client_id if present (AWS Cognito puts it in a separate field)
-    if let Some(ref client_id) = token_data.claims.client_id
-        && configuration.client_id != *client_id
+    // Cognito requires both claims; other providers may omit them.
+    let is_cognito = matches!(configuration.provider, AuthProvider::AwsCognito(_));
+    if token_data
+        .claims
+        .client_id
+        .as_deref()
+        .map_or(is_cognito, |client_id| client_id != configuration.client_id)
     {
         return Err(jsonwebtoken::errors::ErrorKind::InvalidAudience.into());
     }
 
-    // Validate token_use if present (AWS Cognito requires "access" for access tokens)
-    if let Some(ref token_use) = token_data.claims.token_use
-        && token_use != "access"
+    if token_data
+        .claims
+        .token_use
+        .as_deref()
+        .map_or(is_cognito, |token_use| token_use != "access")
     {
         return Err(jsonwebtoken::errors::ErrorKind::InvalidToken.into());
     }
@@ -1831,9 +1891,8 @@ mod test {
     }
 
     fn validation(aud: &str, iss: &str) -> Validation {
-        let mut validation = Validation::new(Algorithm::RS256);
+        let mut validation = super::login_validation(iss, None);
         validation.set_audience(&[aud]);
-        validation.set_issuer(&[iss]);
         validation
     }
 
@@ -2029,7 +2088,8 @@ mod test {
     #[actix_web::test]
     async fn invalid_url() {
         ensure_default_crypto_provider();
-        let url = "http://localhost/doesnotexist".to_owned();
+        // Fail URL parsing without depending on whether localhost serves HTTP.
+        let url = "http://[invalid".to_owned();
         let res = fetch_jwk_oidc_keys(&url, &OidcClients::new(&[]).unwrap()).await;
         assert!(matches!(res.err().unwrap(), AuthError::JwkFetch(_)));
     }
@@ -2094,6 +2154,72 @@ mod test {
             .to_request();
         let res = run_test(req, Some(decoding_key), None, validation).await;
         assert_eq!(200, res.status());
+    }
+
+    #[tokio::test]
+    async fn cognito_requires_client_and_access_token_use() {
+        for missing in ["client_id", "token_use"] {
+            let mut claim = default_claim();
+            match missing {
+                "client_id" => claim.client_id = None,
+                "token_use" => claim.token_use = None,
+                _ => unreachable!(),
+            }
+            let (token, decoding_key) = setup(claim).await;
+            let req = test::TestRequest::get()
+                .uri("/")
+                .insert_header((http::header::AUTHORIZATION, format!("Bearer {token}")))
+                .to_request();
+            let res = run_test(
+                req,
+                Some(decoding_key),
+                None,
+                validation("some-client", "some-iss"),
+            )
+            .await;
+            assert_eq!(res.status(), 401, "accepted token without {missing}");
+        }
+    }
+
+    #[tokio::test]
+    async fn login_validation_requires_audience_and_enforces_nbf() {
+        for audience in [None, Some("some-client")] {
+            for nbf in [None, Some(serde_json::json!(Utc::now().timestamp() + 3600))] {
+                let mut claim = default_claim();
+                claim.aud = audience.map(|aud| serde_json::json!(aud));
+                if let Some(nbf) = &nbf {
+                    claim
+                        .additional_claims
+                        .insert("nbf".to_string(), nbf.clone());
+                }
+                let (token, key) = setup(claim).await;
+                let result = jsonwebtoken::decode::<OidcClaim>(
+                    &token,
+                    &key,
+                    &super::login_validation("some-iss", Some("some-client")),
+                );
+                assert_eq!(result.is_ok(), audience.is_some() && nbf.is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_selector_rejects_ambiguous_or_malformed_headers() {
+        use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+        let name = HeaderName::from_static("feldera-tenant");
+        let mut headers = HeaderMap::new();
+        assert_eq!(super::tenant_selector(&headers).unwrap(), None);
+        for valid in ["tenant-x", "00000000-0000-0000-0000-000000000000"] {
+            headers.insert(name.clone(), HeaderValue::from_str(valid).unwrap());
+            assert_eq!(super::tenant_selector(&headers).unwrap(), Some(valid));
+        }
+        for invalid in [b"".as_slice(), b"   ", b"\xff"] {
+            headers.insert(name.clone(), HeaderValue::from_bytes(invalid).unwrap());
+            assert!(super::tenant_selector(&headers).is_err());
+        }
+        headers.insert(name.clone(), HeaderValue::from_static("tenant-x"));
+        headers.append(name, HeaderValue::from_static("tenant-y"));
+        assert!(super::tenant_selector(&headers).is_err());
     }
 
     #[tokio::test]

--- a/docs.feldera.com/docs/get-started/enterprise/authentication/generic-oidc.md
+++ b/docs.feldera.com/docs/get-started/enterprise/authentication/generic-oidc.md
@@ -102,7 +102,7 @@ After setting up your OIDC provider, configure Feldera using the Helm chart valu
 |-----------|-------------|---------|
 | `auth.clientId` | Your OIDC application's client ID | `abc123xyz456` |
 | `auth.issuer` | Your OIDC provider's issuer URL | `https://auth.example.com` |
-| `authorization.authAudience` | Expected audience claim value in Access tokens | `feldera-api` |
+| `authorization.authAudience` | Required audience claim value in access tokens | `feldera-api` |
 
 :::tip
 

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -50,6 +50,23 @@ To run a specific test:
 uv run python -m pytest tests/platform/test_shared_pipeline.py::TestPipeline::test_adhoc_query_hash -v
 ```
 
+### RBAC and authentication tests
+
+The RBAC suite starts its own manager and HTTPS identity providers. Run it
+serially because the scenarios retain database state across manager restarts:
+
+```bash
+cargo build -p pipeline-manager
+cd python
+uv run python -m pytest -n0 tests/platform_rbac
+```
+
+`test_8_boundaries.py` also runs independently. It extends the route matrix with
+API keys, OIDC trusts, and encoded URLs, and checks malformed tenant headers,
+invalid signed tokens, and access across tenants. Set `FELDERA_TEST_BINARY` to
+test a different manager binary, or `FELDERA_TEST_IMAGE` for the container backend.
+Run only one native suite at a time: embedded Postgres binds port 8082.
+
 ### Reducing Compilation Cycles
 
 To reduce redundant compilation cycles during testing:

--- a/python/tests/platform_rbac/idp.py
+++ b/python/tests/platform_rbac/idp.py
@@ -16,6 +16,7 @@ the manager, and the manager trusts the CA behind it through `SSL_CERT_FILE`.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 from dataclasses import dataclass
@@ -45,6 +46,8 @@ class Issuer:
         tenants: list[str] | None = None,
         audience: str | None = DEFAULT_AUDIENCE,
         expires_in: int = 3600,
+        claims: dict | None = None,
+        omit_claims: tuple[str, ...] = (),
     ) -> str:
         """Mint an access token asserting these claims.
 
@@ -58,6 +61,10 @@ class Issuer:
             params["aud"] = audience
         if tenants:
             params["tenants"] = ",".join(tenants)
+        if claims is not None:
+            params["claims"] = json.dumps(claims)
+        if omit_claims:
+            params["omit_claims"] = ",".join(omit_claims)
         r = requests.get(
             f"{self.url}/token",
             params=params,

--- a/python/tests/platform_rbac/manager.py
+++ b/python/tests/platform_rbac/manager.py
@@ -19,6 +19,7 @@ one they are driving.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -424,6 +425,31 @@ class Manager:
                 self._proc.kill()
                 self._proc.wait(timeout=10)
             self._proc = None
+            # A killed manager can leave its embedded database running. Stop
+            # that database before restarting or removing its data directory.
+            # postmaster.opts records the exact binary used for this instance.
+            data_dir = self.state_dir / "pg"
+            if (data_dir / "postmaster.pid").exists():
+                postgres = Path(
+                    shlex.split((data_dir / "postmaster.opts").read_text())[0]
+                )
+                pg_ctl = str(postgres.with_name("pg_ctl"))
+                stopped = subprocess.run(
+                    [pg_ctl, "-D", str(data_dir), "-m", "fast", "-w", "stop"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                # The manager's shutdown may have stopped it concurrently.
+                status = subprocess.run(
+                    [pg_ctl, "-D", str(data_dir), "status"],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if status.returncode != 3:
+                    raise RuntimeError(
+                        f"Could not stop test Postgres: {stopped.stderr}"
+                    )
         self.config = None
 
     def restart(self, config: AuthConfig) -> None:

--- a/python/tests/platform_rbac/test_8_boundaries.py
+++ b/python/tests/platform_rbac/test_8_boundaries.py
@@ -1,0 +1,416 @@
+"""Additional authentication, role, and tenant boundaries over real HTTP.
+
+This module provisions its own identities and tenants, so it also runs alone.
+Invalid JWTs are signed by the trusted issuer: rejecting a bad signature would
+not prove that the manager checks the claims behind it.
+"""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import ssl
+import time
+
+import pytest
+
+from .conftest import Api, membership_auth
+from .idp import DEFAULT_AUDIENCE, Issuer
+from .manager import Manager
+from .rbac_matrix import Route, load_routes, probe_body
+
+pytestmark = pytest.mark.rbac
+
+TENANT_X = "rbac-audit-x"
+TENANT_Y = "rbac-audit-y"
+TENANT_Z = "rbac-audit-z"
+EXTRA_ROUTES = [
+    Route("POST", "/v0/pipelines/{pipeline_name}/testing", "write"),
+    Route(
+        "POST",
+        "/v0/pipelines/{pipeline_name}/views/{view_name}/connectors/{connector_name}/command",
+        "write",
+    ),
+]
+ROUTES = load_routes() + EXTRA_ROUTES
+# test_1_scenarios already exercises these routes with a write trust.
+COVERED_TRUST_ROUTES = {
+    ("write", "GET", "/v0/pipelines"),
+    ("write", "POST", "/v0/pipelines"),
+    ("write", "GET", "/v0/tenant/users"),
+}
+CREDENTIALS = [
+    (kind, role)
+    for kind, roles in [
+        ("login", ["read", "write", "admin", "owner"]),
+        ("key", ["read", "write"]),
+        ("trust", ["read", "write", "admin"]),
+    ]
+    for role in roles
+]
+
+
+@pytest.fixture(scope="module")
+def boundaries(manager: Manager, api: Api, primary_idp: Issuer, workload_idp: Issuer):
+    manager.restart(membership_auth(primary_idp))
+    owner = primary_idp.token("owner", email="owner@example.com")
+    tenants = {}
+    tokens = {("login", "owner"): owner}
+    for name in [TENANT_X, TENANT_Y, TENANT_Z]:
+        response = api.v0("POST", "/tenants", token=owner, body={"name": name})
+        assert response.status_code == 201, response.text
+        tenants[name] = response.json()["id"]
+
+    for role in ["read", "write", "admin"]:
+        subject = f"audit-{role}"
+        response = api.v0(
+            "POST",
+            "/tenant/users",
+            token=owner,
+            tenant=TENANT_X,
+            body={"subject": subject, "role": role},
+        )
+        assert response.status_code == 200, response.text
+        tokens["login", role] = primary_idp.token(subject)
+        response = api.v0(
+            "POST",
+            "/oidc_trust",
+            token=owner,
+            tenant=TENANT_X,
+            body={
+                "name": subject,
+                "issuer": workload_idp.url,
+                "subject": subject,
+                "audience": DEFAULT_AUDIENCE,
+                "role": role,
+            },
+        )
+        assert response.status_code == 201, response.text
+        tokens["trust", role] = workload_idp.token(subject)
+
+    for role in ["read", "write"]:
+        response = api.v0(
+            "POST",
+            "/api_keys",
+            token=owner,
+            tenant=TENANT_X,
+            body={"name": f"audit-{role}", "role": role},
+        )
+        assert response.status_code == 201, response.text
+        tokens["key", role] = response.json()["api_key"]
+
+    # The same identity has admin in X and read in Y, through either auth path.
+    response = api.v0(
+        "POST",
+        "/tenant/users",
+        token=owner,
+        tenant=TENANT_Y,
+        body={"subject": "audit-admin", "role": "read"},
+    )
+    assert response.status_code == 200, response.text
+    response = api.v0(
+        "POST",
+        "/oidc_trust",
+        token=owner,
+        tenant=TENANT_Y,
+        body={
+            "name": "audit-admin",
+            "issuer": workload_idp.url,
+            "subject": "audit-admin",
+            "audience": DEFAULT_AUDIENCE,
+            "role": "read",
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    for tenant in [TENANT_X, TENANT_Y]:
+        response = api.v0(
+            "POST",
+            "/pipelines",
+            token=owner,
+            tenant=tenant,
+            body={
+                "name": "audit-shared",
+                "description": tenant,
+                "program_code": "CREATE TABLE t (id INT);",
+            },
+        )
+        assert response.status_code == 201, response.text
+    response = api.v0(
+        "POST",
+        "/pipelines",
+        token=owner,
+        tenant=TENANT_Y,
+        body={"name": "audit-private-y", "program_code": "CREATE TABLE t (id INT);"},
+    )
+    assert response.status_code == 201, response.text
+    return tokens, tenants
+
+
+# test_2_route_matrix covers plain login requests to all documented routes.
+@pytest.mark.parametrize(
+    "kind,role,route,encoded",
+    [
+        pytest.param(
+            kind,
+            role,
+            route,
+            encoded,
+            id=f"{kind}-{role}-{route.id}-{'encoded' if encoded else 'plain'}",
+        )
+        for kind, role in CREDENTIALS
+        for route in ROUTES
+        for encoded in [False, True]
+        if encoded
+        or (kind == "login" and route in EXTRA_ROUTES)
+        or kind == "key"
+        or (
+            kind == "trust"
+            and (role, route.method, route.path) not in COVERED_TRUST_ROUTES
+        )
+    ],
+)
+def test_additional_route_cases_obey_the_role_floor(
+    api: Api, boundaries, kind, role, route, encoded
+):
+    tokens, _ = boundaries
+    path = encode_path(route.probe_path) if encoded else route.probe_path
+    response = api.raw_request(
+        route.method,
+        path,
+        token=tokens[kind, role],
+        tenant=TENANT_X,
+        body=probe_body(route),
+    )
+    if route.allows(role):
+        assert response.status_code not in (401, 403), response.text
+    else:
+        assert response.status_code == 403, response.text
+        assert response.json()["error_code"] == "InsufficientPermissions", response.text
+
+
+@pytest.mark.parametrize("kind", ["login", "trust"])
+def test_ungranted_tenant_uuid_is_rejected(api: Api, boundaries, kind):
+    tokens, tenants = boundaries
+    response = api.v0(
+        "GET", "/pipelines", token=tokens[kind, "admin"], tenant=tenants[TENANT_Z]
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.parametrize("role", ["read", "write"])
+def test_api_keys_accept_only_their_own_tenant(api: Api, boundaries, role):
+    tokens, tenants = boundaries
+    for selector in [None, TENANT_X, tenants[TENANT_X]]:
+        response = api.v0(
+            "GET",
+            "/pipelines/audit-shared",
+            token=tokens["key", role],
+            tenant=selector,
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["description"] == TENANT_X
+    for selector in [TENANT_Z, tenants[TENANT_Z], "audit-no-such-tenant"]:
+        response = api.v0(
+            "GET", "/pipelines", token=tokens["key", role], tenant=selector
+        )
+        assert response.status_code == 403, response.text
+
+
+@pytest.mark.parametrize("kind,role", CREDENTIALS)
+def test_empty_tenant_selector_is_rejected(api: Api, boundaries, kind, role):
+    tokens, _ = boundaries
+    response = api.v0("GET", "/pipelines", token=tokens[kind, role], tenant="")
+    assert response.status_code == 400, response.text
+
+
+@pytest.mark.parametrize(
+    "values", [(TENANT_X, TENANT_Y), (TENANT_Y, TENANT_X), (b"\xff",)]
+)
+def test_malformed_tenant_headers_do_not_fall_back_to_a_membership(
+    manager: Manager,
+    boundaries,
+    values,
+):
+    tokens, _ = boundaries
+    connection = http.client.HTTPSConnection(
+        "localhost",
+        manager.port,
+        timeout=10,
+        context=ssl.create_default_context(cafile=str(manager.ca_cert)),
+    )
+    try:
+        connection.putrequest("GET", "/v0/pipelines")
+        connection.putheader("Authorization", f"Bearer {tokens['login', 'read']}")
+        for value in values:
+            connection.putheader("Feldera-Tenant", value)
+        connection.endheaders()
+        response = connection.getresponse()
+        assert response.status == 400, response.read()
+    finally:
+        connection.close()
+
+
+# test_1_scenarios already checks login-token reads across tenant boundaries.
+@pytest.mark.parametrize(
+    "kind,method,suffix,body",
+    [
+        (kind, method, suffix, body)
+        for kind in ["login", "key", "trust"]
+        for method, suffix, body in [
+            ("GET", "", None),
+            ("PATCH", "", {"description": "cross-tenant mutation"}),
+            ("DELETE", "", None),
+            ("POST", "/stop?force=true", None),
+        ]
+        if kind != "login" or method != "GET"
+    ],
+)
+def test_other_tenants_pipeline_is_inaccessible_by_name(
+    api: Api,
+    boundaries,
+    kind,
+    method,
+    suffix,
+    body,
+):
+    tokens, _ = boundaries
+    response = api.v0(
+        method,
+        f"/pipelines/audit-private-y{suffix}",
+        token=tokens[kind, "write"],
+        tenant=TENANT_X,
+        body=body,
+    )
+    assert response.status_code == 404, response.text
+    response = api.v0(
+        "GET",
+        "/pipelines/audit-private-y",
+        token=tokens["login", "owner"],
+        tenant=TENANT_Y,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["description"] != "cross-tenant mutation"
+
+
+@pytest.mark.parametrize("kind", ["login", "key", "trust"])
+def test_request_body_and_query_cannot_override_the_tenant(api: Api, boundaries, kind):
+    tokens, tenants = boundaries
+    name = f"audit-body-{kind}"
+    response = api.v0(
+        "POST",
+        f"/pipelines?tenant_id={tenants[TENANT_Y]}",
+        token=tokens[kind, "write"],
+        tenant=TENANT_X,
+        body={
+            "name": name,
+            "tenant_id": tenants[TENANT_Y],
+            "program_code": "CREATE TABLE t (id INT);",
+        },
+    )
+    assert response.status_code == 201, response.text
+    for tenant, status in [(TENANT_X, 200), (TENANT_Y, 404)]:
+        response = api.v0(
+            "GET",
+            f"/pipelines/{name}",
+            token=tokens["login", "owner"],
+            tenant=tenant,
+        )
+        assert response.status_code == status, response.text
+
+
+# The login/name combination is covered by test_08_one_subject_holds_a_role_per_tenant.
+@pytest.mark.parametrize(
+    "kind,by_id", [("login", True), ("trust", False), ("trust", True)]
+)
+def test_role_is_resolved_again_for_the_selected_tenant(
+    api: Api, boundaries, kind, by_id
+):
+    tokens, tenants = boundaries
+    token = tokens[kind, "admin"]
+    for name in [TENANT_X, TENANT_Y, TENANT_X]:
+        selector = tenants[name] if by_id else name
+        response = api.v0(
+            "GET", "/pipelines/audit-shared", token=token, tenant=selector
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["description"] == name
+        response = api.v0("GET", "/tenant/users", token=token, tenant=selector)
+        assert response.status_code == (200 if name == TENANT_X else 403), response.text
+
+
+@pytest.mark.parametrize("claim", ["aud", "client_id", "token_use"])
+def test_required_login_claims_cannot_be_omitted(
+    api: Api,
+    boundaries,
+    primary_idp: Issuer,
+    claim: str,
+):
+    # Generic OIDC requires aud; Cognito-specific fields remain optional here.
+    token = primary_idp.token("audit-admin", omit_claims=(claim,))
+    response = api.v0("GET", "/tenant/users", token=token, tenant=TENANT_X)
+    assert response.status_code == (401 if claim == "aud" else 200), response.text
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {"aud": None},
+        {"aud": 42},
+        {"aud": []},
+        {"nbf": "invalid"},
+        {"token_use": "id"},
+        {"client_id": "another-client"},
+    ],
+)
+def test_invalid_login_claims_are_rejected(
+    api: Api, boundaries, primary_idp: Issuer, claims
+):
+    token = primary_idp.token("audit-admin", claims=claims)
+    response = api.v0("GET", "/tenant/users", token=token, tenant=TENANT_X)
+    assert response.status_code == 401, response.text
+
+
+def test_login_token_is_rejected_before_its_validity_period(
+    api: Api, boundaries, primary_idp
+):
+    token = primary_idp.token("audit-admin", claims={"nbf": int(time.time()) + 3600})
+    response = api.v0("GET", "/tenant/users", token=token, tenant=TENANT_X)
+    assert response.status_code == 401, response.text
+
+
+def protocol(prefix: str, value: str) -> str:
+    encoded = base64.urlsafe_b64encode(value.encode()).rstrip(b"=").decode()
+    return f"feldera-{prefix}.{encoded}"
+
+
+@pytest.mark.parametrize("kind,role", CREDENTIALS)
+def test_websocket_credentials_keep_their_role_and_tenant(
+    api: Api, boundaries, kind, role
+):
+    tokens, _ = boundaries
+    token = tokens[kind, role]
+    for tenant in [TENANT_X, TENANT_Z]:
+        headers = {
+            "Sec-WebSocket-Protocol": ", ".join(
+                [
+                    protocol("bearer", token),
+                    protocol("tenant", tenant),
+                ]
+            )
+        }
+        response = api.v0("GET", "/tenant/users", headers=headers)
+        allowed = role == "owner" or (tenant == TENANT_X and role == "admin")
+        assert response.status_code == (200 if allowed else 403), response.text
+
+
+@pytest.mark.parametrize("route", ROUTES, ids=lambda route: route.id)
+def test_encoded_routes_require_authentication(api: Api, boundaries, route):
+    # Encode the scope prefix as well as every literal and parameter segment.
+    path = encode_path(route.probe_path)
+    response = api.raw_request(route.method, path, body=probe_body(route))
+    assert response.status_code == 401, response.text
+
+
+def encode_path(path: str) -> str:
+    return "/".join("".join(f"%{ord(c):02x}" for c in part) for part in path.split("/"))

--- a/scripts/dummy_oidc.py
+++ b/scripts/dummy_oidc.py
@@ -236,6 +236,11 @@ def make_handler(
         if (groups := one("groups")) is not None:
             claims["groups"] = split_csv(groups)
 
+        # Negative auth tests need correctly signed tokens with invalid claims.
+        claims.update(json.loads(one("claims", "{}")))
+        for name in split_csv(one("omit_claims", "")):
+            claims.pop(name, None)
+
         return {
             "access_token": sign(claims),
             "token_type": "Bearer",


### PR DESCRIPTION
Login JWT validation could accept tokens without an audience or before their `nbf` time. This change requires the configured audience for generic OIDC, enforces `nbf` when present, and requires Cognito access tokens to identify the client and token purpose.

Tenant selection now rejects malformed or repeated headers and checks API-key selectors. A key for tenant X selecting Y previously operated in X; it now receives `403`. Omitting the header still uses the tenant of the key.

Add regression coverage for signed invalid tokens, credential roles, encoded URLs, tenant isolation, and credentials supplied through the WebSocket protocol header. The new cases supplement the existing RBAC tests. Test utilities can override JWT claims and clean up embedded Postgres between manager restarts.

### Describe Manual Test Plan

Exercised the manager over real HTTP with local HTTPS identity providers, including API-key requests with omitted, matching, and mismatched tenant selectors.

- `cargo build -p pipeline-manager` passed.
- `cargo test -p pipeline-manager --lib auth::test`: 19 passed.
- `uv run python -m pytest -n0 tests/platform_rbac -q`: 1,635 passed.
- Rust formatting, Ruff, and `git diff --check` passed.

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

- [x] OpenAPI / REST HTTP API / feldera-types / manager
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.)
- [ ] Python SDK
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

- Generic OIDC tokens must contain a valid `aud` matching the configured audience. Missing or malformed audiences are rejected.
- Login tokens with a future `nbf` beyond the clock-skew allowance, or a malformed `nbf`, are rejected.
- Cognito access tokens must include the configured `client_id` and `token_use=access`; those claims were previously checked only when present.
- Empty, whitespace-only, unreadable, or repeated `Feldera-Tenant` headers return `400`.
- API keys return `403` when an explicit tenant selector names another or unknown tenant. Clients should omit the header or select the tenant of the key by name or UUID.
