### PR TITLE
[connectors] Pin parquet to 58.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8590,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "43d7efd3052f7d6ef601085559a246bc991e9a8cc77e02753737df6322ce35f1"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,12 @@ object_store = "0.14.1"
 once_cell = "1.20.2"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 ouroboros = "0.18.4"
-parquet = "58"
+# Pinned: 58.3 and later cannot apply a `RowSelection` to a column Databricks
+# Photon wrote with `DELTA_BINARY_PACKED`, which is how the Delta connector
+# applies a deletion vector in follow/CDC mode. 58.4 and 59.3 are affected too,
+# so there is nothing newer to move to. Reproduction and the version matrix:
+# https://github.com/ryzhyk/parquet-photon-miniblock-repro
+parquet = "=58.2.0"
 # The Parquet variant binary encoding, used to read and write Delta and
 # Iceberg VARIANT columns. Released from arrow-rs alongside `parquet`, and
 # sharing `arrow` with it, so keep the three on one point release.


### PR DESCRIPTION
Pin a version of parquet crate before this regression: https://github.com/apache/arrow-rs/issues/11018

From 58.3 the Parquet reader refuses to apply a `RowSelection` to a column encoded `DELTA_BINARY_PACKED` with miniblocks of any size but 32 or 64:

    cannot skip miniblock of size 256

Databricks Photon writes 256 whenever a table carries `delta.parquet.format.version = 2.12.0`, which Unity Catalog can set as a schema default, so tables inherit it without asking. The Delta connector applies a deletion vector in follow and CDC mode by handing the reader exactly such a selection, so those reads fail on those files, and the connector retries the file rather than reporting it -- the symptom is a stall, not an error. Snapshot reads are unaffected: delta-rs masks after decode instead.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
