### PR TITLE
[connectors] Backport a fix to a data corruption bug in delta-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,7 +4393,7 @@ checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 [[package]]
 name = "deltalake"
 version = "0.32.3"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "buoyant_kernel",
  "ctor 0.10.1",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "deltalake-azure"
 version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "bytes",
  "deltalake-core",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "deltalake-catalog-unity"
 version = "0.16.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.32.3"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "deltalake-gcp"
 version = "0.16.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=78a5d066d60feffcc7dcd9bae62d1c537dd9018c#78a5d066d60feffcc7dcd9bae62d1c537dd9018c"
+source = "git+https://github.com/feldera/delta-rs.git?rev=9c85899091c75f5f3283e9628157f7b739807002#9c85899091c75f5f3283e9628157f7b739807002"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,12 +136,10 @@ datafusion-functions-json = "0.53.1"
 dbsp_nexmark = { path = "crates/nexmark" }
 deadpool-postgres = "0.14.1"
 # Feldera fork of delta-rs: upstream tag `rust-v0.32.3` + 6 patches, on branch
-# `dv-async-load`. When bumping the pinned revision, preserve these patches:
+# `dv-scan-order-backport-0.32.3`. When bumping the pinned revision, preserve
+# these patches:
 #   - 7f8bb445 "Disable unsupported feature check." — relax the writer-side
 #     protocol-feature gate so we can write tables produced by newer clients.
-#   - 5b35c098 "delta-rs: round-robin pre-split unpartitioned scans into
-#     target_partitions FileGroups" — improves snapshot read parallelism for
-#     unpartitioned tables; pairs with the DataFusion knobs we tune in adapters.
 #   - 297f2dd1 "delta-rs: resolve column-mapped Uniform/Iceberg columns by
 #     Parquet field id." — fixes `col-<id> is missing from the physical schema`
 #     when reading UC-Uniform-over-Iceberg tables (columnMapping.mode=id). #6557.
@@ -157,10 +155,24 @@ deadpool-postgres = "0.14.1"
 #   - 78a5d066 "delta-rs: regression test for the deletion-vector blocking-pool
 #     deadlock": eight vectors against four blocking threads, which wedges
 #     without the patch above.
+#   - 9c858990 "delta-rs: backport delta-io/delta-rs#4692 onto 0.32.3" — the
+#     deletion-vector keep mask is consumed in physical row order, so a scan
+#     that splits, filters or reorders a file underneath it returns the right
+#     number of rows made of the wrong records. Onto 0.32.3 rather than a
+#     rebase, because #4692 targets DataFusion 54/55 and our iceberg fork pins
+#     53; one part of it needs `FileScanConfigBuilder::with_output_partitioning`,
+#     which 53 lacks, and is done with a file-source wrapper instead. The commit
+#     message lists what was and was not ported.
+#
+# Reverted along the way, do not reinstate without reading #4692:
+#   - 5b35c098 "round-robin pre-split unpartitioned scans into target_partitions
+#     FileGroups" — incompatible with #4692, which requires a single input
+#     partition wherever masks are applied. DataFusion's own
+#     repartition_file_scans covers the same ground.
 # Diff vs. upstream:
-#   https://github.com/delta-io/delta-rs/compare/rust-v0.32.3...feldera:delta-rs:dv-async-load
-deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "78a5d066d60feffcc7dcd9bae62d1c537dd9018c" }
-deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "78a5d066d60feffcc7dcd9bae62d1c537dd9018c" }
+#   https://github.com/delta-io/delta-rs/compare/rust-v0.32.3...feldera:delta-rs:dv-scan-order-backport-0.32.3
+deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "9c85899091c75f5f3283e9628157f7b739807002" }
+deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "9c85899091c75f5f3283e9628157f7b739807002" }
 
 delta_kernel = { package = "buoyant_kernel", version = "0.22" }
 derive_more = { version = "1.0.0" }

--- a/python/tests/platform/fixtures/unity_api.py
+++ b/python/tests/platform/fixtures/unity_api.py
@@ -1,0 +1,151 @@
+"""Minimal Databricks REST client for the Unity Catalog fixtures.
+
+Only what the fixtures need: an OAuth token, a statement runner that polls, and
+the two Unity calls that turn a table name into an ``s3://`` location plus a
+temporary credential.
+
+Credentials come from the environment; source ``~/.feldera-dbx-test.env``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+#: The API caps `wait_timeout` at 50s, so anything longer has to be polled.
+STATEMENT_TIMEOUT_S = 1800
+
+#: Per-request ceiling. Generous: a statement call blocks server-side for up to
+#: `wait_timeout`, and these run against a warehouse that may be cold. It exists
+#: to break a stalled connection, not to bound a slow query -- without it a
+#: hung socket never returns and `STATEMENT_TIMEOUT_S`, which is only checked
+#: between calls, is never reached.
+REQUEST_TIMEOUT_S = 300
+
+
+class UnityApiError(Exception):
+    """A Unity Catalog call failed, or its configuration is missing.
+
+    Deliberately not `SystemExit`: this module is imported by tests as well as
+    run from `__main__`, and `SystemExit` is a `BaseException` that sidesteps
+    pytest's normal failure reporting. `main()` turns it back into an exit code.
+    """
+
+
+def require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise UnityApiError(f"{name} is not set; source ~/.feldera-dbx-test.env")
+    return value
+
+
+def token(host: str, client_id: str, client_secret: str) -> str:
+    """An OAuth M2M token. Unity vends the storage credentials separately."""
+    basic = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    request = urllib.request.Request(
+        f"{host}/oidc/v1/token",
+        data=b"grant_type=client_credentials&scope=all-apis",
+        headers={
+            "Authorization": f"Basic {basic}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    return json.load(urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S))[
+        "access_token"
+    ]
+
+
+def token_from_env(host: str) -> str:
+    return token(
+        host,
+        require("DELTA_TABLE_TEST_UNITY_CLIENT_ID"),
+        require("DELTA_TABLE_TEST_UNITY_CLIENT_SECRET"),
+    )
+
+
+def get(host: str, tok: str, path: str) -> dict:
+    request = urllib.request.Request(
+        f"{host}{path}", headers={"Authorization": f"Bearer {tok}"}
+    )
+    return json.load(urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S))
+
+
+def post(host: str, tok: str, path: str, body: dict) -> dict:
+    request = urllib.request.Request(
+        f"{host}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"},
+    )
+    return json.load(urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S))
+
+
+def _run(host: str, tok: str, warehouse: str, statement: str) -> dict:
+    try:
+        result = post(
+            host,
+            tok,
+            "/api/2.0/sql/statements",
+            {"warehouse_id": warehouse, "statement": statement, "wait_timeout": "50s"},
+        )
+    except urllib.error.HTTPError as e:
+        raise UnityApiError(f"HTTP {e.code}: {e.read().decode()[:400]}") from e
+
+    deadline = time.monotonic() + STATEMENT_TIMEOUT_S
+    while result["status"]["state"] in ("PENDING", "RUNNING"):
+        if time.monotonic() > deadline:
+            raise UnityApiError(
+                f"timed out after {STATEMENT_TIMEOUT_S}s:\n{statement[:200]}"
+            )
+        time.sleep(5)
+        result = get(host, tok, f"/api/2.0/sql/statements/{result['statement_id']}")
+
+    state = result["status"]["state"]
+    if state != "SUCCEEDED":
+        raise UnityApiError(
+            f"{state}: {json.dumps(result['status'])[:400]}\n{statement[:200]}"
+        )
+    return result
+
+
+def sql(host: str, tok: str, warehouse: str, statement: str) -> list:
+    """Run one statement to completion and return its rows as lists of cells."""
+    return _run(host, tok, warehouse, statement).get("result", {}).get("data_array", [])
+
+
+def sql_dicts(host: str, tok: str, warehouse: str, statement: str) -> list[dict]:
+    """As `sql`, but keyed by column name.
+
+    `DESCRIBE DETAIL` has no stable column *order* worth relying on, and
+    Databricks rejects `SELECT ... FROM (DESCRIBE DETAIL t)`, so read the names
+    off the result manifest instead of counting positions.
+    """
+    result = _run(host, tok, warehouse, statement)
+    names = [c["name"] for c in result["manifest"]["schema"]["columns"]]
+    return [
+        dict(zip(names, row)) for row in result.get("result", {}).get("data_array", [])
+    ]
+
+
+def table_location_and_credentials(host: str, tok: str, full_name: str) -> dict:
+    """Resolve a table to its ``s3://`` location and a temporary read credential.
+
+    Reading over the raw location rather than ``uc://`` is deliberate where a
+    test needs the object-store reader itself in the picture.
+    """
+    table = get(host, tok, f"/api/2.1/unity-catalog/tables/{full_name}")
+    creds = post(
+        host,
+        tok,
+        "/api/2.1/unity-catalog/temporary-table-credentials",
+        {"table_id": table["table_id"], "operation": "READ"},
+    )["aws_temp_credentials"]
+    return {
+        "uri": table["storage_location"],
+        "aws_access_key_id": creds["access_key_id"],
+        "aws_secret_access_key": creds["secret_access_key"],
+        "aws_session_token": creds["session_token"],
+    }

--- a/python/tests/platform/fixtures/unity_deletion_vectors.py
+++ b/python/tests/platform/fixtures/unity_deletion_vectors.py
@@ -1,0 +1,117 @@
+"""Create the Unity Catalog fixture for the deletion-vector read test.
+
+Run by hand, not by pytest, from the ``python`` directory:
+
+    source ~/.feldera-dbx-test.env
+    .venv/bin/python -m tests.platform.fixtures.unity_deletion_vectors
+    .venv/bin/python -m tests.platform.fixtures.unity_deletion_vectors --drop
+
+Two properties make this table resurrect deleted rows against an unfixed
+reader. Drop either and the read comes back correct whether or not the bug is
+present.
+
+Partitioned
+    This is the one that matters, and it is not about size. A partitioned
+    deletion-vector table is read through several scan streams that share one
+    map of keep masks, and a stream can drain a mask that is not its own. An
+    unpartitioned table of the same rows -- even 6x larger, over DataFusion's
+    10 MB split threshold, scanned across 32 partitions -- was correct in every
+    attempt against the same unfixed pin.
+
+Written by Databricks, read over S3
+    The writer and object store the connector meets in production, rather than
+    a local file written by Spark.
+
+The delete is lopsided (4978 rows from the first partition, 43 from the second)
+and lands in a single commit, so Delta packs both vectors into one `.bin` at
+different offsets and the second vector's offset depends on the first one's
+length. That mirrors the customer table this was built to explain.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from tests.platform.fixtures import unity_api
+
+#: The service principal cannot create schemas, so this one has to exist.
+SCHEMA = os.environ.get("DELTA_TABLE_TEST_UNITY_SCHEMA", "default")
+TABLE = "deletion_vectors"
+ROWS = 400_000
+HALF = ROWS // 2
+DELETED_HEAD = 4978
+DELETED_TAIL = 43
+EXPECTED_ROWS = ROWS - DELETED_HEAD - DELETED_TAIL
+
+#: Rows the deletion vectors mark deleted; none may be read back.
+DELETED_PREDICATE = (
+    f"id < {DELETED_HEAD} OR (id >= {HALF} AND id < {HALF} + {DELETED_TAIL})"
+)
+
+
+def statements(catalog: str) -> list[str]:
+    t = f"{catalog}.{SCHEMA}.{TABLE}"
+    return [
+        f"DROP TABLE IF EXISTS {t}",
+        f"CREATE TABLE {t} (id BIGINT, half INT, name STRING) USING delta"
+        f" PARTITIONED BY (half)"
+        f" TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')",
+        f"INSERT INTO {t} SELECT id, cast(id / {HALF} as int) AS half,"
+        f" concat('n', id) AS name FROM range(0, {ROWS})",
+        # One commit, both files: Delta packs the two vectors into one file.
+        f"DELETE FROM {t} WHERE {DELETED_PREDICATE}",
+    ]
+
+
+def main() -> None:
+    host = unity_api.require("DELTA_TABLE_TEST_UNITY_HOST").rstrip("/")
+    catalog = unity_api.require("DELTA_TABLE_TEST_UNITY_CATALOG")
+    warehouse = unity_api.require("DELTA_TABLE_TEST_UNITY_WAREHOUSE_ID")
+    token = unity_api.token_from_env(host)
+    t = f"{catalog}.{SCHEMA}.{TABLE}"
+
+    if "--drop" in sys.argv:
+        unity_api.sql(host, token, warehouse, f"DROP TABLE IF EXISTS {t}")
+        print("  dropped", t)
+        return
+
+    for statement in statements(catalog):
+        unity_api.sql(host, token, warehouse, statement)
+        print("  ok:", statement[:80].replace("\n", " "))
+
+    total, deleted = unity_api.sql(
+        host,
+        token,
+        warehouse,
+        f"SELECT count(*), count_if({DELETED_PREDICATE}) FROM {t}",
+    )[0]
+    assert int(total) == EXPECTED_ROWS, f"expected {EXPECTED_ROWS} rows, got {total}"
+    assert int(deleted) == 0, f"Databricks itself returns {deleted} deleted rows"
+
+    # A fixture that loses either property yields a test that passes with the
+    # bug present, so check them rather than trust the recipe.
+    detail = unity_api.sql_dicts(host, token, warehouse, f"DESCRIBE DETAIL {t}")[0]
+    assert "deletionVectors" in str(detail["tableFeatures"]), (
+        f"no deletion vectors on {t}: the delete was materialised instead"
+    )
+    assert detail["partitionColumns"], (
+        f"{t} is not partitioned; an unpartitioned table reads correctly even "
+        "against the unfixed reader and the test would be vacuous"
+    )
+
+    print(
+        f"\n{t} ready: {total} rows, {DELETED_HEAD + DELETED_TAIL} deleted by vectors"
+    )
+    print(f"  {detail['numFiles']} files, {detail['sizeInBytes']} bytes")
+    print("  DELTA_TABLE_TEST_UNITY_DV_TABLE=" + t)
+
+
+if __name__ == "__main__":
+    # `unity_api` raises rather than exits, so that importing it from a test
+    # does not bypass pytest's failure reporting; as a script, report the
+    # message and an exit code instead of a traceback.
+    try:
+        main()
+    except unity_api.UnityApiError as error:
+        sys.exit(str(error))

--- a/python/tests/platform/test_delta_input_deletion_vector_s3.py
+++ b/python/tests/platform/test_delta_input_deletion_vector_s3.py
@@ -1,0 +1,129 @@
+"""Read a Databricks deletion-vector table over raw S3 and check the rows.
+
+Regression test for delta-io/delta-rs#4692, which the fork carries as a
+backport. The per-file deletion-vector keep masks live in a map shared by the
+scan's streams and are drained positionally as batches arrive, so a stream can
+consume a mask that is not its own. The right *number* of rows is dropped at
+the wrong offsets: the count stays correct and the membership does not.
+
+The read has to be partitioned to catch it. An unpartitioned table of the same
+data was correct in every attempt against the unfixed reader, at any size and
+scan width; see the fixture for what the table needs.
+
+Which rows come back varies run to run, because it depends on the order the
+streams reach the mask. This table resurrected 1917 rows through the connector,
+and the stock Python client returned 0, 43, 4978 and 5021 on the same table
+across six runs. A single green run against an unfixed reader therefore proves
+nothing -- repeat it.
+
+The failure is quiet: the count is right and the records are wrong, so a
+count-only assertion sees nothing. The test asserts the deleted rows are absent.
+
+Gated on ``DELTA_TABLE_TEST_UNITY_DV_TABLE``; build the fixture with::
+
+    source ~/.feldera-dbx-test.env
+    cd python && .venv/bin/python -m tests.platform.fixtures.unity_deletion_vectors
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
+
+from tests import TEST_CLIENT
+from tests.platform.fixtures import unity_api, unity_deletion_vectors as fixture
+
+REQUIRED_ENV = [
+    "DELTA_TABLE_TEST_UNITY_DV_TABLE",
+    "DELTA_TABLE_TEST_UNITY_HOST",
+    "DELTA_TABLE_TEST_UNITY_CLIENT_ID",
+    "DELTA_TABLE_TEST_UNITY_CLIENT_SECRET",
+]
+MISSING_ENV = [name for name in REQUIRED_ENV if not os.environ.get(name)]
+
+pytestmark = pytest.mark.skipif(
+    bool(MISSING_ENV),
+    reason=(
+        f"unset: {', '.join(MISSING_ENV)}. Build the table with "
+        "`.venv/bin/python -m tests.platform.fixtures.unity_deletion_vectors`."
+    ),
+)
+
+TABLE = "dv_rows"
+CONNECTOR = "dv_in"
+
+
+def _s3_connector_config() -> dict[str, object]:
+    """Resolve the table's S3 location and a temporary credential from Unity.
+
+    The connector is pointed at the raw ``s3://`` location rather than
+    ``uc://``: the defect lives in how the object-store reader delivers batches,
+    so the test has to exercise that path.
+    """
+    host = os.environ["DELTA_TABLE_TEST_UNITY_HOST"].rstrip("/")
+    token = unity_api.token_from_env(host)
+    full_name = os.environ["DELTA_TABLE_TEST_UNITY_DV_TABLE"].removeprefix("uc://")
+    return {
+        **unity_api.table_location_and_credentials(host, token, full_name),
+        "mode": "snapshot",
+        "aws_region": os.environ.get("DELTA_TABLE_TEST_UNITY_REGION", "us-west-1"),
+        "timeout": "1000 secs",
+    }
+
+
+def test_delta_input_deletion_vectors_over_s3(pipeline_name):
+    """No row a deletion vector deletes may be read back.
+
+    The count is checked too, but it is the weaker half: the defect this guards
+    against returned exactly the right number of rows.
+    """
+    connectors = json.dumps(
+        [
+            {
+                "name": CONNECTOR,
+                "transport": {
+                    "name": "delta_table_input",
+                    "config": _s3_connector_config(),
+                },
+            }
+        ]
+    ).replace("'", "''")
+    sql = (
+        f"CREATE TABLE {TABLE} (id BIGINT, half INT, name VARCHAR)"
+        f" WITH ('materialized' = 'true', 'connectors' = '{connectors}');\n"
+        f"CREATE MATERIALIZED VIEW {TABLE}_summary AS SELECT COUNT(*) AS total,"
+        f" COUNT(*) FILTER (WHERE {fixture.DELETED_PREDICATE}) AS resurrected"
+        f" FROM {TABLE};"
+    )
+
+    pipeline = PipelineBuilder(
+        TEST_CLIENT,
+        pipeline_name,
+        sql=sql,
+        runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
+        ),
+    ).create_or_replace()
+    pipeline.start()
+    try:
+        pipeline.wait_for_completion(force_stop=False, timeout_s=1800)
+        row = list(pipeline.query(f"SELECT * FROM {TABLE}_summary"))[0]
+    finally:
+        pipeline.stop(force=True)
+
+    resurrected, total = int(row["resurrected"]), int(row["total"])
+    assert resurrected == 0, (
+        f"{resurrected} rows the deletion vectors delete were read back; the "
+        "keep mask was applied at the wrong offsets. The row count alone can "
+        "still be right when this happens."
+    )
+    assert total == fixture.EXPECTED_ROWS, (
+        f"expected {fixture.EXPECTED_ROWS} rows, got {total}"
+    )


### PR DESCRIPTION
Bump delta-rs dependency to point to our backport of https://github.com/delta-io/delta-rs/pull/4692.

The bug makes records disappear from tables with DVs while making deleted records reappear in customer workloads. Note that the fix hasn't been reviewed and merged to upstream delta-rs yet, but it seems to work around the issue in my testing. I suggest we merge it now and re-apply the final fix later if it changes.

The bug only shows up in S3 tables, not local FS, since it has to do with how datafusion plans scans over object store files. The PR includes a test that creates a table in S3 that reproduces the bug. This test won't run in CI yet, since we need to create a rotating Unity catalog credential for use in CI first. 

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
