### PR TITLE
[adapters] delta: run the object-store tests in CI

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   CARGO_FLAGS: "--release --locked --all-targets"
-  CARGO_FEATURES_BASE: "fips,pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue"
+  CARGO_FEATURES_BASE: "fips,pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue,delta-s3-test"
   FELDERA_PLATFORM_VERSION_SUFFIX: ${{ github.sha }}
   FELDERA_BUILD_ORIGIN: ci
   RUSTC_WRAPPER: sccache

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -127,18 +127,13 @@ jobs:
           PUBSUB_EMULATOR_HOST: 127.0.0.1:8681
           ICEBERG_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.delta_table_test_aws_access_key_id }}
           ICEBERG_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.delta_table_test_aws_secret_access_key }}
-          # The Delta object-store tests read the same two buckets as the Python
-          # suite, but over the S3-compatible API with static keys rather than
-          # `gs://` with Workload Identity, so they need their own credentials.
-          # Variable names follow the S3-compatible shape in
-          # python/tests/utils.py. Tables the tests write go to CI_MINIO_BUCKET,
-          # which expires objects after 7 days; read-only fixtures live in
-          # CI_MINIO_INPUTS_BUCKET, which does not.
-          CI_K8S_MINIO_ACCESS_KEY_ID: ${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}
-          CI_K8S_MINIO_SECRET_ACCESS_KEY: ${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}
-          CI_MINIO_ENDPOINT: https://storage.googleapis.com
-          CI_MINIO_BUCKET: feldera-ci-test-feldera-ci
-          CI_MINIO_INPUTS_BUCKET: feldera-ci-inputs-feldera-ci
+          # The Delta object-store tests, same stores and variables as the
+          # Python suite. No credentials: Workload Identity authenticates the
+          # runner. Tables the tests write go to the per-run store, which
+          # expires objects after 7 days.
+          CI_OBJECT_STORE_URI: gs://feldera-ci-test-feldera-ci
+          # Long-lived datasets tests only read.
+          CI_OBJECT_STORE_INPUTS_URI: gs://feldera-ci-inputs-feldera-ci
           POSTGRES_SSL_URL: postgres://postgres:${{ secrets.ci_postgres_password }}@ci-postgres-internal.postgres.svc.cluster.local:5432/postgres?sslmode=require
           POSTGRES_SSL_CA_PEM: ${{ secrets.ci_postgres_tls_crt }}
           POSTGRES_SSL_VERIFY_HOSTNAME: "false"

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -127,12 +127,13 @@ jobs:
           PUBSUB_EMULATOR_HOST: 127.0.0.1:8681
           ICEBERG_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.delta_table_test_aws_access_key_id }}
           ICEBERG_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.delta_table_test_aws_secret_access_key }}
-          DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.delta_table_test_aws_access_key_id }}
-          DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.delta_table_test_aws_secret_access_key }}
-          # GCS test buckets for the Delta S3 tests, reached over the S3-compatible
-          # API under the same names the Python Delta tests use. Tables the tests
-          # write go to CI_MINIO_BUCKET, which expires objects after 7 days;
-          # read-only fixtures live in CI_MINIO_INPUTS_BUCKET, which does not.
+          # The Delta object-store tests read the same two buckets as the Python
+          # suite, but over the S3-compatible API with static keys rather than
+          # `gs://` with Workload Identity, so they need their own credentials.
+          # Variable names follow the S3-compatible shape in
+          # python/tests/utils.py. Tables the tests write go to CI_MINIO_BUCKET,
+          # which expires objects after 7 days; read-only fixtures live in
+          # CI_MINIO_INPUTS_BUCKET, which does not.
           CI_K8S_MINIO_ACCESS_KEY_ID: ${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}
           CI_K8S_MINIO_SECRET_ACCESS_KEY: ${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}
           CI_MINIO_ENDPOINT: https://storage.googleapis.com

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -129,6 +129,15 @@ jobs:
           ICEBERG_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.delta_table_test_aws_secret_access_key }}
           DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.delta_table_test_aws_access_key_id }}
           DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.delta_table_test_aws_secret_access_key }}
+          # GCS test buckets for the Delta S3 tests, reached over the S3-compatible
+          # API under the same names the Python Delta tests use. Tables the tests
+          # write go to CI_MINIO_BUCKET, which expires objects after 7 days;
+          # read-only fixtures live in CI_MINIO_INPUTS_BUCKET, which does not.
+          CI_K8S_MINIO_ACCESS_KEY_ID: ${{ secrets.CI_GCS_HMAC_ACCESS_KEY_ID }}
+          CI_K8S_MINIO_SECRET_ACCESS_KEY: ${{ secrets.CI_GCS_HMAC_SECRET_ACCESS_KEY }}
+          CI_MINIO_ENDPOINT: https://storage.googleapis.com
+          CI_MINIO_BUCKET: feldera-ci-test-feldera-ci
+          CI_MINIO_INPUTS_BUCKET: feldera-ci-inputs-feldera-ci
           POSTGRES_SSL_URL: postgres://postgres:${{ secrets.ci_postgres_password }}@ci-postgres-internal.postgres.svc.cluster.local:5432/postgres?sslmode=require
           POSTGRES_SSL_CA_PEM: ${{ secrets.ci_postgres_tls_crt }}
           POSTGRES_SSL_VERIFY_HOSTNAME: "false"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -56,6 +56,10 @@ with-nats = []
 # Run delta table tests against an S3 bucket.  Requires S3 authentication key
 # to be provided via an environment variable.
 delta-s3-test = []
+# Databricks Unity Catalog tests. Separate from `delta-s3-test`: those run in CI
+# against the CI object store, while these need a Databricks workspace whose
+# credentials CI does not hold.
+delta-unity-test = []
 # Run Pub/Sub connector tests agains an emulator.
 # The emulator must be running. See `pubsub/test.rs`.
 pubsub-emulator-test = []

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -41,8 +41,10 @@ use proptest::proptest;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
 use serde_json::{Value, json};
-#[cfg(any(feature = "delta-s3-test", feature = "delta-unity-test"))]
-use serial_test::{parallel, serial};
+#[cfg(feature = "delta-s3-test")]
+use serial_test::parallel;
+#[cfg(feature = "delta-unity-test")]
+use serial_test::serial;
 use size_of::SizeOf;
 use std::cmp::min;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -3467,27 +3469,43 @@ fn except_all_unsupported_types_are_only_map() {
     );
 }
 
+/// Value of `name`, or a panic naming the variable that has to be set.
+///
+/// `env::var(..).unwrap()` reports only `NotPresent`, which does not say what
+/// to set. Mirrors `required_env` in `python/tests/utils.py`.
+#[cfg(feature = "delta-s3-test")]
+fn required_env(name: &str) -> String {
+    std::env::var(name)
+        .unwrap_or_else(|_| panic!("{name} must be set to run the delta-s3-test tests"))
+}
+
 /// Credentials, endpoint and region for the CI object store.
 ///
 /// The store is a GCS bucket reached through its S3-compatible API, so the
-/// tables stay `s3://` URIs and only gain an endpoint. The variable names match
-/// `.github/workflows/test-integration-platform.yml`, so one set of secrets
-/// serves both these tests and the Python Delta tests.
+/// tables stay `s3://` URIs and only gain an endpoint.
+///
+/// The names are the S3-compatible shape that `python/tests/utils.py` defines
+/// (see its `MINIO_*` constants). The Python suite reads the same buckets, but
+/// over `gs://` with Workload Identity, so the two suites share the buckets
+/// rather than the credentials. Everything is required: a default that is right
+/// for one variable and stale for another fails obscurely, e.g. by resolving
+/// `s3://ci-tests/` against `storage.googleapis.com`.
 #[cfg(feature = "delta-s3-test")]
 fn ci_object_store_config() -> Vec<(String, String)> {
-    let endpoint = std::env::var("CI_MINIO_ENDPOINT")
-        .unwrap_or_else(|_| "https://storage.googleapis.com".to_string());
+    let endpoint = required_env("CI_MINIO_ENDPOINT");
     vec![
         (
             "aws_access_key_id".to_string(),
-            std::env::var("CI_K8S_MINIO_ACCESS_KEY_ID").unwrap(),
+            required_env("CI_K8S_MINIO_ACCESS_KEY_ID"),
         ),
         (
             "aws_secret_access_key".to_string(),
-            std::env::var("CI_K8S_MINIO_SECRET_ACCESS_KEY").unwrap(),
+            required_env("CI_K8S_MINIO_SECRET_ACCESS_KEY"),
         ),
         // Meaningless for GCS, but the S3 store insists on one
-        // (see https://github.com/delta-io/delta-rs/issues/1095).
+        // (see https://github.com/delta-io/delta-rs/issues/1095). Defaulted,
+        // as `python/tests/utils.py` defaults it, because every store this
+        // talks to ignores it.
         (
             "aws_region".to_string(),
             std::env::var("CI_MINIO_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
@@ -3503,7 +3521,7 @@ fn ci_object_store_config() -> Vec<(String, String)> {
 /// Bucket for tables the tests write. Everything in it is deleted after 7 days.
 #[cfg(feature = "delta-s3-test")]
 fn ci_bucket() -> String {
-    std::env::var("CI_MINIO_BUCKET").unwrap_or_else(|_| "ci-tests".to_string())
+    required_env("CI_MINIO_BUCKET")
 }
 
 /// Bucket for read-only input data, which has no expiry rule. Fixtures that
@@ -3511,8 +3529,7 @@ fn ci_bucket() -> String {
 /// deletes them a week after upload.
 #[cfg(feature = "delta-s3-test")]
 fn ci_inputs_bucket() -> String {
-    std::env::var("CI_MINIO_INPUTS_BUCKET")
-        .unwrap_or_else(|_| "feldera-ci-inputs-feldera-ci".to_string())
+    required_env("CI_MINIO_INPUTS_BUCKET")
 }
 
 /// Location for a table the test writes. No test removes the table it creates;

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -3479,64 +3479,39 @@ fn required_env(name: &str) -> String {
         .unwrap_or_else(|_| panic!("{name} must be set to run the delta-s3-test tests"))
 }
 
-/// Credentials, endpoint and region for the CI object store.
+/// Object-store options for the CI buckets.
 ///
-/// The store is a GCS bucket reached through its S3-compatible API, so the
-/// tables stay `s3://` URIs and only gain an endpoint.
-///
-/// The names are the S3-compatible shape that `python/tests/utils.py` defines
-/// (see its `MINIO_*` constants). The Python suite reads the same buckets, but
-/// over `gs://` with Workload Identity, so the two suites share the buckets
-/// rather than the credentials. Everything is required: a default that is right
-/// for one variable and stale for another fails obscurely, e.g. by resolving
-/// `s3://ci-tests/` against `storage.googleapis.com`.
+/// Empty: the buckets are GCS, and both the test process and the pipeline
+/// authenticate with Workload Identity in CI and application-default
+/// credentials locally, so no key ever reaches a connector config. Same
+/// reasoning as `delta_storage_options` in `python/tests/utils.py`.
 #[cfg(feature = "delta-s3-test")]
 fn ci_object_store_config() -> Vec<(String, String)> {
-    let endpoint = required_env("CI_MINIO_ENDPOINT");
-    vec![
-        (
-            "aws_access_key_id".to_string(),
-            required_env("CI_K8S_MINIO_ACCESS_KEY_ID"),
-        ),
-        (
-            "aws_secret_access_key".to_string(),
-            required_env("CI_K8S_MINIO_SECRET_ACCESS_KEY"),
-        ),
-        // Meaningless for GCS, but the S3 store insists on one
-        // (see https://github.com/delta-io/delta-rs/issues/1095). Defaulted,
-        // as `python/tests/utils.py` defaults it, because every store this
-        // talks to ignores it.
-        (
-            "aws_region".to_string(),
-            std::env::var("CI_MINIO_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
-        ),
-        (
-            "aws_allow_http".to_string(),
-            (!endpoint.starts_with("https://")).to_string(),
-        ),
-        ("aws_endpoint".to_string(), endpoint),
-    ]
+    Vec::new()
 }
 
-/// Bucket for tables the tests write. Everything in it is deleted after 7 days.
+/// Store for per-run test data, as `gs://<bucket>[/<prefix>]`. Everything in it
+/// is deleted after 7 days.
 #[cfg(feature = "delta-s3-test")]
-fn ci_bucket() -> String {
-    required_env("CI_MINIO_BUCKET")
+fn ci_store_uri() -> String {
+    required_env("CI_OBJECT_STORE_URI").trim_end_matches('/').to_string()
 }
 
-/// Bucket for read-only input data, which has no expiry rule. Fixtures that
-/// cannot be regenerated from this repo have to live here: the scratch bucket
+/// Store for read-only input data, which has no expiry rule. Fixtures that
+/// cannot be regenerated from this repo have to live here: the per-run store
 /// deletes them a week after upload.
 #[cfg(feature = "delta-s3-test")]
-fn ci_inputs_bucket() -> String {
-    required_env("CI_MINIO_INPUTS_BUCKET")
+fn ci_inputs_store_uri() -> String {
+    required_env("CI_OBJECT_STORE_INPUTS_URI")
+        .trim_end_matches('/')
+        .to_string()
 }
 
 /// Location for a table the test writes. No test removes the table it creates;
 /// the bucket's lifecycle rule deletes objects after 7 days instead.
 #[cfg(feature = "delta-s3-test")]
 fn ci_scratch_table_uri(uuid: uuid::Uuid) -> String {
-    format!("s3://{}/rust-delta-tests/{uuid}/", ci_bucket())
+    format!("{}/rust-delta-tests/{uuid}/", ci_store_uri())
 }
 
 #[cfg(feature = "delta-s3-test")]
@@ -3557,7 +3532,6 @@ async fn delta_table_cdc_s3_test_suspend() {
     let object_store_config = ci_object_store_config()
         .into_iter()
         .map(|(key, value)| (key, value.into()))
-        .chain([("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".into())])
         .collect::<HashMap<String, Value>>();
 
     let input_table_uri = ci_scratch_table_uri(input_uuid);
@@ -3860,7 +3834,6 @@ async fn delta_table_follow_s3_test_common(snapshot: bool, suspend: bool) {
 
     let object_store_config = ci_object_store_config()
         .into_iter()
-        .chain([("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".to_string())])
         .collect::<HashMap<_, _>>();
 
     let input_table_uri = ci_scratch_table_uri(input_uuid);
@@ -4108,10 +4081,10 @@ proptest! {
 /// Read a large (2M records) dataset from the CI object store.
 ///
 /// Copied there from the Databricks workspace bucket it was created in, so CI
-/// can reach it with the same credentials as every other Delta test. It sits in
-/// the inputs bucket rather than the scratch one because nothing in this repo
-/// can rebuild it -- it came from a Databricks notebook (below) -- and the
-/// scratch bucket deletes everything after 7 days.
+/// can read it without credentials of its own. It sits in the inputs store
+/// rather than the per-run one because nothing in this repo can rebuild it --
+/// it came from a Databricks notebook (below) -- and the per-run store deletes
+/// everything after 7 days.
 ///
 /// This dataset was derived from
 /// `/databricks-datasets/learning-spark-v2/people/people-10m.delta`; however the full dataset
@@ -4143,8 +4116,8 @@ fn delta_table_s3_people_2m() {
         .collect::<HashMap<_, _>>();
 
     let table_uri = format!(
-        "s3://{}/delta-connector-tests/people_2m/",
-        ci_inputs_bucket()
+        "{}/delta-connector-tests/people_2m/",
+        ci_inputs_store_uri()
     );
     let table_uri = table_uri.as_str();
     let mut json_file = delta_table_snapshot_to_json::<DatabricksPeople>(

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -3494,7 +3494,9 @@ fn ci_object_store_config() -> Vec<(String, String)> {
 /// is deleted after 7 days.
 #[cfg(feature = "delta-s3-test")]
 fn ci_store_uri() -> String {
-    required_env("CI_OBJECT_STORE_URI").trim_end_matches('/').to_string()
+    required_env("CI_OBJECT_STORE_URI")
+        .trim_end_matches('/')
+        .to_string()
 }
 
 /// Store for read-only input data, which has no expiry rule. Fixtures that
@@ -4115,10 +4117,7 @@ fn delta_table_s3_people_2m() {
         .chain([("timeout".to_string(), "1000 secs".to_string())])
         .collect::<HashMap<_, _>>();
 
-    let table_uri = format!(
-        "{}/delta-connector-tests/people_2m/",
-        ci_inputs_store_uri()
-    );
+    let table_uri = format!("{}/delta-connector-tests/people_2m/", ci_inputs_store_uri());
     let table_uri = table_uri.as_str();
     let mut json_file = delta_table_snapshot_to_json::<DatabricksPeople>(
         table_uri,

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -12,7 +12,7 @@ use crate::{Catalog, CircuitCatalog};
 use arrow::datatypes::Schema as ArrowSchema;
 use chrono::NaiveDate;
 use dbsp::circuit::CircuitConfig;
-#[cfg(feature = "delta-s3-test")]
+#[cfg(any(feature = "delta-s3-test", feature = "delta-unity-test"))]
 use dbsp::typed_batch::DynBatchReader;
 use dbsp::utils::Tup2;
 use dbsp::{DBData, DBSPHandle, OrdZSet, Runtime};
@@ -41,7 +41,7 @@ use proptest::proptest;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
 use serde_json::{Value, json};
-#[cfg(feature = "delta-s3-test")]
+#[cfg(any(feature = "delta-s3-test", feature = "delta-unity-test"))]
 use serial_test::{parallel, serial};
 use size_of::SizeOf;
 use std::cmp::min;
@@ -3467,6 +3467,61 @@ fn except_all_unsupported_types_are_only_map() {
     );
 }
 
+/// Credentials, endpoint and region for the CI object store.
+///
+/// The store is a GCS bucket reached through its S3-compatible API, so the
+/// tables stay `s3://` URIs and only gain an endpoint. The variable names match
+/// `.github/workflows/test-integration-platform.yml`, so one set of secrets
+/// serves both these tests and the Python Delta tests.
+#[cfg(feature = "delta-s3-test")]
+fn ci_object_store_config() -> Vec<(String, String)> {
+    let endpoint = std::env::var("CI_MINIO_ENDPOINT")
+        .unwrap_or_else(|_| "https://storage.googleapis.com".to_string());
+    vec![
+        (
+            "aws_access_key_id".to_string(),
+            std::env::var("CI_K8S_MINIO_ACCESS_KEY_ID").unwrap(),
+        ),
+        (
+            "aws_secret_access_key".to_string(),
+            std::env::var("CI_K8S_MINIO_SECRET_ACCESS_KEY").unwrap(),
+        ),
+        // Meaningless for GCS, but the S3 store insists on one
+        // (see https://github.com/delta-io/delta-rs/issues/1095).
+        (
+            "aws_region".to_string(),
+            std::env::var("CI_MINIO_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
+        ),
+        (
+            "aws_allow_http".to_string(),
+            (!endpoint.starts_with("https://")).to_string(),
+        ),
+        ("aws_endpoint".to_string(), endpoint),
+    ]
+}
+
+/// Bucket for tables the tests write. Everything in it is deleted after 7 days.
+#[cfg(feature = "delta-s3-test")]
+fn ci_bucket() -> String {
+    std::env::var("CI_MINIO_BUCKET").unwrap_or_else(|_| "ci-tests".to_string())
+}
+
+/// Bucket for read-only input data, which has no expiry rule. Fixtures that
+/// cannot be regenerated from this repo have to live here: the scratch bucket
+/// deletes them a week after upload.
+#[cfg(feature = "delta-s3-test")]
+fn ci_inputs_bucket() -> String {
+    std::env::var("CI_MINIO_INPUTS_BUCKET")
+        .unwrap_or_else(|_| "feldera-ci-inputs-feldera-ci".to_string())
+}
+
+/// Location for a table the test writes. No test removes the table it creates;
+/// the bucket's lifecycle rule deletes objects after 7 days instead.
+#[cfg(feature = "delta-s3-test")]
+fn ci_scratch_table_uri(uuid: uuid::Uuid) -> String {
+    format!("s3://{}/rust-delta-tests/{uuid}/", ci_bucket())
+}
+
 #[cfg(feature = "delta-s3-test")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[parallel(delta_s3)]
@@ -3482,27 +3537,13 @@ async fn delta_table_cdc_s3_test_suspend() {
 
     let input_uuid = uuid::Uuid::new_v4();
 
-    let object_store_config = [
-        (
-            "aws_access_key_id".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID")
-                .unwrap()
-                .into(),
-        ),
-        (
-            "aws_secret_access_key".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY")
-                .unwrap()
-                .into(),
-        ),
-        // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
-        ("aws_region".to_string(), "us-east-2".into()),
-        ("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".into()),
-    ]
-    .into_iter()
-    .collect::<HashMap<String, Value>>();
+    let object_store_config = ci_object_store_config()
+        .into_iter()
+        .map(|(key, value)| (key, value.into()))
+        .chain([("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".into())])
+        .collect::<HashMap<String, Value>>();
 
-    let input_table_uri = format!("s3://feldera-delta-table-test/{input_uuid}/");
+    let input_table_uri = ci_scratch_table_uri(input_uuid);
 
     test_cdc(
         &relation_schema,
@@ -3800,24 +3841,13 @@ async fn delta_table_follow_s3_test_common(snapshot: bool, suspend: bool) {
     let input_uuid = uuid::Uuid::new_v4();
     let output_uuid = uuid::Uuid::new_v4();
 
-    let object_store_config = [
-        (
-            "aws_access_key_id".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap(),
-        ),
-        (
-            "aws_secret_access_key".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap(),
-        ),
-        // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
-        ("aws_region".to_string(), "us-east-2".to_string()),
-        ("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".to_string()),
-    ]
-    .into_iter()
-    .collect::<HashMap<_, _>>();
+    let object_store_config = ci_object_store_config()
+        .into_iter()
+        .chain([("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".to_string())])
+        .collect::<HashMap<_, _>>();
 
-    let input_table_uri = format!("s3://feldera-delta-table-test/{input_uuid}/");
-    let output_table_uri = format!("s3://feldera-delta-table-test/{output_uuid}/");
+    let input_table_uri = ci_scratch_table_uri(input_uuid);
+    let output_table_uri = ci_scratch_table_uri(output_uuid);
 
     test_follow(
         &relation_schema,
@@ -4040,16 +4070,9 @@ proptest! {
     fn delta_table_s3_output_proptest(data in delta_data(20_000))
     {
         let uuid = uuid::Uuid::new_v4();
-        let object_store_config = [
-            ("aws_access_key_id".to_string(), std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap()),
-            ("aws_secret_access_key".to_string(), std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap()),
-            // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
-            ("aws_region".to_string(), "us-east-2".to_string()),
-        ]
-            .into_iter()
-            .collect::<HashMap<_,_>>();
+        let object_store_config = ci_object_store_config().into_iter().collect::<HashMap<_,_>>();
 
-        let table_uri = format!("s3://feldera-delta-table-test/{uuid}/");
+        let table_uri = ci_scratch_table_uri(uuid);
         // TODO: enable verification when it's supported for S3.
         delta_table_output_test(data.clone(), &table_uri, &object_store_config, false, None, false);
         //delta_table_output_test(data.clone(), &table_uri, &object_store_config, false, None);
@@ -4065,7 +4088,14 @@ proptest! {
     }
 }
 
-/// Read a large (2M records) dataset created in S3 from Databricks.
+/// Read a large (2M records) dataset from the CI object store.
+///
+/// Copied there from the Databricks workspace bucket it was created in, so CI
+/// can reach it with the same credentials as every other Delta test. It sits in
+/// the inputs bucket rather than the scratch one because nothing in this repo
+/// can rebuild it -- it came from a Databricks notebook (below) -- and the
+/// scratch bucket deletes everything after 7 days.
+///
 /// This dataset was derived from
 /// `/databricks-datasets/learning-spark-v2/people/people-10m.delta`; however the full dataset
 /// is 200MB and can be slow to download, so we cut it down to 2M.
@@ -4089,25 +4119,17 @@ proptest! {
 fn delta_table_s3_people_2m() {
     use crate::test::DatabricksPeople;
 
-    let object_store_config = [
-        (
-            "aws_access_key_id".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap(),
-        ),
-        (
-            "aws_secret_access_key".to_string(),
-            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap(),
-        ),
-        // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
-        ("aws_region".to_string(), "us-west-1".to_string()),
-        // Set long timeout for reading large files from S3.
-        ("timeout".to_string(), "1000 secs".to_string()),
-    ]
-    .into_iter()
-    .collect::<HashMap<_, _>>();
+    let object_store_config = ci_object_store_config()
+        .into_iter()
+        // Set long timeout for reading large files.
+        .chain([("timeout".to_string(), "1000 secs".to_string())])
+        .collect::<HashMap<_, _>>();
 
-    //let table_uri = "s3://databricks-workspace-stack-d437e-bucket/unity-catalog/5496131495366467/__unitystorage/catalogs/d1e3a643-f243-4798-8554-d32bf5a7205a/tables/cee86cb4-a525-41b9-82fe-616ae62287fc/";
-    let table_uri = "s3://databricks-workspace-stack-d437e-bucket/unity-catalog/5496131495366467/__unitystorage/catalogs/d1e3a643-f243-4798-8554-d32bf5a7205a/tables/90cc5aba-25cd-4ed7-a498-8d08f0ddaa21/";
+    let table_uri = format!(
+        "s3://{}/delta-connector-tests/people_2m/",
+        ci_inputs_bucket()
+    );
+    let table_uri = table_uri.as_str();
     let mut json_file = delta_table_snapshot_to_json::<DatabricksPeople>(
         table_uri,
         &DatabricksPeople::schema(),
@@ -4122,7 +4144,10 @@ fn delta_table_s3_people_2m() {
     forget(json_file);
 }
 
-/// Read the same table using Unity Catalog path.
+/// Read the 2M-record dataset over a Unity Catalog path.
+///
+/// Behind `delta-unity-test`, not `delta-s3-test`: this one needs a Databricks
+/// workspace, so it stays out of CI while the rest of the S3 tests run there.
 // I haven't investigated this in depth but it appears that, when running
 // multiple delta connectors in parallel, some of which use unity catalog,
 // and others use direct S3 URL to connect to the table, this confuses the
@@ -4136,7 +4161,7 @@ fn delta_table_s3_people_2m() {
 // Running the unity test sequentially with S3 tests seems to solve this
 // reliably.
 
-#[cfg(feature = "delta-s3-test")]
+#[cfg(feature = "delta-unity-test")]
 #[test]
 #[serial(delta_s3)]
 fn delta_table_unity_people_2m() {


### PR DESCRIPTION
Partially addresses https://github.com/feldera/feldera/issues/6900.

The Delta object-store tests were gated behind `delta-s3-test` and never ran in CI: their buckets lived in a personal AWS account CI cannot reach.

We point them to GCS CI buckets instead: the tests that write their own Delta tables point to the bucket that gets automatically cleaned up after 7 days. The one test that needs a static dataset (people_2m) now points to the new bucket with infinite retainment period, which now contains this dataset.

The unity catalog test is still feature gated until we have rotating unity credentials in CI.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
