### PR TITLE
[python] Wait for the circuit, not just the connector, before checkpointing

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -422,6 +422,14 @@ def check_end_of_input(pipeline: Pipeline) -> bool:
 
 
 def wait_end_of_input(pipeline: Pipeline, timeout_s: Optional[int] = None):
+    """Waits until every input connector has read its source to the end.
+
+    End of input is not completion: a connector reports it once it has read its
+    last record, and records it has already read may still be waiting to reach
+    the circuit. `Pipeline.wait_for_completion` waits for those to be processed
+    as well; this weaker wait is for the cases that cannot reach completion,
+    such as an open transaction.
+    """
     start_time = time.monotonic()
     # Reused by the warning message below so a stalled ingest can be told
     # apart from a slow one; check_end_of_input() would fetch and discard it.

--- a/python/tests/runtime/test_bloom_filter_eviction.py
+++ b/python/tests/runtime/test_bloom_filter_eviction.py
@@ -34,7 +34,6 @@ from feldera.testutils import (
     FELDERA_TEST_NUM_HOSTS,
     FELDERA_TEST_NUM_WORKERS,
     log,
-    wait_end_of_input,
 )
 from tests import TEST_CLIENT, enterprise_only
 from tests.platform.helper import gen_pipeline_name
@@ -130,9 +129,9 @@ def runtime_config(rate: float) -> RuntimeConfig:
 def measure_at_rate(pipeline: Pipeline, rate: float) -> tuple[int, int]:
     """Reopens the checkpoint at `rate` and measures the filters it loads.
 
-    Starts paused so the datagen connector cannot run again: this pipeline is
-    not fault tolerant, so a running connector would re-ingest from scratch and
-    the filters would no longer describe the checkpointed batches.
+    Starts paused so that nothing runs on top of the checkpoint: a running
+    pipeline could write new batches, and the filters would then describe those
+    rather than the ones the checkpoint holds.
     """
     config = pipeline.runtime_config()
     config.storage = storage_config(rate).__dict__
@@ -167,7 +166,7 @@ def test_bloom_filter_eviction_follows_the_rate(pipeline_name: str) -> None:
     try:
         log(f"ingesting {ROW_LIMIT} records at the default rate {DEFAULT_RATE:g}")
         pipeline.start()
-        wait_end_of_input(pipeline)
+        pipeline.wait_for_completion(timeout_s=3600)
         # Checkpoints before stopping, which is the checkpoint every step below
         # reopens.
         pipeline.stop(force=False)


### PR DESCRIPTION
test_bloom_filter_eviction_follows_the_rate stopped the pipeline as soon as datagen reported end of input and then asserted that the checkpoint held all ten million rows.

Wait on wait_for_completion instead.
Fixes #7069.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
