### PR TITLE
[SQL] Do not materialize indexes if the indexed view is not materialized

### DIFF
--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -981,7 +981,7 @@ impl Catalog {
         self.register_materialized_index_persistent(None, stream, index_name, view_name, key_fields)
     }
 
-    /// Like `register_index`, but also assigns persistent id to the index.
+    /// Like `register_materialized_index`, but also assigns persistent id to the index.
     pub fn register_materialized_index_persistent<K, KD, V, VD>(
         &mut self,
         persistent_id: Option<&str>,

--- a/docs.feldera.com/docs/connectors/unique_keys.md
+++ b/docs.feldera.com/docs/connectors/unique_keys.md
@@ -50,6 +50,11 @@ as follows:
 
 2. Associate the index with an output connector by setting the connector’s `index` property to the name of the index. This allows the connector to merge insert and delete events for the same key into a single update event.
 
+An index stores data only when its view is materialized.  A connector attached to an index
+of a view that is not materialized receives the changes to the view, but cannot use
+`send_snapshot`; declare the view with `CREATE MATERIALIZED VIEW` to send a snapshot
+through an index (see [Materialized Tables and Views](/sql/materialized)).
+
 The specific behavior of this transformation depends on the data format and transport protocol used. Currently, the `index` property is supported only for:
 - Kafka output connectors configured with the [Avro format](/formats/avro/)
 - [Postgres output connector](/connectors/sinks/postgresql)

--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -604,6 +604,14 @@ Indexes only have effect for views that are not `LOCAL`.
 
 A view can have multiple indexes.
 
+An index of a view that is not `MATERIALIZED` only groups the changes
+of the view by the index columns; the index stores no data.  The first
+index of a [materialized view](materialized.md) shares the stored
+contents of the view.  Each additional index of a materialized view
+stores its own copy of the contents of the view, ordered by the index
+columns, so that an output connector can request a snapshot through
+any index.
+
 ### Aggregate queries
 
 An aggregate query is a query that contains a `GROUP BY` or a `HAVING`

--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -604,14 +604,6 @@ Indexes only have effect for views that are not `LOCAL`.
 
 A view can have multiple indexes.
 
-An index of a view that is not `MATERIALIZED` only groups the changes
-of the view by the index columns; the index stores no data.  The first
-index of a [materialized view](materialized.md) shares the stored
-contents of the view.  Each additional index of a materialized view
-stores its own copy of the contents of the view, ordered by the index
-columns, so that an output connector can request a snapshot through
-any index.
-
 ### Aggregate queries
 
 An aggregate query is a query that contains a `GROUP BY` or a `HAVING`

--- a/docs.feldera.com/docs/sql/materialized.md
+++ b/docs.feldera.com/docs/sql/materialized.md
@@ -32,6 +32,12 @@ CREATE MATERIALIZED VIEW my_view AS SELECT * FROM my_table;
 
 These declarations instruct Feldera to maintain a complete snapshot of the table or view.
 
+An [index](grammar.md#creating-indexes) of a view that is not materialized stores no data.
+The first index of a materialized view shares the stored contents of the view; each additional
+index stores its own copy of the contents, ordered by the index columns.  An output connector
+attached to any index of a materialized view can send a snapshot of the view when the connector
+starts (`send_snapshot`).
+
 ## Inspecting materialized tables and views
 
 You can explore the contents of materialized tables and views by issuing `SELECT ...` [ad-hoc SQL queries](/sql/ad-hoc).

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -1191,13 +1191,15 @@ public class ToRustVisitor extends CircuitVisitor {
         this.innerVisitor.setOperatorContext(operator);
         if (!this.useHandles) {
             /*
-               Current register API:
-               - `register_materialized_output_zset_persistent` (existing method) - to be used to register
-                  materialized views _without_ indexes only.
-               - `register_materialized_output_map_persistent` - used to simultaneously register a
-                  materialized view and an index, which will share a common integral.
-               - `register_materialized_index_persistent` - used with views that have multiple indexes
-                  to register the second, third, etc. index.
+               Catalog registration API:
+               - `register_output_zset_persistent` - a non-materialized view.
+               - `register_index_persistent` - an index of a non-materialized view; keeps no integral.
+               - `register_materialized_output_zset_persistent` - a materialized view without indexes.
+               - `register_materialized_output_map_persistent` - a materialized view together with
+                  its first index; the two share one integral.
+               - `register_materialized_index_persistent` - every other index of a materialized view;
+                  each keeps its own integral so that a connector can request a snapshot through
+                  any index.
              */
 
             final DBSPType type = operator.originalRowType;
@@ -1205,12 +1207,16 @@ public class ToRustVisitor extends CircuitVisitor {
             if (operator.isIndex()) {
                 ViewAndIndexes indexes = this.indexes.get(operator.query);
                 Utilities.enforce(indexes != null);
-                boolean registerAsMap =
-                        indexes.getView().metadata.viewKind == SqlCreateView.ViewKind.MATERIALIZED
-                        && indexes.firstIndex() == operator;
-                String registerFunction = registerAsMap
-                        ? "register_materialized_output_map_persistent"
-                        : "register_materialized_index_persistent";
+                boolean viewMaterialized =
+                        indexes.getView().metadata.viewKind == SqlCreateView.ViewKind.MATERIALIZED;
+                boolean registerAsMap = viewMaterialized && indexes.firstIndex() == operator;
+                String registerFunction;
+                if (registerAsMap)
+                    registerFunction = "register_materialized_output_map_persistent";
+                else if (viewMaterialized)
+                    registerFunction = "register_materialized_index_persistent";
+                else
+                    registerFunction = "register_index_persistent";
                 this.writeComments(operator);
                 DBSPTypeRawTuple raw = operator.originalRowType.to(DBSPTypeRawTuple.class);
                 Utilities.enforce(raw.size() == 2);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -2015,7 +2015,8 @@ public class SqlToRelCompiler implements IWritesLogs {
         return root;
     }
 
-    void validateViewProperty(ProgramIdentifier view, SqlFragment key, SqlFragment value) {
+    void validateViewProperty(ProgramIdentifier view, SqlCreateView.ViewKind viewKind,
+                              SqlFragment key, SqlFragment value) {
         CalciteObject node = CalciteObject.create(key.getParserPosition());
         String keyString = key.getString();
         switch (keyString) {
@@ -2024,7 +2025,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                 break;
             case "rust":
             case "connectors":
-                this.validateConnectorsProperty(node, false, view, List.of(), key, value);
+                this.validateConnectorsProperty(node, false, view, List.of(), viewKind, key, value);
                 break;
             default:
                 throw new CompilationError("Unknown view property " + Utilities.singleQuote(keyString), node);
@@ -2059,10 +2060,12 @@ public class SqlToRelCompiler implements IWritesLogs {
     }
 
     /** @param primaryKey Primary key columns of the table; empty for a view or for a table
-     *                    without a primary key. */
+     *                    without a primary key.
+     *  @param viewKind   Kind of the view; null for a table. */
     @SuppressWarnings("unused")
     void validateConnectorsProperty(CalciteObject ignored, boolean isTable, ProgramIdentifier tableView,
                                     List<ProgramIdentifier> primaryKey,
+                                    @Nullable SqlCreateView.ViewKind viewKind,
                                     SqlFragment keyIgnored, SqlFragment value) {
         final String json = value.getString();
         final Result<JsonNode> jsonNode = Utilities.validateJson(json);
@@ -2112,6 +2115,16 @@ public class SqlToRelCompiler implements IWritesLogs {
                                 String.join(", ", Linq.map(primaryKey, ProgramIdentifier::name)) +
                                 "); soft deletes are only supported for tables without a primary key", pos);
                     }
+                }
+                JsonNode sendSnapshot = connector.get(CreateViewStatement.SEND_SNAPSHOT);
+                if (sendSnapshot != null && sendSnapshot.asBoolean(false)
+                        && !isTable && viewKind != SqlCreateView.ViewKind.MATERIALIZED) {
+                    // The pipeline stores the contents of a view only when the view is materialized
+                    SourcePositionRange pos = elementPositionRange(value,
+                            path + "/" + CreateViewStatement.SEND_SNAPSHOT, true);
+                    throw new CompilationError("\"" + CreateViewStatement.SEND_SNAPSHOT +
+                            "\" property for " + objectName +
+                            " requires a materialized view; declare the view with CREATE MATERIALIZED VIEW", pos);
                 }
                 JsonNode preprocessor = connector.get(CreateTableStatement.PREPROCESSOR);
                 if (preprocessor != null) {
@@ -2233,7 +2246,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                 this.validateBooleanProperty(node, key, value);
                 break;
             case CreateTableStatement.CONNECTORS:
-                this.validateConnectorsProperty(node, true, table, primaryKey, key, value);
+                this.validateConnectorsProperty(node, true, table, primaryKey, null, key, value);
                 break;
             case CreateTableStatement.EXPECTED_SIZE:
                 this.validateNumericProperty(node, key, value);
@@ -2338,7 +2351,7 @@ public class SqlToRelCompiler implements IWritesLogs {
             }
 
             for (var prop: viewProperties) {
-                this.validateViewProperty(viewName, prop.getKey(), prop.getValue());
+                this.validateViewProperty(viewName, cv.viewKind, prop.getKey(), prop.getValue());
             }
             props = new Properties(viewProperties);
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateViewStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateViewStatement.java
@@ -43,6 +43,7 @@ public class CreateViewStatement extends CreateRelationStatement {
     public static final String EMIT_FINAL = "emit_final";
     public static final String MATERIALIZED = "materialized";
     public static final String POSTPROCESSOR = "postprocessor";
+    public static final String SEND_SNAPSHOT = "send_snapshot";
 
     /** Compiled and optimized query. */
     private final RelRoot compiled;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -495,7 +495,9 @@ public class CatalogTests extends BaseSQLTests {
         Assert.assertEquals(1, Utilities.countMatches(sources, "register_input_zset"));
         // One extra for the error_view
         Assert.assertEquals(2, Utilities.countMatches(sources, "register_output_zset_persistent"));
-        Assert.assertEquals(2, Utilities.countMatches(sources, "register_materialized_index_persistent"));
+        // Indexes of a non-materialized view keep no integral
+        Assert.assertEquals(2, Utilities.countMatches(sources, "register_index_persistent"));
+        Assert.assertEquals(0, Utilities.countMatches(sources, "register_materialized_index_persistent"));
     }
 
     @Test
@@ -511,7 +513,9 @@ public class CatalogTests extends BaseSQLTests {
         Assert.assertEquals(1, Utilities.countMatches(sources, "register_input_zset"));
         Assert.assertEquals(1, Utilities.countMatches(sources, "register_output_zset_persistent"));
         Assert.assertEquals(1, Utilities.countMatches(sources, "register_materialized_output_map_persistent"));
+        // The second index of a materialized view keeps its own integral
         Assert.assertEquals(1, Utilities.countMatches(sources, "register_materialized_index_persistent"));
+        Assert.assertEquals(0, Utilities.countMatches(sources, "register_index_persistent"));
         // When the view is materialized and indexed, it is no longer registered as an output at all
         // That's why there are only 4 outputs instead of 5
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
@@ -703,6 +703,63 @@ public class ConnectorTests extends BaseSQLTests {
                 "\"threads\" must be greater than 0");
     }
 
+    @Test
+    public void sendSnapshotRequiresMaterializedView() {
+        String sql = """
+                CREATE TABLE T (x INT);
+                CREATE VIEW V WITH (
+                  'connectors' = '[{
+                    "name": "c",
+                    "send_snapshot": true,
+                    "transport": {
+                      "name": "delta_table_output",
+                      "config": { "uri": "s3://bucket/table", "mode": "truncate" }
+                    }
+                  }]'
+                ) AS SELECT * FROM T;""";
+        this.statementsFailingInCompilation(sql,
+                "\"send_snapshot\" property for view 'v' requires a materialized view");
+    }
+
+    @Test
+    public void sendSnapshotThroughIndexRequiresMaterializedView() {
+        // The index of a non-materialized view stores no data, so it cannot serve a snapshot
+        String sql = """
+                CREATE TABLE T (x INT);
+                CREATE VIEW V WITH (
+                  'connectors' = '[{
+                    "name": "c",
+                    "index": "ix",
+                    "send_snapshot": true,
+                    "transport": {
+                      "name": "delta_table_output",
+                      "config": { "uri": "s3://bucket/table", "mode": "truncate" }
+                    }
+                  }]'
+                ) AS SELECT * FROM T;
+                CREATE INDEX IX ON V(x);""";
+        this.statementsFailingInCompilation(sql,
+                "\"send_snapshot\" property for view 'v' requires a materialized view");
+    }
+
+    @Test
+    public void sendSnapshotThroughIndexOfMaterializedView() {
+        runCleanConnectorTest("""
+                CREATE TABLE T (x INT);
+                CREATE MATERIALIZED VIEW V WITH (
+                  'connectors' = '[{
+                    "name": "c",
+                    "index": "ix",
+                    "send_snapshot": true,
+                    "transport": {
+                      "name": "delta_table_output",
+                      "config": { "uri": "s3://bucket/table", "mode": "truncate" }
+                    }
+                  }]'
+                ) AS SELECT * FROM T;
+                CREATE INDEX IX ON V(x);""");
+    }
+
     // ---- HTTP transport config ----
 
     @Test


### PR DESCRIPTION
Fixes #7085 

Prior to this change every output view that had an index was also storing the view's content in the index.
After this change only MATERIALIZED views will keep a copy of the data.

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated
