### PR TITLE
[SQL] Emit warnings for programs that perform floating point equality comparisons

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -43,6 +43,21 @@ import TabItem from '@theme/TabItem';
           `SET FELDERA_IGNORE_WARNING_UNBOUNDED_STATE = ON`. See
           [Unbounded state warnings](/sql/streaming#unbounded-state-warnings).
 
+        - The SQL compiler emits the warning `Floating point equality` for
+          constructs that compare `REAL` or `DOUBLE` values for equality:
+          comparison operators, `IN`, `GROUP BY`, `DISTINCT`, `UNION`,
+          `INTERSECT`, `EXCEPT`, `PARTITION BY`, `NATURAL JOIN`, `USING`, and
+          the ties of `RANK`, `PIVOT`, and the array and map functions that
+          compare elements or keys.  Each warning points at the clause that
+          compares.  `SET FELDERA_IGNORE_WARNING_FLOATING_POINT_EQUALITY = ON`
+          silences it; a program that sets `FELDERA_WARNINGS_ARE_ERRORS` and
+          compares floating point values no longer compiles until it does.
+          See [comparing floating point values](/sql/comparisons#comparing-floating-point-values).
+
+        - The SQL compiler reports an error inside a multi-line `CREATE FUNCTION`
+          body at its line; an error past the first line of the body used to be
+          reported above the statement.
+
         ## v0.344.0
 
         - The Delta Lake and Iceberg input connectors read a `VARIANT` column

--- a/docs.feldera.com/docs/sql/comparisons.md
+++ b/docs.feldera.com/docs/sql/comparisons.md
@@ -12,17 +12,17 @@ but always return a Boolean value (sometimes nullable):
   <tr>
     <td><a id="eq"></a><code>=</code></td>
     <td>equality test</td>
-    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a></td>
+    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a>; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="ne"></a><code>&lt;&gt;</code></td>
     <td>inequality test</td>
-    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a></td>
+    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a>; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="neq"></a><code>!=</code></td>
     <td>inequality test, same as above</td>
-    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a></td>
+    <td>rejected for <a href="#comparing-row-values"><code>ROW</code> values</a>; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="gt"></a><code>&gt;</code></td>
@@ -57,17 +57,17 @@ but always return a Boolean value (sometimes nullable):
   <tr>
     <td><a id="nne"></a><code>&lt;=&gt;</code></td>
     <td>equality check that treats <code>NULL</code> values as equal</td>
-    <td>result is not nullable</td>
+    <td>result is not nullable; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="distinct"></a><code>IS DISTINCT FROM</code></td>
     <td>check if two values are not equal, treating <code>NULL</code> as equal</td>
-    <td>result is not nullable</td>
+    <td>result is not nullable; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="notdistinct"></a><code>IS NOT DISTINCT FROM</code></td>
     <td>check if two values are the same, treating <code>NULL</code> values as equal</td>
-    <td>result is not nullable</td>
+    <td>result is not nullable; <a href="#comparing-floating-point-values">warns</a> for floating point values</td>
   </tr>
   <tr>
     <td><a id="between"></a><code>BETWEEN [ASYMMETRIC] ... AND ...</code></td>
@@ -105,6 +105,47 @@ Note that the SQL standard mandates `IS NULL` to return `true` for a
 `ROW` object where all fields are `NULL` (similarly, `IS NOT NULL` is
 required to return `false`).  Our compiler diverges from the standard,
 returning `false` for `ROW(null) is null`.
+
+## Comparing floating point values {#comparing-floating-point-values}
+
+Floating point arithmetic rounds its results, so two computations of
+the same quantity can produce `REAL` or `DOUBLE` values that differ in
+their last bits: `0.1e0 + 0.2e0 = 0.3e0` is `false`.  Testing floating point
+values for equality, or grouping by such columns, gives results that
+depend on how the values were computed rather than on the quantities
+they represent.
+
+The compiler therefore emits the warning `Floating point equality` when
+one of the constructs listed below compares floating point values for
+equality, including values nested inside `ROW`, `ARRAY`, and `MAP`
+values:
+
+| Construct | What is compared |
+|-----------|------------------|
+| `=`, `<>`, `!=`, `<=>`, `IS [NOT] DISTINCT FROM`, `NULLIF` | the two operands |
+| `IN`, `NOT IN`, `CASE x WHEN v` | the value and each candidate |
+| `GROUP BY`, `PARTITION BY` | the grouping keys |
+| `DISTINCT`, `UNION`, `INTERSECT [ALL]`, `EXCEPT [ALL]` | whole rows |
+| `COUNT(DISTINCT x)` and other `DISTINCT` aggregates, `MODE` | the aggregated values |
+| `NATURAL JOIN`, `JOIN ... USING` | the shared columns |
+| `RANK`, `DENSE_RANK`, `PERCENT_RANK`, `CUME_DIST` | the `ORDER BY` keys, to detect ties |
+| `PIVOT` | the `FOR` columns and the pivot values |
+| `ARRAY_CONTAINS`, `ARRAY_POSITION`, `ARRAY_REMOVE`, `ARRAY_DISTINCT`, `ARRAY_EXCEPT`, `ARRAY_UNION`, `ARRAY_INTERSECT`, `ARRAYS_OVERLAP` | the array elements |
+| `map[key]`, `MAP_CONTAINS_KEY` | the map keys |
+
+The analysis inspects declared types only, so it does not report a
+`VARIANT` value that holds a floating point number at run time.
+
+To avoid the problem, store quantities that are compared or grouped as
+`DECIMAL` values, or convert them before comparing: `ROUND(x, 2) =
+ROUND(y, 2)` still compares floating point values, whereas `CAST(x AS
+DECIMAL(10, 2)) = CAST(y AS DECIMAL(10, 2))` compares exact values.  A
+comparison with a tolerance, such as `ABS(x - y) < 1e-9`, is an
+ordering comparison and produces no warning either.
+
+The statement `SET FELDERA_IGNORE_WARNING_FLOATING_POINT_EQUALITY = ON`
+silences the warning for the whole program; see the
+[compiler options](/sql/grammar#supported-options).
 
 ## Comparing complex values
 

--- a/docs.feldera.com/docs/sql/float.md
+++ b/docs.feldera.com/docs/sql/float.md
@@ -26,6 +26,10 @@ an example is `NaN` raised to the zero power yields one.
 
 In sorting order `NaN` is considered greater than all other values.
 
+Rounding makes floating point values unreliable operands for equality
+tests, `GROUP BY`, and `DISTINCT`; the compiler warns about such uses.
+See [comparing floating point values](/sql/comparisons#comparing-floating-point-values).
+
 The legal operations are `+` (plus, unary and binary), `-` (minus,
 unary and binary), `*` (multiplication), `/` (division), `%`
 (modulus).

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/Documentation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/Documentation.java
@@ -1,0 +1,109 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** The Feldera documentation site: builds the links that compiler messages cite and
+ * resolves them against the Markdown sources of the site. */
+public class Documentation {
+    /** Root of the published site */
+    public static final String SITE = "https://docs.feldera.com/";
+    /** Markdown sources of the site, relative to the SQL-compiler directory */
+    public static final String SOURCES = "../../docs.feldera.com/docs";
+
+    /** A page of the site, or a heading of a page.
+     *
+     * @param page    Path of the page below {@link #SITE}, such as {@code sql/comparisons}.
+     * @param anchor  Anchor of the heading within the page, or null for the whole page. */
+    public record Link(String page, @Nullable String anchor) {
+        public Link(String page) {
+            this(page, null);
+        }
+
+        public String url() {
+            String url = SITE + this.page;
+            if (this.anchor != null)
+                url += "#" + this.anchor;
+            return url;
+        }
+
+        /** The line that a compiler message appends to cite the documentation */
+        public String citation() {
+            return "See " + this.url();
+        }
+
+        /** The Markdown source of the page: a {@code .md} file, or a {@code .mdx} file
+         * when that is the one that exists */
+        public Path source() {
+            Path markdown = Paths.get(SOURCES, this.page + ".md");
+            Path mdx = Paths.get(SOURCES, this.page + ".mdx");
+            return Files.exists(mdx) && !Files.exists(markdown) ? mdx : markdown;
+        }
+
+        /** The link that a URL of the site denotes, or null for any other string */
+        @Nullable
+        public static Link parse(String url) {
+            if (!url.startsWith(SITE))
+                return null;
+            String path = url.substring(SITE.length());
+            int hash = path.indexOf('#');
+            if (hash < 0)
+                return new Link(path);
+            return new Link(path.substring(0, hash), path.substring(hash + 1));
+        }
+    }
+
+    /** Slugify a Markdown heading the way Docusaurus (github-slugger) does:
+     * lowercase, drop punctuation, replace spaces with hyphens.
+     * Underscores and hyphens are preserved. */
+    public static String slugify(String heading) {
+        String slug = heading.trim().toLowerCase(Locale.ENGLISH);
+        slug = slug.replaceAll("[^a-z0-9 _-]", "");
+        return slug.trim().replaceAll("\\s+", "-");
+    }
+
+    static final Pattern EXPLICIT_HEADING_ANCHOR = Pattern.compile("\\{#([^}]+)}\\s*$");
+    static final Pattern ANCHOR_TAG = Pattern.compile("<a id=\"([^\"]+)\">");
+
+    /** The anchors that Markdown contents define: a heading's explicit {@code {#id}}
+     * or otherwise its slug, and every {@code <a id="...">} tag.  A link resolves
+     * only against a full anchor; a substring match breaks in the rendered site. */
+    public static Set<String> anchors(String markdown) {
+        Set<String> anchors = new HashSet<>();
+        for (String line : markdown.split("\n")) {
+            if (line.startsWith("#")) {
+                String heading = line.replaceFirst("^#+", "");
+                Matcher explicit = EXPLICIT_HEADING_ANCHOR.matcher(heading);
+                if (explicit.find())
+                    anchors.add(explicit.group(1));
+                else
+                    anchors.add(slugify(heading));
+            }
+            Matcher tag = ANCHOR_TAG.matcher(line);
+            while (tag.find())
+                anchors.add(tag.group(1));
+        }
+        return anchors;
+    }
+
+    /** Throws if the source of the page does not exist or does not define the anchor */
+    public static void checkResolves(Link link) throws IOException {
+        Path source = link.source();
+        if (!Files.exists(source))
+            throw new RuntimeException("Documentation page not found: " + source.normalize());
+        if (link.anchor() == null)
+            return;
+        Set<String> anchors = anchors(Files.readString(source));
+        if (!anchors.contains(link.anchor()))
+            throw new RuntimeException("Anchor `" + link.anchor() + "` does not appear in file " +
+                    source.normalize() + "; the anchors are " + anchors);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/StubsWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/StubsWriter.java
@@ -10,7 +10,6 @@ import org.dbsp.sqlCompiler.ir.IDBSPNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.IndentStream;
 import org.dbsp.util.Linq;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/StubsWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/StubsWriter.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.backend.rust;
 
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.DBSPDeclaration;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
@@ -25,6 +26,7 @@ import java.util.List;
 
 /** Generates the stubs.rs file with declarations for the Rust user-defined functions */
 public class StubsWriter extends BaseRustCodeGenerator {
+    public static final Documentation.Link UDF_DOCUMENTATION = new Documentation.Link("sql/udf");
     final Path path;
     @Nullable
     PrintStream stream = null;
@@ -74,13 +76,13 @@ public class StubsWriter extends BaseRustCodeGenerator {
 // This file contains stubs for user-defined functions declared in the SQL program.
 // Each stub defines a function prototype that must be implemented in `udf.rs`.
 // Copy these stubs to `udf.rs`, replacing their bodies with the actual UDF implementation.
-// See detailed documentation in https://docs.feldera.com/sql/udf.
+// See detailed documentation in %s.
 
 #![allow(non_snake_case)]
 
 use feldera_sqllib::*;
 use crate::*;
-""");
+""".formatted(UDF_DOCUMENTATION.url()));
         List<DBSPFunction> extern = new ArrayList<>();
         if (this.circuit != null) {
             for (DBSPDeclaration decl : this.circuit.declarations) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -54,6 +54,7 @@ import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ExternalFunction;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.WarnFloatingPointEquality;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.DBSPParameter;
@@ -1712,6 +1713,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     }
                     case "arrays_overlap": {
                         validateArgCount(node, operationName, ops.size(), 2);
+                        this.checkFloatingPointEquality(node, call,
+                                call.operands.get(0).getType().getComponentType());
                         DBSPExpression arg0 = ops.get(0);
                         DBSPExpression arg1 = ops.get(1);
                         if (arg0.getType().is(DBSPTypeNull.class) || arg1.getType().is(DBSPTypeNull.class))
@@ -1739,6 +1742,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     }
                     case "array_remove": {
                         validateArgCount(node, operationName, call.operandCount(), 2);
+                        this.checkFloatingPointEquality(node, call,
+                                call.operands.get(0).getType().getComponentType());
                         DBSPExpression arg0 = ops.get(0);
                         DBSPExpression arg1 = ops.get(1);
                         DBSPTypeArray vec = arg0.getType().to(DBSPTypeArray.class);
@@ -2002,6 +2007,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 if (collectionType.is(DBSPTypeMap.class)) {
                     // index into a map
                     Utilities.enforce(name.equals("ITEM"));
+                    this.checkFloatingPointEquality(node, "MAP[key]", call.operands.get(0).getType().getKeyType());
                     DBSPTypeMap map = collectionType.to(DBSPTypeMap.class);
                     index = index.applyCloneIfNeeded()
                             .cast(node, map.getKeyType(), DBSPCastExpression.CastType.SqlUnsafe);
@@ -2096,6 +2102,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             case ARRAY_INTERSECT:
             case ARRAY_CONCAT: {
                 int operands = ops.size();
+                if (call.getKind() != SqlKind.ARRAY_CONCAT)
+                    this.checkFloatingPointEquality(node, call, call.getType().getComponentType());
                 DBSPExpression result = ops.get(0).cast(node, type, DBSPCastExpression.CastType.SqlUnsafe);
                 for (int i = 1; i < operands; i++) {
                     // Extra check due to https://issues.apache.org/jira/browse/CALCITE-7105
@@ -2157,6 +2165,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             case ARRAY_CONTAINS:
             case ARRAY_POSITION: {
                 validateArgCount(node, operationName, call.operandCount(), 2);
+                this.checkFloatingPointEquality(node, call,
+                        call.operands.get(0).getType().getComponentType());
                 DBSPExpression arg0 = ops.get(0);
                 DBSPExpression arg1 = ops.get(1);
                 DBSPTypeArray vec = arg0.getType().to(DBSPTypeArray.class);
@@ -2191,6 +2201,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             }
             case MAP_CONTAINS_KEY: {
                 validateArgCount(node, operationName, call.operandCount(), 2);
+                this.checkFloatingPointEquality(node, call,
+                        call.operands.get(0).getType().getKeyType());
                 DBSPExpression arg0 = ops.get(0);
                 DBSPExpression arg1 = ops.get(1);
                 DBSPTypeMap map = arg0.getType().to(DBSPTypeMap.class);
@@ -2212,6 +2224,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             }
             case ARRAY_DISTINCT: {
                 DBSPExpression arg0 = ops.get(0);
+                this.checkFloatingPointEquality(node, call,
+                        call.operands.get(0).getType().getComponentType());
                 String method = getCallName(call);
                 if (arg0.type.mayBeNull)
                     method += "N";
@@ -2386,6 +2400,17 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 throw new UnimplementedException("Function " + Utilities.singleQuote(call.getOperator().toString())
                         + " not yet implemented", 1265, node);
         }
+    }
+
+    /** Warn if {@code construct} compares floating point values for equality; {@code type} is
+     * the type of the values compared, such as the element type of an array argument */
+    void checkFloatingPointEquality(CalciteObject node, RexCall call, @Nullable RelDataType type) {
+        // Some functions are registered with lowercase names
+        this.checkFloatingPointEquality(node, call.op.getName().toUpperCase(Locale.ENGLISH), type);
+    }
+
+    void checkFloatingPointEquality(CalciteObject node, String construct, @Nullable RelDataType type) {
+        WarnFloatingPointEquality.checkType(this.compiler, node.getPositionRange(), construct, type);
     }
 
     private DBSPExpression warnAlwaysNull(CalciteObject node, DBSPType type) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FunctionDocumentation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FunctionDocumentation.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
 
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
 
@@ -100,8 +101,7 @@ public class FunctionDocumentation {
                     throw new RuntimeException("Function `" + func.functionName() + "` does not appear in file " + docFile);
             }
             if (!anchor.isEmpty()) {
-                if (!contents.contains("<a id=\"" + anchor + "\"></a>")
-                        && !headingSlugs(contents).contains(anchor))
+                if (!Documentation.anchors(contents).contains(anchor))
                     throw new RuntimeException("Anchor `" + anchor + "` does not appear in file " + docFile);
                 anchor = "#" + anchor;
             } else {
@@ -118,28 +118,6 @@ public class FunctionDocumentation {
             writer.print("[" + Utilities.getBaseName(docFile) + "](" + toPrint + ")");
         }
         writer.println();
-    }
-
-    /** Slugify a Markdown heading the way Docusaurus (github-slugger) does:
-     * lowercase, drop punctuation, replace spaces with hyphens.
-     * Underscores and hyphens are preserved. */
-    static String slugify(String heading) {
-        String slug = heading.trim().toLowerCase(Locale.ENGLISH);
-        slug = slug.replaceAll("[^a-z0-9 _-]", "");
-        return slug.trim().replaceAll("\\s+", "-");
-    }
-
-    /** The slugs of all Markdown headings in the file contents.
-     * A `#anchor` link resolves only against the FULL heading slug;
-     * substring matches produce links that break in the rendered docs. */
-    static Set<String> headingSlugs(String contents) {
-        Set<String> slugs = new HashSet<>();
-        for (String line: contents.split("\n")) {
-            if (!line.startsWith("#"))
-                continue;
-            slugs.add(slugify(line.replaceFirst("^#+", "")));
-        }
-        return slugs;
     }
 
     static boolean sameFunction(FunctionDescription left, FunctionDescription right) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RejectUnsupportedPlans.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RejectUnsupportedPlans.java
@@ -9,6 +9,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.SqlKind;
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
@@ -37,8 +38,8 @@ import org.dbsp.util.Utilities;
 public class RejectUnsupportedPlans extends RelHomogeneousShuttle {
     private static final String ERROR_KIND = "Unsupported comparison";
 
-    private static final String ROW_DOCUMENTATION =
-            "See https://docs.feldera.com/sql/comparisons#comparing-row-values";
+    public static final Documentation.Link ROW_DOCUMENTATION =
+            new Documentation.Link("sql/comparisons", "comparing-row-values");
 
     private final CheckExpression checker;
 
@@ -101,7 +102,7 @@ public class RejectUnsupportedPlans extends RelHomogeneousShuttle {
             if (message == null)
                 return;
             this.reporter.reportError(new SourcePositionRange(call.getParserPosition()),
-                    ERROR_KIND, message + ".\n" + ROW_DOCUMENTATION);
+                    ERROR_KIND, message + ".\n" + ROW_DOCUMENTATION.citation());
         }
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -205,6 +205,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -776,6 +777,10 @@ public class SqlToRelCompiler implements IWritesLogs {
      * There is no way to reuse the previous parser one, unfortunately. */
     public static final Documentation.Link RECURSION_DOCUMENTATION = new Documentation.Link("sql/recursion");
     final StringBuilder newlines = new StringBuilder();
+    /** Maps a position in the program being compiled to the position reported to the user.
+     * This is normally the identity function, except while compiling the body of a user-defined
+     * function. */
+    UnaryOperator<SqlParserPos> sourcePositionRemap = UnaryOperator.identity();
 
     /** Create a new parser.
      * @param sql       Program to parse.
@@ -1609,6 +1614,8 @@ public class SqlToRelCompiler implements IWritesLogs {
                     .append(sql)
                     .newline();
             SqlToRelCompiler clone = new SqlToRelCompiler(this);
+            int bodyStartLine = newLineNumber;
+            clone.sourcePositionRemap = generated -> positionInFunctionBody(generated, bodyStartLine, position);
             List<ParsedStatement> list = clone.parseStatements(sql, true, true);
             RelStatement statement = null;
             for (ParsedStatement node : list) {
@@ -1854,23 +1861,32 @@ public class SqlToRelCompiler implements IWritesLogs {
         return Objects.requireNonNull(query);
     }
 
-    // Adjust the source position in the exception to match the original position
+    /** Position in the user's program of {@code generated}.  The function body starts at line
+     * {@code bodyStartLine} of the generated program and at {@code body} in the user's program. */
+    static SqlParserPos positionInFunctionBody(SqlParserPos generated, int bodyStartLine, SqlParserPos body) {
+        int line = body.getLineNum() + generated.getLineNum() - bodyStartLine;
+        int endLine = body.getLineNum() + generated.getEndLineNum() - bodyStartLine;
+        // The body is copied verbatim, so only its first line is shifted to the right
+        int column = generated.getColumnNum();
+        if (generated.getLineNum() == bodyStartLine)
+            column += body.getColumnNum() - 1;
+        int endColumn = generated.getEndColumnNum();
+        if (generated.getEndLineNum() == bodyStartLine)
+            endColumn += body.getColumnNum() - 1;
+        return new SqlParserPos(line, column, endLine, endColumn);
+    }
+
+    /** The exception {@code e}, raised while compiling a function body inside a generated
+     * program, with its position moved into the user's program */
     CalciteContextException rewriteException(
-            CalciteContextException e,
-            int startLineNumberInGeneratedCode, SqlParserPos original) {
-        int line = original.getLineNum() - e.getPosLine() + startLineNumberInGeneratedCode;
-        int endLine = original.getEndLineNum() - e.getEndPosLine() + startLineNumberInGeneratedCode;
-        // If the error is on the first line, we need to adjust the column, otherwise we don't.
-        // The temporary generated code always starts after a newline.
-        int col = e.getPosColumn();
-        int endCol = e.getEndPosColumn();
-        if (e.getPosLine() == startLineNumberInGeneratedCode)
-            col += original.getColumnNum() - 1;
-        if (e.getEndPosLine() == startLineNumberInGeneratedCode)
-            endCol += original.getColumnNum() - 1;
+            CalciteContextException e, int bodyStartLine, SqlParserPos body) {
+        SqlParserPos generated = new SqlParserPos(
+                e.getPosLine(), e.getPosColumn(), e.getEndPosLine(), e.getEndPosColumn());
+        SqlParserPos position = positionInFunctionBody(generated, bodyStartLine, body);
         return new CalciteContextException(
                 e.getMessage() == null ? "" : e.getMessage(), e.getCause(),
-                line, col, endLine, endCol);
+                position.getLineNum(), position.getColumnNum(),
+                position.getEndLineNum(), position.getEndColumnNum());
     }
 
     private DropTableStatement compileDropTable(ParsedStatement node) {
@@ -2012,7 +2028,10 @@ public class SqlToRelCompiler implements IWritesLogs {
 
     RelRoot sqlToRel(SqlNode node) {
         SqlToRelConverter converter = this.getConverter();
-        RelRoot root = converter.convertQuery(node, true, true);
+        SqlNode validated = this.getValidator().validate(node);
+        validated.accept(new WarnFloatingPointEquality(
+                this.getValidator(), this.errorReporter, this.sourcePositionRemap));
+        RelRoot root = converter.convertQuery(validated, false, true);
         root.rel.accept(new RejectUnsupportedPlans(this.errorReporter));
         return root;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -133,6 +133,7 @@ import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.dbsp.generated.parser.DbspParserImpl;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
@@ -560,7 +561,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                         "Not supported",
                         "RECURSIVE queries in WITH are not supported; " +
                                 "use DECLARE RECURSIVE VIEW instead. " +
-                                "See https://docs.feldera.com/sql/recursion");
+                                RECURSION_DOCUMENTATION.citation());
             }
             SqlOperator operator = call.getOperator();
             if (operator instanceof SqlFunction) {
@@ -773,6 +774,7 @@ public class SqlToRelCompiler implements IWritesLogs {
     /** Keep here a number of empty lines.  This is done to fool the SqlParser
      * below: for each invocation of parseStatements we create a new SqlParser.
      * There is no way to reuse the previous parser one, unfortunately. */
+    public static final Documentation.Link RECURSION_DOCUMENTATION = new Documentation.Link("sql/recursion");
     final StringBuilder newlines = new StringBuilder();
 
     /** Create a new parser.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/WarnFloatingPointEquality.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/WarnFloatingPointEquality.java
@@ -1,0 +1,390 @@
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.JoinConditionType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlPivot;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlSelectKeyword;
+import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.SqlWindow;
+import org.apache.calcite.sql.fun.SqlInOperator;
+import org.apache.calcite.sql.fun.SqlQuantifyOperator;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.calcite.sql.validate.SqlNameMatcher;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorNamespace;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.dbsp.sqlCompiler.compiler.Documentation;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/** Warns about the constructs of a validated SQL statement that compare floating point
+ * values for equality.
+ *
+ * <p>Equality is explicit in {@code =}, {@code <>}, {@code IS [NOT] DISTINCT FROM},
+ * {@code NULLIF}, and {@code IN}; the parser rewrites {@code CASE x WHEN v} into {@code x = v}.
+ * Equality is implicit in {@code GROUP BY}, {@code DISTINCT}, {@code DISTINCT}
+ * aggregates, {@code MODE}, {@code UNION}, {@code INTERSECT}, {@code EXCEPT},
+ * {@code PARTITION BY}, {@code NATURAL JOIN}, {@code USING}, and in the ties of the
+ * {@code RANK} family of window functions.
+ *
+ * <p>A value is floating point when its type is {@code REAL} or {@code DOUBLE}; a
+ * {@code ROW}, {@code ARRAY}, or {@code MAP} value contains floating point values when
+ * one of its component types does. */
+public class WarnFloatingPointEquality extends SqlBasicVisitor<Void> {
+    /** Name of the warning; silenced by {@code SET FELDERA_IGNORE_WARNING_FLOATING_POINT_EQUALITY = ON} */
+    public static final String WARNING = "Floating point equality";
+    public static final Documentation.Link DOCUMENTATION =
+            new Documentation.Link("sql/comparisons", "comparing-floating-point-values");
+
+    /** Operators that compare their operands for equality */
+    static final Set<SqlKind> EQUALITY_OPERATORS = EnumSet.of(
+            SqlKind.EQUALS, SqlKind.NOT_EQUALS,
+            SqlKind.IS_DISTINCT_FROM, SqlKind.IS_NOT_DISTINCT_FROM, SqlKind.NULLIF);
+    /** Window functions whose result depends on which rows tie under ORDER BY */
+    static final Set<SqlKind> RANK_FUNCTIONS = EnumSet.of(
+            SqlKind.RANK, SqlKind.DENSE_RANK, SqlKind.PERCENT_RANK, SqlKind.CUME_DIST);
+    /** GROUP BY items that group other items rather than being expressions */
+    static final Set<SqlKind> GROUPING_CONSTRUCTS = EnumSet.of(
+            SqlKind.GROUPING_SETS, SqlKind.ROLLUP, SqlKind.CUBE, SqlKind.GROUP_BY_DISTINCT);
+    /** Wrappers of an ORDER BY key that specify its direction or NULL placement */
+    static final Set<SqlKind> ORDERING_MODIFIERS = EnumSet.of(
+            SqlKind.DESCENDING, SqlKind.NULLS_FIRST, SqlKind.NULLS_LAST);
+
+    private final SqlValidator validator;
+    private final IErrorReporter reporter;
+    /** Maps a position in the statement to the position reported to the user */
+    private final UnaryOperator<SqlParserPos> sourcePositionRemap;
+    /** The SELECT statements that enclose the node being visited, innermost first;
+     * a named window is declared in the WINDOW clause of one of them */
+    private final Deque<SqlSelect> enclosingSelects = new ArrayDeque<>();
+
+    public WarnFloatingPointEquality(
+            SqlValidator validator, IErrorReporter reporter,
+            UnaryOperator<SqlParserPos> sourcePositionRemap) {
+        this.validator = validator;
+        this.reporter = reporter;
+        this.sourcePositionRemap = sourcePositionRemap;
+    }
+
+    /** True if values of the type are, or contain, floating point numbers */
+    public static boolean containsFloatingPoint(RelDataType type) {
+        if (SqlTypeName.APPROX_TYPES.contains(type.getSqlTypeName()))
+            return true;
+        if (type.isStruct())
+            return Linq.any(type.getFieldList(), field -> containsFloatingPoint(field.getType()));
+        RelDataType component = type.getComponentType();
+        if (component != null)
+            return containsFloatingPoint(component);
+        RelDataType key = type.getKeyType();
+        RelDataType value = type.getValueType();
+        if (key != null && value != null)
+            return containsFloatingPoint(key) || containsFloatingPoint(value);
+        return false;
+    }
+
+    @Override
+    public Void visit(SqlCall call) {
+        if (call instanceof SqlSelect select) {
+            this.enclosingSelects.push(select);
+            this.checkDistinct(select);
+            this.checkGroupBy(select);
+            super.visit(call);
+            this.enclosingSelects.pop();
+            return null;
+        }
+        if (call instanceof SqlJoin join)
+            this.checkJoin(join);
+        else if (call instanceof SqlPivot pivot)
+            this.checkPivot(pivot);
+        else if (call instanceof SqlWindow window)
+            this.checkPartitionBy(window);
+        else if (call.getOperator() instanceof SqlSetOperator setOperator)
+            this.checkSetOperation(call, setOperator);
+        else if (call.getKind() == SqlKind.OVER)
+            this.checkRankTies(call);
+        else if (call.getOperator() instanceof SqlAggFunction)
+            this.checkAggregate(call);
+        else if (call.getOperator() instanceof SqlInOperator in)
+            this.checkIn(call, in);
+        else if (EQUALITY_OPERATORS.contains(call.getKind()))
+            this.checkOperands(call, call.getOperator().getName());
+        return super.visit(call);
+    }
+
+    void checkDistinct(SqlSelect select) {
+        SqlNode distinct = select.getModifierNode(SqlSelectKeyword.DISTINCT);
+        if (distinct == null)
+            return;
+        RelDataType row = this.validator.getValidatedNodeTypeIfKnown(select);
+        if (row == null || !row.isStruct())
+            return;
+        this.checkColumns(distinct.getParserPosition(), "DISTINCT", row.getFieldList());
+    }
+
+    void checkGroupBy(SqlSelect select) {
+        SqlNodeList group = select.getGroup();
+        if (group == null)
+            return;
+        for (SqlNode item : group)
+            this.checkGroupItem(item);
+    }
+
+    void checkGroupItem(SqlNode item) {
+        if (item instanceof SqlNodeList list) {
+            for (SqlNode element : list)
+                this.checkGroupItem(element);
+        } else if (item instanceof SqlCall call && GROUPING_CONSTRUCTS.contains(call.getKind())) {
+            for (SqlNode operand : call.getOperandList())
+                this.checkGroupItem(operand);
+        } else {
+            this.checkValues(item, "GROUP BY", "");
+        }
+    }
+
+    /** A UNION without ALL, an INTERSECT, or an EXCEPT matches equal rows of its inputs */
+    void checkSetOperation(SqlCall call, SqlSetOperator setOperator) {
+        if (setOperator.getKind() == SqlKind.UNION && setOperator.isAll())
+            return;
+        RelDataType row = this.validator.getValidatedNodeTypeIfKnown(call);
+        if (row == null || !row.isStruct())
+            return;
+        this.checkColumns(call.getParserPosition(), setOperator.getName(), row.getFieldList());
+    }
+
+    /** NATURAL JOIN and USING compare the columns that the two inputs share */
+    void checkJoin(SqlJoin join) {
+        RelDataType left = this.rowType(join.getLeft());
+        RelDataType right = this.rowType(join.getRight());
+        if (left == null || right == null)
+            return;
+        SqlNameMatcher nameMatcher = this.validator.getCatalogReader().nameMatcher();
+        List<String> shared;
+        String construct;
+        SqlParserPos position;
+        if (join.isNatural()) {
+            shared = SqlValidatorUtil.deriveNaturalJoinColumnList(nameMatcher, left, right);
+            construct = "NATURAL JOIN";
+            position = join.getParserPosition();
+        } else if (join.getConditionType() == JoinConditionType.USING) {
+            SqlNodeList columns = (SqlNodeList) join.getCondition();
+            shared = Linq.map(columns, column -> ((SqlIdentifier) column).getSimple());
+            construct = "USING";
+            position = columns.getParserPosition();
+        } else {
+            return;
+        }
+        // A shared column is coerced to a common type, so either side may be the floating point one
+        List<RelDataTypeField> fields = new ArrayList<>();
+        for (String name : shared) {
+            RelDataTypeField leftField = nameMatcher.field(left, name);
+            RelDataTypeField rightField = nameMatcher.field(right, name);
+            if (leftField != null && containsFloatingPoint(leftField.getType()))
+                fields.add(leftField);
+            else if (rightField != null && containsFloatingPoint(rightField.getType()))
+                fields.add(rightField);
+        }
+        this.checkColumns(position, construct, fields);
+    }
+
+    /** PIVOT compares the FOR columns with each of the pivot values */
+    void checkPivot(SqlPivot pivot) {
+        for (SqlNode axis : pivot.axisList)
+            this.checkValues(axis, "PIVOT", "");
+    }
+
+    void checkPartitionBy(SqlWindow window) {
+        for (SqlNode key : window.getPartitionList())
+            this.checkValues(key, "PARTITION BY", "");
+    }
+
+    /** RANK and its relatives give the same result to rows whose ORDER BY keys are equal */
+    void checkRankTies(SqlCall over) {
+        SqlCall function = over.operand(0);
+        if (!RANK_FUNCTIONS.contains(function.getKind()))
+            return;
+        for (SqlNode key : this.orderKeys(over.operand(1))) {
+            SqlNode expression = key;
+            while (expression instanceof SqlCall call && ORDERING_MODIFIERS.contains(call.getKind()))
+                expression = call.operand(0);
+            this.checkValues(expression, function.getOperator().getName(), " to detect ties");
+        }
+    }
+
+    /** The ORDER BY keys of a window, or of the named window it refers to */
+    SqlNodeList orderKeys(SqlNode windowOrName) {
+        SqlWindow window = windowOrName instanceof SqlWindow inline ?
+                inline : this.declaredWindow((SqlIdentifier) windowOrName);
+        while (window != null) {
+            if (!window.getOrderList().isEmpty())
+                return window.getOrderList();
+            SqlIdentifier reference = window.getRefName();
+            window = reference == null ? null : this.declaredWindow(reference);
+        }
+        return SqlNodeList.EMPTY;
+    }
+
+    /** The window that a WINDOW clause of an enclosing SELECT declares under {@code name} */
+    @Nullable
+    SqlWindow declaredWindow(SqlIdentifier name) {
+        for (SqlSelect select : this.enclosingSelects) {
+            for (SqlNode declaration : select.getWindowList()) {
+                SqlWindow window = (SqlWindow) declaration;
+                SqlIdentifier declared = window.getDeclName();
+                if (declared != null && declared.getSimple().equalsIgnoreCase(name.getSimple()))
+                    return window;
+            }
+        }
+        return null;
+    }
+
+    /** An aggregate with DISTINCT deduplicates its arguments; MODE counts equal arguments */
+    void checkAggregate(SqlCall call) {
+        SqlLiteral quantifier = call.getFunctionQuantifier();
+        String name = call.getOperator().getName();
+        if (quantifier != null && quantifier.symbolValue(SqlSelectKeyword.class) == SqlSelectKeyword.DISTINCT)
+            this.checkOperands(call, name + "(DISTINCT)");
+        else if (call.getKind() == SqlKind.MODE)
+            this.checkOperands(call, name);
+    }
+
+    /** IN and NOT IN test membership by equality; a quantified comparison
+     * such as {@code = SOME} does so only when its comparison is an equality */
+    void checkIn(SqlCall call, SqlInOperator in) {
+        if (in instanceof SqlQuantifyOperator quantified
+                && quantified.comparisonKind != SqlKind.EQUALS
+                && quantified.comparisonKind != SqlKind.NOT_EQUALS)
+            return;
+        this.checkOperands(call, in.getName());
+    }
+
+    /** Warn if any operand of the call is, or contains, a floating point value */
+    void checkOperands(SqlCall call, String construct) {
+        for (SqlNode operand : call.getOperandList()) {
+            RelDataType type = this.floatingPointType(operand);
+            if (type != null) {
+                this.warn(call.getParserPosition(), construct, describeValues(type), "");
+                return;
+            }
+        }
+    }
+
+    /** Warn if the expression is, or contains, a floating point value */
+    void checkValues(SqlNode expression, String construct, String suffix) {
+        RelDataType type = this.floatingPointType(expression);
+        if (type != null)
+            this.warn(expression.getParserPosition(), construct, describeValues(type), suffix);
+    }
+
+    /** Warn if any of the columns is, or contains, a floating point value */
+    void checkColumns(SqlParserPos position, String construct, List<RelDataTypeField> columns) {
+        List<RelDataTypeField> floating = Linq.where(columns, field -> containsFloatingPoint(field.getType()));
+        if (!floating.isEmpty())
+            this.warn(position, construct, describeColumns(floating), "");
+    }
+
+    void warn(SqlParserPos position, String construct, String values, String suffix) {
+        SourcePositionRange range = new SourcePositionRange(this.sourcePositionRemap.apply(position));
+        this.reporter.reportWarning(range, WARNING, message(construct, values, suffix));
+    }
+
+    /** Warn if the values that {@code construct} compares for equality, whose type is
+     * {@code type}, are or contain floating point values.  For the functions compiled by
+     * {@link org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler}, which compare
+     * their arguments or the elements of their arguments. */
+    public static void checkType(IErrorReporter reporter, SourcePositionRange position,
+                                 String construct, @Nullable RelDataType type) {
+        if (type == null || !containsFloatingPoint(type))
+            return;
+        reporter.reportWarning(position, WARNING, message(construct, describeValues(type), ""));
+    }
+
+    static String message(String construct, String values, String suffix) {
+        return Utilities.singleQuote(construct) + " compares " + values +
+                " for equality" + suffix + ".\n" + DOCUMENTATION.citation();
+    }
+
+    /** The type of the node when it is, or contains, floating point values; for a
+     * list of nodes, the type of the first such element; null otherwise. */
+    @Nullable
+    RelDataType floatingPointType(@Nullable SqlNode node) {
+        if (node == null)
+            return null;
+        if (node instanceof SqlNodeList list) {
+            for (SqlNode element : list) {
+                RelDataType type = this.floatingPointType(element);
+                if (type != null)
+                    return type;
+            }
+            return null;
+        }
+        RelDataType type = this.typeOf(node);
+        if (type == null || !containsFloatingPoint(type))
+            return null;
+        return type;
+    }
+
+    /** The type of an expression, or null if the analysis cannot determine it */
+    @Nullable
+    RelDataType typeOf(SqlNode expression) {
+        RelDataType type = this.validator.getValidatedNodeTypeIfKnown(expression);
+        if (type != null || this.enclosingSelects.isEmpty() || SqlKind.QUERY.contains(expression.getKind()))
+            return type;
+        // The validator resolves a plain column reference in PARTITION BY or in the ORDER BY
+        // of a window without recording its type, so derive the type in the scope that
+        // resolved the reference.  The analysis only warns, so a failure to derive the type
+        // must not fail the compilation.
+        try {
+            SqlValidatorScope scope = this.validator.getSelectScope(this.enclosingSelects.peek());
+            return this.validator.deriveType(scope, expression);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /** The row type of a FROM item, or null if the validator did not resolve the item */
+    @Nullable
+    RelDataType rowType(SqlNode fromItem) {
+        SqlValidatorNamespace namespace = this.validator.getNamespace(fromItem);
+        return namespace == null ? null : namespace.getRowType();
+    }
+
+    static String describeValues(RelDataType type) {
+        SqlTypeName name = type.getSqlTypeName();
+        if (SqlTypeName.APPROX_TYPES.contains(name))
+            return "floating point values of type " + name;
+        return name + " values containing floating point values";
+    }
+
+    static String describeColumns(List<RelDataTypeField> columns) {
+        List<String> names = Linq.map(columns, field -> Utilities.singleQuote(field.getName()));
+        if (names.size() == 1)
+            return "the floating point values in column " + names.get(0);
+        String last = names.remove(names.size() - 1);
+        String separator = names.size() == 1 ? " and " : ", and ";
+        return "the floating point values in columns " + String.join(", ", names) + separator + last;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindUnboundedState.java
@@ -58,6 +58,7 @@ import org.dbsp.sqlCompiler.circuit.operator.ILinear;
 import org.dbsp.sqlCompiler.circuit.operator.INonLinearAggregate;
 import org.dbsp.sqlCompiler.circuit.operator.IStateful;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.sqlCompiler.compiler.ViewOrigins;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRanges;
@@ -95,11 +96,12 @@ import java.util.Set;
 public class FindUnboundedState extends Passes {
     /** Error type shared by all warnings emitted by this pass */
     public static final String WARNING = "Unbounded state";
+    public static final Documentation.Link DOCUMENTATION =
+            new Documentation.Link("sql/streaming", "unbounded-state-warnings");
     /** Continuation of the first warning of a compilation; tells the user how to silence all of them
      * and where they are documented */
     public static final String HINT = "Silence these warnings with SET " +
-            DBSPCompiler.silencingVariable(WARNING) + " = ON\n" +
-            "See https://docs.feldera.com/sql/streaming#unbounded-state-warnings";
+            DBSPCompiler.silencingVariable(WARNING) + " = ON\n" + DOCUMENTATION.citation();
 
     /**
      * An operator whose state may grow without bound.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/RewriteNow.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
 
+import org.dbsp.sqlCompiler.compiler.Documentation;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.annotation.AlwaysMonotone;
@@ -69,6 +70,7 @@ import java.util.Objects;
  * ("temporal filters"), the others are compiled in a similar way with MAP operators.
  */
 public class RewriteNow extends CircuitCloneVisitor {
+    public static final Documentation.Link NOW_DOCUMENTATION = new Documentation.Link("sql/datetime", "now");
     // Holds the indexed version of the 'now' operator (indexed with an empty key).
     // (actually, it's the differentiator after the index)
     @Nullable
@@ -220,7 +222,7 @@ public class RewriteNow extends CircuitCloneVisitor {
         this.compiler.reportWarning(
                 Objects.requireNonNull(expression).getSourcePosition(), "Inefficient pattern",
                 "NOW() expression is used in a pattern that could require expensive computations\n"
-                        + "See https://docs.feldera.com/sql/datetime/#now");
+                        + NOW_DOCUMENTATION.citation());
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DocumentationTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DocumentationTests.java
@@ -1,0 +1,64 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import org.dbsp.sqlCompiler.compiler.backend.rust.StubsWriter;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RejectUnsupportedPlans;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlToRelCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.FindUnboundedState;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.RewriteNow;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+/** Tests for {@link Documentation} */
+public class DocumentationTests {
+    /** The links that compiler messages cite */
+    static final List<Documentation.Link> CITED = List.of(
+            RejectUnsupportedPlans.ROW_DOCUMENTATION,
+            SqlToRelCompiler.RECURSION_DOCUMENTATION,
+            RewriteNow.NOW_DOCUMENTATION,
+            StubsWriter.UDF_DOCUMENTATION,
+            FindUnboundedState.DOCUMENTATION);
+
+    @Test
+    public void citedLinksResolve() throws IOException {
+        for (Documentation.Link link : CITED)
+            Documentation.checkResolves(link);
+    }
+
+    @Test
+    public void citation() {
+        Documentation.Link link = new Documentation.Link("sql/comparisons", "comparing-row-values");
+        Assert.assertEquals("See https://docs.feldera.com/sql/comparisons#comparing-row-values", link.citation());
+        Assert.assertEquals(link, Documentation.Link.parse(link.url()));
+        Assert.assertNull(Documentation.Link.parse("https://example.com/page#anchor"));
+        Documentation.Link page = new Documentation.Link("sql/recursion");
+        Assert.assertEquals("See https://docs.feldera.com/sql/recursion", page.citation());
+        Assert.assertEquals(page, Documentation.Link.parse(page.url()));
+    }
+
+    /** A heading with an explicit id defines that id and not its slug */
+    @Test
+    public void anchors() {
+        Set<String> anchors = Documentation.anchors("""
+                # Comparison Operations
+                Text with <a id="eq"></a> and <a id="ne"></a> tags.
+                ### Comparing `ROW` values {#comparing-row-values}
+                ## Date_parsing and formatting
+                not a heading # with a hash""");
+        Assert.assertEquals(Set.of("comparison-operations", "eq", "ne",
+                "comparing-row-values", "date_parsing-and-formatting"), anchors);
+    }
+
+    @Test
+    public void missingAnchorIsReported() {
+        Documentation.Link link = new Documentation.Link("sql/comparisons", "no-such-heading");
+        RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> Documentation.checkResolves(link));
+        Assert.assertTrue(e.getMessage(), e.getMessage().startsWith("Anchor `no-such-heading` does not appear in file"));
+        Documentation.Link missing = new Documentation.Link("sql/no-such-page", "x");
+        e = Assert.assertThrows(RuntimeException.class, () -> Documentation.checkResolves(missing));
+        Assert.assertTrue(e.getMessage(), e.getMessage().startsWith("Documentation page not found"));
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DocumentationTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DocumentationTests.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler;
 import org.dbsp.sqlCompiler.compiler.backend.rust.StubsWriter;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RejectUnsupportedPlans;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlToRelCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.WarnFloatingPointEquality;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.FindUnboundedState;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.RewriteNow;
 import org.junit.Assert;
@@ -16,6 +17,7 @@ import java.util.Set;
 public class DocumentationTests {
     /** The links that compiler messages cite */
     static final List<Documentation.Link> CITED = List.of(
+            WarnFloatingPointEquality.DOCUMENTATION,
             RejectUnsupportedPlans.ROW_DOCUMENTATION,
             SqlToRelCompiler.RECURSION_DOCUMENTATION,
             RewriteNow.NOW_DOCUMENTATION,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -155,6 +155,19 @@ public class NegativeParserTests extends BaseSQLTests {
         this.statementsFailingInCompilation(statement, "Do not use");
     }
 
+    /** The body of a function is compiled inside a generated program; an error on
+     * the second line of the body must point at that line of the user's program */
+    @Test
+    public void functionBodyErrorPosition() {
+        this.statementsFailingInCompilation("""
+                CREATE TABLE T(x INT);
+                CREATE FUNCTION f(a INT) RETURNS INT AS
+                  a +
+                  nosuch;
+                CREATE VIEW V AS SELECT f(x) FROM T;""",
+                "(no input file):4:3: error");
+    }
+
     @Test
     public void errorTest() throws IOException, SQLException {
         File file = createInputScript("This is not SQL");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/FloatingPointEqualityTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/FloatingPointEqualityTests.java
@@ -1,0 +1,340 @@
+package org.dbsp.sqlCompiler.compiler.sql.simple;
+
+import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.WarnFloatingPointEquality;
+import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Tests for {@link WarnFloatingPointEquality} */
+public class FloatingPointEqualityTests extends BaseSQLTests {
+    /** Two tables; the views under test start on line 3 */
+    static final String TABLES = """
+            CREATE TABLE T(x DOUBLE, y DOUBLE, i INT, d DECIMAL(10, 2), r REAL, f REAL, arr DOUBLE ARRAY, rw ROW(a DOUBLE, b INT), m MAP<VARCHAR, DOUBLE>, md MAP<DOUBLE, INT>);
+            CREATE TABLE S(x DOUBLE, z INT);
+            """;
+
+    static final String DOUBLE = "compares floating point values of type DOUBLE for equality.";
+
+    List<CompilerMessages.Message> compileAndGetFPWarnings(String program) {
+        var cc = this.getCC(TABLES + program);
+        List<CompilerMessages.Message> result = new ArrayList<>();
+        for (CompilerMessages.Message message : cc.compiler.messages.messages)
+            if (message.errorType.equals(WarnFloatingPointEquality.WARNING))
+                result.add(message);
+        return result;
+    }
+
+    /** The floating point equality warnings for the program as the compiler prints them on stderr */
+    String outputFPWarnings(String program) {
+        StringBuilder result = new StringBuilder();
+        for (CompilerMessages.Message message : this.compileAndGetFPWarnings(program))
+            result.append(message);
+        return result.toString().stripTrailing();
+    }
+
+    /** The content of each floating point equality warning */
+    List<String> warnings(String program) {
+        List<String> result = new ArrayList<>();
+        for (CompilerMessages.Message message : this.compileAndGetFPWarnings(program))
+            for (String line : message.toString().split("\n"))
+                if (line.contains("warning: "))
+                    result.add(line.replace("(no input file):", ""));
+        return result;
+    }
+
+    void assertWarnings(String program, String... expected) {
+        Assert.assertEquals(List.of(expected), this.warnings(program));
+    }
+
+    void assertNoWarnings(String program) {
+        this.assertWarnings(program);
+    }
+
+    @Test
+    public void equalsRendered() {
+        Assert.assertEquals("""
+                While compiling:
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT * FROM T WHERE x = y;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                (no input file): Floating point equality
+                (no input file):3:40: warning: Floating point equality: '=' compares floating point values of type DOUBLE for equality.
+                See https://docs.feldera.com/sql/comparisons#comparing-floating-point-values
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT * FROM T WHERE x = y;
+                                                             ^^^^^""",
+                this.outputFPWarnings("CREATE VIEW V AS SELECT * FROM T WHERE x = y;"));
+    }
+
+    @Test
+    public void equalityOperators() {
+        // '!=' is a synonym of '<>' and '<=>' of 'IS NOT DISTINCT FROM'
+        this.assertWarnings(
+                "CREATE VIEW V AS SELECT x <> y, x != y, x IS DISTINCT FROM y, x IS NOT DISTINCT FROM y, x <=> y FROM T;",
+                "3:25: warning: Floating point equality: '<>' " + DOUBLE,
+                "3:33: warning: Floating point equality: '<>' " + DOUBLE,
+                "3:41: warning: Floating point equality: 'IS DISTINCT FROM' " + DOUBLE,
+                "3:63: warning: Floating point equality: 'IS NOT DISTINCT FROM' " + DOUBLE,
+                "3:89: warning: Floating point equality: '<=>' " + DOUBLE);
+    }
+
+    /** A comparison is floating point when either operand is; ordering comparisons should produce no warnings */
+    @Test
+    public void mixedOperands() {
+        this.assertWarnings(
+                "CREATE VIEW V AS SELECT x = 1.5, i = 1.5e0, d = 1.5, x < y, i = 1, r = f FROM T;",
+                "3:25: warning: Floating point equality: '=' " + DOUBLE,
+                "3:34: warning: Floating point equality: '=' " + DOUBLE,
+                "3:68: warning: Floating point equality: '=' compares floating point values of type REAL for equality.");
+    }
+
+    @Test
+    public void exactTypesAreSilent() {
+        this.assertNoWarnings("""
+                CREATE VIEW V AS SELECT i, d, COUNT(DISTINCT d) FROM T
+                WHERE d = 1.5 AND i IN (1, 2) AND x < y GROUP BY i, d;""");
+    }
+
+    @Test
+    public void groupBy() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x, COUNT(*) FROM T GROUP BY x;",
+                "3:53: warning: Floating point equality: 'GROUP BY' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT x, i, COUNT(*) FROM T GROUP BY ROLLUP(x, i);",
+                "3:63: warning: Floating point equality: 'GROUP BY' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT x, i, COUNT(*) FROM T GROUP BY GROUPING SETS ((x), (i));",
+                "3:71: warning: Floating point equality: 'GROUP BY' " + DOUBLE);
+        this.assertNoWarnings("CREATE VIEW V AS SELECT i, COUNT(*) FROM T GROUP BY i;");
+    }
+
+    /** The warning points at the DISTINCT keyword and names the columns */
+    @Test
+    public void distinctEmitted() {
+        Assert.assertEquals("""
+                While compiling:
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT DISTINCT x FROM T;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                (no input file): Floating point equality
+                (no input file):3:25: warning: Floating point equality: 'DISTINCT' compares the floating point values in column 'x' for equality.
+                See https://docs.feldera.com/sql/comparisons#comparing-floating-point-values
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT DISTINCT x FROM T;
+                                              ^^^^^^^^""",
+                this.outputFPWarnings("CREATE VIEW V AS SELECT DISTINCT x FROM T;"));
+    }
+
+    @Test
+    public void distinct() {
+        this.assertWarnings("CREATE VIEW V AS SELECT DISTINCT x, r, i FROM T;",
+                "3:25: warning: Floating point equality: 'DISTINCT' compares the floating point values in columns 'x' and 'r' for equality.");
+        this.assertWarnings("CREATE VIEW V AS SELECT DISTINCT * FROM T;",
+                "3:25: warning: Floating point equality: 'DISTINCT' compares the floating point values in columns 'x', 'y', 'r', 'f', 'arr', 'rw', 'm', and 'md' for equality.");
+        this.assertWarnings("CREATE VIEW V AS WITH W AS (SELECT DISTINCT x FROM T) SELECT * FROM W;",
+                "3:36: warning: Floating point equality: 'DISTINCT' compares the floating point values in column 'x' for equality.");
+        this.assertNoWarnings("CREATE VIEW V AS SELECT DISTINCT i FROM T;");
+    }
+
+    @Test
+    public void aggregates() {
+        this.assertWarnings("CREATE VIEW V AS SELECT COUNT(DISTINCT x) FROM T;",
+                "3:25: warning: Floating point equality: 'COUNT(DISTINCT)' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT MODE(x) FROM T;",
+                "3:25: warning: Floating point equality: 'MODE' " + DOUBLE);
+        this.assertNoWarnings("CREATE VIEW V AS SELECT SUM(x), MAX(x), COUNT(x) FROM T;");
+    }
+
+    @Test
+    public void setOperations() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x FROM T UNION SELECT x FROM S;",
+                "3:18: warning: Floating point equality: 'UNION' compares the floating point values in column 'x' for equality.");
+        this.assertWarnings("CREATE VIEW V AS SELECT x FROM T INTERSECT SELECT x FROM S;",
+                "3:18: warning: Floating point equality: 'INTERSECT' compares the floating point values in column 'x' for equality.");
+        this.assertWarnings("CREATE VIEW V AS SELECT x FROM T EXCEPT ALL SELECT x FROM S;",
+                "3:18: warning: Floating point equality: 'EXCEPT ALL' compares the floating point values in column 'x' for equality.");
+        this.assertNoWarnings("CREATE VIEW V AS SELECT x FROM T UNION ALL SELECT x FROM S;");
+    }
+
+    @Test
+    public void joins() {
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM T JOIN S ON T.x = S.x;",
+                "3:44: warning: Floating point equality: '=' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM T JOIN S USING (x);",
+                "3:41: warning: Floating point equality: 'USING' compares the floating point values in column 'x' for equality.");
+        this.assertNoWarnings("CREATE VIEW V AS SELECT * FROM T JOIN S ON T.i = S.z;");
+    }
+
+    /** The shared column is coerced to DOUBLE whichever side declares it exact */
+    @Test
+    public void joinsCoerceSharedColumns() {
+        String tables = """
+                CREATE TABLE U(i INT, w DOUBLE);
+                CREATE TABLE V2(i DOUBLE, q INT);
+                """;
+        this.assertWarnings(tables + "CREATE VIEW W AS SELECT * FROM U NATURAL JOIN V2;",
+                "5:42: warning: Floating point equality: 'NATURAL JOIN' compares the floating point values in column 'i' for equality.");
+        this.assertWarnings(tables + "CREATE VIEW W AS SELECT * FROM U JOIN V2 USING (i);",
+                "5:42: warning: Floating point equality: 'USING' compares the floating point values in column 'i' for equality.");
+        this.assertWarnings(tables + "CREATE VIEW W AS SELECT * FROM V2 NATURAL JOIN U;",
+                "5:43: warning: Floating point equality: 'NATURAL JOIN' compares the floating point values in column 'i' for equality.");
+    }
+
+    @Test
+    public void naturalJoinEmitted() {
+        Assert.assertEquals("""
+                While compiling:
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT * FROM T NATURAL JOIN S;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                (no input file): Floating point equality
+                (no input file):3:42: warning: Floating point equality: 'NATURAL JOIN' compares the floating point values in column 'x' for equality.
+                See https://docs.feldera.com/sql/comparisons#comparing-floating-point-values
+                    2|CREATE TABLE S(x DOUBLE, z INT);
+                    3|CREATE VIEW V AS SELECT * FROM T NATURAL JOIN S;
+                                                               ^^^^""",
+                this.outputFPWarnings("CREATE VIEW V AS SELECT * FROM T NATURAL JOIN S;"));
+    }
+
+    @Test
+    public void windows() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x, RANK() OVER (PARTITION BY x ORDER BY i) FROM T;",
+                "3:54: warning: Floating point equality: 'PARTITION BY' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT x, RANK() OVER (ORDER BY x DESC) FROM T;",
+                "3:50: warning: Floating point equality: 'RANK' compares floating point values of type DOUBLE for equality to detect ties.");
+        this.assertWarnings("CREATE VIEW V AS SELECT x, RANK() OVER (PARTITION BY i ORDER BY x, y) FROM T;",
+                "3:65: warning: Floating point equality: 'RANK' compares floating point values of type DOUBLE for equality to detect ties.",
+                "3:68: warning: Floating point equality: 'RANK' compares floating point values of type DOUBLE for equality to detect ties.");
+        // ROW_NUMBER has no ties
+        this.assertNoWarnings("CREATE VIEW V AS SELECT x, ROW_NUMBER() OVER (ORDER BY x) FROM T;");
+    }
+
+    /** Named windows are resolved through the WINDOW clause of the enclosing SELECT */
+    @Test
+    public void namedWindows() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x, RANK() OVER (w ORDER BY y) FROM T WINDOW w AS (PARTITION BY x);",
+                "3:52: warning: Floating point equality: 'RANK' compares floating point values of type DOUBLE for equality to detect ties.",
+                "3:88: warning: Floating point equality: 'PARTITION BY' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT x, DENSE_RANK() OVER w FROM T WINDOW w AS (ORDER BY x, i);",
+                "3:77: warning: Floating point equality: 'DENSE_RANK' compares floating point values of type DOUBLE for equality to detect ties.");
+    }
+
+    @Test
+    public void membership() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x IN (1.0, 2.0), i IN (1, 2) FROM T;",
+                "3:25: warning: Floating point equality: 'IN' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM T WHERE x IN (SELECT x FROM S);",
+                "3:40: warning: Floating point equality: 'IN' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM T WHERE x NOT IN (SELECT x FROM S);",
+                "3:40: warning: Floating point equality: 'NOT IN' " + DOUBLE);
+    }
+
+    /** The parser rewrites 'CASE x WHEN v' into 'x = v' */
+    @Test
+    public void caseAndNullif() {
+        this.assertWarnings("CREATE VIEW V AS SELECT CASE x WHEN 1.0 THEN 1 ELSE 0 END FROM T;",
+                "3:25: warning: Floating point equality: '=' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT NULLIF(x, 1.0) FROM T;",
+                "3:25: warning: Floating point equality: 'NULLIF' " + DOUBLE);
+    }
+
+    @Test
+    public void containers() {
+        this.assertWarnings("CREATE VIEW V AS SELECT arr = ARRAY[1.0e0], m = m, rw <=> rw FROM T;",
+                "3:25: warning: Floating point equality: '=' compares ARRAY values containing floating point values for equality.",
+                "3:45: warning: Floating point equality: '=' compares MAP values containing floating point values for equality.",
+                "3:52: warning: Floating point equality: '<=>' compares ROW values containing floating point values for equality.");
+        this.assertWarnings("CREATE VIEW V AS SELECT DISTINCT rw FROM T;",
+                "3:25: warning: Floating point equality: 'DISTINCT' compares the floating point values in column 'rw' for equality.");
+    }
+
+    /** Functions that compare array elements or map keys are checked where they are compiled */
+    @Test
+    public void arrayFunctions() {
+        this.assertWarnings("CREATE VIEW V AS SELECT ARRAY_CONTAINS(arr, 1.0e0), ARRAY_POSITION(arr, 1.0e0), ARRAY_REMOVE(arr, 1.0e0), ARRAY_DISTINCT(arr) FROM T;",
+                "3:25: warning: Floating point equality: 'ARRAY_CONTAINS' " + DOUBLE,
+                "3:53: warning: Floating point equality: 'ARRAY_POSITION' " + DOUBLE,
+                "3:81: warning: Floating point equality: 'ARRAY_REMOVE' " + DOUBLE,
+                "3:107: warning: Floating point equality: 'ARRAY_DISTINCT' " + DOUBLE);
+        this.assertWarnings("CREATE VIEW V AS SELECT ARRAY_EXCEPT(arr, arr), ARRAY_UNION(arr, arr), ARRAY_INTERSECT(arr, arr), ARRAYS_OVERLAP(arr, arr), ARRAY_CONCAT(arr, arr) FROM T;",
+                "3:25: warning: Floating point equality: 'ARRAY_EXCEPT' " + DOUBLE,
+                "3:49: warning: Floating point equality: 'ARRAY_UNION' " + DOUBLE,
+                "3:72: warning: Floating point equality: 'ARRAY_INTERSECT' " + DOUBLE,
+                "3:99: warning: Floating point equality: 'ARRAYS_OVERLAP' " + DOUBLE);
+        this.assertNoWarnings("CREATE VIEW V AS SELECT ARRAY_DISTINCT(ARRAY[i]), ARRAY_CONTAINS(ARRAY[i], 1) FROM T;");
+    }
+
+    @Test
+    public void mapKeys() {
+        this.assertWarnings("CREATE VIEW V AS SELECT md[1.0e0], MAP_CONTAINS_KEY(md, 1.0e0), m['a'], MAP_CONTAINS_KEY(m, 'a') FROM T;",
+                "3:25: warning: Floating point equality: 'MAP[key]' " + DOUBLE,
+                "3:36: warning: Floating point equality: 'MAP_CONTAINS_KEY' " + DOUBLE);
+    }
+
+    @Test
+    public void pivot() {
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM (SELECT x, i FROM T) PIVOT (COUNT(i) FOR x IN (1.0e0 AS one, 2.0e0 AS two));",
+                "3:73: warning: Floating point equality: 'PIVOT' " + DOUBLE);
+        this.assertNoWarnings("CREATE VIEW V AS SELECT * FROM (SELECT x, i FROM T) PIVOT (SUM(x) FOR i IN (1 AS one, 2 AS two));");
+    }
+
+    /** The validator replaces the ordinal by the select item */
+    @Test
+    public void groupByOrdinal() {
+        this.assertWarnings("CREATE VIEW V AS SELECT x, COUNT(*) FROM T GROUP BY 1;",
+                "3:25: warning: Floating point equality: 'GROUP BY' " + DOUBLE);
+    }
+
+    @Test
+    public void recursiveView() {
+        this.assertWarnings("""
+                DECLARE RECURSIVE VIEW R(x DOUBLE);
+                CREATE VIEW R AS SELECT x FROM T UNION SELECT x + 1 FROM R WHERE x < 10;""",
+                "4:18: warning: Floating point equality: 'UNION' compares the floating point values in column 'x' for equality.");
+    }
+
+    @Test
+    public void correlatedSubquery() {
+        this.assertWarnings("CREATE VIEW V AS SELECT * FROM T WHERE EXISTS (SELECT * FROM S WHERE S.x = T.x);",
+                "3:70: warning: Floating point equality: '=' " + DOUBLE);
+    }
+
+    /** A function body is compiled inside a generated program; the warning
+     * must point into the CREATE FUNCTION statement of the user's program */
+    @Test
+    public void functionBody() {
+        this.assertWarnings("""
+                CREATE FUNCTION eq(a DOUBLE, b DOUBLE) RETURNS BOOLEAN AS a = b;
+                CREATE VIEW V AS SELECT eq(x, y) FROM T;""",
+                "3:59: warning: Floating point equality: '=' " + DOUBLE);
+        Assert.assertEquals("""
+                (no input file): Floating point equality
+                (no input file):5:3: warning: Floating point equality: '=' compares floating point values of type DOUBLE for equality.
+                See https://docs.feldera.com/sql/comparisons#comparing-floating-point-values
+                    5|  a = b;
+                        ^^^^^
+                    6|CREATE VIEW V AS SELECT eq(x, y) FROM T;""",
+                this.outputFPWarnings("""
+                        CREATE FUNCTION eq(a DOUBLE, b DOUBLE) RETURNS BOOLEAN AS
+                          a > 0 AND
+                          a = b;
+                        CREATE VIEW V AS SELECT eq(x, y) FROM T;"""));
+    }
+
+    @Test
+    public void silenced() {
+        this.assertNoWarnings("""
+                SET FELDERA_IGNORE_WARNING_FLOATING_POINT_EQUALITY = ON;
+                CREATE VIEW V AS SELECT * FROM T WHERE x = y;""");
+    }
+
+    @Test
+    public void warningsAreErrors() {
+        this.statementsFailingInCompilation(TABLES + """
+                SET FELDERA_WARNINGS_ARE_ERRORS = ON;
+                CREATE VIEW V AS SELECT * FROM T WHERE x = y;""",
+                "'=' " + DOUBLE);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -432,7 +432,7 @@ public class Regression2Tests extends SqlIoTest {
         System.setErr(saved);
         TestUtil.assertMessagesContain(compiler, """
                 warning: Inefficient pattern: NOW() expression is used in a pattern that could require expensive computations
-                See https://docs.feldera.com/sql/datetime/#now
+                See https://docs.feldera.com/sql/datetime#now
                     6|SELECT ts > NOW()
                                   ^^^^^
                     7|FROM transactions;""");
@@ -458,7 +458,7 @@ public class Regression2Tests extends SqlIoTest {
         System.setErr(saved);
         TestUtil.assertMessagesContain(compiler, """
                 warning: Inefficient pattern: NOW() expression is used in a pattern that could require expensive computations
-                See https://docs.feldera.com/sql/datetime/#now
+                See https://docs.feldera.com/sql/datetime#now
                     7|FROM transactions
                     8|WHERE LEAST(ts, NOW()) < ts - INTERVAL 1 DAY;
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^""");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/IncrementalUnboundedStateTests.java
@@ -4,18 +4,10 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
-import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.FindUnboundedState;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** Tests for the {@link FindUnboundedState#WARNING} warnings.
  * Only incremental circuits contain the garbage collection operators that bound state,
@@ -72,31 +64,6 @@ public class IncrementalUnboundedStateTests extends StreamingTestBase {
 
     void assertNoUnboundedStateWarnings(String sql) {
         this.assertUnboundedStateWarnings(sql, "");
-    }
-
-    /** The anchor that the documentation site generates for a Markdown heading */
-    static String anchor(String heading) {
-        return heading.toLowerCase(Locale.ENGLISH)
-                .replaceAll("[^a-z0-9 ]", "")
-                .trim()
-                .replaceAll(" +", "-");
-    }
-
-    @Test
-    public void documentationLinkIsValid() throws IOException {
-        // Check that the URL in the documentation exists
-        // The hint links to https://docs.feldera.com/<page>#<anchor>, which the site
-        // builds from docs.feldera.com/docs/<page>.md and one of its headings
-        Matcher url = Pattern.compile("https://docs\\.feldera\\.com/([^#\\s]+)#(\\S+)").matcher(FindUnboundedState.HINT);
-        Assert.assertTrue(FindUnboundedState.HINT, url.find());
-        Path page = Path.of(BaseSQLTests.PROJECT_DIRECTORY, "..", "docs.feldera.com", "docs", url.group(1) + ".md");
-        Assert.assertTrue("Documentation page not found: " + page.normalize(), Files.exists(page));
-        List<String> headings = Files.readAllLines(page).stream()
-                .filter(line -> line.startsWith("#"))
-                .map(line -> anchor(line.replaceFirst("^#+", "")))
-                .toList();
-        Assert.assertTrue("No heading for anchor '" + url.group(2) + "' in " + page.normalize() + ": " + headings,
-                headings.contains(url.group(2)));
     }
 
     // ---- Programs that must not produce warnings ----


### PR DESCRIPTION
Fixes #7063

In general it's not safe to compare a = b when either of them is a floating-point value.
This PR adds an analysis (performed on the Calcite IR) which emits warnings whenever such an operation is used or implied.
Equality tests can be implied in operations such as DISTINCT, RANK or UNION.

There's a separate commit factoring out code in the compiler which refers to the documentation in a separate class.

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated
- [x] Changelog updated
