### PR TITLE
[adapters] delta: Avoid errors and OOM parsing Parquet files

### DIFF
--- a/crates/adapters/src/integrated/delta_table.rs
+++ b/crates/adapters/src/integrated/delta_table.rs
@@ -72,9 +72,12 @@ fn view_field(field: &FieldRef) -> FieldRef {
 /// The type exists to ensure that a schema that skipped the rewrite cannot reach a
 /// reader.
 ///
-/// Note: this doesn't apply to the initial snapshot: it reads through delta-rs's table
-/// provider, which builds its own schema from the Delta log, and so keeps the
-/// 32-bit types and their ceiling.
+/// Note: the initial snapshot needs none of this. It reads through delta-rs's
+/// table provider, which asks for view types itself: `DeltaScanConfig::new`
+/// hard-codes `schema_force_view_types` rather than reading it from the
+/// session, so its string columns are `Utf8View` whatever the session says.
+/// Between that and this type, no read path in the connector decodes 32-bit
+/// strings.
 #[derive(Clone, Debug)]
 pub(super) struct ReadSchema(SchemaRef);
 

--- a/crates/adapters/src/integrated/delta_table.rs
+++ b/crates/adapters/src/integrated/delta_table.rs
@@ -5,11 +5,97 @@ mod output;
 #[cfg(test)]
 mod test;
 
+use arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, FieldRef, Schema as ArrowSchema, SchemaRef,
+};
 use feldera_types::serde_with_context::serde_config::{DecimalFormat, UuidFormat};
 use feldera_types::serde_with_context::{DateFormat, SqlSerdeConfig, TimestampFormat};
 pub use input::DeltaTableInputEndpoint;
 pub use output::DeltaTableWriter;
-use std::sync::Once;
+use std::sync::{Arc, Once};
+
+/// The view counterpart of a string or binary type, or `None` for every other
+/// type.
+fn view_counterpart(data_type: &ArrowDataType) -> Option<ArrowDataType> {
+    match data_type {
+        ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => Some(ArrowDataType::Utf8View),
+        ArrowDataType::Binary | ArrowDataType::LargeBinary => Some(ArrowDataType::BinaryView),
+        _ => None,
+    }
+}
+
+/// `data_type` with every string and binary type it contains, at any depth,
+/// replaced by its view counterpart. Other types carry over unchanged.
+fn view_data_type(data_type: &ArrowDataType) -> ArrowDataType {
+    if let Some(view) = view_counterpart(data_type) {
+        return view;
+    }
+    match data_type {
+        ArrowDataType::Struct(fields) => {
+            ArrowDataType::Struct(fields.iter().map(view_field).collect())
+        }
+        ArrowDataType::List(field) => ArrowDataType::List(view_field(field)),
+        ArrowDataType::LargeList(field) => ArrowDataType::LargeList(view_field(field)),
+        ArrowDataType::FixedSizeList(field, len) => {
+            ArrowDataType::FixedSizeList(view_field(field), *len)
+        }
+        ArrowDataType::Map(field, sorted) => ArrowDataType::Map(view_field(field), *sorted),
+        other => other.clone(),
+    }
+}
+
+/// [`view_data_type`] applied to `field`, keeping its name, nullability and
+/// metadata. The Parquet reader validates a supplied schema field by field, so
+/// everything but the type must match what it would have produced.
+fn view_field(field: &FieldRef) -> FieldRef {
+    Arc::new(
+        ArrowField::new(
+            field.name(),
+            view_data_type(field.data_type()),
+            field.is_nullable(),
+        )
+        .with_metadata(field.metadata().clone()),
+    )
+}
+
+/// An Arrow schema where every string and binary column, at
+/// any depth, read as a view type.
+///
+/// A `Utf8`/`Binary` array addresses its values with 32-bit offsets, so one
+/// decoded batch cannot hold more than 2 GiB of a single column, and the reader
+/// fails with "index overflow decoding byte array" when a batch would. A view
+/// array spreads values over several buffers and has no such ceiling. It is also
+/// far cheaper for dictionary-encoded data: the decoder references the
+/// dictionary page's buffers rather than copying each repeat, so a value
+/// repeated across a batch costs one copy plus a 16-byte view per row.
+///
+/// The type exists to ensure that a schema that skipped the rewrite cannot reach a
+/// reader.
+///
+/// Note: this doesn't apply to the initial snapshot: it reads through delta-rs's table
+/// provider, which builds its own schema from the Delta log, and so keeps the
+/// 32-bit types and their ceiling.
+#[derive(Clone, Debug)]
+pub(super) struct ReadSchema(SchemaRef);
+
+impl ReadSchema {
+    pub(super) fn new(schema: &ArrowSchema) -> Self {
+        Self(Arc::new(
+            ArrowSchema::new(
+                schema
+                    .fields()
+                    .iter()
+                    .map(view_field)
+                    .collect::<Vec<FieldRef>>(),
+            )
+            .with_metadata(schema.metadata().clone()),
+        ))
+    }
+
+    pub(super) fn schema(&self) -> &SchemaRef {
+        &self.0
+    }
+}
 
 static REGISTER_STORAGE_HANDLERS: Once = Once::new();
 

--- a/crates/adapters/src/integrated/delta_table/deletion_vector.rs
+++ b/crates/adapters/src/integrated/delta_table/deletion_vector.rs
@@ -107,13 +107,30 @@ fn abbreviate(value: &str) -> String {
     }
 }
 
-/// Build a [`TableProvider`] over the Parquet file at `path` that reads the rows
-/// `mode` picks out of `bitmap` (see [`ReadMode`]).
+/// One Parquet file to read, and the row positions a [`ReadMode`] picks out of
+/// it.
+pub(crate) struct MaskedFile {
+    pub path: Path,
+    /// A `RoaringTreemap` stays compact even for dense sets, and it is dropped
+    /// once the file has been streamed, so the footprint is short-lived.
+    pub bitmap: RoaringTreemap,
+}
+
+/// Build a [`TableProvider`] over `files`, reading from each the rows `mode`
+/// picks out of its bitmap (see [`ReadMode`]).
 ///
-/// The bitmap indexes rows by physical position, so the file is read in order
-/// through a single-partition [`StreamingTable`] (a `ListingTable` could split
-/// and reorder it). Row selection happens inside the Parquet decoder, so memory
-/// stays bounded to one batch.
+/// A bitmap indexes rows by physical position, so each file is read in order
+/// through a [`StreamingTable`] (a `ListingTable` could split and reorder it).
+/// Row selection happens inside the Parquet decoder, so a file costs one batch
+/// of memory while it streams.
+///
+/// The files are dealt into at most `max_partitions` partitions, and a partition
+/// opens its files one after another. That is what bounds the memory: a Parquet
+/// reader's own state is per column per open file and no batch size reaches it,
+/// so N files read at once cost N times that state. DataFusion drives every
+/// partition of a plan concurrently, so partitions are the only lever, and one
+/// provider over N files replaces the N single-file providers this used to be
+/// unioned from, whose count nothing bounded.
 ///
 /// `logical_schema` is the table's Arrow schema, restricted by the caller to the
 /// columns it wants read. Batches are projected to it by name (missing columns
@@ -122,22 +139,41 @@ fn abbreviate(value: &str) -> String {
 /// [`StreamingTable`] does not push projections down.
 pub(crate) async fn filtered_parquet_table(
     store: Arc<dyn ObjectStore>,
-    path: Path,
-    bitmap: RoaringTreemap,
+    files: Vec<MaskedFile>,
     logical_schema: ReadSchema,
     mode: ReadMode,
+    max_partitions: usize,
 ) -> AnyResult<Arc<dyn TableProvider>> {
     let schema = Arc::clone(logical_schema.schema());
-    let partition = MaskedParquetPartition {
-        store,
-        path,
-        bitmap: Arc::new(bitmap),
-        schema: logical_schema,
-        mode,
-    };
-    let provider = StreamingTable::try_new(schema, vec![Arc::new(partition)])
+    let partitions: Vec<Arc<dyn PartitionStream>> = deal(files, max_partitions)
+        .into_iter()
+        .map(|files| {
+            Arc::new(MaskedParquetPartition {
+                store: Arc::clone(&store),
+                files: Arc::new(files),
+                schema: logical_schema.clone(),
+                mode,
+            }) as Arc<dyn PartitionStream>
+        })
+        .collect();
+    let provider = StreamingTable::try_new(schema, partitions)
         .map_err(|e| anyhow!("failed to build DV-filtered streaming table: {e}"))?;
     Ok(Arc::new(provider))
+}
+
+/// Deal `files` round-robin into at most `max_partitions` non-empty groups.
+///
+/// Round-robin rather than contiguous chunks so that a commit whose files vary
+/// in size spreads the large ones across partitions instead of loading one with
+/// all of them. An empty input yields one empty group, because a
+/// [`StreamingTable`] needs a partition to report the schema from.
+fn deal<T>(files: Vec<T>, max_partitions: usize) -> Vec<Vec<T>> {
+    let groups = max_partitions.clamp(1, files.len().max(1));
+    let mut dealt: Vec<Vec<T>> = (0..groups).map(|_| Vec::new()).collect();
+    for (index, file) in files.into_iter().enumerate() {
+        dealt[index % groups].push(file);
+    }
+    dealt
 }
 
 /// Which rows [`filtered_parquet_table`] reads, relative to its `bitmap`.
@@ -158,28 +194,29 @@ impl ReadMode {
     }
 }
 
-/// Single-partition [`PartitionStream`] that lazily opens a Parquet file and
-/// keeps or drops the rows flagged by `bitmap` (per `mode`) as batches flow
-/// through.
+/// [`PartitionStream`] that opens its files one at a time, keeping or dropping
+/// the rows each one's bitmap flags (per `mode`) as batches flow through.
+///
+/// One file is open at a time, so the partition's cost is one Parquet reader
+/// whatever it was given.
 struct MaskedParquetPartition {
     store: Arc<dyn ObjectStore>,
-    path: Path,
-    /// Row positions this partition acts on. A `RoaringTreemap` stays compact
-    /// even for dense sets, and it is dropped once the partition finishes
-    /// streaming, so the footprint is bounded and short-lived.
-    bitmap: Arc<RoaringTreemap>,
-    /// The Delta logical schema; may differ from the file's own schema under
+    files: Arc<Vec<MaskedFile>>,
+    /// The Delta logical schema; may differ from a file's own schema under
     /// schema evolution.
     schema: ReadSchema,
-    /// Which rows to read, relative to `bitmap`.
+    /// Which rows to read, relative to each file's bitmap.
     mode: ReadMode,
 }
 
 impl fmt::Debug for MaskedParquetPartition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MaskedParquetPartition")
-            .field("path", &self.path)
-            .field("bitmap_rows", &self.bitmap.len())
+            .field("files", &self.files.len())
+            .field(
+                "bitmap_rows",
+                &self.files.iter().map(|f| f.bitmap.len()).sum::<u64>(),
+            )
             .finish()
     }
 }
@@ -391,53 +428,58 @@ impl PartitionStream for MaskedParquetPartition {
 
     fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
         let store = Arc::clone(&self.store);
-        let path = self.path.clone();
-        let bitmap = Arc::clone(&self.bitmap);
+        let files = Arc::clone(&self.files);
         let logical_schema = Arc::clone(self.schema.schema());
         let mode = self.mode;
 
         let stream = try_stream! {
-            let probe = ParquetRecordBatchStreamBuilder::new(
-                    ParquetObjectReader::new(Arc::clone(&store), path.clone()))
-                .await
-                .map_err(|e| DataFusionError::External(
-                    format!("failed to open Parquet file '{path}': {e}").into()))?;
-            // Decode string and binary columns straight into view arrays, the
-            // same types `physical_read_schema` declares. Without this the
-            // decoder builds 32-bit-offset arrays, which cap one batch at 2 GiB
-            // per column, and `project_to_logical` then pays to cast them.
-            // Rebuilding the reader metadata reuses the footer read above.
-            let metadata = ArrowReaderMetadata::try_new(
-                    Arc::clone(probe.metadata()),
-                    ArrowReaderOptions::new()
-                        .with_schema(Arc::clone(ReadSchema::new(probe.schema()).schema())))
-                .map_err(|e| DataFusionError::External(
-                    format!("failed to read Parquet file '{path}' as view types: {e}").into()))?;
-            // `num_rows()` is `i64` because Parquet's metadata is signed
-            // throughout; it is non-negative for any file whose footer parsed
-            // (which it did, just above).
-            let total_rows = metadata.metadata().file_metadata().num_rows() as u64;
-            let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(
-                ParquetObjectReader::new(store, path.clone()),
-                metadata,
-            );
-            // Decode only the columns the logical schema names.
-            let mask = logical_projection_mask(&builder, &logical_schema);
-            // Pick rows inside the decoder: skip the flagged rows (apply a DV) or
-            // keep only them (read a DV delta).
-            let selection = bitmap_to_selection(&bitmap, total_rows, mode);
-            let mut parquet_stream = builder
-                .with_projection(mask)
-                .with_row_selection(selection)
-                .build()
-                .map_err(|e| DataFusionError::External(
-                    format!("failed to build Parquet stream for '{path}': {e}").into()))?;
+            // Sequentially: only one file's reader is alive at a time, which is
+            // what keeps a partition's memory independent of how many files it
+            // was given.
+            for file in files.iter() {
+                let path = &file.path;
+                let probe = ParquetRecordBatchStreamBuilder::new(
+                        ParquetObjectReader::new(Arc::clone(&store), path.clone()))
+                    .await
+                    .map_err(|e| DataFusionError::External(
+                        format!("failed to open Parquet file '{path}': {e}").into()))?;
+                // Decode string and binary columns straight into view arrays, the
+                // same types `physical_read_schema` declares. Without this the
+                // decoder builds 32-bit-offset arrays, which cap one batch at 2 GiB
+                // per column, and `project_to_logical` then pays to cast them.
+                // Rebuilding the reader metadata reuses the footer read above.
+                let metadata = ArrowReaderMetadata::try_new(
+                        Arc::clone(probe.metadata()),
+                        ArrowReaderOptions::new()
+                            .with_schema(Arc::clone(ReadSchema::new(probe.schema()).schema())))
+                    .map_err(|e| DataFusionError::External(
+                        format!("failed to read Parquet file '{path}' as view types: {e}").into()))?;
+                // `num_rows()` is `i64` because Parquet's metadata is signed
+                // throughout; it is non-negative for any file whose footer parsed
+                // (which it did, just above).
+                let total_rows = metadata.metadata().file_metadata().num_rows() as u64;
+                let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(
+                    ParquetObjectReader::new(Arc::clone(&store), path.clone()),
+                    metadata,
+                );
+                // Decode only the columns the logical schema names.
+                let mask = logical_projection_mask(&builder, &logical_schema);
+                // Pick rows inside the decoder: skip the flagged rows (apply a DV) or
+                // keep only them (read a DV delta).
+                let selection = bitmap_to_selection(&file.bitmap, total_rows, mode);
+                let mut parquet_stream = builder
+                    .with_projection(mask)
+                    .with_row_selection(selection)
+                    .build()
+                    .map_err(|e| DataFusionError::External(
+                        format!("failed to build Parquet stream for '{path}': {e}").into()))?;
 
-            while let Some(batch) = parquet_stream.next().await {
-                let batch = batch.map_err(|e| DataFusionError::External(
-                    format!("error reading Parquet file '{path}': {e}").into()))?;
-                if batch.num_rows() > 0 {
-                    yield project_to_logical(&batch, &logical_schema, path.as_ref())?;
+                while let Some(batch) = parquet_stream.next().await {
+                    let batch = batch.map_err(|e| DataFusionError::External(
+                        format!("error reading Parquet file '{path}': {e}").into()))?;
+                    if batch.num_rows() > 0 {
+                        yield project_to_logical(&batch, &logical_schema, path.as_ref())?;
+                    }
                 }
             }
         };
@@ -457,6 +499,7 @@ mod tests {
         DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
         Schema as ArrowSchema,
     };
+    use datafusion::physical_plan::ExecutionPlanProperties;
     use datafusion::prelude::SessionContext;
     use deltalake::{DeltaTableBuilder, ensure_table_uri};
     use proptest::prelude::*;
@@ -818,6 +861,151 @@ mod tests {
             .unwrap()
     }
 
+    /// The files are spread over at most `max_partitions` groups, and every
+    /// file lands in exactly one. The cap is the point: a plan runs all its
+    /// partitions at once, so it is the number of Parquet readers open
+    /// together.
+    #[test]
+    fn dealing_caps_the_groups_and_keeps_every_file() {
+        for (files, max_partitions, groups) in [
+            (212, 8, 8),
+            (212, 1, 1),
+            (3, 8, 3),
+            (1, 8, 1),
+            // A caller that asks for none still gets one, since a partition is
+            // what reports the schema.
+            (5, 0, 1),
+        ] {
+            let dealt = deal((0..files).collect::<Vec<_>>(), max_partitions);
+            assert_eq!(dealt.len(), groups, "{files} files over {max_partitions}");
+            assert!(
+                dealt.iter().all(|group| !group.is_empty()),
+                "no group may be empty; got {dealt:?}"
+            );
+            let mut seen: Vec<usize> = dealt.into_iter().flatten().collect();
+            seen.sort();
+            assert_eq!(
+                seen,
+                (0..files).collect::<Vec<_>>(),
+                "every file must be read exactly once"
+            );
+        }
+    }
+
+    /// An empty read still produces a partition, because a `StreamingTable`
+    /// takes its schema from one.
+    #[test]
+    fn dealing_nothing_yields_one_empty_group() {
+        assert_eq!(deal(Vec::<usize>::new(), 8), vec![Vec::<usize>::new()]);
+    }
+
+    /// Round-robin, so a commit whose files vary in size spreads the large ones
+    /// rather than loading one partition with all of them.
+    #[test]
+    fn dealing_is_round_robin() {
+        assert_eq!(
+            deal((0..7).collect::<Vec<_>>(), 3),
+            vec![vec![0, 3, 6], vec![1, 4], vec![2, 5]]
+        );
+    }
+
+    /// Many files through one provider: the partitions are capped, each file's
+    /// bitmap still applies to that file alone, and every kept row comes back.
+    ///
+    /// The cap is what bounds memory, since a plan drives all its partitions
+    /// concurrently and a Parquet reader's per-column state is per open file.
+    #[tokio::test]
+    async fn many_files_read_through_one_capped_provider() {
+        const FILES: usize = 7;
+        const ROWS_PER_FILE: i64 = 10;
+        const MAX_PARTITIONS: usize = 2;
+        let dir = TempDir::new().unwrap();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            ArrowDataType::Int64,
+            false,
+        )]));
+        let mut files = Vec::new();
+        for file in 0..FILES {
+            let first = file as i64 * ROWS_PER_FILE;
+            let batch = RecordBatch::try_new(
+                Arc::clone(&file_schema),
+                vec![Arc::new(Int64Array::from_iter_values(
+                    first..first + ROWS_PER_FILE,
+                ))],
+            )
+            .unwrap();
+            let name = format!("part-{file}.parquet");
+            let handle = std::fs::File::create(dir.path().join(&name)).unwrap();
+            let mut writer =
+                parquet::arrow::ArrowWriter::try_new(handle, Arc::clone(&file_schema), None)
+                    .unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+            // Drop the first row of every file, so a bitmap that leaked to
+            // another file would show up as a wrong row count.
+            files.push(MaskedFile {
+                path: Path::from(name),
+                bitmap: RoaringTreemap::from_iter([0u64]),
+            });
+        }
+
+        let declared = ReadSchema::new(&ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            ArrowDataType::Int64,
+            false,
+        )]));
+        let store = unloaded_table(dir.path()).log_store().object_store(None);
+        let provider = filtered_parquet_table(
+            store,
+            files,
+            declared,
+            ReadMode::NotInBitmap,
+            MAX_PARTITIONS,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            provider
+                .scan(&SessionContext::new().state(), None, &[], None)
+                .await
+                .unwrap()
+                .output_partitioning()
+                .partition_count(),
+            MAX_PARTITIONS,
+            "{FILES} files must read through at most {MAX_PARTITIONS} readers"
+        );
+
+        let batches = SessionContext::new()
+            .read_table(provider)
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut got: Vec<i64> = Vec::new();
+        for batch in &batches {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            got.extend(ids.iter().map(|v| v.unwrap()));
+        }
+        got.sort();
+        let expected: Vec<i64> = (0..FILES as i64)
+            .flat_map(|file| {
+                let first = file * ROWS_PER_FILE;
+                first + 1..first + ROWS_PER_FILE
+            })
+            .collect();
+        assert_eq!(
+            got, expected,
+            "every file must lose exactly its own first row"
+        );
+    }
+
     /// One change data file read whole through the object store using [`filtered_parquet_table`]:
     /// every row comes back, `_change_type` survives alongside the table's own columns, and
     /// `__is_cdc`, which the declared schema leaves out, is dropped.
@@ -866,10 +1054,13 @@ mod tests {
         let store = unloaded_table(dir.path()).log_store().object_store(None);
         let provider = filtered_parquet_table(
             store,
-            Path::from("cdc.parquet"),
-            RoaringTreemap::new(),
+            vec![MaskedFile {
+                path: Path::from("cdc.parquet"),
+                bitmap: RoaringTreemap::new(),
+            }],
             declared.clone(),
             ReadMode::NotInBitmap,
+            1,
         )
         .await
         .unwrap();
@@ -951,10 +1142,13 @@ mod tests {
         let store = unloaded_table(dir.path()).log_store().object_store(None);
         let provider = filtered_parquet_table(
             store,
-            Path::from("data.parquet"),
-            deleted,
+            vec![MaskedFile {
+                path: Path::from("data.parquet"),
+                bitmap: deleted,
+            }],
             logical.clone(),
             ReadMode::NotInBitmap,
+            1,
         )
         .await
         .unwrap();
@@ -1026,10 +1220,13 @@ mod tests {
         let store = unloaded_table(dir.path()).log_store().object_store(None);
         let provider = filtered_parquet_table(
             store,
-            Path::from("data.parquet"),
-            selected,
+            vec![MaskedFile {
+                path: Path::from("data.parquet"),
+                bitmap: selected,
+            }],
             logical.clone(),
             ReadMode::InBitmap,
+            1,
         )
         .await
         .unwrap();

--- a/crates/adapters/src/integrated/delta_table/deletion_vector.rs
+++ b/crates/adapters/src/integrated/delta_table/deletion_vector.rs
@@ -10,6 +10,7 @@
 //! thus fully applied (deleted rows are never emitted), and memory stays bounded
 //! to one batch.
 
+use crate::integrated::delta_table::ReadSchema;
 use anyhow::{Result as AnyResult, anyhow};
 use arrow::array::{Array, ArrayRef, StructArray, new_null_array};
 use arrow::compute::cast;
@@ -31,7 +32,9 @@ use deltalake::logstore::LogStore;
 use deltalake::{DeltaTable, ObjectStore, Path};
 use futures_util::StreamExt;
 use parquet::arrow::ProjectionMask;
-use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector,
+};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use roaring::RoaringTreemap;
 use std::collections::{HashMap, HashSet};
@@ -121,17 +124,18 @@ pub(crate) async fn filtered_parquet_table(
     store: Arc<dyn ObjectStore>,
     path: Path,
     bitmap: RoaringTreemap,
-    logical_schema: SchemaRef,
+    logical_schema: ReadSchema,
     mode: ReadMode,
 ) -> AnyResult<Arc<dyn TableProvider>> {
+    let schema = Arc::clone(logical_schema.schema());
     let partition = MaskedParquetPartition {
         store,
         path,
         bitmap: Arc::new(bitmap),
-        schema: Arc::clone(&logical_schema),
+        schema: logical_schema,
         mode,
     };
-    let provider = StreamingTable::try_new(logical_schema, vec![Arc::new(partition)])
+    let provider = StreamingTable::try_new(schema, vec![Arc::new(partition)])
         .map_err(|e| anyhow!("failed to build DV-filtered streaming table: {e}"))?;
     Ok(Arc::new(provider))
 }
@@ -166,7 +170,7 @@ struct MaskedParquetPartition {
     bitmap: Arc<RoaringTreemap>,
     /// The Delta logical schema; may differ from the file's own schema under
     /// schema evolution.
-    schema: SchemaRef,
+    schema: ReadSchema,
     /// Which rows to read, relative to `bitmap`.
     mode: ReadMode,
 }
@@ -382,26 +386,41 @@ fn bitmap_to_selection(bitmap: &RoaringTreemap, total_rows: u64, mode: ReadMode)
 /// batch stream. Ours opens the Parquet file and masks deleted rows on the fly.
 impl PartitionStream for MaskedParquetPartition {
     fn schema(&self) -> &SchemaRef {
-        &self.schema
+        self.schema.schema()
     }
 
     fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
         let store = Arc::clone(&self.store);
         let path = self.path.clone();
         let bitmap = Arc::clone(&self.bitmap);
-        let logical_schema = Arc::clone(&self.schema);
+        let logical_schema = Arc::clone(self.schema.schema());
         let mode = self.mode;
 
         let stream = try_stream! {
-            let reader = ParquetObjectReader::new(store, path.clone());
-            let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            let probe = ParquetRecordBatchStreamBuilder::new(
+                    ParquetObjectReader::new(Arc::clone(&store), path.clone()))
                 .await
                 .map_err(|e| DataFusionError::External(
                     format!("failed to open Parquet file '{path}': {e}").into()))?;
+            // Decode string and binary columns straight into view arrays, the
+            // same types `physical_read_schema` declares. Without this the
+            // decoder builds 32-bit-offset arrays, which cap one batch at 2 GiB
+            // per column, and `project_to_logical` then pays to cast them.
+            // Rebuilding the reader metadata reuses the footer read above.
+            let metadata = ArrowReaderMetadata::try_new(
+                    Arc::clone(probe.metadata()),
+                    ArrowReaderOptions::new()
+                        .with_schema(Arc::clone(ReadSchema::new(probe.schema()).schema())))
+                .map_err(|e| DataFusionError::External(
+                    format!("failed to read Parquet file '{path}' as view types: {e}").into()))?;
             // `num_rows()` is `i64` because Parquet's metadata is signed
             // throughout; it is non-negative for any file whose footer parsed
             // (which it did, just above).
-            let total_rows = builder.metadata().file_metadata().num_rows() as u64;
+            let total_rows = metadata.metadata().file_metadata().num_rows() as u64;
+            let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(
+                ParquetObjectReader::new(store, path.clone()),
+                metadata,
+            );
             // Decode only the columns the logical schema names.
             let mask = logical_projection_mask(&builder, &logical_schema);
             // Pick rows inside the decoder: skip the flagged rows (apply a DV) or
@@ -424,7 +443,7 @@ impl PartitionStream for MaskedParquetPartition {
         };
 
         Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&self.schema),
+            Arc::clone(self.schema.schema()),
             stream,
         ))
     }
@@ -433,7 +452,7 @@ impl PartitionStream for MaskedParquetPartition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, Int32Array, Int64Array, StringArray, StructArray};
+    use arrow::array::{Array, Int32Array, Int64Array, StringArray, StringViewArray, StructArray};
     use arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
         Schema as ArrowSchema,
@@ -838,7 +857,7 @@ mod tests {
 
         // What `change_data_read_schema` builds: the table's columns plus
         // `_change_type`, and nothing else.
-        let declared = Arc::new(ArrowSchema::new(vec![
+        let declared = ReadSchema::new(&ArrowSchema::new(vec![
             ArrowField::new("id", ArrowDataType::Int64, false),
             ArrowField::new("name", ArrowDataType::Utf8, false),
             ArrowField::new("_change_type", ArrowDataType::Utf8, true),
@@ -849,7 +868,7 @@ mod tests {
             store,
             Path::from("cdc.parquet"),
             RoaringTreemap::new(),
-            Arc::clone(&declared),
+            declared.clone(),
             ReadMode::NotInBitmap,
         )
         .await
@@ -865,7 +884,7 @@ mod tests {
         for batch in &batches {
             assert_eq!(
                 batch.schema().as_ref(),
-                declared.as_ref(),
+                declared.schema().as_ref(),
                 "`__is_cdc` must be pruned: the declared schema drives the read"
             );
             let ids = batch
@@ -876,7 +895,7 @@ mod tests {
             let kinds = batch
                 .column(2)
                 .as_any()
-                .downcast_ref::<StringArray>()
+                .downcast_ref::<StringViewArray>()
                 .unwrap();
             for row in 0..batch.num_rows() {
                 got.push((ids.value(row), kinds.value(row).to_string()));
@@ -923,7 +942,7 @@ mod tests {
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
-        let logical = Arc::new(ArrowSchema::new(vec![
+        let logical = ReadSchema::new(&ArrowSchema::new(vec![
             ArrowField::new("id", ArrowDataType::Int64, true),
             ArrowField::new("added_later", ArrowDataType::Utf8, true),
         ]));
@@ -934,7 +953,7 @@ mod tests {
             store,
             Path::from("data.parquet"),
             deleted,
-            Arc::clone(&logical),
+            logical.clone(),
             ReadMode::NotInBitmap,
         )
         .await
@@ -950,7 +969,7 @@ mod tests {
         for batch in &batches {
             assert_eq!(
                 batch.schema().as_ref(),
-                logical.as_ref(),
+                logical.schema().as_ref(),
                 "batch schema must equal the declared logical schema"
             );
             let id = batch
@@ -996,7 +1015,7 @@ mod tests {
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
-        let logical = Arc::new(ArrowSchema::new(vec![
+        let logical = ReadSchema::new(&ArrowSchema::new(vec![
             ArrowField::new("id", ArrowDataType::Int64, true),
             ArrowField::new("added_later", ArrowDataType::Utf8, true),
         ]));
@@ -1009,7 +1028,7 @@ mod tests {
             store,
             Path::from("data.parquet"),
             selected,
-            Arc::clone(&logical),
+            logical.clone(),
             ReadMode::InBitmap,
         )
         .await
@@ -1023,7 +1042,7 @@ mod tests {
 
         let mut got: Vec<i64> = Vec::new();
         for batch in &batches {
-            assert_eq!(batch.schema().as_ref(), logical.as_ref());
+            assert_eq!(batch.schema().as_ref(), logical.schema().as_ref());
             let id = batch
                 .column(0)
                 .as_any()

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -24,7 +24,9 @@ use datafusion::datasource::listing::{
 };
 use datafusion::execution::memory_pool::MemoryLimit;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
-use datafusion::physical_plan::{PhysicalExpr, displayable};
+use datafusion::physical_plan::{
+    ExecutionPlan, PhysicalExpr, SendableRecordBatchStream, displayable, execute_stream,
+};
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use dbsp::circuit::tokio::TOKIO;
 use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
@@ -138,6 +140,83 @@ fn format_datafusion_error(
     } else {
         base
     }
+}
+
+/// Total decoded bytes a single read may hold across all the files it decodes
+/// at once.
+///
+/// Parquet decode buffers are invisible to the DataFusion memory pool, so
+/// `datafusion_memory_mb` does not bound them. What does is the batch size,
+/// which DataFusion states in *rows* (8192 by default), leaving the byte total
+/// unbounded: a wide row makes one batch arbitrarily large, and up to
+/// `target_partitions` files decode at once.
+///
+/// This is a ceiling, not a target. 1 GiB is chosen so that ordinary tables keep
+/// the full 8192-row batch and only unusually wide rows shrink it: across 32
+/// scan partitions it takes more than 1 KiB of compressed data per row before
+/// the batch gets smaller.
+const DECODE_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Smallest batch the budget may ask for. A read whose rows are wide enough to
+/// hit this floor exceeds `DECODE_BUDGET_BYTES`, which is deliberate: shrinking
+/// batches without limit costs more in per-batch overhead than it saves.
+const MIN_BATCH_ROWS: usize = 64;
+
+/// Assumed ratio of decoded bytes to the byte counts the Delta log reports,
+/// which are compressed file sizes.
+const COMPRESSED_EXPANSION: u64 = 4;
+
+/// How big the Delta log says a read is: bytes on disk and the number of
+/// records those bytes hold.
+///
+/// Both come from the log, so they cost no I/O. `Add.size` is the compressed
+/// file size and `Add.stats.numRecords` its row count.
+/// [`ReadSize::batch_rows`] divides one by the other, so a read whose files
+/// record no row count has no ratio to work from and falls back to the
+/// configured batch size.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ReadSize {
+    bytes: u64,
+    records: u64,
+}
+
+impl ReadSize {
+    fn add(&mut self, bytes: u64, records: u64) {
+        self.bytes += bytes;
+        self.records += records;
+    }
+
+    /// Rows per decoded batch, so that `partitions` readers together stay near
+    /// [`DECODE_BUDGET_BYTES`]. `default_rows` is both the starting point and
+    /// the ceiling: the budget only ever shrinks a batch.
+    fn batch_rows(&self, partitions: usize, default_rows: usize) -> Option<usize> {
+        if self.bytes == 0 || self.records == 0 {
+            return None;
+        }
+        let partitions = partitions.max(1) as u64;
+        let bytes_per_row = (self.bytes * COMPRESSED_EXPANSION)
+            .div_ceil(self.records)
+            .max(1);
+        let rows = (DECODE_BUDGET_BYTES / partitions / bytes_per_row) as usize;
+        Some(rows.clamp(MIN_BATCH_ROWS, default_rows))
+    }
+}
+
+/// The read size DataFusion derived for `plan`, or `None` unless it reports
+/// both a byte total and a row count. `Statistics` states each independently
+/// and either may be absent, and one without the other gives no bytes-per-row
+/// ratio.
+///
+/// The Delta snapshot's table provider states the log's own totals here, so a
+/// snapshot read is sized without the connector passing anything. The listing
+/// tables the connector builds for follow and CDC reads collect no statistics,
+/// so their callers supply a [`ReadSize`] instead.
+fn plan_read_size(plan: &dyn ExecutionPlan) -> Option<ReadSize> {
+    let statistics = plan.partition_statistics(None).ok()?;
+    Some(ReadSize {
+        bytes: *statistics.total_byte_size.get_value()? as u64,
+        records: *statistics.num_rows.get_value()? as u64,
+    })
 }
 
 /// The suffix a read error carries to say which table version produced the data
@@ -2835,6 +2914,10 @@ impl DeltaTableInputEndpointInner {
             self.allocate_snapshot_transaction_label(),
             num_retries,
             None,
+            // The snapshot reads through delta-rs's table provider, which
+            // states the log's totals in the plan, so the batch size is
+            // derived from there.
+            None,
         )
         .await
     }
@@ -2856,6 +2939,10 @@ impl DeltaTableInputEndpointInner {
     ///
     /// * `version` - the table version whose data is being read, named in the
     ///   error message. `None` for the initial snapshot, which spans many.
+    ///
+    /// * `read_size` - how big the Delta log says this read is, used to bound
+    ///   the decoded batch size. `None` falls back to what DataFusion derived
+    ///   for the plan, and then to the configured batch size.
     ///
     /// Returns the total number of records processed.
     ///
@@ -2879,6 +2966,7 @@ impl DeltaTableInputEndpointInner {
         transaction: Option<Option<String>>,
         max_retries: u32,
         version: Option<i64>,
+        read_size: Option<ReadSize>,
     ) -> Result<usize, AnyError> {
         let mut retry_count = 0;
         loop {
@@ -2889,6 +2977,7 @@ impl DeltaTableInputEndpointInner {
                     input_stream,
                     receiver,
                     &transaction,
+                    read_size,
                 )
                 .await
             {
@@ -2923,6 +3012,42 @@ impl DeltaTableInputEndpointInner {
         }
     }
 
+    /// Execute `dataframe`, with the decoded batch bounded in bytes rather than
+    /// only in rows.
+    ///
+    /// `FileScanConfig` resolves the batch size from the task context when the
+    /// plan does not pin one, and neither the connector's listing tables nor
+    /// delta-rs's provider pins one, so the plan is built once and run with a
+    /// task context carrying the chosen size. Anything else the query does
+    /// (sorting a CDC transaction, subtracting its removes) keeps working to
+    /// the same size, which is what it would have used anyway.
+    async fn execute_stream(
+        &self,
+        dataframe: DataFrame,
+        read_size: Option<ReadSize>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        let (mut state, plan) = dataframe.into_parts();
+        let plan = state.create_physical_plan(&plan).await?;
+
+        let partitions = state.config().target_partitions();
+        let default_rows = state.config().batch_size();
+        if let Some(rows) = read_size
+            .or_else(|| plan_read_size(plan.as_ref()))
+            .and_then(|size| size.batch_rows(partitions, default_rows))
+            && rows < default_rows
+        {
+            debug!(
+                "delta_table {}: reading {rows} rows per batch instead of {default_rows}, to keep \
+                 {partitions} concurrent readers within {} MB of decoded data",
+                &self.endpoint_name,
+                DECODE_BUDGET_BYTES / 1024 / 1024,
+            );
+            state.config_mut().options_mut().execution.batch_size = rows;
+        }
+
+        execute_stream(plan, state.task_ctx())
+    }
+
     // A single attempt of the `execute_df` retry loop.
     #[allow(clippy::too_many_arguments)]
     async fn execute_df_inner(
@@ -2932,6 +3057,7 @@ impl DeltaTableInputEndpointInner {
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         transaction: &Option<Option<String>>,
+        read_size: Option<ReadSize>,
     ) -> Result<usize, String> {
         wait_running(receiver).await;
         let transaction = self.follow_start_transaction(transaction);
@@ -2939,7 +3065,7 @@ impl DeltaTableInputEndpointInner {
         // Limit the number of connectors simultaneously reading from Delta Lake.
         let _token = DELTA_READER_SEMAPHORE.acquire().await.unwrap();
 
-        let mut stream = match dataframe.execute_stream().await {
+        let mut stream = match self.execute_stream(dataframe, read_size).await {
             Err(e) => {
                 return Err(format!("{e:?}"));
             }
@@ -3457,6 +3583,10 @@ impl DeltaTableInputEndpointInner {
                 start_transaction.clone(),
                 self.config.max_retries(),
                 Some(new_version),
+                // A `cdc` action carries the file's size but no row count, so
+                // there is no ratio to size the batch from; the plan's own
+                // statistics decide, and the configured size if it has none.
+                None,
             )
             .await?;
         }
@@ -3634,6 +3764,21 @@ impl DeltaTableInputEndpointInner {
             describe_paths(removes_by_path.keys().copied()),
         );
 
+        // How big this read is, from the log rather than from the files: an
+        // `Add` carries its compressed size and its row count. A `Remove`
+        // carries no row count, so the added files decide the bytes-per-row
+        // ratio; both sides of the transaction come from the same table, so
+        // that is the same ratio either way.
+        let mut read_size = ReadSize::default();
+        for add in &adds {
+            let records = add
+                .get_stats()
+                .ok()
+                .flatten()
+                .map_or(0, |stats| stats.num_records);
+            read_size.add(add.size.max(0) as u64, records.max(0) as u64);
+        }
+
         // Drop add/remove pairs on the same path (metadata-only rewrites).
         // This loop must run before the removes side is built below: it
         // drains `removes_by_path` of every matched path, leaving only the
@@ -3703,6 +3848,7 @@ impl DeltaTableInputEndpointInner {
                 start_transaction,
                 self.config.max_retries(),
                 Some(version),
+                Some(read_size),
             )
             .await?;
 
@@ -4409,6 +4555,7 @@ impl DeltaTableInputEndpointInner {
                 start_transaction,
                 self.config.max_retries(),
                 Some(version),
+                None,
             )
             .await?;
 
@@ -5226,6 +5373,94 @@ mod change_data_feed_state_tests {
 }
 
 #[cfg(test)]
+mod read_size_tests {
+    use super::*;
+
+    /// 8192 rows is DataFusion's default and the ceiling here: the budget only
+    /// shrinks a batch, it never asks for a bigger one than configured.
+    const DEFAULT_ROWS: usize = 8192;
+
+    fn rows(bytes: u64, records: u64, partitions: usize) -> Option<usize> {
+        ReadSize { bytes, records }.batch_rows(partitions, DEFAULT_ROWS)
+    }
+
+    /// An ordinary table keeps the full batch, so bounding decode memory costs
+    /// nothing until the rows are actually wide.
+    #[test]
+    fn ordinary_rows_keep_the_default_batch() {
+        // 200 bytes per row compressed over 10M rows.
+        assert_eq!(rows(2_000_000_000, 10_000_000, 32), Some(DEFAULT_ROWS));
+        // Even a single reader is capped by the configured batch size.
+        assert_eq!(rows(2_000_000_000, 10_000_000, 1), Some(DEFAULT_ROWS));
+    }
+
+    /// Wide rows shrink the batch, and the result stays inside the budget.
+    #[test]
+    fn wide_rows_shrink_the_batch() {
+        const PARTITIONS: usize = 32;
+        // 64 KiB per row compressed over 1000 rows.
+        let bytes = 64 * 1024 * 1000;
+        let rows = rows(bytes, 1000, PARTITIONS).expect("a sized read picks a batch");
+        assert!(
+            (MIN_BATCH_ROWS..DEFAULT_ROWS).contains(&rows),
+            "expected a smaller batch inside the floor; got {rows}"
+        );
+        let per_row = 64 * 1024 * COMPRESSED_EXPANSION;
+        let held = rows as u64 * per_row * PARTITIONS as u64;
+        assert!(
+            held <= DECODE_BUDGET_BYTES,
+            "{PARTITIONS} readers of {rows} rows hold {held} bytes, over the budget"
+        );
+    }
+
+    /// More concurrent readers each get a smaller batch, since the budget covers
+    /// the scan and not one reader.
+    #[test]
+    fn concurrency_divides_the_budget() {
+        let bytes = 16 * 1024 * 1000;
+        let few = rows(bytes, 1000, 4).unwrap();
+        let many = rows(bytes, 1000, 64).unwrap();
+        assert!(
+            many < few,
+            "64 readers must take smaller batches than 4; got {many} against {few}"
+        );
+    }
+
+    /// Rows wide enough to make even the floor exceed the budget still get the
+    /// floor: shrinking without limit costs more than it saves.
+    #[test]
+    fn the_floor_holds() {
+        // 8 MiB per row.
+        assert_eq!(rows(8 * 1024 * 1024, 1, 32), Some(MIN_BATCH_ROWS));
+    }
+
+    /// A read the log did not measure falls back to the configured batch size
+    /// rather than guessing. A writer that omits `stats` leaves `numRecords`
+    /// absent, which is the common way this happens.
+    #[test]
+    fn an_unmeasured_read_picks_nothing() {
+        assert_eq!(rows(0, 0, 32), None);
+        assert_eq!(rows(1_000_000, 0, 32), None, "bytes without a row count");
+        assert_eq!(rows(0, 1_000, 32), None, "rows without a byte count");
+    }
+
+    /// Summing the log's files is what produces the pair.
+    #[test]
+    fn sizes_accumulate() {
+        let mut size = ReadSize::default();
+        size.add(100, 10);
+        size.add(200, 20);
+        assert_eq!(
+            size,
+            ReadSize {
+                bytes: 300,
+                records: 30
+            }
+        );
+    }
+}
+
+#[cfg(test)]
 mod version_suffix_tests {
     use super::*;
 
@@ -5365,6 +5600,47 @@ mod read_schema_tests {
         Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "s", data_type, false,
         )]))
+    }
+
+    /// The batch size a file scan uses comes from the task context at execution
+    /// time, not from the session the plan was built with. `execute_stream`
+    /// relies on that: it plans once, sizes the batch from the read, and then
+    /// runs the same plan under a context carrying the size it chose. If
+    /// DataFusion ever binds the size at planning time instead, the override
+    /// becomes silent, so this pins the behavior rather than the API.
+    #[tokio::test]
+    async fn a_file_scan_takes_its_batch_size_from_the_task_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let values: Vec<String> = (0..1000).map(|i| format!("row-{i}")).collect();
+        let path = write_parquet(
+            dir.path(),
+            &values.iter().map(String::as_str).collect::<Vec<_>>(),
+            1000,
+        );
+
+        let planned = SessionConfig::new().set_usize("datafusion.execution.batch_size", 8192);
+        let ctx = SessionContext::new_with_config(planned);
+        let url = ListingTableUrl::parse(format!("file://{}", path.display())).unwrap();
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_file_extension_opt(Some(".parquet"));
+        let table = ListingTable::try_new(
+            ListingTableConfig::new_with_multi_paths(vec![url])
+                .with_listing_options(listing_options)
+                .with_schema(schema_of(ArrowDataType::Utf8)),
+        )
+        .unwrap();
+
+        let (mut state, plan) = ctx.read_table(Arc::new(table)).unwrap().into_parts();
+        let plan = state.create_physical_plan(&plan).await.unwrap();
+        state.config_mut().options_mut().execution.batch_size = 100;
+
+        let mut stream = execute_stream(plan, state.task_ctx()).unwrap();
+        let batch = stream.next().await.expect("the file holds rows").unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            100,
+            "the scan must use the task context's batch size, not the plan's"
+        );
     }
 
     /// A `Utf8` read schema caps one batch at 2 GiB for that column: the reader

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -3,23 +3,27 @@ use crate::format::InputBuffer;
 use crate::integrated::delta_table::deletion_vector::{
     ReadMode, filtered_parquet_table, read_deletion_vector,
 };
-use crate::integrated::delta_table::{delta_input_serde_config, register_storage_handlers};
+use crate::integrated::delta_table::{
+    ReadSchema, delta_input_serde_config, register_storage_handlers,
+};
 use crate::transport::{InputEndpoint, InputQueue, InputReaderCommand, IntegratedInputEndpoint};
 use crate::{ControllerError, InputConsumer, InputReader, PipelineState};
 use anyhow::{Error as AnyError, Result as AnyResult, anyhow, bail};
-use arrow::array::{Array, ArrayData, ArrayRef, BooleanArray, StringArray, make_array};
+use arrow::array::{Array, ArrayData, ArrayRef, AsArray, BooleanArray, make_array};
 use arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, FieldRef, Schema as ArrowSchema, SchemaRef,
 };
 use chrono::{DateTime, Utc};
 use datafusion::catalog::TableProvider;
 use datafusion::common::arrow::array::RecordBatch;
+use datafusion::common::tree_node::{TransformedResult, TreeNode};
 use datafusion::common::{DFSchema, DataFusionError, ScalarValue};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::execution::memory_pool::MemoryLimit;
+use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
 use datafusion::physical_plan::{PhysicalExpr, displayable};
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use dbsp::circuit::tokio::TOKIO;
@@ -1167,6 +1171,21 @@ fn reserved_change_type_column(schema: &ArrowSchema) -> Option<&str> {
         .find(|name| name.eq_ignore_ascii_case(CHANGE_TYPE_COLUMN))
 }
 
+/// Iterate a string column as `Option<&str>`, whichever width of string array
+/// the read produced.
+///
+/// A read schema asks for view types ([`ReadSchema`]), so a string column
+/// arrives as `Utf8View`; a reader that binds `Utf8` cannot read it. `None`
+/// means the column is not a string at all.
+fn string_column_iter(column: &ArrayRef) -> Option<Box<dyn Iterator<Item = Option<&str>> + '_>> {
+    match column.data_type() {
+        ArrowDataType::Utf8 => Some(Box::new(column.as_string::<i32>().iter())),
+        ArrowDataType::LargeUtf8 => Some(Box::new(column.as_string::<i64>().iter())),
+        ArrowDataType::Utf8View => Some(Box::new(column.as_string_view().iter())),
+        _ => None,
+    }
+}
+
 /// Split `batch` into its table columns and one polarity per row, taken from the
 /// change feed's [`CHANGE_TYPE_COLUMN`].
 ///
@@ -1180,15 +1199,14 @@ fn take_change_type_polarities(mut batch: RecordBatch) -> AnyResult<(RecordBatch
         )
     })?;
     let column = batch.remove_column(index);
-    let change_types = column.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+    let change_types = string_column_iter(&column).ok_or_else(|| {
         anyhow!(
-            "internal error reading the Delta change data feed; {REPORT_ERROR}: column '{CHANGE_TYPE_COLUMN}' has type {:?}, expected Utf8",
+            "internal error reading the Delta change data feed; {REPORT_ERROR}: column '{CHANGE_TYPE_COLUMN}' has type {:?}, expected a string column",
             column.data_type()
         )
     })?;
 
     let polarities = change_types
-        .into_iter()
         .map(|change_type| match change_type {
             Some("insert") | Some("update_postimage") => Ok(true),
             Some("delete") | Some("update_preimage") => Ok(false),
@@ -2592,6 +2610,18 @@ impl DeltaTableInputEndpointInner {
                 anyhow!("invalid 'cdc_delete_filter' expression '{delete_filter}': {e}")
             })?;
 
+        // Coerce the expression's types the way the logical analyzer does for a
+        // planned predicate. Compiling a physical expression directly skips that
+        // pass, and then a literal keeps whatever type the parser gave it: a
+        // `Utf8` literal compared against a `Utf8View` column reaches the Arrow
+        // kernel as "Invalid comparison operation: Utf8View == Utf8".
+        let filter_expr = filter_expr
+            .rewrite(&mut TypeCoercionRewriter::new(schema))
+            .data()
+            .map_err(|e| {
+                anyhow!("cannot compile 'cdc_delete_filter' expression '{delete_filter}': {e}")
+            })?;
+
         let physical_expr = DefaultPhysicalPlanner::default()
             .create_physical_expr(&filter_expr, schema, &self.datafusion.state())
             .map_err(|e| {
@@ -3398,7 +3428,7 @@ impl DeltaTableInputEndpointInner {
         &self,
         table: &DeltaTable,
         group: &[&AddCdcAction],
-        read_schema: &SchemaRef,
+        read_schema: &ReadSchema,
         description: &str,
     ) -> AnyResult<DataFrame> {
         let read = |provider: Arc<dyn TableProvider>| {
@@ -3449,16 +3479,16 @@ impl DeltaTableInputEndpointInner {
     /// Arrow schema for reading a change data file: the table's own columns as
     /// [`physical_read_schema`](Self::physical_read_schema) names them, plus the
     /// [`CHANGE_TYPE_COLUMN`] that only these files carry.
-    fn change_data_read_schema(&self) -> AnyResult<SchemaRef> {
+    fn change_data_read_schema(&self) -> AnyResult<ReadSchema> {
         let table_schema = self.physical_read_schema(|_| true)?;
-        let mut fields: Vec<FieldRef> = table_schema.fields().to_vec();
+        let mut fields: Vec<FieldRef> = table_schema.schema().fields().to_vec();
         fields.push(Arc::new(ArrowField::new(
             CHANGE_TYPE_COLUMN,
             ArrowDataType::Utf8,
             true,
         )));
-        Ok(Arc::new(
-            ArrowSchema::new(fields).with_metadata(table_schema.metadata().clone()),
+        Ok(ReadSchema::new(
+            &ArrowSchema::new(fields).with_metadata(table_schema.schema().metadata().clone()),
         ))
     }
 
@@ -3864,7 +3894,10 @@ impl DeltaTableInputEndpointInner {
     ///
     /// Partition columns are always excluded: Delta never stores them in the data
     /// file.
-    fn physical_read_schema(&self, keep: impl Fn(&str) -> bool) -> AnyResult<SchemaRef> {
+    ///
+    /// The result is a [`ReadSchema`], so string and binary columns are read as
+    /// view types and a decoded batch is not capped at 2 GiB per column.
+    fn physical_read_schema(&self, keep: impl Fn(&str) -> bool) -> AnyResult<ReadSchema> {
         let logical = self.logical_schema()?;
         let partition_columns = self.partition_columns()?;
         let fields: Vec<FieldRef> = logical
@@ -3873,8 +3906,8 @@ impl DeltaTableInputEndpointInner {
             .filter(|f| keep(f.name()) && !partition_columns.contains(f.name()))
             .map(field_to_physical)
             .collect();
-        Ok(Arc::new(
-            ArrowSchema::new(fields).with_metadata(logical.metadata().clone()),
+        Ok(ReadSchema::new(
+            &ArrowSchema::new(fields).with_metadata(logical.metadata().clone()),
         ))
     }
 
@@ -3918,7 +3951,7 @@ impl DeltaTableInputEndpointInner {
     async fn create_parquet_table(
         &self,
         urls: Vec<ListingTableUrl>,
-        schema: SchemaRef,
+        schema: ReadSchema,
         description: &str,
     ) -> AnyResult<ListingTable> {
         let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
@@ -3926,7 +3959,7 @@ impl DeltaTableInputEndpointInner {
 
         let table_config = ListingTableConfig::new_with_multi_paths(urls)
             .with_listing_options(listing_options)
-            .with_schema(schema);
+            .with_schema(Arc::clone(schema.schema()));
 
         ListingTable::try_new(table_config).map_err(|e| {
             anyhow!("internal error processing {description}; {REPORT_ERROR}; error creating Parquet table: {e}")
@@ -3955,7 +3988,7 @@ impl DeltaTableInputEndpointInner {
         path: &str,
         bitmap: RoaringTreemap,
         mode: ReadMode,
-        read_schema: SchemaRef,
+        read_schema: ReadSchema,
     ) -> AnyResult<Arc<dyn TableProvider>> {
         // delta-rs already decoded the log's URL-encoded path, so `path` is the
         // object-store key as written.
@@ -4409,24 +4442,79 @@ mod format_datafusion_error_tests {
 #[cfg(test)]
 mod change_type_tests {
     use super::*;
-    use arrow::array::{Int64Array, StringArray};
+    use arrow::array::{Int64Array, LargeStringArray, StringArray, StringViewArray};
     use std::sync::Arc;
 
+    /// Every width of string array a read can produce for `_change_type`.
+    const STRING_TYPES: [ArrowDataType; 3] = [
+        ArrowDataType::Utf8,
+        ArrowDataType::LargeUtf8,
+        ArrowDataType::Utf8View,
+    ];
+
     /// A batch of `id` values tagged with `change_types`, shaped like a change
-    /// data file: the table's columns followed by `_change_type`.
-    fn batch(change_types: Vec<Option<&str>>) -> RecordBatch {
+    /// data file: the table's columns followed by `_change_type` stored as
+    /// `string_type`.
+    fn batch_typed(change_types: Vec<Option<&str>>, string_type: &ArrowDataType) -> RecordBatch {
         let ids: Vec<i64> = (0..change_types.len() as i64).collect();
+        let column: ArrayRef = match string_type {
+            ArrowDataType::Utf8 => Arc::new(StringArray::from(change_types)),
+            ArrowDataType::LargeUtf8 => Arc::new(LargeStringArray::from(change_types)),
+            ArrowDataType::Utf8View => Arc::new(StringViewArray::from(change_types)),
+            other => panic!("{other:?} is not a string type"),
+        };
         RecordBatch::try_new(
             Arc::new(ArrowSchema::new(vec![
                 ArrowField::new("id", ArrowDataType::Int64, false),
-                ArrowField::new(CHANGE_TYPE_COLUMN, ArrowDataType::Utf8, true),
+                ArrowField::new(CHANGE_TYPE_COLUMN, string_type.clone(), true),
             ])),
-            vec![
-                Arc::new(Int64Array::from(ids)),
-                Arc::new(StringArray::from(change_types)),
-            ],
+            vec![Arc::new(Int64Array::from(ids)), column],
         )
         .unwrap()
+    }
+
+    fn batch(change_types: Vec<Option<&str>>) -> RecordBatch {
+        batch_typed(change_types, &ArrowDataType::Utf8)
+    }
+
+    /// The polarity mapping reads `_change_type` at any string width. A read
+    /// schema asks for view types, so this column arrives as `Utf8View` and a
+    /// reader bound to `Utf8` would reject every change data file.
+    #[test]
+    fn change_types_read_at_every_string_width() {
+        for string_type in STRING_TYPES {
+            let (batch, polarities) = take_change_type_polarities(batch_typed(
+                vec![Some("insert"), Some("delete")],
+                &string_type,
+            ))
+            .unwrap_or_else(|e| panic!("{string_type:?} column must be readable: {e}"));
+
+            assert_eq!(polarities, vec![true, false], "at {string_type:?}");
+            assert_eq!(batch.num_rows(), 2, "at {string_type:?}");
+        }
+    }
+
+    /// A column that is not a string at all is an error naming its type, so
+    /// widening the reader did not lose the type check.
+    #[test]
+    fn non_string_change_type_column_is_an_error() {
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                CHANGE_TYPE_COLUMN,
+                ArrowDataType::Int64,
+                true,
+            )])),
+            vec![Arc::new(Int64Array::from(vec![1i64]))],
+        )
+        .unwrap();
+
+        let error = take_change_type_polarities(batch)
+            .expect_err("a non-string change type column must not be ingested")
+            .to_string();
+        assert!(
+            error.contains(CHANGE_TYPE_COLUMN) && error.contains("Int64"),
+            "the error must name the column and its type; got: {error}"
+        );
     }
 
     /// Each `_change_type` the protocol defines maps to a polarity: `insert` and
@@ -4654,7 +4742,9 @@ mod is_skippable_tests {
 #[cfg(test)]
 mod column_mapping_tests {
     use super::{field_to_physical, nested_physical_to_logical, relabel_nested_columns};
-    use arrow::array::{ArrayRef, ListArray, RecordBatch, StringArray, StructArray};
+    use arrow::array::{
+        ArrayRef, ListArray, RecordBatch, StringArray, StringViewArray, StructArray,
+    };
     use arrow::buffer::OffsetBuffer;
     use arrow::datatypes::{DataType, Field, Fields, Schema};
     use std::collections::HashMap;
@@ -4666,6 +4756,45 @@ mod column_mapping_tests {
             "delta.columnMapping.physicalName".to_string(),
             physical.to_string(),
         )]))
+    }
+
+    /// Relabeling rebuilds each column's `ArrayData` with renamed fields, and a
+    /// view array's layout is several data buffers behind a buffer of views
+    /// rather than one values buffer behind offsets. Since reads ask for view
+    /// types, a column-mapped nested string column arrives here as one, so the
+    /// rebuild has to carry that layout through untouched.
+    #[test]
+    fn relabel_carries_view_arrays_through() {
+        let ids: ArrayRef = Arc::new(StringViewArray::from(vec!["t1", "t2"]));
+        let after: ArrayRef = Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("col-id", DataType::Utf8View, true)),
+            ids.clone(),
+        )]));
+        let batch = RecordBatch::try_from_iter(vec![("after", after)]).unwrap();
+
+        let map = nested_physical_to_logical(&Schema::new(vec![mapped(
+            "after",
+            struct_of(vec![mapped("id", DataType::Utf8View, "col-id")]),
+            "col-after",
+        )]));
+        let relabeled = relabel_nested_columns(&batch, &map).unwrap();
+
+        let DataType::Struct(children) = relabeled.schema().field(0).data_type().clone() else {
+            panic!("`after` must stay a struct");
+        };
+        assert_eq!(children[0].name(), "id");
+        assert_eq!(
+            children[0].data_type(),
+            &DataType::Utf8View,
+            "relabeling renames fields, it must not change their types"
+        );
+
+        let after = relabeled
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(after.column(0).as_ref(), ids.as_ref());
     }
 
     /// A `struct<..>` data type from mapped fields.
@@ -4862,7 +4991,7 @@ mod column_mapping_tests {
 #[cfg(test)]
 mod partition_projection_tests {
     use super::*;
-    use arrow::array::Int64Array;
+    use arrow::array::{Int64Array, StringArray};
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;
 
@@ -5120,6 +5249,122 @@ mod read_schema_tests {
         Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "s", data_type, false,
         )]))
+    }
+
+    /// A `Utf8` read schema caps one batch at 2 GiB for that column: the reader
+    /// gives up rather than build an array whose 32-bit offsets would overflow.
+    /// `Utf8View` has no such ceiling.
+    ///
+    /// Ignored because it has to allocate past `i32::MAX` to prove it. Run with
+    /// `cargo test -p dbsp_adapters --lib read_schema_lifts -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn read_schema_lifts_the_two_gib_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        // 8192 x 300 KiB = 2.5 GiB decoded, from a 300 KB file: one distinct
+        // value, dictionary-encoded, referenced by every row.
+        let value = "x".repeat(300 * 1024);
+        let values: Vec<&str> = vec![value.as_str(); 8192];
+        let path = write_parquet(dir.path(), &values, 128);
+
+        let error = read_one_batch(&path, schema_of(ArrowDataType::Utf8), false, 8192)
+            .await
+            .expect_err("2.5 GiB does not fit a Utf8 array");
+        assert!(
+            error
+                .to_string()
+                .contains("index overflow decoding byte array"),
+            "expected the 32-bit offset overflow; got: {error}"
+        );
+
+        let batch = read_one_batch(&path, schema_of(ArrowDataType::Utf8View), false, 8192)
+            .await
+            .expect("a view array has no 2 GiB ceiling");
+        assert_eq!(batch.num_rows(), 8192);
+        assert_eq!(batch.column(0).data_type(), &ArrowDataType::Utf8View);
+    }
+
+    /// A view read schema does not copy a dictionary-encoded value once per row,
+    /// it references the dictionary page's buffer. That is what keeps a small
+    /// file from decoding into gigabytes, so the saving is the point, not an
+    /// incidental optimization.
+    ///
+    /// Sized to stay small: 1024 rows of one 64 KiB value is 64 MiB inlined.
+    #[tokio::test]
+    async fn read_schema_does_not_expand_repeated_values() {
+        let dir = tempfile::tempdir().unwrap();
+        const ROWS: usize = 1024;
+        const VALUE_LEN: usize = 64 * 1024;
+        let value = "x".repeat(VALUE_LEN);
+        let values: Vec<&str> = vec![value.as_str(); ROWS];
+        let path = write_parquet(dir.path(), &values, 128);
+
+        let inlined = read_one_batch(&path, schema_of(ArrowDataType::Utf8), false, ROWS)
+            .await
+            .unwrap();
+        let viewed = read_one_batch(&path, schema_of(ArrowDataType::Utf8View), false, ROWS)
+            .await
+            .unwrap();
+
+        assert_eq!(inlined.num_rows(), ROWS);
+        assert_eq!(viewed.num_rows(), ROWS);
+        assert_eq!(viewed.column(0).data_type(), &ArrowDataType::Utf8View);
+
+        let inlined_bytes = inlined.column(0).get_array_memory_size();
+        let viewed_bytes = viewed.column(0).get_array_memory_size();
+        assert!(
+            inlined_bytes >= ROWS * VALUE_LEN,
+            "Utf8 must inline every repeat; got {inlined_bytes} bytes"
+        );
+        assert!(
+            viewed_bytes < inlined_bytes / 50,
+            "Utf8View must reference the dictionary page, not copy it; \
+             got {viewed_bytes} bytes against {inlined_bytes} inlined"
+        );
+    }
+
+    /// Every string and binary type becomes its view counterpart at every depth,
+    /// and nothing else changes: the Parquet reader validates a supplied schema
+    /// field by field, so a stray difference in name, nullability or any other
+    /// type would be rejected outright.
+    #[test]
+    fn read_schema_rewrites_only_string_and_binary_types() {
+        let element = Arc::new(ArrowField::new("item", ArrowDataType::Utf8, true));
+        let nested = ArrowDataType::Struct(
+            vec![
+                Arc::new(ArrowField::new("s", ArrowDataType::LargeUtf8, false)),
+                Arc::new(ArrowField::new("b", ArrowDataType::LargeBinary, true)),
+                Arc::new(ArrowField::new("n", ArrowDataType::Int64, true)),
+                Arc::new(ArrowField::new("l", ArrowDataType::List(element), true)),
+            ]
+            .into(),
+        );
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("plain", ArrowDataType::Utf8, false),
+            ArrowField::new("bin", ArrowDataType::Binary, true),
+            ArrowField::new("num", ArrowDataType::Float64, true),
+            ArrowField::new("nested", nested, true),
+        ]);
+
+        let viewed = ReadSchema::new(&schema);
+        let viewed = viewed.schema();
+
+        assert_eq!(viewed.field(0).data_type(), &ArrowDataType::Utf8View);
+        assert!(!viewed.field(0).is_nullable());
+        assert_eq!(viewed.field(1).data_type(), &ArrowDataType::BinaryView);
+        assert_eq!(viewed.field(2).data_type(), &ArrowDataType::Float64);
+        let ArrowDataType::Struct(fields) = viewed.field(3).data_type() else {
+            panic!("the nested field must stay a struct");
+        };
+        assert_eq!(fields[0].data_type(), &ArrowDataType::Utf8View);
+        assert_eq!(fields[1].data_type(), &ArrowDataType::BinaryView);
+        assert_eq!(fields[2].data_type(), &ArrowDataType::Int64);
+        let ArrowDataType::List(item) = fields[3].data_type() else {
+            panic!("the list field must stay a list");
+        };
+        assert_eq!(item.data_type(), &ArrowDataType::Utf8View);
+        assert_eq!(item.name(), "item");
+        assert!(item.is_nullable());
     }
 
     /// `schema_force_view_types` cannot reach the connector's reads, whichever

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1,7 +1,7 @@
 use crate::catalog::{ArrowStream, InputCollectionHandle};
 use crate::format::InputBuffer;
 use crate::integrated::delta_table::deletion_vector::{
-    ReadMode, filtered_parquet_table, read_deletion_vector,
+    MaskedFile, ReadMode, filtered_parquet_table, read_deletion_vector,
 };
 use crate::integrated::delta_table::{
     ReadSchema, delta_input_serde_config, register_storage_handlers,
@@ -1290,6 +1290,17 @@ struct CatchupFollowState {
     /// Label for the current Feldera transaction, if one has been started.
     transaction: Option<Option<String>>,
 }
+
+/// A CDC file whose active deletion vector must be applied as it is read.
+type MaskedCdcFile<'a> = (&'a CdcFile<'a>, &'a DeletionVectorDescriptor);
+
+/// A file's partition values in `partition_value_keys` order, as the key that
+/// groups files reading together.
+///
+/// The outer `Option` is load-bearing: a log that omits a partition column is
+/// not a log that records it as NULL, and grouping the two together would let
+/// whichever file the log listed first decide the value for both.
+type PartitionKey = Vec<Option<Option<String>>>;
 
 /// One data file of a CDC transaction, as the log describes it.
 struct CdcFile<'a> {
@@ -3664,13 +3675,18 @@ impl DeltaTableInputEndpointInner {
     /// One frame over the change data files of a single partition.
     ///
     /// A `uc://` table's location has no path for a [`ListingTable`] to resolve,
-    /// so its files are read through the object store one at a time and unioned;
-    /// this is the same split [`add_with_polarity`](Self::add_with_polarity)
-    /// makes, and the reason it exists is the same: a listing needs a directory,
-    /// and a Unity Catalog location is not one.
+    /// so its files are read through the object store instead; this is the same
+    /// split [`add_with_polarity`](Self::add_with_polarity) makes, and the
+    /// reason it exists is the same: a listing needs a directory, and a Unity
+    /// Catalog location is not one.
     ///
-    /// Every other scheme reads the whole group in one listing, which lets
-    /// DataFusion parallelize across its files.
+    /// Both routes read the whole group through a single provider, and both
+    /// spread its files over at most `target_partitions` readers. The object
+    /// store route used to build one provider per file and union them, which
+    /// read nothing one at a time: a plan's partitions all run at once, so a
+    /// commit of a few hundred change data files held a few hundred Parquet
+    /// readers open, one per file, each with its own per-column state that no
+    /// batch size reaches.
     async fn change_data_group_dataframe(
         &self,
         table: &DeltaTable,
@@ -3697,30 +3713,22 @@ impl DeltaTableInputEndpointInner {
 
         // An empty bitmap reads every row: a change data file never carries a
         // deletion vector, and the protocol gives it no field to carry one in.
-        let mut dfs = Vec::with_capacity(group.len());
-        for file in group {
-            let provider = self
-                .file_provider(
-                    table,
-                    &file.path,
-                    RoaringTreemap::new(),
-                    ReadMode::NotInBitmap,
-                    read_schema.clone(),
-                )
-                .await?;
-            dfs.push(read(provider)?);
-        }
-
-        let mut dfs = dfs.into_iter();
-        // A group exists only because a file was put in it.
-        let first = dfs
-            .next()
-            .expect("a partition group holds at least one file");
-        dfs.try_fold(first, |acc, df| {
-            acc.union(df).map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error combining change data files: {e}")
-            })
-        })
+        //
+        // One provider covers the whole group. Reading each file through its own
+        // provider and unioning them gave the plan one partition per file, all
+        // of which DataFusion then drove at once, so a commit of a few hundred
+        // change data files held a few hundred Parquet readers open.
+        let provider = self
+            .file_provider(
+                table,
+                group
+                    .iter()
+                    .map(|file| (file.path.as_str(), RoaringTreemap::new())),
+                ReadMode::NotInBitmap,
+                read_schema.clone(),
+            )
+            .await?;
+        read(provider)
     }
 
     /// Arrow schema for reading a change data file: the table's own columns as
@@ -4247,22 +4255,30 @@ impl DeltaTableInputEndpointInner {
     async fn file_provider(
         &self,
         table: &DeltaTable,
-        path: &str,
-        bitmap: RoaringTreemap,
+        files: impl IntoIterator<Item = (&str, RoaringTreemap)>,
         mode: ReadMode,
         read_schema: ReadSchema,
     ) -> AnyResult<Arc<dyn TableProvider>> {
-        // delta-rs already decoded the log's URL-encoded path, so `path` is the
-        // object-store key as written.
-        let file_path = Path::parse(path)
-            .map_err(|e| anyhow!("invalid file path '{path}' in Delta log action: {e}"))?;
+        // delta-rs already decoded the log's URL-encoded path, so each path is
+        // the object-store key as written.
+        let files = files
+            .into_iter()
+            .map(|(path, bitmap)| {
+                Ok(MaskedFile {
+                    path: Path::parse(path).map_err(|e| {
+                        anyhow!("invalid file path '{path}' in Delta log action: {e}")
+                    })?,
+                    bitmap,
+                })
+            })
+            .collect::<AnyResult<Vec<_>>>()?;
 
         filtered_parquet_table(
             table.log_store().object_store(None),
-            file_path,
-            bitmap,
+            files,
             read_schema,
             mode,
+            self.datafusion.copied_config().target_partitions(),
         )
         .await
     }
@@ -4312,31 +4328,24 @@ impl DeltaTableInputEndpointInner {
         files: &[CdcFile<'_>],
         description: &str,
     ) -> AnyResult<Option<DataFrame>> {
-        // Split by read strategy: files with an active DV are masked one by
-        // one; the rest are read together in one listing, grouped by partition
-        // so each group's constant partition columns apply to all its files.
-        // The key keeps the outer `Option`: a log that omits a partition column
-        // is not a log that records it as NULL, and grouping the two together
-        // would let whichever file the log listed first decide for both.
-        let mut plain: BTreeMap<Vec<Option<Option<String>>>, Vec<&CdcFile<'_>>> = BTreeMap::new();
-        let mut masked: Vec<(&CdcFile<'_>, &DeletionVectorDescriptor)> = Vec::new();
+        // Split by read strategy: files with an active DV are masked, the rest
+        // are read through a listing. Both sides group by partition values, so
+        // each group's constant partition columns apply to all its files.
+        let mut plain: BTreeMap<PartitionKey, Vec<&CdcFile<'_>>> = BTreeMap::new();
+        let mut masked: BTreeMap<PartitionKey, Vec<MaskedCdcFile<'_>>> = BTreeMap::new();
         let partition_keys = self.partition_value_keys()?;
         for file in files {
+            let key: PartitionKey = partition_keys
+                .iter()
+                .map(|key| {
+                    file.partition_values
+                        .and_then(|values| values.get(key))
+                        .cloned()
+                })
+                .collect();
             match file.deletion_vector.filter(|d| is_active_dv(d)) {
-                Some(dv) => masked.push((file, dv)),
-                None => plain
-                    .entry(
-                        partition_keys
-                            .iter()
-                            .map(|key| {
-                                file.partition_values
-                                    .and_then(|values| values.get(key))
-                                    .cloned()
-                            })
-                            .collect(),
-                    )
-                    .or_default()
-                    .push(file),
+                Some(dv) => masked.entry(key).or_default().push((file, dv)),
+                None => plain.entry(key).or_default().push(file),
             }
         }
 
@@ -4363,25 +4372,39 @@ impl DeltaTableInputEndpointInner {
             })?);
         }
 
-        for (file, dv) in masked {
-            let path = file.path;
+        // Each masked group reads through one provider rather than one per
+        // file, which is what bounds how many of their Parquet readers are open
+        // at once: the plan drives every partition it has concurrently, so one
+        // provider per file left the count unbounded.
+        for group in masked.values() {
             // Read the same column set as the plain side; both are projected
             // again below, after the partition columns go back in.
-            let bitmap = self.decode_dv(table, Some(dv), description).await?;
+            let mut files = Vec::with_capacity(group.len());
+            for (file, dv) in group {
+                files.push((
+                    file.path,
+                    self.decode_dv(table, Some(*dv), description).await?,
+                ));
+            }
             let provider = self
                 .file_provider(
                     table,
-                    path,
-                    bitmap,
+                    files,
                     ReadMode::NotInBitmap,
                     self.physical_read_schema(|name| self.keeps_cdc_column(name))?,
                 )
                 .await?;
             let df = self.datafusion.read_table(provider).map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading masked file '{path}': {e}")
+                anyhow!(
+                    "internal error processing {description}; {REPORT_ERROR}; error reading masked files {}: {e}",
+                    describe_paths(group.iter().map(|(file, _)| file.path))
+                )
             })?;
             let df = self.project_physical_to_logical(df)?;
-            let df = self.add_partition_columns(df, file.partition_values, &[], description)?;
+            // Every file in the group agrees on its partition values, so the
+            // first one speaks for all of them, as on the plain side.
+            let df =
+                self.add_partition_columns(df, group[0].0.partition_values, &[], description)?;
             dfs.push(self.project_cdc_columns(df).map_err(|e| {
                 anyhow!("internal error processing {description}; {REPORT_ERROR}; {e}")
             })?);
@@ -4488,8 +4511,7 @@ impl DeltaTableInputEndpointInner {
             };
             self.file_provider(
                 table,
-                path,
-                bitmap,
+                [(path, bitmap)],
                 ReadMode::NotInBitmap,
                 self.physical_read_schema(|name| self.needs_column(name))?,
             )
@@ -4548,8 +4570,7 @@ impl DeltaTableInputEndpointInner {
                 let provider = self
                     .file_provider(
                         table,
-                        path,
-                        positions.clone(),
+                        [(path, positions.clone())],
                         ReadMode::InBitmap,
                         self.physical_read_schema(|name| self.needs_column(name))?,
                     )

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -142,6 +142,25 @@ fn format_datafusion_error(
     }
 }
 
+/// A positive integer from the environment variable `name`, or `None` when it
+/// is unset or does not hold one.
+///
+/// These are process-wide overrides, so they apply to every Delta Lake
+/// connector in the pipeline. A connector setting of the same meaning takes
+/// precedence.
+fn env_override(endpoint_name: &str, name: &str) -> Option<usize> {
+    let value = std::env::var(name).ok()?;
+    match value.parse::<usize>() {
+        Ok(n) if n > 0 => Some(n),
+        _ => {
+            warn!(
+                "delta_table {endpoint_name}: ignoring {name}={value:?}; expected a positive integer"
+            );
+            None
+        }
+    }
+}
+
 /// Total decoded bytes a single read may hold across all the files it decodes
 /// at once.
 ///
@@ -597,55 +616,40 @@ impl DeltaTableInputEndpoint {
     ) -> Self {
         register_storage_handlers();
 
-        // if `DELTA_DF_TARGET_PARTITIONS` env var (process-wide override) is set,
-        // override default target partitions with that value. Target partitions
-        // controls the number of parallel tasks DataFusion uses for scanning during the
-        // snapshot phase.
-        let env_target_partitions = match std::env::var("DELTA_DF_TARGET_PARTITIONS").ok() {
-            None => None,
-            Some(s) => match s.parse::<usize>() {
-                Ok(n) if n > 0 => Some(n),
-                _ => {
-                    warn!(
-                        "delta_table {endpoint_name}: ignoring DELTA_DF_TARGET_PARTITIONS={s:?}; expected a positive integer"
-                    );
-                    None
-                }
-            },
-        };
-        if let Some(n) = env_target_partitions {
-            info!("delta_table {endpoint_name}: DELTA_DF_TARGET_PARTITIONS={n} overriding default");
+        // `scan_parallelism` controls how many files DataFusion decodes at once;
+        // `batch_size` how many rows each decoded batch holds. Both are
+        // per-connector settings, each falling back to a process-wide env var
+        // for the case where a running pipeline needs the knob without a
+        // config change.
+        let target_partitions = config
+            .scan_parallelism
+            .map(|n| n as usize)
+            .or_else(|| env_override(endpoint_name, "DELTA_DF_TARGET_PARTITIONS"));
+        if let Some(n) = target_partitions {
+            info!("delta_table {endpoint_name}: scanning {n} files at a time");
         }
 
-        let env_batch_size = match std::env::var("DELTA_DF_BATCH_SIZE").ok() {
-            None => None,
-            Some(s) => match s.parse::<usize>() {
-                Ok(n) if n > 0 => {
-                    info!("delta_table {endpoint_name}: applying DELTA_DF_BATCH_SIZE={n}");
-                    Some(n)
-                }
-                _ => {
-                    warn!(
-                        "delta_table {endpoint_name}: ignoring DELTA_DF_BATCH_SIZE={s:?}; expected a positive integer"
-                    );
-                    None
-                }
-            },
-        };
+        let batch_size = config
+            .batch_size
+            .map(|n| n as usize)
+            .or_else(|| env_override(endpoint_name, "DELTA_DF_BATCH_SIZE"));
+        if let Some(n) = batch_size {
+            info!("delta_table {endpoint_name}: decoding {n} rows per batch");
+        }
 
         // The `SessionContext` shares the pipeline-wide `RuntimeEnv` so that the
         // CDC-mode ORDER BY query spills to the same bounded memory pool and
         // on-disk scratch dir as every other datafusion user in the pipeline.
         //
         // `target_partitions` inherits `create_session_context_with`'s
-        // worker-derived default; only override if `DELTA_DF_TARGET_PARTITIONS`
-        // was set explicitly. Same for `batch_size`.
+        // worker-derived default, and `batch_size` DataFusion's, unless the
+        // connector configured them above.
         let datafusion = create_session_context_with(pipeline_config, runtime_env, |cfg| {
             let mut cfg = cfg;
-            if let Some(n) = env_target_partitions {
+            if let Some(n) = target_partitions {
                 cfg = cfg.set_usize("datafusion.execution.target_partitions", n);
             }
-            if let Some(n) = env_batch_size {
+            if let Some(n) = batch_size {
                 cfg = cfg.set_usize("datafusion.execution.batch_size", n);
             }
             cfg

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -140,6 +140,16 @@ fn format_datafusion_error(
     }
 }
 
+/// The suffix a read error carries to say which table version produced the data
+/// being read, or nothing when the read is not tied to one commit (the initial
+/// snapshot spans many).
+fn version_suffix(version: Option<i64>) -> String {
+    match version {
+        Some(version) => format!(" (table version: {version})"),
+        None => String::new(),
+    }
+}
+
 /// Render up to [`DESCRIBED_PATHS`] of `paths` for a log message, followed by a
 /// count of the rest.
 ///
@@ -2844,6 +2854,9 @@ impl DeltaTableInputEndpointInner {
     ///
     /// * `max_retries` - the maximum number of retries to attempt if the function fails to read the log entry.
     ///
+    /// * `version` - the table version whose data is being read, named in the
+    ///   error message. `None` for the initial snapshot, which spans many.
+    ///
     /// Returns the total number of records processed.
     ///
     /// Returns an error if the function fails to read the log entry after performing the configured
@@ -2865,7 +2878,7 @@ impl DeltaTableInputEndpointInner {
         receiver: &mut Receiver<PipelineState>,
         transaction: Option<Option<String>>,
         max_retries: u32,
-        current_table_version: Option<i64>,
+        version: Option<i64>,
     ) -> Result<usize, AnyError> {
         let mut retry_count = 0;
         loop {
@@ -2889,11 +2902,7 @@ impl DeltaTableInputEndpointInner {
                     if retry_count - 1 == max_retries {
                         let message = format!(
                             "error retrieving {descr} after {retry_count} attempts{}: {e}",
-                            if let Some(version) = current_table_version {
-                                format!(" (current table version: {version})")
-                            } else {
-                                String::new()
-                            }
+                            version_suffix(version)
                         );
                         self.consumer
                             .update_connector_health(ConnectorHealth::unhealthy(&message));
@@ -2903,11 +2912,7 @@ impl DeltaTableInputEndpointInner {
 
                     let message = format!(
                         "error retrieving {descr} after {retry_count} attempts{}: {e}; retrying in {backoff_delay:?}",
-                        if let Some(version) = current_table_version {
-                            format!(" (current table version: {version})")
-                        } else {
-                            String::new()
-                        }
+                        version_suffix(version)
                     );
                     self.consumer
                         .update_connector_health(ConnectorHealth::unhealthy(&message));
@@ -3161,8 +3166,15 @@ impl DeltaTableInputEndpointInner {
         let timestamp = Utc::now();
 
         if self.config.is_cdc() {
-            self.process_cdc_transaction(actions, table, input_stream, receiver, start_transaction)
-                .await?;
+            self.process_cdc_transaction(
+                actions,
+                new_version,
+                table,
+                input_stream,
+                receiver,
+                start_transaction,
+            )
+            .await?;
         } else if self.config.reads_change_feed() {
             self.process_change_feed_log_entry(
                 new_version,
@@ -3174,8 +3186,15 @@ impl DeltaTableInputEndpointInner {
             )
             .await?;
         } else {
-            self.process_follow_actions(actions, table, input_stream, receiver, start_transaction)
-                .await?;
+            self.process_follow_actions(
+                actions,
+                new_version,
+                table,
+                input_stream,
+                receiver,
+                start_transaction,
+            )
+            .await?;
         }
 
         // Empty buffer to indicate checkpointable state.
@@ -3205,6 +3224,7 @@ impl DeltaTableInputEndpointInner {
     async fn process_follow_actions(
         &self,
         actions: &[Action],
+        version: i64,
         table: &DeltaTable,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
@@ -3282,6 +3302,7 @@ impl DeltaTableInputEndpointInner {
                     remove.partition_values.as_ref(),
                     newly_deleted,
                     false,
+                    version,
                     table,
                     &used_columns,
                     input_stream,
@@ -3303,6 +3324,7 @@ impl DeltaTableInputEndpointInner {
                     Some(&add.partition_values),
                     restored,
                     true,
+                    version,
                     table,
                     &used_columns,
                     input_stream,
@@ -3350,7 +3372,14 @@ impl DeltaTableInputEndpointInner {
                 .commits_from_file_actions
                 .fetch_add(1, Ordering::Relaxed);
             return self
-                .process_follow_actions(actions, table, input_stream, receiver, start_transaction)
+                .process_follow_actions(
+                    actions,
+                    new_version,
+                    table,
+                    input_stream,
+                    receiver,
+                    start_transaction,
+                )
                 .await;
         }
         self.metrics
@@ -3427,7 +3456,7 @@ impl DeltaTableInputEndpointInner {
                 receiver,
                 start_transaction.clone(),
                 self.config.max_retries(),
-                table.version().map(|v| v as i64),
+                Some(new_version),
             )
             .await?;
         }
@@ -3556,6 +3585,7 @@ impl DeltaTableInputEndpointInner {
     async fn process_cdc_transaction(
         &self,
         actions: &[Action],
+        version: i64,
         table: &DeltaTable,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
@@ -3672,7 +3702,7 @@ impl DeltaTableInputEndpointInner {
                 receiver,
                 start_transaction,
                 self.config.max_retries(),
-                table.version().map(|v| v as i64),
+                Some(version),
             )
             .await?;
 
@@ -4159,9 +4189,11 @@ impl DeltaTableInputEndpointInner {
         Ok(Some(df))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_action(
         &self,
         action: &Action,
+        version: i64,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -4175,6 +4207,7 @@ impl DeltaTableInputEndpointInner {
                     true,
                     add.deletion_vector.as_ref(),
                     Some(&add.partition_values),
+                    version,
                     table,
                     used_columns,
                     input_stream,
@@ -4191,6 +4224,7 @@ impl DeltaTableInputEndpointInner {
                     false,
                     remove.deletion_vector.as_ref(),
                     remove.partition_values.as_ref(),
+                    version,
                     table,
                     used_columns,
                     input_stream,
@@ -4217,6 +4251,7 @@ impl DeltaTableInputEndpointInner {
         polarity: bool,
         deletion_vector: Option<&DeletionVectorDescriptor>,
         partition_values: Option<&HashMap<String, Option<String>>>,
+        version: i64,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -4260,7 +4295,7 @@ impl DeltaTableInputEndpointInner {
             used_columns,
             partition_values,
             &description,
-            table,
+            version,
             input_stream,
             receiver,
             start_transaction,
@@ -4279,6 +4314,7 @@ impl DeltaTableInputEndpointInner {
         partition_values: Option<&HashMap<String, Option<String>>>,
         dv_delta: Option<&RoaringTreemap>,
         polarity: bool,
+        version: i64,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -4306,7 +4342,7 @@ impl DeltaTableInputEndpointInner {
                     used_columns,
                     partition_values,
                     &description,
-                    table,
+                    version,
                     input_stream,
                     receiver,
                     start_transaction,
@@ -4319,6 +4355,7 @@ impl DeltaTableInputEndpointInner {
             None => {
                 self.process_action(
                     action,
+                    version,
                     table,
                     used_columns,
                     input_stream,
@@ -4343,7 +4380,7 @@ impl DeltaTableInputEndpointInner {
         used_columns: &[&str],
         partition_values: Option<&HashMap<String, Option<String>>>,
         description: &str,
-        table: &DeltaTable,
+        version: i64,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
@@ -4371,7 +4408,7 @@ impl DeltaTableInputEndpointInner {
                 receiver,
                 start_transaction,
                 self.config.max_retries(),
-                table.version().map(|v| v as i64),
+                Some(version),
             )
             .await?;
 
@@ -5185,6 +5222,26 @@ mod change_data_feed_state_tests {
             ]),
             Some(true)
         );
+    }
+}
+
+#[cfg(test)]
+mod version_suffix_tests {
+    use super::*;
+
+    /// A version-scoped read names the commit it is reading. The follow loop
+    /// never reloads its table handle, so reporting `DeltaTable::version()`
+    /// here named the version the connector *started* from on every retry, and
+    /// sent whoever read the log to the wrong commit.
+    #[test]
+    fn a_version_is_named() {
+        assert_eq!(version_suffix(Some(107273)), " (table version: 107273)");
+    }
+
+    /// The initial snapshot spans many commits, so it names none.
+    #[test]
+    fn no_version_adds_nothing() {
+        assert_eq!(version_suffix(None), "");
     }
 }
 

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -140,6 +140,27 @@ fn format_datafusion_error(
     }
 }
 
+/// Render up to [`DESCRIBED_PATHS`] of `paths` for a log message, followed by a
+/// count of the rest.
+///
+/// A commit can add hundreds of files, and the description it produces is
+/// repeated on every retry of the read. Spelling out every path there once
+/// cost a customer a 7.5 KB log line every 44 seconds, which pushed everything
+/// else out of the pipeline's log buffer.
+fn describe_paths<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {
+    let mut paths = paths.into_iter();
+    let shown: Vec<&str> = paths.by_ref().take(DESCRIBED_PATHS).collect();
+    let rest = paths.count();
+    let mut description = format!("{shown:?}");
+    if rest > 0 {
+        description.push_str(&format!(" and {rest} more"));
+    }
+    description
+}
+
+/// How many file paths a read description names before summarizing the rest.
+const DESCRIBED_PATHS: usize = 3;
+
 /// Whether a `table_builder.load()` failure is transient and worth retrying.
 ///
 /// There is no strongly-typed way to identify these across the transitive
@@ -3340,8 +3361,8 @@ impl DeltaTableInputEndpointInner {
         // protocol requires a reader that finds change data files to take the
         // row-level changes from them alone. Reading both would double-count.
         let description = format!(
-            "change data files {:?}",
-            change_files.iter().map(|f| &f.path).collect::<Vec<_>>()
+            "change data files {}",
+            describe_paths(change_files.iter().map(|f| f.path.as_str()))
         );
 
         // Group files based on the values of partition columns (extracted from filenames).
@@ -3576,11 +3597,11 @@ impl DeltaTableInputEndpointInner {
         }
 
         let description = format!(
-            "CDC transaction with {} adds {:?} and {} removes {:?}",
+            "CDC transaction with {} adds {} and {} removes {}",
             adds.len(),
-            adds.iter().map(|a| &a.path).collect::<Vec<_>>(),
+            describe_paths(adds.iter().map(|a| a.path.as_str())),
             removes_by_path.len(),
-            removes_by_path.keys().collect::<Vec<_>>(),
+            describe_paths(removes_by_path.keys().copied()),
         );
 
         // Drop add/remove pairs on the same path (metadata-only rewrites).
@@ -5163,6 +5184,44 @@ mod change_data_feed_state_tests {
                 metadata(&[(ENABLE_CHANGE_DATA_FEED, "true")]),
             ]),
             Some(true)
+        );
+    }
+}
+
+#[cfg(test)]
+mod describe_paths_tests {
+    use super::*;
+
+    /// Up to `DESCRIBED_PATHS` paths are named in full.
+    #[test]
+    fn short_lists_are_named_in_full() {
+        assert_eq!(describe_paths(Vec::<&str>::new()), "[]");
+        assert_eq!(describe_paths(vec!["a", "b"]), r#"["a", "b"]"#);
+        assert_eq!(
+            describe_paths(vec!["a", "b", "c"]),
+            r#"["a", "b", "c"]"#,
+            "a list at the limit must not claim a remainder"
+        );
+    }
+
+    /// Past the limit the description stays a fixed size whatever the commit
+    /// touched, and still says how much it left out.
+    #[test]
+    fn long_lists_are_summarized() {
+        assert_eq!(
+            describe_paths(vec!["a", "b", "c", "d"]),
+            r#"["a", "b", "c"] and 1 more"#
+        );
+        let many: Vec<String> = (0..100).map(|i| format!("part-{i:05}.parquet")).collect();
+        let description = describe_paths(many.iter().map(String::as_str));
+        assert!(
+            description.ends_with("and 97 more"),
+            "expected a remainder count; got: {description}"
+        );
+        assert!(
+            description.len() < 120,
+            "the description must stay short; got {} chars",
+            description.len()
         );
     }
 }

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -91,10 +91,11 @@ const REPORT_ERROR: &str =
 static DELTA_READER_SEMAPHORE: std::sync::LazyLock<Semaphore> =
     std::sync::LazyLock::new(|| Semaphore::new(DEFAULT_MAX_CONCURRENT_READERS));
 
-/// Default cap for concurrent Delta object-store reads, used both as the
-/// initial token count for `DELTA_READER_SEMAPHORE` and as the fallback
-/// for DataFusion's `target_partitions` when neither
-/// `DELTA_DF_TARGET_PARTITIONS` nor `max_concurrent_readers` is set.
+/// Default cap for concurrent Delta object-store reads: the initial token count
+/// for `DELTA_READER_SEMAPHORE`, which bounds how many connector queries read at
+/// once. It does not bound the scan parallelism *within* one query; that is
+/// DataFusion's `target_partitions`, which `create_session_context_with` derives
+/// from `io_workers` / `workers` unless `DELTA_DF_TARGET_PARTITIONS` overrides it.
 const DEFAULT_MAX_CONCURRENT_READERS: usize = 6;
 
 /// Configured `max_concurrent_readers` value (0 = not set by any connector).
@@ -518,20 +519,15 @@ impl DeltaTableInputEndpoint {
             },
         };
 
-        // Configure datafusion not to generate Utf8View arrow types, which are
-        // not yet supported by the `serde_arrow` crate. The `SessionContext`
-        // shares the pipeline-wide `RuntimeEnv` so that the CDC-mode ORDER BY
-        // query spills to the same bounded memory pool and on-disk scratch
-        // dir as every other datafusion user in the pipeline.
+        // The `SessionContext` shares the pipeline-wide `RuntimeEnv` so that the
+        // CDC-mode ORDER BY query spills to the same bounded memory pool and
+        // on-disk scratch dir as every other datafusion user in the pipeline.
         //
         // `target_partitions` inherits `create_session_context_with`'s
         // worker-derived default; only override if `DELTA_DF_TARGET_PARTITIONS`
         // was set explicitly. Same for `batch_size`.
         let datafusion = create_session_context_with(pipeline_config, runtime_env, |cfg| {
-            let mut cfg = cfg.set_bool(
-                "datafusion.execution.parquet.schema_force_view_types",
-                false,
-            );
+            let mut cfg = cfg;
             if let Some(n) = env_target_partitions {
                 cfg = cfg.set_usize("datafusion.execution.target_partitions", n);
             }
@@ -5039,5 +5035,117 @@ mod change_data_feed_state_tests {
             ]),
             Some(true)
         );
+    }
+}
+
+/// How the Parquet reader decides the Arrow type of a string column, which is
+/// what bounds a decoded batch: `Utf8` carries 32-bit offsets and so caps one
+/// batch at 2 GiB per column, `Utf8View` does not.
+#[cfg(test)]
+mod read_schema_tests {
+    use super::*;
+    use arrow::array::{ArrayRef, StringArray};
+    use datafusion::prelude::SessionConfig;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use std::fs::File;
+    use std::path::{Path, PathBuf};
+
+    /// Write `values` as a single `Utf8` column named `s` and return the file's path.
+    ///
+    /// `rows_per_write` batches keep the writer's own buffers small while every
+    /// row still lands in one row group, so what the reader decodes in one batch
+    /// is decided by the read batch size alone.
+    fn write_parquet(dir: &Path, values: &[&str], rows_per_write: usize) -> PathBuf {
+        let path = dir.join("part-00000.parquet");
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "s",
+            ArrowDataType::Utf8,
+            false,
+        )]));
+        let props = WriterProperties::builder()
+            .set_dictionary_enabled(true)
+            .set_max_row_group_row_count(Some(values.len().max(1)))
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(File::create(&path).unwrap(), schema.clone(), Some(props))
+                .unwrap();
+        for chunk in values.chunks(rows_per_write) {
+            let column: ArrayRef = Arc::new(StringArray::from_iter_values(chunk.iter().copied()));
+            writer
+                .write(&RecordBatch::try_new(schema.clone(), vec![column]).unwrap())
+                .unwrap();
+        }
+        writer.close().unwrap();
+        path
+    }
+
+    /// Read `path` the way the connector reads a data file: one `ListingTable`
+    /// whose schema is supplied rather than inferred (see
+    /// [`DeltaTableInputEndpointInner::create_parquet_table`]).
+    ///
+    /// `force_view_types` sets the session option of the same name, and
+    /// `read_schema` is what the listing table declares.
+    async fn read_one_batch(
+        path: &Path,
+        read_schema: SchemaRef,
+        force_view_types: bool,
+        batch_size: usize,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let config = SessionConfig::new()
+            .set_bool(
+                "datafusion.execution.parquet.schema_force_view_types",
+                force_view_types,
+            )
+            .set_usize("datafusion.execution.batch_size", batch_size);
+        let ctx = SessionContext::new_with_config(config);
+
+        let url = ListingTableUrl::parse(format!("file://{}", path.display())).unwrap();
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_file_extension_opt(Some(".parquet"));
+        let table = ListingTable::try_new(
+            ListingTableConfig::new_with_multi_paths(vec![url])
+                .with_listing_options(listing_options)
+                .with_schema(read_schema),
+        )?;
+
+        let mut stream = ctx.read_table(Arc::new(table))?.execute_stream().await?;
+        stream
+            .next()
+            .await
+            .expect("the file holds at least one row")
+    }
+
+    fn schema_of(data_type: ArrowDataType) -> SchemaRef {
+        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "s", data_type, false,
+        )]))
+    }
+
+    /// `schema_force_view_types` cannot reach the connector's reads, whichever
+    /// way it is set: DataFusion consults it only when `ParquetFormat` *infers*
+    /// a schema, and every Delta read supplies one instead. The type follows the
+    /// supplied schema, which is why setting the option was a no-op and
+    /// [`DeltaTableInputEndpointInner::physical_read_schema`] is the real lever.
+    #[tokio::test]
+    async fn force_view_types_does_not_reach_a_supplied_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_parquet(dir.path(), &["a", "bb"], 2);
+
+        for force_view_types in [false, true] {
+            let batch = read_one_batch(
+                &path,
+                schema_of(ArrowDataType::Utf8),
+                force_view_types,
+                1024,
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                batch.column(0).data_type(),
+                &ArrowDataType::Utf8,
+                "schema_force_view_types={force_view_types} must not change a supplied schema"
+            );
+        }
     }
 }

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -25,7 +25,8 @@ use datafusion::datasource::listing::{
 use datafusion::execution::memory_pool::MemoryLimit;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
 use datafusion::physical_plan::{
-    ExecutionPlan, PhysicalExpr, SendableRecordBatchStream, displayable, execute_stream,
+    ExecutionPlan, ExecutionPlanProperties, PhysicalExpr, SendableRecordBatchStream, displayable,
+    execute_stream,
 };
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use dbsp::circuit::tokio::TOKIO;
@@ -176,9 +177,10 @@ fn env_override(endpoint_name: &str, name: &str) -> Option<usize> {
 /// the batch gets smaller.
 const DECODE_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
 
-/// Smallest batch the budget may ask for. A read whose rows are wide enough to
-/// hit this floor exceeds `DECODE_BUDGET_BYTES`, which is deliberate: shrinking
-/// batches without limit costs more in per-batch overhead than it saves.
+/// Smallest batch the budget may ask for, unless the configured batch size is
+/// smaller still. A read whose rows are wide enough to hit this floor exceeds
+/// `DECODE_BUDGET_BYTES`, which is deliberate: shrinking batches without limit
+/// costs more in per-batch overhead than it saves.
 const MIN_BATCH_ROWS: usize = 64;
 
 /// Assumed ratio of decoded bytes to the byte counts the Delta log reports,
@@ -208,6 +210,9 @@ impl ReadSize {
     /// Rows per decoded batch, so that `partitions` readers together stay near
     /// [`DECODE_BUDGET_BYTES`]. `default_rows` is both the starting point and
     /// the ceiling: the budget only ever shrinks a batch.
+    ///
+    /// `partitions` is how many readers the plan runs at once, which
+    /// [`scan_partitions`] reads off the plan rather than assuming.
     fn batch_rows(&self, partitions: usize, default_rows: usize) -> Option<usize> {
         if self.bytes == 0 || self.records == 0 {
             return None;
@@ -217,8 +222,43 @@ impl ReadSize {
             .div_ceil(self.records)
             .max(1);
         let rows = (DECODE_BUDGET_BYTES / partitions / bytes_per_row) as usize;
-        Some(rows.clamp(MIN_BATCH_ROWS, default_rows))
+        // A configured batch size below the floor is what the connector was
+        // asked for, so it wins: `clamp` requires `min <= max` and would panic
+        // otherwise.
+        Some(rows.clamp(MIN_BATCH_ROWS.min(default_rows), default_rows))
     }
+}
+
+/// The row count the log records for `add`, or 0 when the writer omitted the
+/// `numRecords` statistic or wrote one this cannot parse.
+fn add_records(add: &AddAction) -> u64 {
+    add.get_stats()
+        .ok()
+        .flatten()
+        .map_or(0, |stats| stats.num_records)
+        .max(0) as u64
+}
+
+/// How big the log says one `Add` action's file is, or `None` when it records no
+/// row count and so leaves no bytes-per-row ratio.
+///
+/// `Remove` and `cdc` actions carry a size but never a row count, so a read of
+/// one is unmeasured and falls back to the configured batch size.
+fn add_read_size(add: &AddAction) -> Option<ReadSize> {
+    let mut size = ReadSize::default();
+    size.add(add.size.max(0) as u64, add_records(add));
+    (size.records > 0).then_some(size)
+}
+
+/// How many readers `plan` runs at once: the partitions of its leaves, which
+/// are its scans, summed because a plan with several scans drives them
+/// together.
+fn scan_partitions(plan: &Arc<dyn ExecutionPlan>) -> usize {
+    let children = plan.children();
+    if children.is_empty() {
+        return plan.output_partitioning().partition_count();
+    }
+    children.iter().map(|child| scan_partitions(child)).sum()
 }
 
 /// The read size DataFusion derived for `plan`, or `None` unless it reports
@@ -765,6 +805,8 @@ impl DeltaTableInputReader {
         // Used to communicate the status of connector initialization.
         let (init_status_sender, mut init_status_receiver) =
             mpsc::channel::<Result<(), ControllerError>>(1);
+
+        config.validate().map_err(|e| anyhow!("{e}"))?;
 
         if config.num_parsers == 0 {
             bail!("invalid 'num_parsers' value: 'num_parsers' must be greater than 0");
@@ -3019,35 +3061,45 @@ impl DeltaTableInputEndpointInner {
     /// Execute `dataframe`, with the decoded batch bounded in bytes rather than
     /// only in rows.
     ///
-    /// `FileScanConfig` resolves the batch size from the task context when the
-    /// plan does not pin one, and neither the connector's listing tables nor
-    /// delta-rs's provider pins one, so the plan is built once and run with a
-    /// task context carrying the chosen size. Anything else the query does
-    /// (sorting a CDC transaction, subtracting its removes) keeps working to
-    /// the same size, which is what it would have used anyway.
+    /// The plan is built to derive the batch size from, since that needs the
+    /// scan's statistics and its partition count, and then built again once the
+    /// size is known. Setting the size on the task context alone is not enough:
+    /// `FilterExec` takes its batch size when it is planned
+    /// (`physical_planner.rs` hands it `session_state.config().batch_size()`)
+    /// and feeds that frozen value to a coalescer, so it would buffer the
+    /// smaller batches back up to the size the first plan was built with. One
+    /// is in the plan whenever `filter` or `snapshot_filter` is set, and it
+    /// survives planning because `parquet.pushdown_filters` is off by default.
+    ///
+    /// Planning twice is why the second pass is conditional: a read that keeps
+    /// the configured size, which is the common one, is planned once.
     async fn execute_stream(
         &self,
         dataframe: DataFrame,
         read_size: Option<ReadSize>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
-        let (mut state, plan) = dataframe.into_parts();
-        let plan = state.create_physical_plan(&plan).await?;
+        let (mut state, logical) = dataframe.into_parts();
+        let plan = state.create_physical_plan(&logical).await?;
 
-        let partitions = state.config().target_partitions();
+        let partitions = scan_partitions(&plan);
         let default_rows = state.config().batch_size();
-        if let Some(rows) = read_size
+        let plan = match read_size
             .or_else(|| plan_read_size(plan.as_ref()))
             .and_then(|size| size.batch_rows(partitions, default_rows))
-            && rows < default_rows
+            .filter(|rows| *rows < default_rows)
         {
-            debug!(
-                "delta_table {}: reading {rows} rows per batch instead of {default_rows}, to keep \
-                 {partitions} concurrent readers within {} MB of decoded data",
-                &self.endpoint_name,
-                DECODE_BUDGET_BYTES / 1024 / 1024,
-            );
-            state.config_mut().options_mut().execution.batch_size = rows;
-        }
+            Some(rows) => {
+                debug!(
+                    "delta_table {}: reading {rows} rows per batch instead of {default_rows}, to \
+                     keep {partitions} concurrent readers within {} MB of decoded data",
+                    &self.endpoint_name,
+                    DECODE_BUDGET_BYTES / 1024 / 1024,
+                );
+                state.config_mut().options_mut().execution.batch_size = rows;
+                state.create_physical_plan(&logical).await?
+            }
+            None => plan,
+        };
 
         execute_stream(plan, state.task_ctx())
     }
@@ -3433,6 +3485,16 @@ impl DeltaTableInputEndpointInner {
                     newly_deleted,
                     false,
                     version,
+                    // The `Remove` side of a same-path rewrite reads the file
+                    // its paired `Add` names: one immutable file, two deletion
+                    // vectors, so the same bytes and the same rows. Only the
+                    // `Add` records a row count, which is why the ratio comes
+                    // from there. An unpaired `Remove` finds nothing here and
+                    // is read whole below, unmeasured.
+                    adds_by_path
+                        .get(remove.path.as_str())
+                        .copied()
+                        .and_then(add_read_size),
                     table,
                     &used_columns,
                     input_stream,
@@ -3455,6 +3517,7 @@ impl DeltaTableInputEndpointInner {
                     restored,
                     true,
                     version,
+                    add_read_size(add),
                     table,
                     &used_columns,
                     input_stream,
@@ -3773,14 +3836,12 @@ impl DeltaTableInputEndpointInner {
         // carries no row count, so the added files decide the bytes-per-row
         // ratio; both sides of the transaction come from the same table, so
         // that is the same ratio either way.
+        // Every add counts as a file the scan will open, and one whose row
+        // count the writer omitted still contributes its bytes, which skews the
+        // ratio towards smaller batches rather than larger.
         let mut read_size = ReadSize::default();
         for add in &adds {
-            let records = add
-                .get_stats()
-                .ok()
-                .flatten()
-                .map_or(0, |stats| stats.num_records);
-            read_size.add(add.size.max(0) as u64, records.max(0) as u64);
+            read_size.add(add.size.max(0) as u64, add_records(add));
         }
 
         // Drop add/remove pairs on the same path (metadata-only rewrites).
@@ -4358,6 +4419,7 @@ impl DeltaTableInputEndpointInner {
                     add.deletion_vector.as_ref(),
                     Some(&add.partition_values),
                     version,
+                    add_read_size(add),
                     table,
                     used_columns,
                     input_stream,
@@ -4375,6 +4437,9 @@ impl DeltaTableInputEndpointInner {
                     remove.deletion_vector.as_ref(),
                     remove.partition_values.as_ref(),
                     version,
+                    // A `Remove` action carries no row count, so its read is
+                    // unmeasured.
+                    None,
                     table,
                     used_columns,
                     input_stream,
@@ -4402,6 +4467,7 @@ impl DeltaTableInputEndpointInner {
         deletion_vector: Option<&DeletionVectorDescriptor>,
         partition_values: Option<&HashMap<String, Option<String>>>,
         version: i64,
+        read_size: Option<ReadSize>,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -4446,6 +4512,7 @@ impl DeltaTableInputEndpointInner {
             partition_values,
             &description,
             version,
+            read_size,
             input_stream,
             receiver,
             start_transaction,
@@ -4465,6 +4532,7 @@ impl DeltaTableInputEndpointInner {
         dv_delta: Option<&RoaringTreemap>,
         polarity: bool,
         version: i64,
+        read_size: Option<ReadSize>,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -4493,6 +4561,7 @@ impl DeltaTableInputEndpointInner {
                     partition_values,
                     &description,
                     version,
+                    read_size,
                     input_stream,
                     receiver,
                     start_transaction,
@@ -4531,6 +4600,7 @@ impl DeltaTableInputEndpointInner {
         partition_values: Option<&HashMap<String, Option<String>>>,
         description: &str,
         version: i64,
+        read_size: Option<ReadSize>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
@@ -4559,7 +4629,7 @@ impl DeltaTableInputEndpointInner {
                 start_transaction,
                 self.config.max_retries(),
                 Some(version),
-                None,
+                read_size,
             )
             .await?;
 
@@ -5385,7 +5455,9 @@ mod read_size_tests {
     const DEFAULT_ROWS: usize = 8192;
 
     fn rows(bytes: u64, records: u64, partitions: usize) -> Option<usize> {
-        ReadSize { bytes, records }.batch_rows(partitions, DEFAULT_ROWS)
+        let mut size = ReadSize::default();
+        size.add(bytes, records);
+        size.batch_rows(partitions, DEFAULT_ROWS)
     }
 
     /// An ordinary table keeps the full batch, so bounding decode memory costs
@@ -5404,12 +5476,15 @@ mod read_size_tests {
         const PARTITIONS: usize = 32;
         // 64 KiB per row compressed over 1000 rows.
         let bytes = 64 * 1024 * 1000;
+        let per_row = 64 * 1024 * COMPRESSED_EXPANSION;
+
+        // Spread over enough files to use every partition, so all of them
+        // decode at once and the budget covers the sum.
         let rows = rows(bytes, 1000, PARTITIONS).expect("a sized read picks a batch");
         assert!(
             (MIN_BATCH_ROWS..DEFAULT_ROWS).contains(&rows),
             "expected a smaller batch inside the floor; got {rows}"
         );
-        let per_row = 64 * 1024 * COMPRESSED_EXPANSION;
         let held = rows as u64 * per_row * PARTITIONS as u64;
         assert!(
             held <= DECODE_BUDGET_BYTES,
@@ -5438,6 +5513,23 @@ mod read_size_tests {
         assert_eq!(rows(8 * 1024 * 1024, 1, 32), Some(MIN_BATCH_ROWS));
     }
 
+    /// A configured batch size below the floor is honored rather than raised to
+    /// it, and above all does not panic: `clamp` requires `min <= max`, so a
+    /// floor above the configured size used to abort the connector task on the
+    /// first sized read. A plain `"batch_size": 32` reaches this.
+    #[test]
+    fn a_batch_size_below_the_floor_is_honored() {
+        for configured in [1, 32, MIN_BATCH_ROWS - 1] {
+            let mut size = ReadSize::default();
+            size.add(2_000_000_000, 10_000_000);
+            assert_eq!(
+                size.batch_rows(32, configured),
+                Some(configured),
+                "a configured {configured}-row batch must survive the budget"
+            );
+        }
+    }
+
     /// A read the log did not measure falls back to the configured batch size
     /// rather than guessing. A writer that omits `stats` leaves `numRecords`
     /// absent, which is the common way this happens.
@@ -5448,7 +5540,46 @@ mod read_size_tests {
         assert_eq!(rows(0, 1_000, 32), None, "rows without a byte count");
     }
 
-    /// Summing the log's files is what produces the pair.
+    /// One `Add` action measures the file it adds, which is what makes a follow
+    /// read sized: before this, follow mode passed nothing and every read fell
+    /// back to the configured batch size.
+    #[test]
+    fn an_add_action_measures_its_file() {
+        let add = AddAction {
+            path: "part-00000.parquet".to_string(),
+            size: 4_000_000,
+            stats: Some(r#"{"numRecords":1000}"#.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            add_read_size(&add),
+            Some(ReadSize {
+                bytes: 4_000_000,
+                records: 1000
+            })
+        );
+    }
+
+    /// A writer that omits `numRecords` leaves no ratio, so the read stays
+    /// unmeasured rather than being sized from a guess.
+    #[test]
+    fn an_add_without_statistics_is_unmeasured() {
+        let add = AddAction {
+            path: "part-00000.parquet".to_string(),
+            size: 4_000_000,
+            stats: None,
+            ..Default::default()
+        };
+        assert_eq!(add_read_size(&add), None);
+
+        let malformed = AddAction {
+            stats: Some("not json".to_string()),
+            ..add.clone()
+        };
+        assert_eq!(add_read_size(&malformed), None);
+    }
+
+    /// Summing the log's files is what produces the ratio.
     #[test]
     fn sizes_accumulate() {
         let mut size = ReadSize::default();
@@ -5604,6 +5735,136 @@ mod read_schema_tests {
         Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "s", data_type, false,
         )]))
+    }
+
+    /// A filter keeps the batch size it was planned with, whatever the task
+    /// context says later. That is why `execute_stream` plans a second time
+    /// once it knows the size rather than only setting it on the context.
+    ///
+    /// `FilterExec` takes the size at planning time and hands it to a
+    /// coalescer, so it buffers the scan's smaller batches back up to it. The
+    /// scan itself does follow the context, which is the weaker property
+    /// `a_file_scan_takes_its_batch_size_from_the_task_context` pins; this test
+    /// exists because that one is not enough to conclude anything about a plan.
+    /// If DataFusion ever makes the filter read the context too, this fails and
+    /// the second planning pass can go.
+    #[tokio::test]
+    async fn a_filter_keeps_the_batch_size_it_was_planned_with() {
+        const ROWS: usize = 20_000;
+        const PLANNED: usize = 8192;
+        const AFTER: usize = 100;
+        let dir = tempfile::tempdir().unwrap();
+        let values: Vec<String> = (0..ROWS).map(|i| format!("row-{i:08}")).collect();
+        let path = write_parquet(
+            dir.path(),
+            &values.iter().map(String::as_str).collect::<Vec<_>>(),
+            1000,
+        );
+
+        // One partition, so every row passes through one filter and its
+        // coalescer has enough input to reach the planned size.
+        let config = SessionConfig::new()
+            .set_usize("datafusion.execution.batch_size", PLANNED)
+            .with_target_partitions(1);
+        let ctx = SessionContext::new_with_config(config);
+        let url = ListingTableUrl::parse(format!("file://{}", path.display())).unwrap();
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_file_extension_opt(Some(".parquet"));
+        let table = ListingTable::try_new(
+            ListingTableConfig::new_with_multi_paths(vec![url])
+                .with_listing_options(listing_options)
+                .with_schema(schema_of(ArrowDataType::Utf8)),
+        )
+        .unwrap();
+        let df = ctx
+            .read_table(Arc::new(table))
+            .unwrap()
+            .filter(ident("s").not_eq(lit("absent")))
+            .unwrap();
+
+        let (mut state, logical) = df.into_parts();
+        let plan = state.create_physical_plan(&logical).await.unwrap();
+        state.config_mut().options_mut().execution.batch_size = AFTER;
+
+        let mut largest = 0;
+        let mut stream = execute_stream(plan, state.task_ctx()).unwrap();
+        while let Some(batch) = stream.next().await {
+            largest = largest.max(batch.unwrap().num_rows());
+        }
+        assert_eq!(
+            largest, PLANNED,
+            "the filter must still be emitting the batch size it was planned with"
+        );
+
+        // Planning again with the smaller size is what actually bounds it.
+        let plan = state.create_physical_plan(&logical).await.unwrap();
+        let mut largest = 0;
+        let mut rows = 0;
+        let mut stream = execute_stream(plan, state.task_ctx()).unwrap();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            largest = largest.max(batch.num_rows());
+            rows += batch.num_rows();
+        }
+        assert_eq!(
+            largest, AFTER,
+            "a replanned filter must follow the new size"
+        );
+        assert_eq!(rows, ROWS, "every row must still come through");
+    }
+
+    /// One file can become many scan partitions, which is why the budget reads
+    /// the count off the plan instead of assuming one partition per file.
+    ///
+    /// DataFusion splits a scan's files into byte ranges once the scan reads at
+    /// least `repartition_file_min_size` in total. The test lowers that
+    /// threshold rather than writing a 10 MB file, and asserts both directions:
+    /// above it one file yields several partitions, below it one.
+    #[tokio::test]
+    async fn a_scan_can_open_more_partitions_than_it_has_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let values: Vec<String> = (0..20_000).map(|i| format!("row-{i:08}")).collect();
+        let path = write_parquet(
+            dir.path(),
+            &values.iter().map(String::as_str).collect::<Vec<_>>(),
+            1000,
+        );
+        let file_bytes = std::fs::metadata(&path).unwrap().len() as usize;
+
+        // Below the threshold the one file stays one partition; above it, the
+        // scan splits the file by byte range and runs several readers.
+        for (min_size, expect_split) in [(file_bytes * 2, false), (file_bytes / 4, true)] {
+            let config = SessionConfig::new()
+                .with_target_partitions(8)
+                .set_usize("datafusion.optimizer.repartition_file_min_size", min_size);
+            let ctx = SessionContext::new_with_config(config);
+
+            let url = ListingTableUrl::parse(format!("file://{}", path.display())).unwrap();
+            let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+                .with_file_extension_opt(Some(".parquet"));
+            let table = ListingTable::try_new(
+                ListingTableConfig::new_with_multi_paths(vec![url])
+                    .with_listing_options(listing_options)
+                    .with_schema(schema_of(ArrowDataType::Utf8)),
+            )
+            .unwrap();
+
+            let (state, plan) = ctx.read_table(Arc::new(table)).unwrap().into_parts();
+            let plan = state.create_physical_plan(&plan).await.unwrap();
+            let partitions = scan_partitions(&plan);
+
+            if expect_split {
+                assert!(
+                    partitions > 1,
+                    "one file over the threshold must split; got {partitions} partitions"
+                );
+            } else {
+                assert_eq!(
+                    partitions, 1,
+                    "one file under the threshold must stay one partition"
+                );
+            }
+        }
     }
 
     /// The batch size a file scan uses comes from the task context at execution

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4180,7 +4180,7 @@ fn delta_table_s3_people_2m() {
 /// images of a row therefore land in different change data files.
 ///
 /// NOTE: this test requires a `uc://` table, which exercises the code path that
-/// loads files one at a time rather than via a `ListingTable`.
+/// reads files through the object store rather than via a `ListingTable`.
 ///
 /// `python/tests/platform/fixtures/unity_change_feed.py` builds the table; the
 /// test is inert until `DELTA_TABLE_TEST_UNITY_CDF_TABLE` names it.

--- a/crates/feldera-types/src/transport/delta_table.rs
+++ b/crates/feldera-types/src/transport/delta_table.rs
@@ -555,6 +555,32 @@ pub struct DeltaTableReaderConfig {
     /// The default value is 6.
     pub max_concurrent_readers: Option<u32>,
 
+    /// Maximum number of rows the connector decodes into one Arrow batch.
+    ///
+    /// A batch is the unit the connector decodes a Parquet file into, and its
+    /// memory cost is this many rows of every column it reads. The connector
+    /// already lowers the batch size on its own when the Delta log says the
+    /// rows are wide; set this to pin a value, for instance when the log
+    /// carries no row counts and so cannot be measured.
+    ///
+    /// Lower values reduce the memory a read holds at the cost of throughput.
+    /// The default is 8192.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_size: Option<u64>,
+
+    /// Number of data files the connector decodes concurrently.
+    ///
+    /// Reading more files at a time is faster and holds more decoded data in
+    /// memory at once. Unlike `max_concurrent_readers`, which caps concurrent
+    /// object store reads across every Delta Lake connector in the pipeline,
+    /// this applies to one connector and governs the parallelism of a single
+    /// read.
+    ///
+    /// Defaults to the pipeline's `io_workers`, or its `workers` when
+    /// `io_workers` is not set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_parallelism: Option<u64>,
+
     /// Enable verbose logging.
     ///
     /// When enabled, the connector will log detailed information at INFO level.
@@ -753,6 +779,48 @@ fn test_delta_table_ingest_mode_display() {
         "snapshot_and_follow"
     );
     assert_eq!(DeltaTableIngestMode::Cdc.to_string(), "cdc");
+}
+
+#[cfg(test)]
+mod read_tuning_tests {
+    use super::*;
+
+    fn config(extra: &str) -> DeltaTableReaderConfig {
+        serde_json::from_str(&format!(r#"{{"uri":"memory://","mode":"follow"{extra}}}"#)).unwrap()
+    }
+
+    /// Both settings are optional, and absent means "let the connector decide":
+    /// it derives the batch size from the Delta log and the scan parallelism
+    /// from the pipeline's worker count.
+    #[test]
+    fn absent_by_default() {
+        let config = config("");
+        assert_eq!(config.batch_size, None);
+        assert_eq!(config.scan_parallelism, None);
+    }
+
+    #[test]
+    fn read_from_the_connector_config() {
+        let config = config(r#","batch_size":512,"scan_parallelism":4"#);
+        assert_eq!(config.batch_size, Some(512));
+        assert_eq!(config.scan_parallelism, Some(4));
+    }
+
+    /// An unset setting stays out of the serialized form, so a config that
+    /// omits it round-trips unchanged through a manager that does not know it.
+    #[test]
+    fn absent_settings_are_not_serialized() {
+        let serialized = serde_json::to_string(&config("")).unwrap();
+        assert!(
+            !serialized.contains("batch_size") && !serialized.contains("scan_parallelism"),
+            "unset settings must not be serialized; got: {serialized}"
+        );
+        let serialized = serde_json::to_string(&config(r#","batch_size":512"#)).unwrap();
+        assert!(
+            serialized.contains(r#""batch_size":512"#),
+            "a set value must survive serialization; got: {serialized}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/feldera-types/src/transport/delta_table.rs
+++ b/crates/feldera-types/src/transport/delta_table.rs
@@ -806,6 +806,30 @@ mod read_tuning_tests {
         assert_eq!(config.scan_parallelism, Some(4));
     }
 
+    /// Zero is rejected at config time rather than reaching DataFusion, which
+    /// would be asked for empty batches or no scan partitions.
+    #[test]
+    fn zero_is_rejected() {
+        assert_eq!(
+            config(r#","batch_size":0"#).validate(),
+            Err("'batch_size' must be greater than 0".to_string())
+        );
+        assert_eq!(
+            config(r#","scan_parallelism":0"#).validate(),
+            Err("'scan_parallelism' must be greater than 0".to_string())
+        );
+    }
+
+    /// A set value and an absent one both validate.
+    #[test]
+    fn positive_and_absent_settings_validate() {
+        assert_eq!(config("").validate(), Ok(()));
+        assert_eq!(
+            config(r#","batch_size":512,"scan_parallelism":4"#).validate(),
+            Ok(())
+        );
+    }
+
     /// An unset setting stays out of the serialized form, so a config that
     /// omits it round-trips unchanged through a manager that does not know it.
     #[test]
@@ -929,6 +953,18 @@ mod log_retention_tests {
 }
 
 impl DeltaTableReaderConfig {
+    /// Reject settings the connector cannot act on, so a misconfigured pipeline
+    /// fails at startup naming the setting rather than at the first read.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.batch_size.is_some_and(|n| n == 0) {
+            return Err("'batch_size' must be greater than 0".to_string());
+        }
+        if self.scan_parallelism.is_some_and(|n| n == 0) {
+            return Err("'scan_parallelism' must be greater than 0".to_string());
+        }
+        Ok(())
+    }
+
     /// `true` if the configuration requires taking an initial snapshot of the table.
     pub fn snapshot(&self) -> bool {
         matches!(

--- a/docs.feldera.com/docs/connectors/sources/delta.md
+++ b/docs.feldera.com/docs/connectors/sources/delta.md
@@ -181,6 +181,13 @@ Additional configuration options to configure HTTP client for remote object stor
 | `connect_timeout`             | Set a timeout for only the connect phase of a client. This is the time allowed for the client to establish a connection and if the connection is not established within this time, the client returns a timeout error.|
 | `user_agent`                  | User-Agent header to be used by this client.                                                                                                                   |
 
+### Advanced configuration
+
+| Property                    | Type   | Default    | Description   |
+|-----------------------------|--------|------------|---------------|
+| `batch_size`                | integer| 8192       | <p>Maximum number of rows the connector decodes into one Arrow batch.</p><p>A batch is the unit the connector decodes a Parquet file into, and its memory cost is this many rows of every column it reads. Lower values reduce the memory a read holds at the cost of throughput. The connector already sizes its reads from the table's statistics, so this setting is rarely needed; reach for it when a read holds too much memory, or when the Delta log carries no row counts and so cannot be measured.</p>|
+| `scan_parallelism`          | integer| `io_workers`| <p>Number of data files the connector decodes concurrently.</p><p>Reading more files at a time is faster and holds more decoded data in memory at once. Unlike `max_concurrent_readers`, which caps concurrent object store reads across every Delta Lake connector in the pipeline, this applies to one connector and governs the parallelism of a single read.</p><p>Defaults to the pipeline's `io_workers`, or its `workers` when `io_workers` is not set.</p>|
+
 ## Data type mapping
 
 The following table lists supported Delta Lake data types and corresponding Feldera types.

--- a/js-packages/web-console/src/lib/services/manager/types.gen.ts
+++ b/js-packages/web-console/src/lib/services/manager/types.gen.ts
@@ -1255,6 +1255,19 @@ export type DeltaTableIngestMode = 'snapshot' | 'follow' | 'snapshot_and_follow'
  */
 export type DeltaTableReaderConfig = {
   /**
+   * Maximum number of rows the connector decodes into one Arrow batch.
+   *
+   * A batch is the unit the connector decodes a Parquet file into, and its
+   * memory cost is this many rows of every column it reads. The connector
+   * already lowers the batch size on its own when the Delta log says the
+   * rows are wide; set this to pin a value, for instance when the log
+   * carries no row counts and so cannot be measured.
+   *
+   * Lower values reduce the memory a read holds at the cost of throughput.
+   * The default is 8192.
+   */
+  batch_size?: number | null
+  /**
    * A predicate that determines whether the record represents a deletion.
    *
    * This setting is only valid in the `cdc` mode. It specifies a predicate applied to
@@ -1342,6 +1355,19 @@ export type DeltaTableReaderConfig = {
    * Recommended range: 1–10. The default is 4.
    */
   num_parsers?: number
+  /**
+   * Number of data files the connector decodes concurrently.
+   *
+   * Reading more files at a time is faster and holds more decoded data in
+   * memory at once. Unlike `max_concurrent_readers`, which caps concurrent
+   * object store reads across every Delta Lake connector in the pipeline,
+   * this applies to one connector and governs the parallelism of a single
+   * read.
+   *
+   * Defaults to the pipeline's `io_workers`, or its `workers` when
+   * `io_workers` is not set.
+   */
+  scan_parallelism?: number | null
   /**
    * Don't read unused columns from the Delta table.
    *
@@ -1439,6 +1465,8 @@ export type DeltaTableReaderConfig = {
   version?: number | null
   [key: string]:
     | string
+    | number
+    | null
     | string
     | null
     | string
@@ -1457,6 +1485,8 @@ export type DeltaTableReaderConfig = {
     | null
     | DeltaTableIngestMode
     | number
+    | number
+    | null
     | boolean
     | string
     | null

--- a/openapi.json
+++ b/openapi.json
@@ -10001,6 +10001,13 @@
           "mode"
         ],
         "properties": {
+          "batch_size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of rows the connector decodes into one Arrow batch.\n\nA batch is the unit the connector decodes a Parquet file into, and its\nmemory cost is this many rows of every column it reads. The connector\nalready lowers the batch size on its own when the Delta log says the\nrows are wide; set this to pin a value, for instance when the log\ncarries no row counts and so cannot be measured.\n\nLower values reduce the memory a read holds at the cost of throughput.\nThe default is 8192.",
+            "nullable": true,
+            "minimum": 0
+          },
           "cdc_delete_filter": {
             "type": "string",
             "description": "A predicate that determines whether the record represents a deletion.\n\nThis setting is only valid in the `cdc` mode. It specifies a predicate applied to\neach row in the Delta table to determine whether the row represents a deletion event.\nIts value must be a valid Boolean SQL expression that can be used in a query of the\nform `SELECT * from <table> WHERE <cdc_delete_filter>`.",
@@ -10056,6 +10063,13 @@
             "type": "integer",
             "format": "int32",
             "description": "The number of parallel parsing tasks the connector uses to process data read from the\ntable. Increasing this value can enhance performance by allowing more concurrent processing.\nRecommended range: 1–10. The default is 4.",
+            "minimum": 0
+          },
+          "scan_parallelism": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of data files the connector decodes concurrently.\n\nReading more files at a time is faster and holds more decoded data in\nmemory at once. Unlike `max_concurrent_readers`, which caps concurrent\nobject store reads across every Delta Lake connector in the pipeline,\nthis applies to one connector and governs the parallelism of a single\nread.\n\nDefaults to the pipeline's `io_workers`, or its `workers` when\n`io_workers` is not set.",
+            "nullable": true,
             "minimum": 0
           },
           "skip_unused_columns": {


### PR DESCRIPTION
This series of commits addresses two related issues in the code that parses parquet files directly (not via delta-rs snapshot read).

1. Read string columns as Utf8View instead of Utf8 -- prevents record batches from blowing up in memory due to shared strings get cloned many times.
2. Adjust the number of records per batch based on the average record size, so that batches that contain very large records don't hog memory.

See details in individual commit messages.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
