### PR TITLE
[SQL] Waterline computation for MIN

### DIFF
--- a/docs.feldera.com/docs/tutorials/time-series.md
+++ b/docs.feldera.com/docs/tutorials/time-series.md
@@ -522,6 +522,11 @@ mechanism can discard old records under the following conditions:
   has a waterline.  In the `daily_max` view, the `TIMESTAMP_TRUNC(ts, DAY) as d`
   column has a waterline.
 
+* The `MIN` of a column with a waterline has the same waterline.  This holds
+  only when every aggregate in the same `GROUP BY` is a `MIN` over that same
+  column; adding a `MAX`, a `MIN` over a different column, or a `FILTER`
+  clause loses the waterline.
+
 ### Tumbling and hopping windows
 
 [Tumbling](/sql/table/#tumble) and [hopping](/sql/table/#tumble) window operators

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CanonicalForm.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CanonicalForm.java
@@ -12,6 +12,12 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.Utilities;
+import org.dbsp.sqlCompiler.ir.aggregate.DBSPAggregateList;
+import org.dbsp.sqlCompiler.ir.aggregate.IAggregate;
+import org.dbsp.util.Linq;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
 
 /** Visitor which rewrites a {@link DBSPClosureExpression} in a canonical form,
  * by using standard names for parameters (p0, p1, ...).  Handy for generating deterministic code.
@@ -23,6 +29,9 @@ public class CanonicalForm extends InnerRewriteVisitor {
     final Substitution<DBSPLetExpression, DBSPVariablePath> newLetExprVar;
     final ResolveReferences resolver;
     int counter;
+    /** Row variable of the aggregate list being rewritten, and its canonical replacement */
+    @Nullable String rowVar;
+    @Nullable DBSPVariablePath canonicalRowVar;
 
     /** The canonical form of `node` as a string. */
     public static String asString(DBSPCompiler compiler, IDBSPInnerNode node) {
@@ -106,10 +115,27 @@ public class CanonicalForm extends InnerRewriteVisitor {
         DBSPClosureExpression closure = node.to(DBSPClosureExpression.class);
         for (int i = 0; i < closure.parameters.length; i++) {
             DBSPParameter param = closure.parameters[i];
-            DBSPParameter replacement = new DBSPParameter(param.getNode(), this.nextName(), param.getType());
+            String name = param.name.equals(this.rowVar) ?
+                    Objects.requireNonNull(this.canonicalRowVar).variable : this.nextName();
+            DBSPParameter replacement = new DBSPParameter(param.getNode(), name, param.getType());
             this.newParam.substituteNew(param, replacement);
         }
         return super.preorder(node);
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPAggregateList list) {
+        Utilities.enforce(this.rowVar == null, () -> "Aggregate lists do not nest");
+        DBSPVariablePath canonical = new DBSPVariablePath(list.rowVar.getNode(), this.nextName(), list.rowVar.getType());
+        this.rowVar = list.rowVar.variable;
+        this.canonicalRowVar = canonical;
+        this.push(list);
+        List<IAggregate> aggregates = Linq.map(list.aggregates, a -> this.transform(a).to(IAggregate.class));
+        this.pop(list);
+        this.rowVar = null;
+        this.canonicalRowVar = null;
+        this.map(list, new DBSPAggregateList(list.getNode(), canonical, aggregates));
+        return VisitDecision.STOP;
     }
 
     @Override
@@ -118,6 +144,8 @@ public class CanonicalForm extends InnerRewriteVisitor {
         this.newLetVar.clear();
         this.newLetExprVar.clear();
         this.counter = 0;
+        this.rowVar = null;
+        this.canonicalRowVar = null;
         this.resolver.startVisit(node);
         super.startVisit(node);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ResolveReferences.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ResolveReferences.java
@@ -22,6 +22,11 @@ public class ResolveReferences extends InnerVisitor {
     public final boolean allowFreeVariables;
     boolean freeVariablesFound;
 
+    /** True after a visit that met a variable declared nowhere in the visited node */
+    public boolean hasFreeVariables() {
+        return this.freeVariablesFound;
+    }
+
     public ResolveReferences(DBSPCompiler compiler, boolean allowFreeVariables) {
         super(compiler);
         this.substitutionContext = new Scopes<>();
@@ -100,6 +105,7 @@ public class ResolveReferences extends InnerVisitor {
         this.substitutionContext.clear();
         this.substitutionContext.newContext();
         this.reference.clear();
+        this.freeVariablesFound = false;
         super.startVisit(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -42,11 +42,13 @@ import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.InputColumnMetadata;
 import org.dbsp.sqlCompiler.compiler.ViewColumnMetadata;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.Projection;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.IMaybeMonotoneType;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneClosureType;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneExpression;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ResolveReferences;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneTransferFunctions;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneType;
 import org.dbsp.sqlCompiler.compiler.visitors.monotone.NonMonotoneType;
@@ -57,7 +59,10 @@ import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 import org.dbsp.sqlCompiler.circuit.annotation.AlwaysMonotone;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
+import org.dbsp.sqlCompiler.ir.aggregate.DBSPMinMax;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBaseTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPConditionalIncrementExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPDerefExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -66,7 +71,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTimeAddSub;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.NoExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
@@ -842,7 +846,54 @@ public class Monotonicity extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPPrimitiveAggregateOperator node) {
-        this.aggregate(node);
+        DBSPMinMax minMax = node.function == null ? null : node.function.as(DBSPMinMax.class);
+        if (minMax == null || !this.minAggregate(node, minMax))
+            this.aggregate(node);
+    }
+
+    /** Compute the monotonicity of the output of a MIN.  Every change
+     * (insertion or deletion) to a group's row carries a value at or above the input waterline,
+     * so the output will have the exact same waterline.  Returns false when the aggregate is
+     * not a MIN, or when nothing in the output is monotone. */
+    boolean minAggregate(DBSPPrimitiveAggregateOperator node, DBSPMinMax minMax) {
+        // The output column (payload) has no waterline.
+        // ARG_MIN is not a special case: over a non-nullable compared column it is converted
+        // to Min(compared, payload); over a nullable one it is implemented as ArgMinSome,
+        // which only returns payload, so it is rejected here.
+        if (minMax.aggregation != DBSPMinMax.Aggregation.Min &&
+                minMax.aggregation != DBSPMinMax.Aggregation.MinSome1)
+            return false;
+        MonotoneExpression inputValue = this.getMonotoneExpression(node.inputs.get(0));
+        if (inputValue == null)
+            return false;
+
+        IMaybeMonotoneType projection = Monotonicity.getBodyType(inputValue);
+        DBSPTypeTupleBase pairType = projection.getType().to(DBSPTypeTupleBase.class);
+        if (pairType.size() != 2)
+            return false;
+        DBSPTypeRawTuple varType = new DBSPTypeRawTuple(pairType.tupFields[0].ref(), pairType.tupFields[1].ref());
+        DBSPVariablePath var = varType.var();
+
+        // The minimum of the input value is known in its first field only
+        DBSPExpression input = var.deepCopy().field(1).deref();
+        DBSPExpression minimum = withFirstField(
+            node.getNode(), input.getType(), 
+            firstField(input).applyCloneIfNeeded());
+        DBSPExpression value = minMax.postProcessing == null ? minimum :
+                minMax.postProcessing.call(minimum.borrow()).reduce(this.compiler());
+        DBSPType outputType = node.getOutputIndexedZSetType().elementType;
+        // An output shape the model does not describe yields no waterline
+        if (!value.getType().sameType(outputType))
+            return false;
+        DBSPExpression body = new DBSPRawTupleExpression(var.field(0).deref(), value);
+        MonotoneTransferFunctions analyzer = new MonotoneTransferFunctions(
+                this.compiler(), node, MonotoneTransferFunctions.ArgumentKind.IndexedZSet, projection);
+        // Null when neither the key nor the minimized value is monotone
+        MonotoneExpression result = analyzer.applyAnalysis(body.closure(var));
+        if (result == null)
+            return false;
+        this.set(node, result);
+        return true;
     }
 
     @Override
@@ -870,9 +921,137 @@ public class Monotonicity extends CircuitVisitor {
             return;
         }
 
+        List<DBSPConditionalIncrementExpression> updates = this.minUpdates(node);
+        if (updates != null) {
+            this.setMinChainMonotonicity(node, updates);
+            return;
+        }
         // TODO: for MAX the output is always monotone, but we cannot use this information.
         // https://github.com/feldera/feldera/issues/2805
         this.aggregate(node);
+    }
+
+    /** The list of instructions which update the accumulator of a chain aggregate,
+     * one per accumulator field, when every one of them computes the minimum of
+     * the same expression of the input row; null otherwise. */
+    @Nullable
+    List<DBSPConditionalIncrementExpression> minUpdates(DBSPChainAggregateOperator node) {
+        // The update function has the shape |acc, row, weight| Tup(update0, update1, ...)
+        DBSPClosureExpression function = node.getClosureFunction();
+        DBSPBaseTupleExpression body = function.body.as(DBSPBaseTupleExpression.class);
+        if (function.parameters.length != 3 || body == null || body.fields == null)
+            return null;
+        DBSPParameter row = function.parameters[1];
+        // The first row of a group goes through init, |row, weight| Tup(init0, init1, ...);
+        // each init must compute the minimum of the same expression as its update.
+        DBSPClosureExpression init = node.init;
+        DBSPBaseTupleExpression initBody = init.body.as(DBSPBaseTupleExpression.class);
+        if (init.parameters.length != 2 || initBody == null || initBody.fields == null ||
+                initBody.fields.length != body.fields.length)
+            return null;
+        List<DBSPConditionalIncrementExpression> updates = new ArrayList<>();
+        DBSPClosureExpression first = null;
+        for (int i = 0; i < body.fields.length; i++) {
+            DBSPConditionalIncrementExpression update = body.fields[i].as(DBSPConditionalIncrementExpression.class);
+            if (update == null || update.condition != null)
+                return null;
+            DBSPExpression compared = comparedValue(update);
+            if (compared == null)
+                return null;
+            DBSPClosureExpression closure = compared.closure(row);
+            // Check that the compared depends on the row alone (parameters[1]).
+            ResolveReferences resolver = new ResolveReferences(this.compiler(), true);
+            resolver.apply(closure);
+            if (resolver.hasFreeVariables())
+                return null;
+            if (first == null)
+                first = closure;
+            else if (!first.equivalent(closure))
+                return null;
+            DBSPConditionalIncrementExpression initial = initBody.fields[i].as(DBSPConditionalIncrementExpression.class);
+            if (initial == null || initial.condition != null || initial.opcode != update.opcode)
+                return null;
+            DBSPExpression initCompared = comparedValue(initial);
+            if (initCompared == null || !first.equivalent(initCompared.closure(init.parameters[0])))
+                return null;
+            updates.add(update);
+        }
+        return updates;
+    }
+
+    /** The expression whose minimum an accumulator update computes; null for updates that
+     * compute no minimum. */
+    @Nullable
+    private static DBSPExpression comparedValue(DBSPConditionalIncrementExpression update) {
+        return switch (update.opcode) {
+            case AGG_MIN, AGG_MIN1 -> firstField(update.right);
+            default -> null;
+        };
+    }
+
+    /** The first "field" of {@code value}. */
+    private static DBSPExpression firstField(DBSPExpression value) {
+        if (value.getType().is(DBSPTypeTupleBase.class))
+            return firstField(value.field(0));
+        return value;
+    }
+
+    /** Create a tuple with the specified type and with {@code first} in the first position.
+     * Fill the tuple with NoExpression. */
+    private static DBSPExpression withFirstField(CalciteObject node, DBSPType tupleType, DBSPExpression first) {
+        if (tupleType.is(DBSPTypeTupleBase.class)) {
+            DBSPTypeTupleBase tuple = tupleType.to(DBSPTypeTupleBase.class);
+            DBSPExpression[] fields = new DBSPExpression[tuple.size()];
+            for (int i = 0; i < tuple.size(); i++)
+                fields[i] = i == 0 
+                    ? withFirstField(node, tuple.tupFields[i], first) 
+                    : makeNoExpression(tuple.tupFields[i]);
+            return tuple.makeTuple(fields);
+        }
+        return first.cast(node, tupleType, DBSPCastExpression.CastType.SqlUnsafe);
+    }
+
+    /** Output monotonicity of a chain aggregate whose accumulators are all minimums of
+     * the same expression.  Every change to a group's row carries a compared value at or 
+     * above the input waterline.  The accumulator fields holding the compared value are 
+     * monotone with the input's waterline. */
+    private void setMinChainMonotonicity(DBSPChainAggregateOperator node, List<DBSPConditionalIncrementExpression> updates) {
+        MonotoneExpression inputValue = this.getMonotoneExpression(node.input());
+        if (inputValue == null)
+            return;
+        IMaybeMonotoneType projection = Monotonicity.getBodyType(inputValue);
+        DBSPTypeTupleBase pairType = projection.getType().to(DBSPTypeTupleBase.class);
+        if (pairType.size() != 2)
+            return;
+        DBSPTypeRawTuple varType = new DBSPTypeRawTuple(pairType.tupFields[0].ref(), pairType.tupFields[1].ref());
+        DBSPVariablePath var = varType.var();
+        DBSPParameter row = node.getClosureFunction().parameters[1];
+        if (!row.getType().sameType(var.field(1).getType()))
+            return;
+
+        DBSPTypeTuple accumulators = node.getOutputIndexedZSetType().getElementTypeTuple();
+        if (accumulators.size() != updates.size())
+            return;
+        List<DBSPExpression> fields = new ArrayList<>();
+        int index = 0;
+        for (DBSPConditionalIncrementExpression update : updates) {
+            DBSPType accumulatorType = accumulators.getFieldType(index++);
+            // The compared expression applied to var.1, the row
+            DBSPExpression compared = Objects.requireNonNull(comparedValue(update)).closure(row)
+                    .call(var.field(1)).reduce(this.compiler()).deepCopy();
+            DBSPExpression field = withFirstField(node.getNode(), accumulatorType, compared);
+            if (!field.getType().sameType(accumulatorType))
+                return;
+            fields.add(field);
+        }
+        DBSPExpression body = new DBSPRawTupleExpression(
+                var.field(0).deref(), new DBSPTupleExpression(fields, false));
+        MonotoneTransferFunctions analyzer = new MonotoneTransferFunctions(
+                this.compiler(), node, MonotoneTransferFunctions.ArgumentKind.IndexedZSet, projection);
+        // Null when neither the key nor the compared expression is monotone
+        MonotoneExpression result = analyzer.applyAnalysis(body.closure(var));
+        if (result != null)
+            this.set(node, result);
     }
 
     @Override
@@ -964,19 +1143,16 @@ public class Monotonicity extends CircuitVisitor {
 
         public final List<Comparison> comparisons = new ArrayList<>();
 
-        /** Analyze the condition of a filter and decompose it into a conjunction of comparisons */
+        /** Collect the comparisons among the conjuncts of a filter condition */
         public ComparisonsAnalyzer(DBSPExpression closure) {
             DBSPClosureExpression clo = closure.to(DBSPClosureExpression.class);
             Utilities.enforce(clo.parameters.length == 1);
             DBSPParameter param = clo.parameters[0];
-            DBSPExpression expression = clo.body;
-            if (expression.is(DBSPUnaryExpression.class)) {
-                DBSPUnaryExpression unary = expression.to(DBSPUnaryExpression.class);
-                // If the filter is wrap_bool(expression), analyze expression
-                if (unary.opcode == DBSPOpcode.WRAP_BOOL)
-                    expression = unary.source;
+            for (DBSPExpression conjunct : clo.body.conjuncts()) {
+                DBSPBinaryExpression binary = conjunct.as(DBSPBinaryExpression.class);
+                if (binary != null)
+                    this.findComparison(binary, param);
             }
-            this.complete = this.analyzeConjunction(expression, param);
         }
 
         public boolean isEmpty() {
@@ -1083,57 +1259,29 @@ public class Monotonicity extends CircuitVisitor {
             return false;
         }
 
-        /** Check if `expression` is a comparison and if so add it to the list.
-         * Return true if added. */
-        boolean findComparison(DBSPBinaryExpression binary, DBSPParameter param) {
+        /** If {@code binary} compares a column, or a column offset by a constant, with an
+         * expression, add the comparison to the list. */
+        void findComparison(DBSPBinaryExpression binary, DBSPParameter param) {
             switch (binary.opcode) {
-                case LTE:
-                case LT: {
-                    boolean added = this.addIfRightIsColumn(binary.left, binary.right, inverse(binary.opcode), param);
-                    if (added)
-                        return true;
-                    added = this.addIfOffsetOfColumn(binary.left, binary.right, inverse(binary.opcode), param);
-                    return added;
+                case LTE, LT -> {
+                    DBSPOpcode inverse = inverse(binary.opcode);
+                    if (!this.addIfRightIsColumn(binary.left, binary.right, inverse, param))
+                        this.addIfOffsetOfColumn(binary.left, binary.right, inverse, param);
                 }
-                case GTE:
-                case GT: {
-                    boolean added = this.addIfRightIsColumn(binary.right, binary.left, binary.opcode, param);
-                    if (added)
-                        return true;
-                    added = this.addIfOffsetOfColumn(binary.right, binary.left, binary.opcode, param);
-                    return added;
+                case GTE, GT -> {
+                    if (!this.addIfRightIsColumn(binary.right, binary.left, binary.opcode, param))
+                        this.addIfOffsetOfColumn(binary.right, binary.left, binary.opcode, param);
                 }
-                case EQ: {
-                    // add both ways
-                    boolean added = this.addIfRightIsColumn(binary.left, binary.right, binary.opcode, param);
-                    added = added || this.addIfRightIsColumn(binary.right, binary.left, binary.opcode, param);
-                    if (added)
-                        return true;
-                    added = this.addIfOffsetOfColumn(binary.left, binary.right, binary.opcode, param);
-                    if (added)
-                        return true;
-                    return this.addIfOffsetOfColumn(binary.right, binary.left, binary.opcode, param);
+                case EQ -> {
+                    // The column may be on either side
+                    if (!this.addIfRightIsColumn(binary.left, binary.right, binary.opcode, param)
+                            && !this.addIfRightIsColumn(binary.right, binary.left, binary.opcode, param)
+                            && !this.addIfOffsetOfColumn(binary.left, binary.right, binary.opcode, param))
+                        this.addIfOffsetOfColumn(binary.right, binary.left, binary.opcode, param);
                 }
-                default:
-                    return false;
+                default -> { }
             }
         }
-
-        boolean analyzeConjunction(DBSPExpression expression, DBSPParameter param) {
-            DBSPBinaryExpression binary = expression.as(DBSPBinaryExpression.class);
-            if (binary == null)
-                return false;
-            if (binary.opcode == DBSPOpcode.AND) {
-                boolean foundLeft = this.analyzeConjunction(binary.left, param);
-                boolean foundRight = this.analyzeConjunction(binary.right, param);
-                return foundLeft && foundRight;
-            } else {
-                return this.findComparison(binary, param);
-            }
-        }
-
-        /** True is the entire expression is composed of legal comparisons */
-        final boolean complete;
 
         /** Get all the expressions that are below the specified output column */
         List<DBSPExpression> getLowerBounds(int columnIndex) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/MinWaterlineIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/MinWaterlineIncrementalTests.java
@@ -1,0 +1,423 @@
+package org.dbsp.sqlCompiler.compiler.sql.streaming;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
+import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
+import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuit;
+import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Issue 7093: waterlines for MIN and ARG_MIN, both for append_only=true and append_only=false. */
+public class MinWaterlineIncrementalTests extends StreamingTestBase {
+    /** Events whose timestamps arrive at most one hour out of order. */
+    static final String EVENTS_COLUMNS = """
+            CREATE TABLE events (
+                id INT NOT NULL,
+                payload VARCHAR,
+                ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR
+            )""";
+    /** Events that may be deleted. */
+    static final String EVENTS = EVENTS_COLUMNS + ";\n";
+    /** Events that are never deleted. */
+    static final String APPEND_ONLY_EVENTS = EVENTS_COLUMNS + " WITH ('append_only' = 'true');\n";
+
+    /** Append-only events with two timestamp columns, each with its own waterline. */
+    static final String APPEND_ONLY_TWO_TIMESTAMPS = """
+            CREATE TABLE events (
+                id INT NOT NULL,
+                ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR,
+                ts2 TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR
+            ) WITH ('append_only' = 'true');
+            """;
+
+    /** Asserts that the circuit contains {@code count} integrate_trace_retain_keys operators,
+     * none of them attached to a chain aggregate. */
+    static void checkDownstreamRetainKeys(CompilerCircuit cc, int count) {
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            final List<String> sources = new ArrayList<>();
+
+            @Override
+            public void postorder(DBSPIntegrateTraceRetainKeysOperator operator) {
+                Assert.assertFalse(operator.left().operator.is(DBSPChainAggregateOperator.class));
+                this.sources.add(operator.left().operator.getClass().getSimpleName() + " " + operator.left().operator.getIdString());
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals("retain_keys on " + this.sources, count, this.sources.size());
+            }
+        });
+    }
+
+    /** The MIN of a column with a waterline, computed over an append-only input;
+     * the output inherits the input waterline. */
+    @Test
+    public void issue7093Chain() {
+        CompilerCircuitStream ccs = this.getCCS(APPEND_ONLY_EVENTS + """
+                CREATE LOCAL VIEW first_event AS
+                SELECT id, ARG_MIN(payload, ts) AS payload, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);""")
+                .compactAfterEachStep();
+        // The hourly aggregate garbage-collects its input and its output by hour.
+        checkDownstreamRetainKeys(ccs, 2);
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'a', '2020-01-01 10:30:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 10:00:00 | 1      | 1""");
+        // Waterline = 10:30 - 1 hour = 09:30, so hour 09:00 is live.
+        // The earlier row moves group 1 from hour 10 to hour 9.
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'b', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 10:00:00 | 1      | -1
+                 2020-01-01 09:00:00 | 1      | 1""");
+        // Waterline = 11:00 after this step; hours 9 and 10 fall below it
+        // and are garbage-collected.
+        ccs.step("""
+                INSERT INTO events VALUES (2, 'c', '2020-01-01 12:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 12:00:00 | 2      | 1""");
+        // 11:30 passes the filter and moves group 2 to hour 11, the hour at the waterline.
+        ccs.step("""
+                INSERT INTO events VALUES (2, 'd', '2020-01-01 11:30:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 12:00:00 | 2      | -1
+                 2020-01-01 11:00:00 | 2      | 1""");
+        // 10:59 is late and dropped; 11:00 is later than group 1's minimum.
+        ccs.step("""
+                INSERT INTO events VALUES
+                    (3, 'e', '2020-01-01 10:59:00'),
+                    (1, 'f', '2020-01-01 11:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------""");
+    }
+
+    /** MAX chains and mixed aggregates retract rows whose compared value may lie below the
+     * waterline, so their output does not have a waterline. */
+    @Test
+    public void issue7093ChainNoWaterline() {
+        // The retracted old maximum may be below the waterline.
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_EVENTS + """
+                CREATE LOCAL VIEW per_id AS SELECT id, MAX(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM per_id GROUP BY TIMESTAMP_TRUNC(ts, HOUR);"""), 0);
+        // A MAX in the same chain changes rows whose minimum may be below the waterline.
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_EVENTS + """
+                CREATE LOCAL VIEW per_id AS SELECT id, MIN(ts) AS ts, MAX(ts) AS last FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(last) AS last
+                FROM per_id GROUP BY TIMESTAMP_TRUNC(ts, HOUR);"""), 0);
+        // A change driven by one column retracts a row whose other minimum may be
+        // below that column's waterline.
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_TWO_TIMESTAMPS + """
+                CREATE LOCAL VIEW per_id AS SELECT id, MIN(ts) AS ts, MIN(ts2) AS ts2 FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(ts2) AS last
+                FROM per_id GROUP BY TIMESTAMP_TRUNC(ts, HOUR);"""), 0);
+        // The minimized column has no waterline, although another column of the input does.
+        checkDownstreamRetainKeys(this.getCC("""
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    amount INT NOT NULL,
+                    ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR
+                ) WITH ('append_only' = 'true');
+                CREATE LOCAL VIEW per_id AS SELECT id, MIN(amount) AS amount FROM events GROUP BY id;
+                CREATE VIEW by_amount AS
+                SELECT amount / 100 AS bucket, MAX(id) AS max_id FROM per_id GROUP BY amount / 100;"""), 0);
+    }
+
+    /** NULL timestamps pass the lateness filter and lose to any timestamp in a MIN, so a
+     * group's NULL minimum is retracted when its first timestamped row arrives.  The hourly
+     * view keeps its NULL group, since a NULL counts as at or above the waterline. */
+    @Test
+    public void issue7093NullTimestamps() {
+        CompilerCircuitStream ccs = this.getCCS("""
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    payload VARCHAR,
+                    ts TIMESTAMP LATENESS INTERVAL 1 HOUR
+                ) WITH ('append_only' = 'true');
+                CREATE LOCAL VIEW first_event AS
+                SELECT id, ARG_MIN(payload, ts) AS payload, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);""")
+                .compactAfterEachStep();
+        checkDownstreamRetainKeys(ccs, 2);
+        // Group 1 has only a NULL timestamp, so its minimum is NULL.
+        ccs.step("""
+                INSERT INTO events VALUES
+                    (1, 'a', NULL),
+                    (2, 'b', '2020-01-01 10:30:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 1      | 1
+                 2020-01-01 10:00:00 | 2      | 1""");
+        // Waterline = 09:30.  The first timestamp of group 1 replaces its NULL minimum.
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'c', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 1      | -1
+                 2020-01-01 09:00:00 | 1      | 1""");
+        // A NULL timestamp never lowers a minimum; a new all-NULL group appears.
+        ccs.step("""
+                INSERT INTO events VALUES
+                    (1, 'd', NULL),
+                    (3, 'e', NULL);""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 3      | 1""");
+        // Waterline = 11:00 after this step; hours 9 and 10 are garbage-collected,
+        // the NULL group is not.
+        ccs.step("""
+                INSERT INTO events VALUES (4, 'f', '2020-01-01 12:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 12:00:00 | 4      | 1""");
+        // 11:30 passes the filter and replaces group 3's NULL minimum; 10:59 is late.
+        ccs.step("""
+                INSERT INTO events VALUES
+                    (3, 'g', '2020-01-01 11:30:00'),
+                    (5, 'h', '2020-01-01 10:59:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 3      | -1
+                 2020-01-01 11:00:00 | 3      | 1""");
+    }
+
+    /** Two independent waterlines drive garbage collection at the same time.  The final
+     * view unions the two hourly views so that one output shows both; `ts` advances to the
+     * afternoon while `ts2` stays in the morning, so hours are pruned on one side only. */
+    @Test
+    public void issue7093TwoColumnsData() {
+        CompilerCircuitStream ccs = this.getCCS(APPEND_ONLY_TWO_TIMESTAMPS + """
+                CREATE LOCAL VIEW a AS SELECT id, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE LOCAL VIEW b AS SELECT id, MIN(ts2) AS ts2 FROM events GROUP BY id;
+                CREATE LOCAL VIEW h1 AS SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM a GROUP BY TIMESTAMP_TRUNC(ts, HOUR);
+                CREATE LOCAL VIEW h2 AS SELECT TIMESTAMP_TRUNC(ts2, HOUR) AS hour, MAX(id) AS max_id
+                FROM b GROUP BY TIMESTAMP_TRUNC(ts2, HOUR);
+                CREATE VIEW hourly AS
+                SELECT 'a' AS src, hour, max_id FROM h1
+                UNION ALL
+                SELECT 'b' AS src, hour, max_id FROM h2;""")
+                .withStringTrim().compactAfterEachStep();
+        checkDownstreamRetainKeys(ccs, 4);
+        ccs.step("""
+                INSERT INTO events VALUES (1, '2020-01-01 10:30:00', '2020-01-01 10:30:00');""", """
+                 src | hour                | max_id | weight
+                ---------------------------------------------
+                 a   | 2020-01-01 10:00:00 | 1      | 1
+                 b   | 2020-01-01 10:00:00 | 1      | 1""");
+        // Waterlines: ts 13:00, ts2 09:45.  Hour 10 of h1 falls below its waterline.
+        ccs.step("""
+                INSERT INTO events VALUES (2, '2020-01-01 14:00:00', '2020-01-01 10:45:00');""", """
+                 src | hour                | max_id | weight
+                ---------------------------------------------
+                 a   | 2020-01-01 14:00:00 | 2      | 1
+                 b   | 2020-01-01 10:00:00 | 1      | -1
+                 b   | 2020-01-01 10:00:00 | 2      | 1""");
+        // 09:50 is above the ts2 waterline although far below the ts one: group 1 moves
+        // to hour 9 in h2 while h1 is untouched.
+        ccs.step("""
+                INSERT INTO events VALUES (1, '2020-01-01 13:30:00', '2020-01-01 09:50:00');""", """
+                 src | hour                | max_id | weight
+                ---------------------------------------------
+                 b   | 2020-01-01 09:00:00 | 1      | 1""");
+        // A row late in ts alone is dropped as a whole.
+        ccs.step("""
+                INSERT INTO events VALUES (3, '2020-01-01 09:59:00', '2020-01-01 10:10:00');""", """
+                 src | hour                | max_id | weight
+                ---------------------------------------------""");
+        // Both timestamps exactly at their waterlines: a new group in both views.
+        ccs.step("""
+                INSERT INTO events VALUES (3, '2020-01-01 13:00:00', '2020-01-01 09:45:00');""", """
+                 src | hour                | max_id | weight
+                ---------------------------------------------
+                 a   | 2020-01-01 13:00:00 | 3      | 1
+                 b   | 2020-01-01 09:00:00 | 1      | -1
+                 b   | 2020-01-01 09:00:00 | 3      | 1""");
+    }
+
+    /** MIN over a nullable column on an input that allows deletions: deleting a group's only
+     * timestamped row restores its NULL minimum. */
+    @Test
+    public void issue7093NullableAggregate() {
+        CompilerCircuitStream ccs = this.getCCS("""
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    payload VARCHAR,
+                    ts TIMESTAMP LATENESS INTERVAL 1 HOUR
+                );
+                CREATE LOCAL VIEW first_event AS SELECT id, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);""")
+                .compactAfterEachStep();
+        checkDownstreamRetainKeys(ccs, 2);
+        ccs.step("""
+                INSERT INTO events VALUES
+                    (1, 'a', NULL),
+                    (2, 'b', '2020-01-01 10:30:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 1      | 1
+                 2020-01-01 10:00:00 | 2      | 1""");
+        // Waterline = 09:30.  Group 1 gets a timestamp, then loses it again.
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'c', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 1      | -1
+                 2020-01-01 09:00:00 | 1      | 1""");
+        ccs.step("""
+                REMOVE FROM events VALUES (1, 'c', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 09:00:00 | 1      | -1
+                 NULL                | 1      | 1""");
+        // Waterline = 11:00 after this step; hour 10 is garbage-collected.
+        ccs.step("""
+                INSERT INTO events VALUES (3, 'd', '2020-01-01 12:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 12:00:00 | 3      | 1""");
+        // Deleting group 2's row is late and dropped; group 1 leaves the NULL hour.
+        ccs.step("""
+                REMOVE FROM events VALUES (2, 'b', '2020-01-01 10:30:00');
+                INSERT INTO events VALUES (1, 'e', '2020-01-01 11:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 NULL                | 1      | -1
+                 2020-01-01 11:00:00 | 1      | 1""");
+    }
+
+    /** A FILTER clause makes the aggregate a fold rather than a MIN; no waterline on either path. */
+    @Test
+    public void issue7093Filter() {
+        String views = """
+                CREATE LOCAL VIEW first_event AS
+                SELECT id, MIN(ts) FILTER (WHERE payload IS NOT NULL) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);""";
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_EVENTS + views), 0);
+        checkDownstreamRetainKeys(this.getCC(EVENTS + views), 0);
+    }
+
+    /** Two chains minimizing different columns each carry their own column's waterline, and
+     * consumers of each use it independently. */
+    @Test
+    public void issue7093TwoColumns() {
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_TWO_TIMESTAMPS + """
+                CREATE LOCAL VIEW a AS SELECT id, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE LOCAL VIEW b AS SELECT id, MIN(ts2) AS ts2 FROM events GROUP BY id;
+                CREATE VIEW h1 AS SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM a GROUP BY TIMESTAMP_TRUNC(ts, HOUR);
+                CREATE VIEW h2 AS SELECT TIMESTAMP_TRUNC(ts2, HOUR) AS hour, MAX(id) AS max_id
+                FROM b GROUP BY TIMESTAMP_TRUNC(ts2, HOUR);"""), 4);
+    }
+
+    /** The same two minimums computed by one GROUP BY share one chain, whose row changes
+     * whenever either minimum moves and then carries the other column's old minimum,
+     * possibly below that column's waterline: neither output column has a waterline. */
+    @Test
+    public void issue7093TwoColumnsOneAggregate() {
+        checkDownstreamRetainKeys(this.getCC(APPEND_ONLY_TWO_TIMESTAMPS + """
+                CREATE LOCAL VIEW ab AS SELECT id, MIN(ts) AS ts, MIN(ts2) AS ts2 FROM events GROUP BY id;
+                CREATE VIEW h1 AS SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM ab GROUP BY TIMESTAMP_TRUNC(ts, HOUR);
+                CREATE VIEW h2 AS SELECT TIMESTAMP_TRUNC(ts2, HOUR) AS hour, MAX(id) AS max_id
+                FROM ab GROUP BY TIMESTAMP_TRUNC(ts2, HOUR);"""), 0);
+    }
+
+    @Test
+    public void issue7093Aggregate() {
+        CompilerCircuitStream ccs = this.getCCS(EVENTS + """
+                CREATE LOCAL VIEW first_event AS
+                SELECT id, MIN(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);""")
+                .compactAfterEachStep();
+        // The hourly aggregate garbage-collects its input and its output by hour.
+        checkDownstreamRetainKeys(ccs, 2);
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'a', '2020-01-01 10:30:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 10:00:00 | 1      | 1""");
+        // Waterline = 09:30.  An earlier row moves group 1 to hour 9.
+        ccs.step("""
+                INSERT INTO events VALUES (1, 'b', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 10:00:00 | 1      | -1
+                 2020-01-01 09:00:00 | 1      | 1""");
+        // Deleting the minimum row (09:45, above the waterline) moves group 1 back to hour 10.
+        ccs.step("""
+                REMOVE FROM events VALUES (1, 'b', '2020-01-01 09:45:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 09:00:00 | 1      | -1
+                 2020-01-01 10:00:00 | 1      | 1""");
+        // Waterline = 11:00 after this step; hours 9 and 10 are garbage-collected.
+        ccs.step("""
+                INSERT INTO events VALUES (2, 'c', '2020-01-01 12:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 12:00:00 | 2      | 1""");
+        // Deleting group 1's remaining row is late (10:30 < 11:00) and dropped;
+        // the new group lands in the hour at the waterline.
+        ccs.step("""
+                REMOVE FROM events VALUES (1, 'a', '2020-01-01 10:30:00');
+                INSERT INTO events VALUES (3, 'd', '2020-01-01 11:00:00');""", """
+                 hour                | max_id | weight
+                ---------------------------------------
+                 2020-01-01 11:00:00 | 3      | 1""");
+    }
+
+    @Test
+    public void issue7093AggregateNoWaterline() {
+        // MAX: no waterline
+        checkDownstreamRetainKeys(this.getCC(EVENTS + """
+                CREATE LOCAL VIEW last_event AS SELECT id, MAX(ts) AS ts FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(ts, HOUR) AS hour, MAX(id) AS max_id
+                FROM last_event GROUP BY TIMESTAMP_TRUNC(ts, HOUR);"""), 0);
+        // seen has no waterline
+        checkDownstreamRetainKeys(this.getCC("""
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR,
+                    seen TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR
+                );
+                CREATE LOCAL VIEW first_seen AS SELECT id, ARG_MIN(seen, ts) AS seen FROM events GROUP BY id;
+                CREATE VIEW hourly AS
+                SELECT TIMESTAMP_TRUNC(seen, HOUR) AS hour, MAX(id) AS max_id
+                FROM first_seen GROUP BY TIMESTAMP_TRUNC(seen, HOUR);"""), 0);
+        // amount has no waterline
+        checkDownstreamRetainKeys(this.getCC("""
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    amount INT NOT NULL,
+                    ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR
+                );
+                CREATE LOCAL VIEW per_id AS SELECT id, MIN(amount) AS amount FROM events GROUP BY id;
+                CREATE VIEW by_amount AS
+                SELECT amount / 100 AS bucket, MAX(id) AS max_id FROM per_id GROUP BY amount / 100;"""), 0);
+    }
+}


### PR DESCRIPTION
Fixes #7093

## Checklist

- [x] Unit tests added/updated
- [x] Documentation updated

The waterline of a MIN is exactly the waterline of its input. That's essentially what this PR is computing.
The PR is larger than you would expect because computing multiple aggregates that each have waterlines does not produce a result with a waterline necessarily (I am not talking about the waterline of the group key, but of the aggregates themselves).
So the code has to deal with multiple chain aggregates computed together.

It works pretty well; I will attach a series of before/after graphs for the test programs.

This was motivated by #7086, and it may be a piece of that solution.