### PR TITLE
[dbsp] Fix several bugs in GC logic for top-k and asof operators.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
@@ -259,8 +259,6 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
-        // A group filter that retains no failing value is just `Simple`.
-        // Nothing should ask for that, so a zero limit is a caller bug.
         assert!(
             n > 0,
             "dyn_accumulate_integrate_trace_retain_values_last_n called with n = 0"
@@ -288,8 +286,6 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
-        // A group filter that retains no failing value is just `Simple`.
-        // Nothing should ask for that, so a zero limit is a caller bug.
         assert!(
             n > 0,
             "dyn_accumulate_integrate_trace_retain_values_top_n called with n = 0"
@@ -317,8 +313,6 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
-        // A group filter that retains no failing value is just `Simple`.
-        // Nothing should ask for that, so a zero limit is a caller bug.
         assert!(
             n > 0,
             "dyn_accumulate_integrate_trace_retain_values_bottom_n called with n = 0"

--- a/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
@@ -259,6 +259,13 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
+        // A group filter that retains no failing value is just `Simple`.
+        // Nothing should ask for that, so a zero limit is a caller bug.
+        assert!(
+            n > 0,
+            "dyn_accumulate_integrate_trace_retain_values_last_n called with n = 0"
+        );
+
         let bounds = self.accumulate_trace_bounds();
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 
@@ -281,6 +288,13 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
+        // A group filter that retains no failing value is just `Simple`.
+        // Nothing should ask for that, so a zero limit is a caller bug.
+        assert!(
+            n > 0,
+            "dyn_accumulate_integrate_trace_retain_values_top_n called with n = 0"
+        );
+
         let bounds = self.accumulate_trace_bounds();
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 
@@ -303,6 +317,13 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
+        // A group filter that retains no failing value is just `Simple`.
+        // Nothing should ask for that, so a zero limit is a caller bug.
+        assert!(
+            n > 0,
+            "dyn_accumulate_integrate_trace_retain_values_bottom_n called with n = 0"
+        );
+
         let bounds = self.accumulate_trace_bounds();
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -437,8 +437,6 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
-        // A group filter that retains no failing value is just `Simple`.
-        // Nothing should ask for that, so a zero limit is a caller bug.
         assert!(
             n > 0,
             "dyn_integrate_trace_retain_values_last_n called with n = 0"
@@ -465,8 +463,6 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
-        // A group filter that retains no failing value is just `Simple`.
-        // Nothing should ask for that, so a zero limit is a caller bug.
         assert!(
             n > 0,
             "dyn_integrate_trace_retain_values_top_n called with n = 0"

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -437,6 +437,13 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
+        // A group filter that retains no failing value is just `Simple`.
+        // Nothing should ask for that, so a zero limit is a caller bug.
+        assert!(
+            n > 0,
+            "dyn_integrate_trace_retain_values_last_n called with n = 0"
+        );
+
         let bounds = self.trace_bounds();
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 
@@ -458,6 +465,13 @@ where
         TS: DataTrait + ?Sized,
         Box<TS>: Clone,
     {
+        // A group filter that retains no failing value is just `Simple`.
+        // Nothing should ask for that, so a zero limit is a caller bug.
+        assert!(
+            n > 0,
+            "dyn_integrate_trace_retain_values_top_n called with n = 0"
+        );
+
         let bounds = self.trace_bounds();
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 

--- a/crates/dbsp/src/trace/cursor.rs
+++ b/crates/dbsp/src/trace/cursor.rs
@@ -1178,11 +1178,17 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
                 }
 
                 if below_waterline + above_waterline > 0 {
-                    // Skip to the next value that belongs to the filtered cursor,
-                    // which is either the next value that satisfies the filter or `min_val`.
+                    // Skip to the first value the filtered cursor keeps: the next
+                    // one that satisfies the filter or `min_val`, whichever comes
+                    // first.  The disjunction is not monotonic, since `filter` is
+                    // arbitrary, so this cannot use `seek_val_with`.
                     if *min_val_valid {
-                        cursor
-                            .seek_val_with(&|val| (filter.filter_func())(val) || val >= &**min_val)
+                        while let Some(val) = cursor.get_val() {
+                            if (filter.filter_func())(val) || *val >= **min_val {
+                                break;
+                            }
+                            cursor.step_val();
+                        }
                     }
                     cursor.val_valid()
                 } else {
@@ -1216,7 +1222,23 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
                     trace_cursor.step_val();
                 }
 
-                below_waterline + above_waterline > 0
+                if below_waterline + above_waterline > 0 {
+                    // Skip to the first value the filtered cursor keeps: the next
+                    // one that satisfies the filter or `max_val`, whichever comes
+                    // first.  The disjunction is not monotonic, since `filter` is
+                    // arbitrary, so this cannot use `seek_val_with`.
+                    if *max_val_valid {
+                        while let Some(val) = cursor.get_val() {
+                            if (filter.filter_func())(val) || *val <= **max_val {
+                                break;
+                            }
+                            cursor.step_val();
+                        }
+                    }
+                    cursor.val_valid()
+                } else {
+                    false
+                }
             }
         }
     }

--- a/crates/dbsp/src/trace/cursor.rs
+++ b/crates/dbsp/src/trace/cursor.rs
@@ -1047,6 +1047,20 @@ where
 
 impl<V: DataTrait + ?Sized> GroupFilter<V> {
     fn new_cursor(&self) -> GroupFilterCursor<V> {
+        // These filters mark the n'th value that fails the filter and retain
+        // everything from there on, so "no n'th value" has to mean "the group
+        // holds fewer than `n` of them, and all of them stay". A limit of zero
+        // means the opposite and the marking cannot express it. Rather than
+        // reading it as `Simple`, which is what it denotes, reject it: the
+        // compiler never emits a zero limit, so one signals a bug upstream.
+        assert!(
+            !matches!(
+                self,
+                Self::LastN(0, _) | Self::TopN(0, _, _) | Self::BottomN(0, _, _)
+            ),
+            "group filter built with n = 0"
+        );
+
         match self {
             Self::Simple(filter) => GroupFilterCursor::Simple {
                 filter: filter.clone(),

--- a/crates/dbsp/src/trace/cursor.rs
+++ b/crates/dbsp/src/trace/cursor.rs
@@ -1062,9 +1062,10 @@ impl<V: DataTrait + ?Sized> GroupFilter<V> {
         );
 
         match self {
-            Self::Simple(filter) => GroupFilterCursor::Simple {
-                filter: filter.clone(),
-            },
+            // `merge_cursor_with_snapshot` serves `Simple` from
+            // `FilteredMergeCursor`, and it is the only caller, so a `Simple`
+            // filter never reaches this cursor.
+            Self::Simple(_) => unreachable!("`Simple` does not need a snapshot"),
             Self::LastN(n, filter) => GroupFilterCursor::LastN {
                 n: *n,
                 filter: filter.clone(),
@@ -1087,9 +1088,6 @@ impl<V: DataTrait + ?Sized> GroupFilter<V> {
 
 /// State maintained by a `GroupFilter` for a cursor.
 enum GroupFilterCursor<V: ?Sized> {
-    Simple {
-        filter: Filter<V>,
-    },
     LastN {
         n: usize,
         filter: Filter<V>,
@@ -1126,19 +1124,10 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
         trace_cursor: &mut dyn Cursor<K, V, T, R>,
     ) -> bool {
         if !trace_cursor.seek_key_exact(cursor.key(), None) {
-            return false;
+            return self.retain_whole_key(cursor);
         }
 
         match self {
-            Self::Simple { filter } => {
-                while let Some(val) = cursor.get_val() {
-                    if (filter.filter_func())(val) {
-                        return true;
-                    }
-                    cursor.step_val();
-                }
-                false
-            }
             Self::LastN { n, filter } => {
                 // Find the last value below the waterline.
                 trace_cursor.fast_forward_vals();
@@ -1257,6 +1246,28 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
         }
     }
 
+    /// Positions the cursor on a key the spine snapshot does not hold.
+    ///
+    /// The spine's weights for such a key cancel out, so there is no group to
+    /// measure against and no ground for dropping any of it. The records that
+    /// cancel the key live in batches this merge does not cover and so survive
+    /// it; dropping the records it does cover would leave those unbalanced, and
+    /// the trace would gain a retraction that matches nothing.
+    fn retain_whole_key<K: ?Sized, T, R: ?Sized>(
+        &mut self,
+        cursor: &mut dyn Cursor<K, V, T, R>,
+    ) -> bool {
+        match self {
+            // Retain the key whole. Clearing the mark stops `on_step_val`
+            // measuring this key against a previous key's value.
+            Self::LastN { .. } => {}
+            Self::TopN { min_val_valid, .. } => *min_val_valid = false,
+            Self::BottomN { max_val_valid, .. } => *max_val_valid = false,
+        }
+
+        cursor.val_valid()
+    }
+
     /// Called after the cursor has advanced to a new value.
     ///
     /// Skip over values that don't satisfy the filter.
@@ -1266,14 +1277,6 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
         _trace_cursor: &mut dyn Cursor<K, V, T, R>,
     ) {
         match self {
-            Self::Simple { filter } => {
-                while let Some(val) = cursor.get_val() {
-                    if (filter.filter_func())(val) {
-                        return;
-                    }
-                    cursor.step_val();
-                }
-            }
             Self::LastN { .. } => {}
             Self::TopN {
                 filter,

--- a/crates/dbsp/src/trace/cursor.rs
+++ b/crates/dbsp/src/trace/cursor.rs
@@ -1047,12 +1047,8 @@ where
 
 impl<V: DataTrait + ?Sized> GroupFilter<V> {
     fn new_cursor(&self) -> GroupFilterCursor<V> {
-        // These filters mark the n'th value that fails the filter and retain
-        // everything from there on, so "no n'th value" has to mean "the group
-        // holds fewer than `n` of them, and all of them stay". A limit of zero
-        // means the opposite and the marking cannot express it. Rather than
-        // reading it as `Simple`, which is what it denotes, reject it: the
-        // compiler never emits a zero limit, so one signals a bug upstream.
+        // A zero limit denotes `Simple`, and the compiler never emits one, so
+        // treat it as a caller bug rather than quietly substituting `Simple`.
         assert!(
             !matches!(
                 self,
@@ -1246,20 +1242,20 @@ impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
         }
     }
 
-    /// Positions the cursor on a key the spine snapshot does not hold.
+    /// Retains every value of a key that the spine snapshot does not hold.
     ///
-    /// The spine's weights for such a key cancel out, so there is no group to
-    /// measure against and no ground for dropping any of it. The records that
-    /// cancel the key live in batches this merge does not cover and so survive
-    /// it; dropping the records it does cover would leave those unbalanced, and
-    /// the trace would gain a retraction that matches nothing.
+    /// The spine's weights for such a key add up to zero, so the filter has no
+    /// group to find its n'th value in, and no reason to drop anything. The
+    /// records that cancel the key sit in batches outside this merge and survive
+    /// it, so dropping the ones inside it would leave those without their
+    /// counterpart and add a row to the trace.
     fn retain_whole_key<K: ?Sized, T, R: ?Sized>(
         &mut self,
         cursor: &mut dyn Cursor<K, V, T, R>,
     ) -> bool {
         match self {
-            // Retain the key whole. Clearing the mark stops `on_step_val`
-            // measuring this key against a previous key's value.
+            // Clearing the mark stops `on_step_val` comparing this key's
+            // values against the previous key's.
             Self::LastN { .. } => {}
             Self::TopN { min_val_valid, .. } => *min_val_valid = false,
             Self::BottomN { max_val_valid, .. } => *max_val_valid = false,

--- a/crates/dbsp/src/trace/filter.rs
+++ b/crates/dbsp/src/trace/filter.rs
@@ -68,13 +68,20 @@ impl<V: ?Sized> Clone for Filter<V> {
 ///   last N values in the group.
 ///   Assumes that the predicate is monotonic: once it is satisfied for a value,
 ///   it is also satisfied for all subsequent values for the same key.
-///   Also assumed that the values are ordered in some way, so that the last N
-///   values under the cursor ate the ones that need to be preserved.
+///   Also assumes that the values are ordered in some way, so that the last N
+///   values under the cursor are the ones that need to be preserved.
 /// * `TopN` - retains all values that satisfy a predicate and up to a
 ///   constant number of largest values that do not satisfy the predicate.
 ///   This is similar to `LastN`, but it does not assume that the predicate is
 ///   monotonic.
+/// * `BottomN` - retains all values that satisfy a predicate and up to a
+///   constant number of smallest values that do not satisfy the predicate.
+///   Like `TopN`, it does not assume that the predicate is monotonic.
 ///
+/// Because `TopN` and `BottomN` admit a non-monotonic predicate, neither can
+/// locate the first value to retain with a galloping search such as
+/// `Cursor::seek_val_with`, which requires a predicate that stays true once it
+/// turns true.
 ///
 /// Note that the `LastN`, `TopN` and `BottomN` filters can not be evaluated against
 /// an individual batch and require access to the complete spine that the batch belongs

--- a/crates/dbsp/src/trace/test.rs
+++ b/crates/dbsp/src/trace/test.rs
@@ -2071,17 +2071,8 @@ mod non_monotone_retention {
         out
     }
 
-    /// Runs the filtered merge that actually performs retention, and reports
-    /// what survived.
-    ///
-    /// It has to be the merge path that takes a trace snapshot.
-    /// `Spine::complete_merges` goes through `merge_batches`, whose cursors come
-    /// from the `merge_cursor` default, and that default drops every group
-    /// filter except `Simple`: "Other forms of GroupFilters cannot be evaluated
-    /// without a trace snapshot". So forced compaction applies no `TopN` at all.
-    /// The spine's background merger instead calls `merge_cursor_with_snapshot`
-    /// (spine_async/list_merger.rs:53-58), which is what this mirrors, with a
-    /// batch of every value standing in for the spine snapshot.
+    /// `retain_within_spine` for a spine that holds nothing but the merged
+    /// batches.
     fn retain(
         filter: GroupFilter<DynI32>,
         batches: &[&[(i32, ZWeight)]],
@@ -2089,9 +2080,18 @@ mod non_monotone_retention {
         retain_within_spine(filter, batches, &[])
     }
 
-    /// As `retain`, except that the spine also holds `elsewhere`, which the
-    /// merge does not cover. A merge takes some of the spine's batches, not all
-    /// of them, so this is the ordinary case rather than a corner of it.
+    /// Runs the filtered merge that performs retention, and reports what
+    /// survived.
+    ///
+    /// `elsewhere` is what the spine holds in batches this merge does not cover.
+    /// That is the usual case: a merge takes some of the spine's batches, while
+    /// the snapshot it reads spans all of them.
+    ///
+    /// Retention only happens in the merge that reads a snapshot.
+    /// `Spine::complete_merges` does not read one, so it applies no `TopN` or
+    /// `BottomN` retention at all. The spine's background merger does, through
+    /// `merge_cursor_with_snapshot`, and that is the path this mirrors, with one
+    /// batch of every value standing in for the snapshot.
     fn retain_within_spine(
         filter: GroupFilter<DynI32>,
         batches: &[&[(i32, ZWeight)]],
@@ -2228,9 +2228,9 @@ mod non_monotone_retention {
     /// FIRST value is emitted with no filter check at all.
     ///
     /// A value that cancels across the spine is invisible to the snapshot, so
-    /// the filter never reasons about it (`CursorList::seek_key_exact` skips
-    /// zero-weight values, cursor_list.rs:692-720) -- the situation
-    /// filter.rs:79-83 warns about. Here value 5 leads one batch and trails the
+    /// the filter never reasons about it: `CursorList::seek_key_exact` skips
+    /// values whose weights sum to zero. This is what the `GroupFilter` docs
+    /// warn about. Here value 5 leads one batch and trails the
     /// other. Both copies must reach the same verdict, or they stop cancelling
     /// and the deleted row comes back; that is what happened while `BottomN`
     /// left the leading copy unexamined.

--- a/crates/dbsp/src/trace/test.rs
+++ b/crates/dbsp/src/trace/test.rs
@@ -2035,7 +2035,11 @@ fn file_val_batch_filter_follows_the_rate() {
 /// disagreed over a value, resurrected deleted rows. The snapshot key gate was a
 /// separate defect that needed no predicate at all.
 mod non_monotone_retention {
+    use std::collections::BTreeMap;
     use std::sync::Arc;
+
+    use proptest::collection::vec as prop_vec;
+    use proptest::prelude::*;
 
     use super::{CircuitConfig, DynI32, Filter, indexed_zset_tuples};
     use crate::algebra::{OrdIndexedZSet, OrdIndexedZSetFactories};
@@ -2243,5 +2247,177 @@ mod non_monotone_retention {
             vec![0, 1, 8],
             "6 fails the filter and is not among the 2 smallest that do"
         );
+    }
+
+    /// Values come from a small domain so that a random bitmask ranges over
+    /// every shape of predicate, and so that one batch can hold more than the
+    /// eight values `advance` probes before it starts skipping.
+    const VALUES: i32 = 16;
+    const BATCHES: usize = 3;
+
+    /// `(value, batch, weight)` triples. Repeating a value across batches with
+    /// opposing weights cancels it, which is how a value becomes invisible to
+    /// the snapshot while still present in the batches being merged.
+    fn entries() -> impl Strategy<Value = Vec<(i32, usize, ZWeight)>> {
+        prop_vec(
+            (
+                0..VALUES,
+                0..BATCHES,
+                prop::sample::select(vec![-2 as ZWeight, -1, 1, 2]),
+            ),
+            1..32usize,
+        )
+    }
+
+    /// `fold` collapses the batch assignment onto fewer batches. Whether a key's
+    /// values sit in one batch or are spread over several decides how far the
+    /// cursor has to skip, and skipping is where the bugs are, so the property
+    /// tests need both shapes.
+    fn split(entries: &[(i32, usize, ZWeight)], fold: usize) -> Vec<Vec<(i32, ZWeight)>> {
+        let mut batches = vec![Vec::new(); fold];
+        for &(value, batch, weight) in entries {
+            batches[batch % fold].push((value, weight));
+        }
+        batches.retain(|batch| !batch.is_empty());
+        batches
+    }
+
+    /// The values the spine snapshot holds: weights summed across batches, with
+    /// anything that cancels gone.
+    fn snapshot_of(entries: &[(i32, usize, ZWeight)]) -> BTreeMap<i32, ZWeight> {
+        let mut snapshot = BTreeMap::new();
+        for &(value, _batch, weight) in entries {
+            *snapshot.entry(value).or_insert(0) += weight;
+        }
+        snapshot.retain(|_value, weight| *weight != 0);
+        snapshot
+    }
+
+    fn retained(
+        snapshot: &BTreeMap<i32, ZWeight>,
+        keep: impl Fn(&[i32]) -> Vec<bool>,
+    ) -> Vec<(i32, i32, ZWeight)> {
+        let values: Vec<i32> = snapshot.keys().copied().collect();
+        values
+            .iter()
+            .zip(keep(&values))
+            .filter(|&(_value, keep)| keep)
+            .map(|(&value, _keep)| (1, value, snapshot[&value]))
+            .collect()
+    }
+
+    /// What `TopN`/`BottomN` must retain, derived from the documented semantics
+    /// rather than from the cursor: every value satisfying the filter, plus the
+    /// `n` failing values nearest the chosen end of the group.
+    fn model_n(
+        mask: u32,
+        n: usize,
+        keep_largest: bool,
+        entries: &[(i32, usize, ZWeight)],
+    ) -> Vec<(i32, i32, ZWeight)> {
+        let snapshot = snapshot_of(entries);
+        retained(&snapshot, |values| {
+            let mut keep = vec![false; values.len()];
+            let mut failing = 0;
+            let order: Box<dyn Iterator<Item = usize>> = if keep_largest {
+                Box::new((0..values.len()).rev())
+            } else {
+                Box::new(0..values.len())
+            };
+            for i in order {
+                if satisfies(mask, values[i]) {
+                    keep[i] = true;
+                } else if failing < n {
+                    keep[i] = true;
+                    failing += 1;
+                }
+            }
+            keep
+        })
+    }
+
+    /// What `LastN` must retain: every value from the `n`'th before the first
+    /// one satisfying the filter onwards, or the last `n` when none satisfies it.
+    fn model_last_n(
+        threshold: i32,
+        n: usize,
+        entries: &[(i32, usize, ZWeight)],
+    ) -> Vec<(i32, i32, ZWeight)> {
+        let snapshot = snapshot_of(entries);
+        retained(&snapshot, |values| {
+            let first = values
+                .iter()
+                .position(|&value| value >= threshold)
+                .unwrap_or(values.len());
+            let from = first.saturating_sub(n);
+            (0..values.len()).map(|i| i >= from).collect()
+        })
+    }
+
+    fn satisfies(mask: u32, value: i32) -> bool {
+        mask >> value & 1 == 1
+    }
+
+    fn bitmask_filter(mask: u32) -> Filter<DynI32> {
+        Filter::new(Box::new(move |v: &DynI32| {
+            satisfies(mask, *unsafe { v.downcast::<i32>() })
+        }))
+    }
+
+    /// A monotone filter, the only kind `LastN` supports.
+    fn threshold_filter(threshold: i32) -> Filter<DynI32> {
+        Filter::new(Box::new(move |v: &DynI32| {
+            *unsafe { v.downcast::<i32>() } >= threshold
+        }))
+    }
+
+    fn run(
+        filter: GroupFilter<DynI32>,
+        batches: &[Vec<(i32, ZWeight)>],
+    ) -> Vec<(i32, i32, ZWeight)> {
+        let refs: Vec<&[(i32, ZWeight)]> = batches.iter().map(|b| b.as_slice()).collect();
+        retain(filter, &refs)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// `n` starts at 1 because `TopN(0)` conflates "no failing value may be
+        /// retained" with "the group holds fewer than `n` failing values", and
+        /// retains everything. The compiler only ever emits n >= 1.
+        #[test]
+        fn top_n_matches_the_documented_semantics(
+            mask in any::<u32>(),
+            n in 1usize..4,
+            fold in 1usize..=BATCHES,
+            entries in entries(),
+        ) {
+            let filter = GroupFilter::TopN(n, bitmask_filter(mask), <DynData as WithFactory<i32>>::FACTORY);
+            prop_assert_eq!(run(filter, &split(&entries, fold)), model_n(mask, n, true, &entries));
+        }
+
+        #[test]
+        fn bottom_n_matches_the_documented_semantics(
+            mask in any::<u32>(),
+            n in 1usize..4,
+            fold in 1usize..=BATCHES,
+            entries in entries(),
+        ) {
+            let filter = GroupFilter::BottomN(n, bitmask_filter(mask), <DynData as WithFactory<i32>>::FACTORY);
+            prop_assert_eq!(run(filter, &split(&entries, fold)), model_n(mask, n, false, &entries));
+        }
+
+        /// `LastN` is only defined for a monotone filter, so this drives it with
+        /// a threshold rather than a bitmask.
+        #[test]
+        fn last_n_matches_the_documented_semantics(
+            threshold in 0i32..=VALUES,
+            n in 1usize..4,
+            fold in 1usize..=BATCHES,
+            entries in entries(),
+        ) {
+            let filter = GroupFilter::LastN(n, threshold_filter(threshold));
+            prop_assert_eq!(run(filter, &split(&entries, fold)), model_last_n(threshold, n, &entries));
+        }
     }
 }

--- a/crates/dbsp/src/trace/test.rs
+++ b/crates/dbsp/src/trace/test.rs
@@ -2379,12 +2379,68 @@ mod non_monotone_retention {
         retain(filter, &refs)
     }
 
+    /// `n = 0` denotes `Simple`, but the marking these filters rely on cannot
+    /// express it, and the compiler never emits it. Rejecting it turns a silent
+    /// wrong answer into a loud one.
+    ///
+    /// The rejection panics on a worker thread, and the runtime re-raises it as
+    /// its own panic, so the message does not survive to be matched on. Running
+    /// the same call with a limit of one instead pins the panic to the zero
+    /// rather than to the surrounding machinery.
+    fn assert_rejects_zero_n(zero: GroupFilter<DynI32>, one: GroupFilter<DynI32>) {
+        let values: [(i32, ZWeight); 2] = [(0, 1), (8, 1)];
+
+        retain(one, &[&values]);
+
+        let panicked =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| retain(zero, &[&values])));
+        assert!(panicked.is_err(), "a group filter with n = 0 was accepted");
+    }
+
+    #[test]
+    fn top_n_rejects_a_zero_limit() {
+        assert_rejects_zero_n(
+            GroupFilter::TopN(
+                0,
+                threshold_filter(8),
+                <DynData as WithFactory<i32>>::FACTORY,
+            ),
+            GroupFilter::TopN(
+                1,
+                threshold_filter(8),
+                <DynData as WithFactory<i32>>::FACTORY,
+            ),
+        );
+    }
+
+    #[test]
+    fn bottom_n_rejects_a_zero_limit() {
+        assert_rejects_zero_n(
+            GroupFilter::BottomN(
+                0,
+                threshold_filter(8),
+                <DynData as WithFactory<i32>>::FACTORY,
+            ),
+            GroupFilter::BottomN(
+                1,
+                threshold_filter(8),
+                <DynData as WithFactory<i32>>::FACTORY,
+            ),
+        );
+    }
+
+    #[test]
+    fn last_n_rejects_a_zero_limit() {
+        assert_rejects_zero_n(
+            GroupFilter::LastN(0, threshold_filter(8)),
+            GroupFilter::LastN(1, threshold_filter(8)),
+        );
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(512))]
 
-        /// `n` starts at 1 because `TopN(0)` conflates "no failing value may be
-        /// retained" with "the group holds fewer than `n` failing values", and
-        /// retains everything. The compiler only ever emits n >= 1.
+        /// `n` starts at 1 because a zero limit is rejected.
         #[test]
         fn top_n_matches_the_documented_semantics(
             mask in any::<u32>(),

--- a/crates/dbsp/src/trace/test.rs
+++ b/crates/dbsp/src/trace/test.rs
@@ -2086,11 +2086,27 @@ mod non_monotone_retention {
         filter: GroupFilter<DynI32>,
         batches: &[&[(i32, ZWeight)]],
     ) -> Vec<(i32, i32, ZWeight)> {
+        retain_within_spine(filter, batches, &[])
+    }
+
+    /// As `retain`, except that the spine also holds `elsewhere`, which the
+    /// merge does not cover. A merge takes some of the spine's batches, not all
+    /// of them, so this is the ordinary case rather than a corner of it.
+    fn retain_within_spine(
+        filter: GroupFilter<DynI32>,
+        batches: &[&[(i32, ZWeight)]],
+        elsewhere: &[(i32, ZWeight)],
+    ) -> Vec<(i32, i32, ZWeight)> {
         let batches: Vec<Vec<(i32, ZWeight)>> = batches.iter().map(|b| b.to_vec()).collect();
         // The snapshot is the whole spine, so weights sum and anything that
         // cancels becomes invisible to it, exactly as `CursorList` makes it.
         let values: Vec<(i32, ZWeight)> = {
-            let mut v: Vec<(i32, ZWeight)> = batches.iter().flatten().copied().collect();
+            let mut v: Vec<(i32, ZWeight)> = batches
+                .iter()
+                .flatten()
+                .chain(elsewhere.iter())
+                .copied()
+                .collect();
             v.sort_unstable();
             v
         };
@@ -2106,10 +2122,11 @@ mod non_monotone_retention {
             };
 
             // How key 1's values are split across batches matters, so each
-            // caller chooses. The extra key exists only so that a merge of a
-            // single batch is not the identity.
+            // caller chooses. The extra key keeps a single-batch merge from
+            // being the identity, and, since the snapshot never holds it, puts
+            // every run through `retain_whole_key`.
             let mut inputs: Vec<Batched> = batches.iter().map(|b| build_key(1, b)).collect();
-            inputs.push(build_key(2, &[(0, 1)]));
+            inputs.push(build_key(ABSENT_KEY, &ABSENT_KEY_VALUES));
 
             // Everything under key 1, as the spine snapshot would see it.
             let snapshot = Some(Arc::new(build_key(1, &values)));
@@ -2125,17 +2142,41 @@ mod non_monotone_retention {
                 .collect();
 
             let merged: Batched = ListMerger::merge(&factories, builder, cursors);
-            *out.lock().unwrap() = contents_of(&merged)
-                .into_iter()
-                .filter(|&(k, _, _)| k == 1)
-                .collect();
+            *out.lock().unwrap() = contents_of(&merged);
         })
         .unwrap()
         .join()
         .unwrap();
 
-        result.lock().unwrap().clone()
+        let contents = result.lock().unwrap().clone();
+
+        // The snapshot holds key 1 alone, so `ABSENT_KEY` reaches
+        // `retain_whole_key` on every run and must come back whole: nothing
+        // measures it, so nothing may be dropped from it. It carries several
+        // values, so a filter still holding the previous key's mark shows up.
+        let absent: Vec<(i32, i32, ZWeight)> = contents
+            .iter()
+            .copied()
+            .filter(|&(key, _value, _weight)| key == ABSENT_KEY)
+            .collect();
+        assert_eq!(
+            absent,
+            ABSENT_KEY_VALUES
+                .iter()
+                .map(|&(value, weight)| (ABSENT_KEY, value, weight))
+                .collect::<Vec<_>>(),
+            "a key the snapshot does not hold must survive the merge whole"
+        );
+
+        contents
+            .into_iter()
+            .filter(|&(key, _value, _weight)| key == 1)
+            .collect()
     }
+
+    /// A key the snapshot never holds, present in every merge.
+    const ABSENT_KEY: i32 = 2;
+    const ABSENT_KEY_VALUES: [(i32, ZWeight); 4] = [(0, 1), (5, 1), (9, 1), (14, 1)];
 
     /// A monotone predicate, which is all the in-tree tests use. The filters
     /// behave correctly here, so this pins the baseline the bug is measured
@@ -2269,6 +2310,57 @@ mod non_monotone_retention {
         )
     }
 
+    /// How the records outside the merge cancel the merged ones. Cancelling a
+    /// key's whole group is what empties the snapshot for it, and a free draw
+    /// essentially never does that, so it has to be constructed.
+    #[derive(Clone, Copy, Debug)]
+    enum Cancel {
+        Nothing,
+        Subset,
+        Everything,
+    }
+
+    fn cancellation() -> impl Strategy<Value = (Cancel, Vec<bool>)> {
+        (
+            prop::sample::select(vec![Cancel::Nothing, Cancel::Subset, Cancel::Everything]),
+            prop_vec(any::<bool>(), 0..32usize),
+        )
+    }
+
+    /// What the spine holds outside the merge: `extra`, drawn freely, plus exact
+    /// negations of some merged records.
+    fn spine_only(
+        entries: &[(i32, usize, ZWeight)],
+        extra: &[(i32, ZWeight)],
+        (cancel, mask): &(Cancel, Vec<bool>),
+    ) -> Vec<(i32, ZWeight)> {
+        let mut out = extra.to_vec();
+        for (i, &(value, _batch, weight)) in entries.iter().enumerate() {
+            let cancelled = match cancel {
+                Cancel::Nothing => false,
+                Cancel::Everything => true,
+                Cancel::Subset => mask.get(i).copied().unwrap_or(false),
+            };
+            if cancelled {
+                out.push((value, -weight));
+            }
+        }
+        out
+    }
+
+    /// Records the spine holds in batches the merge does not cover. They decide
+    /// retention without being emitted, and can cancel a merged record so that
+    /// the snapshot never sees it.
+    fn elsewhere() -> impl Strategy<Value = Vec<(i32, ZWeight)>> {
+        prop_vec(
+            (
+                0..VALUES,
+                prop::sample::select(vec![-2 as ZWeight, -1, 1, 2]),
+            ),
+            0..8usize,
+        )
+    }
+
     /// `fold` collapses the batch assignment onto fewer batches. Whether a key's
     /// values sit in one batch or are spread over several decides how far the
     /// cursor has to skip, and skipping is where the bugs are, so the property
@@ -2282,76 +2374,101 @@ mod non_monotone_retention {
         batches
     }
 
-    /// The values the spine snapshot holds: weights summed across batches, with
-    /// anything that cancels gone.
-    fn snapshot_of(entries: &[(i32, usize, ZWeight)]) -> BTreeMap<i32, ZWeight> {
-        let mut snapshot = BTreeMap::new();
-        for &(value, _batch, weight) in entries {
-            *snapshot.entry(value).or_insert(0) += weight;
+    /// The spine as the snapshot sees it: weights summed over every batch,
+    /// including the ones outside the merge, with anything that cancels gone.
+    fn spine_of(
+        merged: &[(i32, usize, ZWeight)],
+        elsewhere: &[(i32, ZWeight)],
+    ) -> BTreeMap<i32, ZWeight> {
+        let mut spine = BTreeMap::new();
+        for &(value, _batch, weight) in merged {
+            *spine.entry(value).or_insert(0) += weight;
         }
-        snapshot.retain(|_value, weight| *weight != 0);
-        snapshot
+        for &(value, weight) in elsewhere {
+            *spine.entry(value).or_insert(0) += weight;
+        }
+        spine.retain(|_value, weight| *weight != 0);
+        spine
     }
 
-    fn retained(
-        snapshot: &BTreeMap<i32, ZWeight>,
-        keep: impl Fn(&[i32]) -> Vec<bool>,
+    /// What the merge holds, and so all that it can emit. Retention is decided
+    /// against the whole spine, but only these records pass through the merge.
+    fn merged_of(merged: &[(i32, usize, ZWeight)]) -> BTreeMap<i32, ZWeight> {
+        let mut batch = BTreeMap::new();
+        for &(value, _batch, weight) in merged {
+            *batch.entry(value).or_insert(0) += weight;
+        }
+        batch.retain(|_value, weight| *weight != 0);
+        batch
+    }
+
+    fn expected(
+        merged: &BTreeMap<i32, ZWeight>,
+        keep: impl Fn(i32) -> bool,
     ) -> Vec<(i32, i32, ZWeight)> {
-        let values: Vec<i32> = snapshot.keys().copied().collect();
-        values
+        merged
             .iter()
-            .zip(keep(&values))
-            .filter(|&(_value, keep)| keep)
-            .map(|(&value, _keep)| (1, value, snapshot[&value]))
+            .filter(|&(&value, _weight)| keep(value))
+            .map(|(&value, &weight)| (1, value, weight))
             .collect()
     }
 
-    /// What `TopN`/`BottomN` must retain, derived from the documented semantics
-    /// rather than from the cursor: every value satisfying the filter, plus the
-    /// `n` failing values nearest the chosen end of the group.
-    fn model_n(
+    /// Which values `TopN` and `BottomN` must retain, from the semantics stated
+    /// in filter.rs rather than from the cursor: every value satisfying the
+    /// filter, plus the `n` failing values nearest the chosen end of the group.
+    fn keep_n(
+        spine: &BTreeMap<i32, ZWeight>,
         mask: u32,
         n: usize,
         keep_largest: bool,
-        entries: &[(i32, usize, ZWeight)],
-    ) -> Vec<(i32, i32, ZWeight)> {
-        let snapshot = snapshot_of(entries);
-        retained(&snapshot, |values| {
-            let mut keep = vec![false; values.len()];
-            let mut failing = 0;
-            let order: Box<dyn Iterator<Item = usize>> = if keep_largest {
-                Box::new((0..values.len()).rev())
-            } else {
-                Box::new(0..values.len())
-            };
-            for i in order {
-                if satisfies(mask, values[i]) {
-                    keep[i] = true;
-                } else if failing < n {
-                    keep[i] = true;
-                    failing += 1;
-                }
+    ) -> Box<dyn Fn(i32) -> bool> {
+        // The spine holds nothing for this key, so nothing measures it and all
+        // of it stays.
+        if spine.is_empty() {
+            return Box::new(|_value| true);
+        }
+
+        let failing: Vec<i32> = spine
+            .keys()
+            .copied()
+            .filter(|&value| !satisfies(mask, value))
+            .collect();
+        let bound = if keep_largest {
+            failing.iter().rev().nth(n - 1).copied()
+        } else {
+            failing.get(n - 1).copied()
+        };
+
+        match bound {
+            // Fewer than `n` values fail the filter, so all of them stay.
+            None => Box::new(|_value| true),
+            Some(bound) if keep_largest => {
+                Box::new(move |value| satisfies(mask, value) || value >= bound)
             }
-            keep
-        })
+            Some(bound) => Box::new(move |value| satisfies(mask, value) || value <= bound),
+        }
     }
 
-    /// What `LastN` must retain: every value from the `n`'th before the first
-    /// one satisfying the filter onwards, or the last `n` when none satisfies it.
-    fn model_last_n(
+    /// Which values `LastN` must retain: every one from the `n`'th before the
+    /// first satisfying value onwards, or the last `n` when none satisfies it.
+    fn keep_last_n(
+        spine: &BTreeMap<i32, ZWeight>,
         threshold: i32,
         n: usize,
-        entries: &[(i32, usize, ZWeight)],
-    ) -> Vec<(i32, i32, ZWeight)> {
-        let snapshot = snapshot_of(entries);
-        retained(&snapshot, |values| {
-            let first = values
-                .iter()
-                .position(|&value| value >= threshold)
-                .unwrap_or(values.len());
-            let from = first.saturating_sub(n);
-            (0..values.len()).map(|i| i >= from).collect()
-        })
+    ) -> Box<dyn Fn(i32) -> bool> {
+        if spine.is_empty() {
+            return Box::new(|_value| true);
+        }
+
+        let values: Vec<i32> = spine.keys().copied().collect();
+        let first = values
+            .iter()
+            .position(|&value| value >= threshold)
+            .unwrap_or(values.len());
+        // Fewer than `n` values precede the first satisfying one, so all of them
+        // are retained and nothing bounds the group from below.
+        let bound = (first >= n).then(|| values[first - n]);
+        Box::new(move |value| bound.is_none_or(|bound| value >= bound))
     }
 
     fn satisfies(mask: u32, value: i32) -> bool {
@@ -2374,9 +2491,78 @@ mod non_monotone_retention {
     fn run(
         filter: GroupFilter<DynI32>,
         batches: &[Vec<(i32, ZWeight)>],
+        elsewhere: &[(i32, ZWeight)],
     ) -> Vec<(i32, i32, ZWeight)> {
         let refs: Vec<&[(i32, ZWeight)]> = batches.iter().map(|b| b.as_slice()).collect();
-        retain(filter, &refs)
+        retain_within_spine(filter, &refs, elsewhere)
+    }
+
+    /// A merge covers some of the spine's batches. When the spine's weights for a
+    /// key cancel out, `on_step_key` cannot find the key in the snapshot and
+    /// drops every record it holds for that key. The records that cancel it live
+    /// in batches this merge does not cover, so they survive, and the retraction
+    /// they used to balance is gone.
+    #[test]
+    fn a_key_cancelled_elsewhere_in_the_spine_keeps_its_records() {
+        let filter = GroupFilter::TopN(
+            2,
+            Filter::new(Box::new(|v: &DynI32| {
+                *unsafe { v.downcast::<i32>() } >= 100
+            })),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        // 150 satisfies the filter, so retention must keep it and the operator
+        // will read it. The merge sees the insertion; the matching deletion sits
+        // in a batch outside the merge, so the spine nets to zero for key 1.
+        let survived = retain_within_spine(filter, &[&[(150, 1)]], &[(150, -1)]);
+
+        assert_eq!(
+            survived,
+            vec![(1, 150, 1)],
+            "the deletion that balances this record is in a batch the merge does \
+             not cover, so dropping the record leaves that deletion unbalanced"
+        );
+    }
+
+    /// The mirror of the case above: the merge holds the deletion and a batch
+    /// outside it holds the insertion. Dropping the deletion resurrects a row.
+    #[test]
+    fn a_key_cancelled_elsewhere_keeps_its_deletion() {
+        let filter = GroupFilter::TopN(
+            2,
+            Filter::new(Box::new(|v: &DynI32| {
+                *unsafe { v.downcast::<i32>() } >= 100
+            })),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        let survived = retain_within_spine(filter, &[&[(150, -1)]], &[(150, 1)]);
+
+        assert_eq!(survived, vec![(1, 150, -1)]);
+    }
+
+    /// The same for `BottomN`, which is what MIN and ARG_MIN install.
+    #[test]
+    fn bottom_n_keeps_a_key_cancelled_elsewhere() {
+        let filter = GroupFilter::BottomN(
+            1,
+            Filter::new(Box::new(|v: &DynI32| {
+                *unsafe { v.downcast::<i32>() } >= 100
+            })),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        let survived = retain_within_spine(filter, &[&[(150, 1)]], &[(150, -1)]);
+
+        assert_eq!(survived, vec![(1, 150, 1)]);
+    }
+
+    /// And for `LastN`. The gate runs before any arm, so its monotone predicate
+    /// makes no difference here.
+    #[test]
+    fn last_n_keeps_a_key_cancelled_elsewhere() {
+        let filter = GroupFilter::LastN(2, threshold_filter(100));
+        let survived = retain_within_spine(filter, &[&[(150, 1)]], &[(150, -1)]);
+
+        assert_eq!(survived, vec![(1, 150, 1)]);
     }
 
     /// `n = 0` denotes `Simple`, but the marking these filters rely on cannot
@@ -2440,16 +2626,21 @@ mod non_monotone_retention {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(512))]
 
-        /// `n` starts at 1 because a zero limit is rejected.
         #[test]
         fn top_n_matches_the_documented_semantics(
             mask in any::<u32>(),
             n in 1usize..4,
             fold in 1usize..=BATCHES,
             entries in entries(),
+            extra in elsewhere(),
+            cancellation in cancellation(),
         ) {
+            let elsewhere = spine_only(&entries, &extra, &cancellation);
             let filter = GroupFilter::TopN(n, bitmask_filter(mask), <DynData as WithFactory<i32>>::FACTORY);
-            prop_assert_eq!(run(filter, &split(&entries, fold)), model_n(mask, n, true, &entries));
+            let spine = spine_of(&entries, &elsewhere);
+            prop_assert_eq!(
+                run(filter, &split(&entries, fold), &elsewhere),
+                expected(&merged_of(&entries), keep_n(&spine, mask, n, true)));
         }
 
         #[test]
@@ -2458,9 +2649,15 @@ mod non_monotone_retention {
             n in 1usize..4,
             fold in 1usize..=BATCHES,
             entries in entries(),
+            extra in elsewhere(),
+            cancellation in cancellation(),
         ) {
+            let elsewhere = spine_only(&entries, &extra, &cancellation);
             let filter = GroupFilter::BottomN(n, bitmask_filter(mask), <DynData as WithFactory<i32>>::FACTORY);
-            prop_assert_eq!(run(filter, &split(&entries, fold)), model_n(mask, n, false, &entries));
+            let spine = spine_of(&entries, &elsewhere);
+            prop_assert_eq!(
+                run(filter, &split(&entries, fold), &elsewhere),
+                expected(&merged_of(&entries), keep_n(&spine, mask, n, false)));
         }
 
         /// `LastN` is only defined for a monotone filter, so this drives it with
@@ -2471,9 +2668,15 @@ mod non_monotone_retention {
             n in 1usize..4,
             fold in 1usize..=BATCHES,
             entries in entries(),
+            extra in elsewhere(),
+            cancellation in cancellation(),
         ) {
+            let elsewhere = spine_only(&entries, &extra, &cancellation);
             let filter = GroupFilter::LastN(n, threshold_filter(threshold));
-            prop_assert_eq!(run(filter, &split(&entries, fold)), model_last_n(threshold, n, &entries));
+            let spine = spine_of(&entries, &elsewhere);
+            prop_assert_eq!(
+                run(filter, &split(&entries, fold), &elsewhere),
+                expected(&merged_of(&entries), keep_last_n(&spine, threshold, n)));
         }
     }
 }

--- a/crates/dbsp/src/trace/test.rs
+++ b/crates/dbsp/src/trace/test.rs
@@ -2022,3 +2022,226 @@ fn file_val_batch_filter_follows_the_rate() {
         LADDER_KEYS,
     );
 }
+
+/// Retention by `LastN`, `TopN` and `BottomN`: every value satisfying the filter
+/// survives, along with a bounded number that do not.
+///
+/// `TopN` and `BottomN` accept a predicate that is not monotone, and most of
+/// what these tests pin came from treating one as monotone. `TopN` used to reach
+/// the first value to keep with `Cursor::seek_val_with`, a galloping search that
+/// holds only for a predicate staying true once it turns true, so it skipped
+/// values it had to keep. `BottomN` never positioned the batch cursor, so it
+/// kept values it had to collect, and, because the cursors of one merge then
+/// disagreed over a value, resurrected deleted rows. The snapshot key gate was a
+/// separate defect that needed no predicate at all.
+mod non_monotone_retention {
+    use std::sync::Arc;
+
+    use super::{CircuitConfig, DynI32, Filter, indexed_zset_tuples};
+    use crate::algebra::{OrdIndexedZSet, OrdIndexedZSetFactories};
+    use crate::dynamic::{DowncastTrait, DynData, WithFactory};
+    use crate::trace::{
+        Batch, BatchLocation, BatchReader, BatchReaderFactories, Builder, GroupFilter, ListMerger,
+        cursor::Cursor,
+    };
+    use crate::utils::Tup2;
+    use crate::{Runtime, ZWeight};
+
+    type Batched = OrdIndexedZSet<DynI32, DynI32>;
+
+    /// Every `(key, value, weight)` a batch holds.
+    fn contents_of(batch: &Batched) -> Vec<(i32, i32, ZWeight)> {
+        let mut out = Vec::new();
+        let mut cursor = batch.cursor();
+        while cursor.key_valid() {
+            while cursor.val_valid() {
+                out.push((
+                    *unsafe { cursor.key().downcast::<i32>() },
+                    *unsafe { cursor.val().downcast::<i32>() },
+                    **cursor.weight(),
+                ));
+                cursor.step_val();
+            }
+            cursor.step_key();
+        }
+        out
+    }
+
+    /// Runs the filtered merge that actually performs retention, and reports
+    /// what survived.
+    ///
+    /// It has to be the merge path that takes a trace snapshot.
+    /// `Spine::complete_merges` goes through `merge_batches`, whose cursors come
+    /// from the `merge_cursor` default, and that default drops every group
+    /// filter except `Simple`: "Other forms of GroupFilters cannot be evaluated
+    /// without a trace snapshot". So forced compaction applies no `TopN` at all.
+    /// The spine's background merger instead calls `merge_cursor_with_snapshot`
+    /// (spine_async/list_merger.rs:53-58), which is what this mirrors, with a
+    /// batch of every value standing in for the spine snapshot.
+    fn retain(
+        filter: GroupFilter<DynI32>,
+        batches: &[&[(i32, ZWeight)]],
+    ) -> Vec<(i32, i32, ZWeight)> {
+        let batches: Vec<Vec<(i32, ZWeight)>> = batches.iter().map(|b| b.to_vec()).collect();
+        // The snapshot is the whole spine, so weights sum and anything that
+        // cancels becomes invisible to it, exactly as `CursorList` makes it.
+        let values: Vec<(i32, ZWeight)> = {
+            let mut v: Vec<(i32, ZWeight)> = batches.iter().flatten().copied().collect();
+            v.sort_unstable();
+            v
+        };
+        let result = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let out = result.clone();
+
+        Runtime::run(CircuitConfig::with_workers(1), move |_parker| {
+            let factories = <OrdIndexedZSetFactories<DynI32, DynI32>>::new::<i32, i32, ZWeight>();
+            let build_key = |key: i32, vals: &[(i32, ZWeight)]| {
+                let mut tuples =
+                    indexed_zset_tuples(vals.iter().map(|&(v, w)| Tup2(Tup2(key, v), w)).collect());
+                Batched::dyn_from_tuples(&factories, (), &mut tuples)
+            };
+
+            // How key 1's values are split across batches matters, so each
+            // caller chooses. The extra key exists only so that a merge of a
+            // single batch is not the identity.
+            let mut inputs: Vec<Batched> = batches.iter().map(|b| build_key(1, b)).collect();
+            inputs.push(build_key(2, &[(0, 1)]));
+
+            // Everything under key 1, as the spine snapshot would see it.
+            let snapshot = Some(Arc::new(build_key(1, &values)));
+
+            let builder = <Batched as Batch>::Builder::for_merge(
+                &factories,
+                inputs.iter(),
+                Some(BatchLocation::Memory),
+            );
+            let cursors = inputs
+                .iter()
+                .map(|b| b.merge_cursor_with_snapshot(None, Some(filter.clone()), &snapshot))
+                .collect();
+
+            let merged: Batched = ListMerger::merge(&factories, builder, cursors);
+            *out.lock().unwrap() = contents_of(&merged)
+                .into_iter()
+                .filter(|&(k, _, _)| k == 1)
+                .collect();
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+
+        result.lock().unwrap().clone()
+    }
+
+    /// A monotone predicate, which is all the in-tree tests use. The filters
+    /// behave correctly here, so this pins the baseline the bug is measured
+    /// against.
+    #[test]
+    fn top_n_is_correct_for_a_monotone_predicate() {
+        // Retain everything >= 8, plus the 2 largest below it.
+        let filter = GroupFilter::TopN(
+            2,
+            Filter::new(Box::new(|v: &DynI32| *unsafe { v.downcast::<i32>() } >= 8)),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        let all: Vec<(i32, ZWeight)> = (0..12).map(|v| (v, 1)).collect();
+        let survived = retain(filter, &[&all]);
+        let values: Vec<i32> = survived.iter().map(|&(_, v, _)| v).collect();
+        assert_eq!(values, vec![6, 7, 8, 9, 10, 11]);
+    }
+
+    /// The same shape of filter, but not monotone: it holds for value 3 and for
+    /// nothing else below the top. Value 3 satisfies the filter, so it survives.
+    /// The galloping seek used to skip it.
+    #[test]
+    fn top_n_keeps_a_retained_value_for_a_non_monotone_predicate() {
+        let filter = GroupFilter::TopN(
+            2,
+            Filter::new(Box::new(|v: &DynI32| *unsafe { v.downcast::<i32>() } == 3)),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        // One batch, so the seek runs over more than 8 values and `advance`
+        // takes its galloping path.
+        let all: Vec<(i32, ZWeight)> = (0..12).map(|v| (v, 1)).collect();
+        let survived = retain(filter, &[&all]);
+        let values: Vec<i32> = survived.iter().map(|&(_, v, _)| v).collect();
+
+        // Documented semantics: every value satisfying the filter, which is {3},
+        // plus the 2 largest that do not, which are {10, 11}.
+        assert_eq!(
+            values,
+            vec![3, 10, 11],
+            "value 3 satisfies the filter and must be retained"
+        );
+    }
+
+    /// `BottomN` resurrects a deleted row.
+    ///
+    /// This is the worst of the three, and it needs no non-monotonicity: the
+    /// filter here is a plain threshold. It follows purely from
+    /// `BottomN::on_step_key` never touching the batch cursor, so each batch's
+    /// FIRST value is emitted with no filter check at all.
+    ///
+    /// A value that cancels across the spine is invisible to the snapshot, so
+    /// the filter never reasons about it (`CursorList::seek_key_exact` skips
+    /// zero-weight values, cursor_list.rs:692-720) -- the situation
+    /// filter.rs:79-83 warns about. Here value 5 leads one batch and trails the
+    /// other. Both copies must reach the same verdict, or they stop cancelling
+    /// and the deleted row comes back; that is what happened while `BottomN`
+    /// left the leading copy unexamined.
+    #[test]
+    fn bottom_n_does_not_resurrect_a_deleted_value() {
+        // Nothing satisfies the filter, so retention keeps only the n smallest.
+        let filter = GroupFilter::BottomN(
+            1,
+            Filter::new(Box::new(|v: &DynI32| {
+                *unsafe { v.downcast::<i32>() } >= 100
+            })),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+
+        // Spine total for key 1: {1: +1, 5: 0, 20: +1}. Value 5 is deleted.
+        // With n = 1 the only value to retain is 1, the smallest failing one.
+        let survived = retain(
+            filter,
+            &[
+                &[(5, 1), (20, 1)], // 5 leads this batch
+                &[(1, 1), (5, -1)], // and trails this one
+            ],
+        );
+
+        assert_eq!(
+            survived,
+            vec![(1, 1, 1)],
+            "value 5 was deleted; retention must not bring it back"
+        );
+    }
+
+    /// `BottomN` retains everything satisfying the filter plus the `n` smallest
+    /// that do not. Anything else is collected; it used to be kept.
+    #[test]
+    fn bottom_n_collects_a_collectable_value_for_a_non_monotone_predicate() {
+        let filter = GroupFilter::BottomN(
+            2,
+            Filter::new(Box::new(|v: &DynI32| *unsafe { v.downcast::<i32>() } == 8)),
+            <DynData as WithFactory<i32>>::FACTORY,
+        );
+        // Split so the second batch starts at 6. `BottomN`'s `on_step_key` does
+        // no seek, unlike `TopN`'s, so nothing ever skips the values leading
+        // each batch.
+        let survived = retain(
+            filter,
+            &[
+                &[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)],
+                &[(6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1)],
+            ],
+        );
+        let values: Vec<i32> = survived.iter().map(|&(_, v, _)| v).collect();
+
+        assert_eq!(
+            values,
+            vec![0, 1, 8],
+            "6 fails the filter and is not among the 2 smallest that do"
+        );
+    }
+}

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -168,9 +168,6 @@ where
 }
 
 /// A key's tuples grouped by distinct value, in value order.
-///
-/// A value can occur at several times. `GroupFilterCursor` steps over distinct
-/// values, so it spends one of its `n` places on such a value, not one per time.
 fn by_value<V: DataTrait + ?Sized, T, R: WeightTrait + ?Sized>(
     tuples: Vec<(Box<V>, T, Box<R>)>,
 ) -> Vec<(Box<V>, Vec<(T, Box<R>)>)> {
@@ -1640,7 +1637,7 @@ mod tests {
 
     type Tuples = Vec<((Box<DynData>, Box<DynData>, u32), Box<DynZWeight>)>;
 
-    /// `(key, value, time, weight)` in the shape `filter` takes.
+    /// `(key, value, time, weight)` rows, boxed the way the model takes them.
     fn tuples(rows: &[(i32, i32, u32, ZWeight)]) -> Tuples {
         rows.iter()
             .map(|&(key, value, time, weight)| {
@@ -1666,13 +1663,12 @@ mod tests {
             .collect()
     }
 
-    fn keeps_8() -> Filter<DynData> {
+    fn keeps_at_least_8() -> Filter<DynData> {
         Filter::new(Box::new(|v: &DynData| *unsafe { v.downcast::<i32>() } >= 8))
     }
 
-    /// Nothing else drives this model, so pin the semantics it is supposed to
-    /// state: everything satisfying the filter, plus the `n` failing values
-    /// nearest the chosen end, and per key rather than across the batch.
+    /// Each key keeps every value that satisfies the filter, plus the `n`
+    /// failing values nearest the chosen end of that key's own group.
     #[test]
     fn retains_the_n_failing_values_nearest_each_end() {
         let rows = tuples(&[
@@ -1684,7 +1680,7 @@ mod tests {
             (2, 4, 0, 1),
         ]);
 
-        let top = retain_n_unsatisfying(rows.clone(), &keeps_8(), 2, Extreme::Largest);
+        let top = retain_n_unsatisfying(rows.clone(), &keeps_at_least_8(), 2, Extreme::Largest);
         assert_eq!(
             plain(&top),
             vec![
@@ -1697,7 +1693,7 @@ mod tests {
             "the two largest failing values of each key, plus everything >= 8"
         );
 
-        let bottom = retain_n_unsatisfying(rows, &keeps_8(), 2, Extreme::Smallest);
+        let bottom = retain_n_unsatisfying(rows, &keeps_at_least_8(), 2, Extreme::Smallest);
         assert_eq!(
             plain(&bottom),
             vec![
@@ -1711,15 +1707,14 @@ mod tests {
         );
     }
 
-    /// A value at several times is one value to the cursor, so it spends one of
-    /// the `n` places, not one per time.
+    /// A value occurring at several times still counts once against `n`.
     #[test]
     fn a_value_at_several_times_counts_once() {
-        // Value 5 occurs twice. Counting tuples would spend both places on it
-        // and drop value 3.
+        // Value 5 occurs twice. Counting tuples would account for it twice and
+        // drop value 3.
         let rows = tuples(&[(1, 3, 0, 1), (1, 5, 0, 1), (1, 5, 7, 1)]);
 
-        let top = retain_n_unsatisfying(rows, &keeps_8(), 2, Extreme::Largest);
+        let top = retain_n_unsatisfying(rows, &keeps_at_least_8(), 2, Extreme::Largest);
         assert_eq!(
             plain(&top),
             vec![(1, 3, 0, 1), (1, 5, 0, 1), (1, 5, 7, 1)],
@@ -1738,7 +1733,7 @@ mod tests {
             &None,
             &Some(GroupFilter::TopN(
                 1,
-                keeps_8(),
+                keeps_at_least_8(),
                 <DynData as WithFactory<i32>>::FACTORY,
             )),
         );
@@ -1749,7 +1744,7 @@ mod tests {
             &None,
             &Some(GroupFilter::BottomN(
                 1,
-                keeps_8(),
+                keeps_at_least_8(),
                 <DynData as WithFactory<i32>>::FACTORY,
             )),
         );

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -167,6 +167,82 @@ where
         .collect::<Vec<_>>()
 }
 
+/// A key's tuples grouped by distinct value, in value order.
+///
+/// A value can occur at several times. `GroupFilterCursor` steps over distinct
+/// values, so it spends one of its `n` places on such a value, not one per time.
+fn by_value<V: DataTrait + ?Sized, T, R: WeightTrait + ?Sized>(
+    tuples: Vec<(Box<V>, T, Box<R>)>,
+) -> Vec<(Box<V>, Vec<(T, Box<R>)>)> {
+    let mut grouped: BTreeMap<Box<V>, Vec<(T, Box<R>)>> = BTreeMap::new();
+    for (value, time, weight) in tuples {
+        grouped.entry(value).or_default().push((time, weight));
+    }
+    grouped.into_iter().collect()
+}
+
+/// Which end of a group of values `retain_n_unsatisfying` retains.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Extreme {
+    Largest,
+    Smallest,
+}
+
+/// Models `GroupFilter::TopN` and `GroupFilter::BottomN`.
+///
+/// Retains, for each key, every value that satisfies `filter`, plus the `n` values
+/// that do not satisfy it and that are largest (`Extreme::Largest`) or smallest
+/// (`Extreme::Smallest`) within the key's group.  A group with fewer than `n`
+/// values that fail the filter retains all of them.
+fn retain_n_unsatisfying<
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T,
+    R: WeightTrait + ?Sized,
+>(
+    tuples: Vec<((Box<K>, Box<V>, T), Box<R>)>,
+    filter: &Filter<V>,
+    n: usize,
+    extreme: Extreme,
+) -> Vec<((Box<K>, Box<V>, T), Box<R>)> {
+    let mut tuples_by_key: BTreeMap<Box<K>, Vec<(Box<V>, T, Box<R>)>> = BTreeMap::new();
+    for ((k, v, t), w) in tuples.into_iter() {
+        tuples_by_key.entry(k).or_default().push((v, t, w));
+    }
+
+    let mut result = Vec::new();
+    for (k, group) in tuples_by_key.into_iter() {
+        let group = by_value(group);
+
+        // Walk the group from the end that `extreme` names, keeping every value
+        // that satisfies the filter and the first `n` values that do not.
+        let mut retain = vec![false; group.len()];
+        let mut unsatisfying = 0;
+        let indexes: Box<dyn Iterator<Item = usize>> = match extreme {
+            Extreme::Largest => Box::new((0..group.len()).rev()),
+            Extreme::Smallest => Box::new(0..group.len()),
+        };
+        for i in indexes {
+            if (filter.filter_func())(group[i].0.as_ref()) {
+                retain[i] = true;
+            } else if unsatisfying < n {
+                retain[i] = true;
+                unsatisfying += 1;
+            }
+        }
+
+        for ((value, times), retain) in group.into_iter().zip(retain) {
+            if retain {
+                for (time, weight) in times {
+                    result.push(((clone_box(&*k), clone_box(&*value), time), weight));
+                }
+            }
+        }
+    }
+
+    result
+}
+
 pub fn filter<K: DataTrait + ?Sized, V: DataTrait + ?Sized, T, R: WeightTrait + ?Sized>(
     mut tuples: Vec<((Box<K>, Box<V>, T), Box<R>)>,
     key_filter: &Option<Filter<K>>,
@@ -193,31 +269,27 @@ pub fn filter<K: DataTrait + ?Sized, V: DataTrait + ?Sized, T, R: WeightTrait + 
 
                 let mut result = Vec::new();
 
-                for (k, mut tuples) in tuples_by_key.into_iter() {
-                    let index = tuples
+                for (k, tuples) in tuples_by_key.into_iter() {
+                    let group = by_value(tuples);
+                    let index = group
                         .iter()
-                        .position(|(v, _t, _w)| (filter.filter_func())(v.as_ref()))
-                        .unwrap_or(tuples.len());
+                        .position(|(value, _times)| (filter.filter_func())(value.as_ref()))
+                        .unwrap_or(group.len());
                     let first_index = index.saturating_sub(*n);
-                    tuples
-                        .drain(first_index..)
-                        .for_each(|(v, t, w)| result.push(((clone_box(&*k), v, t), w)));
+                    for (value, times) in group.into_iter().skip(first_index) {
+                        for (time, weight) in times {
+                            result.push(((clone_box(&*k), clone_box(&*value), time), weight));
+                        }
+                    }
                 }
 
                 return result;
             }
             GroupFilter::TopN(n, filter, _val_factory) => {
-                tuples.retain(|((_k, v, _t), _r)| (filter.filter_func())(v.as_ref()));
-                // take the last n elements of tuples only
-                if tuples.len() > *n {
-                    tuples.drain(..tuples.len() - *n);
-                }
-                return tuples;
+                return retain_n_unsatisfying(tuples, filter, *n, Extreme::Largest);
             }
             GroupFilter::BottomN(n, filter, _vals_factory) => {
-                tuples.retain(|((_k, v, _t), _r)| (filter.filter_func())(v.as_ref()));
-                tuples.truncate(*n);
-                return tuples;
+                return retain_n_unsatisfying(tuples, filter, *n, Extreme::Smallest);
             }
         }
     }
@@ -1555,5 +1627,132 @@ pub fn test_trace_sampling<T: Trace<Time = ()>>(trace: &T) {
     let all_keys_set = all_keys.dyn_iter().map(clone_box).collect::<BTreeSet<_>>();
     for key in sample.dyn_iter() {
         assert!(all_keys_set.contains(key));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Extreme, filter, retain_n_unsatisfying};
+    use crate::dynamic::{DowncastTrait, DynData, Erase, WithFactory};
+    use crate::trace::{Filter, GroupFilter};
+    use crate::{DynZWeight, ZWeight};
+    use dyn_clone::clone_box;
+
+    type Tuples = Vec<((Box<DynData>, Box<DynData>, u32), Box<DynZWeight>)>;
+
+    /// `(key, value, time, weight)` in the shape `filter` takes.
+    fn tuples(rows: &[(i32, i32, u32, ZWeight)]) -> Tuples {
+        rows.iter()
+            .map(|&(key, value, time, weight)| {
+                (
+                    (clone_box(key.erase()), clone_box(value.erase()), time),
+                    clone_box(weight.erase()),
+                )
+            })
+            .collect()
+    }
+
+    fn plain(tuples: &Tuples) -> Vec<(i32, i32, u32, ZWeight)> {
+        tuples
+            .iter()
+            .map(|((key, value, time), weight)| {
+                (
+                    *unsafe { key.as_ref().downcast::<i32>() },
+                    *unsafe { value.as_ref().downcast::<i32>() },
+                    *time,
+                    *unsafe { weight.as_ref().downcast::<ZWeight>() },
+                )
+            })
+            .collect()
+    }
+
+    fn keeps_8() -> Filter<DynData> {
+        Filter::new(Box::new(|v: &DynData| *unsafe { v.downcast::<i32>() } >= 8))
+    }
+
+    /// Nothing else drives this model, so pin the semantics it is supposed to
+    /// state: everything satisfying the filter, plus the `n` failing values
+    /// nearest the chosen end, and per key rather than across the batch.
+    #[test]
+    fn retains_the_n_failing_values_nearest_each_end() {
+        let rows = tuples(&[
+            (1, 1, 0, 1),
+            (1, 3, 0, 1),
+            (1, 5, 0, 1),
+            (1, 9, 0, 1),
+            (2, 2, 0, 1),
+            (2, 4, 0, 1),
+        ]);
+
+        let top = retain_n_unsatisfying(rows.clone(), &keeps_8(), 2, Extreme::Largest);
+        assert_eq!(
+            plain(&top),
+            vec![
+                (1, 3, 0, 1),
+                (1, 5, 0, 1),
+                (1, 9, 0, 1),
+                (2, 2, 0, 1),
+                (2, 4, 0, 1)
+            ],
+            "the two largest failing values of each key, plus everything >= 8"
+        );
+
+        let bottom = retain_n_unsatisfying(rows, &keeps_8(), 2, Extreme::Smallest);
+        assert_eq!(
+            plain(&bottom),
+            vec![
+                (1, 1, 0, 1),
+                (1, 3, 0, 1),
+                (1, 9, 0, 1),
+                (2, 2, 0, 1),
+                (2, 4, 0, 1)
+            ],
+            "the two smallest failing values of each key, plus everything >= 8"
+        );
+    }
+
+    /// A value at several times is one value to the cursor, so it spends one of
+    /// the `n` places, not one per time.
+    #[test]
+    fn a_value_at_several_times_counts_once() {
+        // Value 5 occurs twice. Counting tuples would spend both places on it
+        // and drop value 3.
+        let rows = tuples(&[(1, 3, 0, 1), (1, 5, 0, 1), (1, 5, 7, 1)]);
+
+        let top = retain_n_unsatisfying(rows, &keeps_8(), 2, Extreme::Largest);
+        assert_eq!(
+            plain(&top),
+            vec![(1, 3, 0, 1), (1, 5, 0, 1), (1, 5, 7, 1)],
+            "values 3 and 5 are the two largest failing values"
+        );
+    }
+
+    /// The same, through `filter`, which is what `TestBatch::retain_values` and
+    /// `assert_trace_eq` call.
+    #[test]
+    fn filter_dispatches_top_and_bottom_n() {
+        let rows = tuples(&[(1, 1, 0, 1), (1, 5, 0, 1), (1, 9, 0, 1)]);
+
+        let top = filter(
+            rows.clone(),
+            &None,
+            &Some(GroupFilter::TopN(
+                1,
+                keeps_8(),
+                <DynData as WithFactory<i32>>::FACTORY,
+            )),
+        );
+        assert_eq!(plain(&top), vec![(1, 5, 0, 1), (1, 9, 0, 1)]);
+
+        let bottom = filter(
+            rows,
+            &None,
+            &Some(GroupFilter::BottomN(
+                1,
+                keeps_8(),
+                <DynData as WithFactory<i32>>::FACTORY,
+            )),
+        );
+        assert_eq!(plain(&bottom), vec![(1, 1, 0, 1), (1, 9, 0, 1)]);
     }
 }


### PR DESCRIPTION
Fix several bugs in GC logic for top-k and asof operators.

See commit messages for details. The fixes are tiny, most of the code is tests.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
