### PR TITLE
[python] Fix test_suspend_enterprise max_rss_bytes expectation

### DIFF
--- a/python/tests/platform/test_checkpoint_suspend.py
+++ b/python/tests/platform/test_checkpoint_suspend.py
@@ -140,6 +140,10 @@ def test_suspend_enterprise(pipeline_name):
     """
     before_max_rss_mb = 64_000
     after_max_rss_mb = 65_000
+    # The pipeline carves the DataFusion pool out of `max_rss_mb` before sizing
+    # the circuit (`Controller::circuit_config` in crates/adapters); pinning the
+    # pool makes the expected circuit RSS exact.
+    datafusion_memory_mb = 1_000
 
     def runtime_config(max_rss_mb: int) -> dict:
         return {
@@ -147,7 +151,11 @@ def test_suspend_enterprise(pipeline_name):
             "hosts": FELDERA_TEST_NUM_HOSTS,
             "logging": "debug",
             "max_rss_mb": max_rss_mb,
+            "datafusion_memory_mb": datafusion_memory_mb,
         }
+
+    def expected_circuit_rss_bytes(max_rss_mb: int) -> int:
+        return (max_rss_mb - datafusion_memory_mb) * 1_000_000
 
     sql = r"""
     CREATE TABLE t1 (
@@ -208,7 +216,9 @@ def test_suspend_enterprise(pipeline_name):
     # Start pipeline (all connectors remain paused)
     start_pipeline(pipeline_name)
     wait_for_pipeline_reachable(pipeline_name)
-    assert _max_rss_bytes_metric(pipeline_name) == before_max_rss_mb * 1_000_000
+    assert _max_rss_bytes_metric(pipeline_name) == expected_circuit_rss_bytes(
+        before_max_rss_mb
+    )
     assert connector_paused(pipeline_name, "t1", "c1")
     assert connector_paused(pipeline_name, "t1", "c2")
     assert connector_paused(pipeline_name, "t1", "c3")
@@ -234,7 +244,9 @@ def test_suspend_enterprise(pipeline_name):
     assert resp.status_code == HTTPStatus.OK, resp.text
     start_pipeline(pipeline_name)
     wait_for_pipeline_reachable(pipeline_name)
-    assert _max_rss_bytes_metric(pipeline_name) == after_max_rss_mb * 1_000_000
+    assert _max_rss_bytes_metric(pipeline_name) == expected_circuit_rss_bytes(
+        after_max_rss_mb
+    )
     # After resume: c1 running (EOI), c2,c3 still paused
     assert not connector_paused(pipeline_name, "t1", "c1")
     assert connector_paused(pipeline_name, "t1", "c2")


### PR DESCRIPTION
The pipeline controller carves the DataFusion pool out of `max_rss_mb` before sizing the DBSP circuit (`Controller::circuit_config` in `crates/adapters/src/controller.rs`, via `RuntimeConfig::resolved_datafusion_memory_mb`), so the `max_rss_bytes` metric reports the remainder, not `max_rss_mb` itself. The test asserted exact equality and failed with `61952000000 == 64000 * 1000000` once cloud CI stopped deselecting `test_checkpoint_suspend.py` (feldera/cloud#1833).

The test now pins `datafusion_memory_mb` in its runtime config and expects `(max_rss_mb - datafusion_memory_mb)` bytes. Pinning keeps the expected value independent of the default 5% / 2048 MB carve-out rule, so the test does not duplicate that rule in Python.

The test is enterprise-only. Verified in cloud CI with the full python suite and no deselect list, green on both arches: https://github.com/feldera/cloud/actions/runs/34004741882