### PR TITLE
[adapters] delta: keep column case when adding partition columns

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -27,7 +27,7 @@ use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
 use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::execution::context::SQLOptions;
 use deltalake::datafusion::logical_expr::{ExprSchemable, SortExpr};
-use deltalake::datafusion::prelude::{Expr, SessionContext, col, lit};
+use deltalake::datafusion::prelude::{Expr, SessionContext, ident, lit};
 use deltalake::datafusion::sql::sqlparser::dialect::GenericDialect;
 use deltalake::datafusion::sql::sqlparser::parser::Parser;
 use deltalake::datafusion::sql::sqlparser::tokenizer::Token;
@@ -3769,9 +3769,42 @@ impl DeltaTableInputEndpointInner {
             return Ok(df);
         }
 
-        let schema = df.schema().clone();
+        let file_schema = df.schema().clone();
+        let logical_schema = self.logical_schema()?;
+        let projection = Self::partition_projection(
+            &logical_schema,
+            &partition_columns,
+            partition_values,
+            &file_schema,
+            extra_columns,
+            description,
+        )?;
+
+        df.select(projection).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error adding partition columns: {e}")
+        })
+    }
+
+    /// The projection [`add_partition_columns`](Self::add_partition_columns)
+    /// applies: every column the table declares, in schema order, with each
+    /// partition column supplied as a literal from `partition_values`, followed
+    /// by whichever `extra_columns` the data file's `file_schema` carries.
+    ///
+    /// Columns are named with `ident`, never `col`: `col` reads its argument as
+    /// SQL and lowercases an unquoted identifier, so a table holding an uppercase
+    /// column `ORDER_ID` would be projected through a reference to
+    /// `order_id`, which matches nothing. `ident` takes the name verbatim, as
+    /// does `alias`.
+    fn partition_projection(
+        logical_schema: &ArrowSchema,
+        partition_columns: &[String],
+        partition_values: Option<&HashMap<String, Option<String>>>,
+        file_schema: &DFSchema,
+        extra_columns: &[&str],
+        description: &str,
+    ) -> AnyResult<Vec<Expr>> {
         let mut projection: Vec<Expr> = Vec::new();
-        for field in self.logical_schema()?.fields() {
+        for field in logical_schema.fields() {
             if partition_columns.contains(field.name()) {
                 // The log keys partition values by physical name. The Hive
                 // `key=value` directory layout is convention, not protocol, so
@@ -3792,7 +3825,7 @@ impl DeltaTableInputEndpointInner {
                 };
                 projection.push(
                     literal
-                        .cast_to(field.data_type(), &schema)
+                        .cast_to(field.data_type(), file_schema)
                         .map_err(|e| {
                             anyhow!(
                                 "error processing {description}: cannot read partition column '{}' as {}: {e}",
@@ -3802,19 +3835,17 @@ impl DeltaTableInputEndpointInner {
                         })?
                         .alias(field.name()),
                 );
-            } else if schema.has_column_with_unqualified_name(field.name()) {
-                projection.push(col(field.name()));
+            } else if file_schema.has_column_with_unqualified_name(field.name()) {
+                projection.push(ident(field.name()));
             }
         }
         for name in extra_columns {
-            if schema.has_column_with_unqualified_name(name) {
-                projection.push(col(*name));
+            if file_schema.has_column_with_unqualified_name(name) {
+                projection.push(ident(*name));
             }
         }
 
-        df.select(projection).map_err(|e| {
-            anyhow!("internal error processing {description}; {REPORT_ERROR}; error adding partition columns: {e}")
-        })
+        Ok(projection)
     }
 
     /// The Delta table's logical Arrow schema at the version being read.
@@ -3858,6 +3889,9 @@ impl DeltaTableInputEndpointInner {
     /// while the rest of the pipeline expects logical names. Unmapped columns
     /// (already logical, or Delta metadata like `__feldera_op`) pass through.
     /// This function is a no-op when column mapping is off.
+    ///
+    /// Names are taken verbatim, with `ident`, for the reason
+    /// [`partition_projection`](Self::partition_projection) gives.
     fn project_physical_to_logical(&self, df: DataFrame) -> AnyResult<DataFrame> {
         let pairs = self.column_mapping()?;
         if pairs.is_empty() {
@@ -3872,8 +3906,8 @@ impl DeltaTableInputEndpointInner {
             .fields()
             .iter()
             .map(|f| match to_logical.get(f.name().as_str()) {
-                Some(logical) => col(f.name()).alias(*logical),
-                None => col(f.name()),
+                Some(logical) => ident(f.name()).alias(*logical),
+                None => ident(f.name()),
             })
             .collect();
         df.select(exprs)
@@ -4826,6 +4860,110 @@ mod column_mapping_tests {
             .downcast_ref::<StructArray>()
             .unwrap();
         assert_eq!(element.column(0).as_ref(), ids.as_ref());
+    }
+}
+
+#[cfg(test)]
+mod partition_projection_tests {
+    use super::*;
+    use arrow::array::Int64Array;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    /// The partition value the log action records for the file under test.
+    const PARTITION_VALUE: &str = "EAST";
+
+    /// Project one data file holding `data_column` from a table partitioned by
+    /// `partition_column`, the way a follow-mode read does.
+    ///
+    /// Delta keeps a partition column in the log action alone, so the file holds
+    /// every other column and the projection puts the partition value back.
+    async fn project(data_column: &str, partition_column: &str) -> DataFrame {
+        let table_schema = ArrowSchema::new(vec![
+            ArrowField::new(data_column, ArrowDataType::Int64, false),
+            ArrowField::new(partition_column, ArrowDataType::Utf8, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                data_column,
+                ArrowDataType::Int64,
+                false,
+            )])),
+            vec![Arc::new(Int64Array::from(vec![1i64, 2]))],
+        )
+        .expect("the batch is well formed");
+
+        let df = SessionContext::new()
+            .read_batch(batch)
+            .expect("a batch reads as a frame");
+        let file_schema = df.schema().clone();
+        let partition_values = HashMap::from([(
+            partition_column.to_string(),
+            Some(PARTITION_VALUE.to_string()),
+        )]);
+        let projection = DeltaTableInputEndpointInner::partition_projection(
+            &table_schema,
+            &[partition_column.to_string()],
+            Some(&partition_values),
+            &file_schema,
+            &[],
+            "a data file",
+        )
+        .expect("the projection is built");
+
+        df.select(projection)
+            .expect("the projection resolves against the file's columns")
+    }
+
+    fn column_names(df: &DataFrame) -> Vec<String> {
+        df.schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().clone())
+            .collect()
+    }
+
+    async fn partition_column_values(df: DataFrame, column: &str) -> Vec<String> {
+        df.collect()
+            .await
+            .expect("the frame collects")
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name(column)
+                    .expect("the partition column is projected")
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("the partition column reads as a string")
+                    .iter()
+                    .map(|value| value.expect("the log recorded a value").to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// Uppercase column names, as a table loaded from a system that folds
+    /// identifiers to upper case carries. Read as SQL, an unquoted `ID` names
+    /// column `id`, which such a table does not have.
+    #[tokio::test]
+    async fn an_uppercase_column_keeps_its_case() {
+        let df = project("ID", "REGION").await;
+
+        assert_eq!(column_names(&df), vec!["ID", "REGION"]);
+        assert_eq!(
+            partition_column_values(df, "REGION").await,
+            vec![PARTITION_VALUE; 2],
+            "every row takes the partition value from the log action"
+        );
+    }
+
+    /// A column name holding a dot. Read as SQL it splits into a table
+    /// qualifier and a column, naming neither.
+    #[tokio::test]
+    async fn a_dotted_column_name_is_not_a_qualifier() {
+        let df = project("src.id", "src.app").await;
+
+        assert_eq!(column_names(&df), vec!["src.id", "src.app"]);
     }
 }
 

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4581,12 +4581,35 @@ where
         + for<'de> DeserializeWithContext<'de, SqlSerdeConfig, Variant>
         + Sync,
 {
+    let arrow_schema = ArrowSchema::new(relation_to_arrow_fields(relation, delta_schema_options()));
+    run_follow_partition_test_on(&arrow_schema, relation, rows, rows, partition_columns).await
+}
+
+/// [`run_follow_partition_test`] with the Delta table's columns named apart from
+/// the SQL table's, for a test whose two sides spell them differently.
+///
+/// Hence the two record types: `W` serializes under the Delta table's column
+/// names, which is what the writer needs, and `T` under the SQL table's, which
+/// is what the ad hoc query reading the output back needs. They hold the same
+/// rows.
+async fn run_follow_partition_test_on<W, T>(
+    arrow_schema: &ArrowSchema,
+    relation: &[Field],
+    written_rows: &[W],
+    expected_rows: &[T],
+    partition_columns: &[&str],
+) where
+    W: DBData + SerializeWithContext<SqlSerdeConfig> + Sync,
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig, Variant>
+        + Sync,
+{
     init_logging();
 
-    let arrow_schema = ArrowSchema::new(relation_to_arrow_fields(relation, delta_schema_options()));
     let table_dir = TempDir::new().unwrap();
     let table_uri = table_dir.path().display().to_string();
-    let table = create_table_from_arrow(&table_uri, &arrow_schema, partition_columns).await;
+    let table = create_table_from_arrow(&table_uri, arrow_schema, partition_columns).await;
 
     let storage_dir = TempDir::new().unwrap();
     let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -4601,11 +4624,11 @@ where
     .unwrap();
     read_pipeline.start();
 
-    write_data_to_table(table, &arrow_schema, rows).await;
+    write_data_to_table(table, arrow_schema, written_rows).await;
     wait_or_connector_error(
         &read_pipeline,
         &SqlIdentifier::from("test_output1"),
-        rows,
+        expected_rows,
         &errors,
     )
     .await;
@@ -4669,6 +4692,225 @@ async fn delta_table_follow_partition_column_types_test() {
     rows[1].unused = Some("present".to_string());
 
     run_follow_partition_test(&DeltaTestStruct::schema(), &rows, PARTITION_COLUMNS).await;
+}
+
+/// A table whose column names are quoted uppercase SQL identifiers, as a table
+/// imported from a system that folds identifiers to upper case carries.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct UpperCaseTestStruct {
+    id: i64,
+    payload: String,
+    region: String,
+}
+
+serialize_table_record!(UpperCaseTestStruct[3]{
+    id["ID"]: i64,
+    payload["PAYLOAD"]: String,
+    region["REGION"]: String
+});
+
+// Deserialized case-sensitively: the connector must deliver each column under
+// the name the Delta table gives it, not a case-folded one.
+deserialize_table_record!(UpperCaseTestStruct["UpperCaseTestStruct", Variant, 3] {
+    (id, "ID", true, i64, |_| None),
+    (payload, "PAYLOAD", true, String, |_| None),
+    (region, "REGION", true, String, |_| None)
+});
+
+impl UpperCaseTestStruct {
+    fn schema() -> Vec<Field> {
+        vec![
+            Field::new(SqlIdentifier::new("ID", true), ColumnType::bigint(false)),
+            Field::new(
+                SqlIdentifier::new("PAYLOAD", true),
+                ColumnType::varchar(false),
+            ),
+            Field::new(
+                SqlIdentifier::new("REGION", true),
+                ColumnType::varchar(false),
+            ),
+        ]
+    }
+}
+
+/// Follow a partitioned table whose column names are not lower case.
+///
+/// A partitioned read names every other column in a projection, and a name read
+/// as SQL rather than taken verbatim would arrive lowercased, matching no column
+/// of such a table.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_partition_uppercase_columns_test() {
+    let rows: Vec<UpperCaseTestStruct> = (0..6)
+        .map(|id| UpperCaseTestStruct {
+            id,
+            payload: format!("row-{id}"),
+            region: if id % 2 == 0 { "EAST" } else { "WEST" }.to_string(),
+        })
+        .collect();
+
+    run_follow_partition_test(&UpperCaseTestStruct::schema(), &rows, &["REGION"]).await;
+}
+
+/// The same table declared in SQL without quotes, so the two sides spell the
+/// columns differently.
+///
+/// An unquoted SQL identifier folds to lower case, and the compiler then emits a
+/// deserializer that matches column names ignoring case: the `false` below is
+/// the column's `isQuoted()` flag, and the names are the folded ones.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    IsNone,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+struct UnquotedSqlTestStruct {
+    id: i64,
+    payload: String,
+    region: String,
+}
+
+serialize_table_record!(UnquotedSqlTestStruct[3]{
+    id["id"]: i64,
+    payload["payload"]: String,
+    region["region"]: String
+});
+
+deserialize_table_record!(UnquotedSqlTestStruct["UnquotedSqlTestStruct", Variant, 3] {
+    (id, "id", false, i64, |_| None),
+    (payload, "payload", false, String, |_| None),
+    (region, "region", false, String, |_| None)
+});
+
+impl UnquotedSqlTestStruct {
+    fn schema() -> Vec<Field> {
+        vec![
+            Field::new("id".into(), ColumnType::bigint(false)),
+            Field::new("payload".into(), ColumnType::varchar(false)),
+            Field::new("region".into(), ColumnType::varchar(false)),
+        ]
+    }
+}
+
+/// Follow the same uppercase partitioned table through a SQL table that declares
+/// its columns unquoted.
+///
+/// The connector matches the two schemas ignoring case, so the SQL side resolves
+/// whatever it is spelled; the projection still has to name each column the way
+/// the Delta table does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_partition_unquoted_sql_columns_test() {
+    let arrow_schema = ArrowSchema::new(relation_to_arrow_fields(
+        &UpperCaseTestStruct::schema(),
+        delta_schema_options(),
+    ));
+    let written_rows: Vec<UpperCaseTestStruct> = (0..6)
+        .map(|id| UpperCaseTestStruct {
+            id,
+            payload: format!("row-{id}"),
+            region: if id % 2 == 0 { "EAST" } else { "WEST" }.to_string(),
+        })
+        .collect();
+    let expected_rows: Vec<UnquotedSqlTestStruct> = written_rows
+        .iter()
+        .map(|row| UnquotedSqlTestStruct {
+            id: row.id,
+            payload: row.payload.clone(),
+            region: row.region.clone(),
+        })
+        .collect();
+
+    run_follow_partition_test_on(
+        &arrow_schema,
+        &UnquotedSqlTestStruct::schema(),
+        &written_rows,
+        &expected_rows,
+        &["REGION"],
+    )
+    .await;
+}
+
+/// An ordered snapshot read of a table whose column names are case sensitive.
+///
+/// `timestamp_column` holds an SQL identifier rather than a bare column name,
+/// so a case-sensitive column has to be quoted. Unquoted, it folds to lower
+/// case and the connector rejects it at startup as missing from the table.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_snapshot_uppercase_timestamp_column_test() {
+    init_logging();
+
+    // An ordered read needs LATENESS on the timestamp column.
+    let relation = vec![
+        Field::new(SqlIdentifier::new("ID", true), ColumnType::bigint(false)).with_lateness("2"),
+        Field::new(
+            SqlIdentifier::new("PAYLOAD", true),
+            ColumnType::varchar(false),
+        ),
+        Field::new(
+            SqlIdentifier::new("REGION", true),
+            ColumnType::varchar(false),
+        ),
+    ];
+    let rows: Vec<UpperCaseTestStruct> = (0..6)
+        .map(|id| UpperCaseTestStruct {
+            id,
+            payload: format!("row-{id}"),
+            region: "EAST".to_string(),
+        })
+        .collect();
+
+    let arrow_schema =
+        ArrowSchema::new(relation_to_arrow_fields(&relation, delta_schema_options()));
+    let table_dir = TempDir::new().unwrap();
+    let table_uri = table_dir.path().display().to_string();
+    let table = create_table_from_arrow(&table_uri, &arrow_schema, &[]).await;
+    write_data_to_table(table, &arrow_schema, &rows).await;
+
+    let storage_dir = TempDir::new().unwrap();
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let pipeline = delta_input_controller::<UpperCaseTestStruct>(
+        &table_uri,
+        json!({ "mode": "snapshot", "timestamp_column": "\"ID\"" }),
+        &relation,
+        storage_dir.path(),
+        &errors,
+    )
+    .await
+    .unwrap();
+    pipeline.start();
+
+    wait_or_connector_error(
+        &pipeline,
+        &SqlIdentifier::from("test_output1"),
+        &rows,
+        &errors,
+    )
+    .await;
+    pipeline.stop().unwrap();
 }
 
 /// CDC mode over a partitioned table: the adds side reads files that span two


### PR DESCRIPTION
The actual fix is two lines of code. The rest of the changes are tests + refactoring `fn add_partition_columns` into two functions for testing.

A follow or change-data read of a partitioned table failed for any table whose column names are not lower case:

    internal error processing file 'REGION=EAST/part-00000-....parquet';
    error adding partition columns: Schema error: No field named
    order_id. Valid fields are "?table?"."ORDER_ID", ...

Delta keeps a partition column's value in the log action rather than in the data file, so the reader reprojects the file's own columns alongside that value as a literal. The projection named each column with DataFusion's `col`, which reads its argument as SQL and lowercases an unquoted identifier: `ORDER_ID` became a reference to `order_id`, which matches no column. `ident` takes the name verbatim. It also leaves alone a name holding a dot, which `col` splits into a qualifier and a column.

The column-mapping rename builds the same kind of projection and gets the same treatment.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
