### PR TITLE
Cache GitHub Actions artifacts in GCS through Workload Identity

### DIFF
--- a/.github/actions/feldera-gcs-cache/action.yml
+++ b/.github/actions/feldera-gcs-cache/action.yml
@@ -1,9 +1,7 @@
 name: 'Feldera GCS cache'
 description: |
-  Wrapper around runs-on/cache that targets the GCS bucket used for GitHub
-  Actions caches over the S3-interop endpoint. The caller is responsible for
-  providing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the job or
-  workflow env (the CI_GCS_HMAC_* secrets, a GCS HMAC key pair).
+  An actions/cache implementation that stores caches in GCS. The runner pod
+  authenticates through Workload Identity, so callers pass no credentials.
 
 inputs:
   path:
@@ -24,18 +22,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
-      env:
-        # GCS S3-interop: HMAC auth, path-style; the region is syntactically
-        # required but ignored by GCS.
-        AWS_REGION: auto
-        AWS_ENDPOINT_URL: https://storage.googleapis.com
-        AWS_S3_FORCE_PATH_STYLE: "true"
-        RUNS_ON_S3_BUCKET_CACHE: ${{ inputs.bucket }}
-        # Defend against AWS_SESSION_TOKEN leaking from a configure-aws-credentials
-        # step run earlier in the job — HMAC requests must not carry it.
-        AWS_SESSION_TOKEN: ""
+    # On any GCS error the action logs a warning and silently falls back to
+    # GitHub's hosted cache; look for "Cache restored from GCS" in the step
+    # log when a cache seems slow or missing.
+    - uses: danySam/gcs-cache@63ff70449726b2d2094abf2fbc85c9dce2919758 # v1.1.0
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
         restore-keys: ${{ inputs.restore-keys }}
+        gcs-bucket: ${{ inputs.bucket }}

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -16,13 +16,6 @@ jobs:
     runs-on: [gke-runners-amd64]
     permissions:
       contents: read
-    env:
-      # GCS HMAC credentials — feldera-gcs-cache reads these to talk to the
-      # actions-cache bucket. Scoped to this job: ambient AWS_* credentials
-      # confuse configure-aws-credentials in upload-jar, which must
-      # authenticate purely via OIDC.
-      AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-      AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
     container:
       image: us-central1-docker.pkg.dev/feldera-ci/ghcr-remote/feldera/feldera-dev:sha-6694c709e8a150203f56b80c5058286e4378e2ee
     steps:
@@ -67,9 +60,8 @@ jobs:
           path: build-artifacts
           retention-days: 7
 
-  # S3 upload runs in a separate job so the OIDC session token never enters
-  # the build-jar environment, where it would poison the cache save phase
-  # of runs-on/cache (MinIO rejects requests carrying a stray AWS_SESSION_TOKEN).
+  # S3 upload runs in a separate job so only this job holds id-token: write
+  # and the build job never carries AWS credentials.
   upload-jar:
     name: Upload JAR to S3
     needs: build-jar

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -13,8 +13,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
   # sccache cannot cache incremental rustc invocations; release already
   # disables incremental, but doc tests run in debug mode.
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -10,8 +10,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
 
 jobs:
   # Ideally this would just invoke `publish-python.yml`

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -10,8 +10,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
   # sccache cannot cache rustc invocations when incremental is on.
   CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,8 +10,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
 
 on:
   workflow_call:

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -11,8 +11,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
   # sccache cannot cache rustc when incremental is on; required for the
   # Rust builds invoked by mvn → sql-to-dbsp to hit the sccache MinIO store.
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -10,8 +10,6 @@ env:
   # Workload Identity (no secrets).
   SCCACHE_GCS_BUCKET: ${{ vars.SCCACHE_GCS_BUCKET }}
   SCCACHE_GCS_RW_MODE: READ_WRITE
-  AWS_ACCESS_KEY_ID: "${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}"
   RUST_MIN_STACK: 8388608
   # sccache cannot cache rustc invocations when incremental is on.
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Replaces runs-on/cache (AWS SDK, SigV4, needs a GCS HMAC key) with danySam/gcs-cache, an actions/cache fork that talks to GCS natively through Application Default Credentials. On the ci-cluster the job pods run as arc-job-sa, mapped to the ci-runner GSA with objectAdmin on the cache bucket, so no secret is involved. sccache was already keyless, and #7067 moved the integration tests off the S3-interop endpoint, so after this PR nothing in the repo reads `CI_GCS_HMAC_*`.

## Trial on this branch

Run 34019672668 (ci.yml dispatched on the branch, rebased since without code changes). Every cache call site restored through the metadata server from inside the feldera-dev container with no GCS warning and saved to the bucket:

| Job | Saved object |
|---|---|
| Pre Merge Queue main | cargo 240 MB, pre-commit 14 MB |
| Build Compiler | jvm 1.4 GB |
| Build Rust Binaries amd64, arm64 | cargo 248 MB each |
| Execute Java Tests amd64, arm64 | jvm 1.5 GB, cargo 95 MB each |

The run itself ended cancelled: the amd64 runtime integration job got a runner shutdown signal and the sentinel cancelled the rest. No test failed, and those jobs do not use the cache action.

## Pin and audit

Pinned to `63ff70449726b2d2094abf2fbc85c9dce2919758` (tag v1.1.0, 2026-06-01). Checked at that commit:

- `dist/` rebuilds from `src/` + `package-lock.json` with `npm ci && npm run build`; the only difference is CRLF vs LF (`.gitattributes` normalizes to LF).
- All 602 lockfile packages resolve to registry.npmjs.org with integrity hashes.
- Source diff against upstream actions/cache at the merge base is the GCS module (`src/utils/gcsCache.ts`), the restore/save import swap, and docs.
- Hosts referenced by the bundle: googleapis.com (storage, oauth2, iamcredentials, sts), metadata.google.internal / 169.254.169.254, and the GitHub / Azure blob hosts inherited from `@actions/cache`.
- child_process use: `@actions/exec` (tar), google-auth-library gcloud project lookup, and its pluggable-auth executable path (only active with an executable credential source).
- Upstream check-dist and the GCS integration tests passed on the PR that produced this dist.
- `npm audit`: 8 known CVEs in transitive deps (undici, form-data, brace-expansion, uuid), DoS and header-injection class, no malicious packages.

## Known inefficiency, follow-up upstream

The fork restores the newest object under any of the keys instead of preferring the exact primary-key object, and reports the search key rather than the matched key. When a sibling job with a different lockfile hash saved more recently, a job restores that sibling cache and re-uploads its own tree in the post step. Dependency caches are validated by cargo, Maven, and uv, so this costs upload time only: 240 MB for cargo, 1.4 GB for jvm, on the runs where it triggers. The object is overwritten under the same key and the bucket has a 14-day lifecycle rule, so nothing accumulates. Fix is a small change to `findLatestFileOnGCS` (return on the first key with a match, report the matched key); to be sent upstream and re-pinned after the same audit.

Other properties worth knowing: on any GCS error the action logs a warning and falls back to the GitHub hosted cache instead of failing, and uploads are non-resumable. A wrong identity therefore shows up as a slow job, not a red one; the wrapper comment says where to look.

## After merge

- cloud-deployments: delete `argo/manifests/ci-cluster/resources/sccache-secret.yaml` (sccache is disabled on the CI instances).
- infrastructure: drop `google_storage_hmac_key.ci_runner` and its two outputs from terraform/gcp/ci.
- ci-runner has two active HMAC keys; terraform owns `GOOG1EMQCR4XY...NUTAJXVZI`, the other (`GOOG1EA5SL72...JJIXTH7U`, 2026-07-25 02:16Z) is an orphan to deactivate and delete by hand.
- Delete the `CI_GCS_HMAC_*` org secrets and the Infisical `/GCP-GKE-CI` entries.