### PR TITLE
Fix profiler calls toLowerCase on a field that is null

### DIFF
--- a/js-packages/profiler-lib/src/dataflow.ts
+++ b/js-packages/profiler-lib/src/dataflow.ts
@@ -21,8 +21,12 @@ export interface OutputPort {
 
 export interface MirNode {
     operation: string;
-    table: string | null;
-    view: string | null;
+    // A named operator carries one of these: `table` on source tables and view declarations, `view`
+    // on sinks. Every other operator carries neither, spelled two ways depending on the producer:
+    // the SQL compiler omits the key, while a support bundle round-trips the graph through
+    // `crates/ir/src/mir.rs`, whose `Option<String>` fields serialize None as null.
+    table?: string | null;
+    view?: string | null;
     inputs: Array<OutputPort>;
     // We don't care about this yet
     calcite: any;

--- a/js-packages/profiler-lib/src/profile.test.ts
+++ b/js-packages/profiler-lib/src/profile.test.ts
@@ -1313,8 +1313,10 @@ describe('CircuitProfile.consumerCount', () => {
 })
 
 describe('CircuitProfile.byName', () => {
-    const mirNode = (persistent_id: string, table: string | null, view: string | null) => ({
-        operation: 'op', table, view, inputs: [], calcite: {}, positions: [], persistent_id
+    // An omitted key models the SQL compiler's own dataflow file; an explicit null models a support
+    // bundle, whose graph is round-tripped through serde in `crates/ir/src/mir.rs`.
+    const mirNode = (persistent_id: string, names: { table?: string | null; view?: string | null } = {}) => ({
+        operation: 'op', ...names, inputs: [], calcite: {}, positions: [], persistent_id
     })
 
     const makeProfile = () => {
@@ -1329,9 +1331,9 @@ describe('CircuitProfile.byName', () => {
         const dataflow: Dataflow = {
             calcite_plan: {},
             mir: {
-                s1: mirNode('abc123', 'CUSTOMERS', null),
-                s2: mirNode('def456', null, 'report'),
-                s3: mirNode('789fed', 'port', null)
+                s1: mirNode('abc123', { table: 'CUSTOMERS' }),
+                s2: mirNode('def456', { view: 'report' }),
+                s3: mirNode('789fed', { table: 'port' })
             }
         }
         profile.setDataflow(dataflow)
@@ -1359,6 +1361,49 @@ describe('CircuitProfile.byName', () => {
         expect(profile.findByName('port').unwrap()).toBe(port)
     })
 
+    // `table` wins when both are named; a missing name is spelled either way by the two producers,
+    // and neither spelling may reach `toLowerCase`.
+    describe.each([
+        { case: 'both absent', names: {}, expected: undefined },
+        { case: 'table absent, view null', names: { view: null }, expected: undefined },
+        { case: 'table absent, view named', names: { view: 'v' }, expected: 'v' },
+        { case: 'table null, view absent', names: { table: null }, expected: undefined },
+        { case: 'both null', names: { table: null, view: null }, expected: undefined },
+        { case: 'table null, view named', names: { table: null, view: 'v' }, expected: 'v' },
+        { case: 'table named, view absent', names: { table: 't' }, expected: 't' },
+        { case: 'table named, view null', names: { table: 't', view: null }, expected: 't' },
+        { case: 'both named', names: { table: 't', view: 'v' }, expected: 't' }
+    ])('with $case', ({ names, expected }) => {
+        const run = () => {
+            const profile = new CircuitProfile(1, 'n')
+            const region = new ComplexNode('c1', 'region', 1)
+            const node = new SimpleNode('n1', 'map', 1)
+            profile.complexNodes.set(region.id, region)
+            profile.simpleNodes.set(node.id, node)
+            profile.parents.set(node.id, region.id)
+            profile.byPersistentId.set('abc123', node)
+            profile.setDataflow({ calcite_plan: {}, mir: { s1: mirNode('abc123', names) } })
+            return { profile, region, node }
+        }
+
+        it('parses without throwing', () => {
+            expect(run).not.toThrow()
+        })
+
+        it(`indexes ${expected ?? 'nothing'}`, () => {
+            const { profile, region, node } = run()
+            if (expected === undefined) {
+                expect(profile.byName.size).toBe(0)
+                expect(node.operation).toBe('map')
+                expect(region.collapsedOperation()).toBe('region')
+            } else {
+                expect(profile.byName.get(expected).unwrap()).toBe(node)
+                expect(node.operation).toBe(`map ${expected}`)
+                expect(region.collapsedOperation()).toBe(`region ${expected}`)
+            }
+        })
+    })
+
     it('propagates the name to ancestors for collapsed display', () => {
         const profile = new CircuitProfile(1, 'n')
         const outer = new ComplexNode('c1', 'region', 1)
@@ -1371,7 +1416,7 @@ describe('CircuitProfile.byName', () => {
         profile.parents.set(source.id, inner.id)
         profile.byPersistentId.set('abc123', source)
 
-        profile.setDataflow({ calcite_plan: {}, mir: { s1: mirNode('abc123', 'customers', null) } })
+        profile.setDataflow({ calcite_plan: {}, mir: { s1: mirNode('abc123', { table: 'customers' }) } })
 
         expect(outer.collapsedOperation()).toBe('region customers')
         expect(inner.collapsedOperation()).toBe('subregion customers')

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -1719,8 +1719,8 @@ export class CircuitProfile {
         // This can happen for some Z nodes in recursive components
         if (profileNode.isNone()) return;
         let n = profileNode.unwrap();
-        const name = mir.table !== null ? mir.table : mir.view;
-        if (name !== null) {
+        const name = mir.table ?? mir.view;
+        if (name !== undefined && name !== null) {
             n.operation += " " + name;
             this.byName.set(name.toLowerCase(), n);
             // Ancestors display the contained names when collapsed


### PR DESCRIPTION
The profiler failed to load a profile with TypeError: cant access property "toLowerCase". processMirNode was calling .toLowerCase on operators that didnt have a name or table. Now the profiler checks that there is a value before calling the method

### Describe Manual Test Plan

Before:
<img width="1667" height="471" alt="image" src="https://github.com/user-attachments/assets/d3f25355-0b6e-4f55-8525-e49765bc1c78" />


After:
<img width="1661" height="401" alt="image" src="https://github.com/user-attachments/assets/a680ce82-71c1-4074-b670-51cb35aa498a" />


## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
