### PR TITLE
[ci] Bump oidc-auth-action to v4.1.0

### DIFF
--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -41,7 +41,7 @@ jobs:
       # The instances identify this workflow by the audience it requests, so
       # the value has to match the one their trust pins.
       - name: Authenticate to Feldera
-        uses: feldera/oidc-auth-action@8d6ac3e4be2ce12d3d70c4418f97eebd28b66f29 # v4.0.0
+        uses: feldera/oidc-auth-action@5497ffbb6c5a4e562c528c04a1858712a956cbad # v4.1.0
         with:
           host: ${{ matrix.feldera_host }}
           audience: feldera-ci-runtime-tests


### PR DESCRIPTION
v4.0.0 re-minted the OIDC token every 240 seconds against a 300-second token and, on a failed mint, waited a whole further interval before trying again. One lost mint left the token file holding a token that expired before the next write, and every pytest worker was rejected for that whole window. That is #7048: twice on this job, 122 seconds past a refresh cycle both times.

v4.1.0 re-mints every 90 seconds so missing two consecutive cycles still leaves the file's token valid, retries a lost mint after 10 seconds rather than at the next cycle, and logs what it did to a file the post step prints, which is what was missing when three reports of #7048 could only guess whether the refresher had missed a cycle or died.